### PR TITLE
feat(app): validate input + nút khôi phục mặc định trong Settings

### DIFF
--- a/app/src/components/Settings.tsx
+++ b/app/src/components/Settings.tsx
@@ -18,13 +18,38 @@ const DEFAULTS: Settings = {
   whisperModel: null,
 };
 
+// Form nháp: audioThreads có thể rỗng (null) trong lúc gõ, chỉ Settings đã validate mới lưu.
+type SettingsForm = Omit<Settings, "audioThreads"> & { audioThreads: number | null };
+
+type FormErrors = Partial<Record<"ocrLangs" | "audioLang" | "audioThreads", string>>;
+
+// Mã ngôn ngữ tesseract: vie, eng, chi_sim… nối bằng "+"
+const OCR_LANGS_RE = /^[a-z_]+(\+[a-z_]+)*$/i;
+
+function validate(form: SettingsForm): FormErrors {
+  const errors: FormErrors = {};
+  if (!form.ocrLangs.trim() || !OCR_LANGS_RE.test(form.ocrLangs.trim())) {
+    errors.ocrLangs = "Ngôn ngữ OCR không hợp lệ (ví dụ: vie+eng)";
+  }
+  if (!form.audioLang.trim()) {
+    errors.audioLang = "Ngôn ngữ audio không được để trống";
+  }
+  if (form.audioThreads == null || Number.isNaN(form.audioThreads) || form.audioThreads < 1 || form.audioThreads > 32) {
+    errors.audioThreads = "Thread audio phải từ 1 đến 32";
+  }
+  return errors;
+}
+
 export function SettingsModal({ onClose }: { onClose: () => void }) {
   const current = useStore((s) => s.settings) ?? DEFAULTS;
   const saveSettings = useStore((s) => s.saveSettings);
   const setError = useStore((s) => s.setError);
-  const [form, setForm] = useState<Settings>(current);
+  const [form, setForm] = useState<SettingsForm>(current);
 
-  function set<K extends keyof Settings>(key: K, val: Settings[K]) {
+  const errors = validate(form);
+  const hasErrors = Object.keys(errors).length > 0;
+
+  function set<K extends keyof SettingsForm>(key: K, val: SettingsForm[K]) {
     setForm((f) => ({ ...f, [key]: val }));
   }
 
@@ -42,7 +67,8 @@ export function SettingsModal({ onClose }: { onClose: () => void }) {
   }
 
   async function onSave() {
-    await saveSettings(form);
+    if (hasErrors) return;
+    await saveSettings(form as Settings);
     onClose();
   }
 
@@ -52,12 +78,33 @@ export function SettingsModal({ onClose }: { onClose: () => void }) {
         header={<DialogHeader title="Cài đặt convert" onOpenChange={(open: boolean) => !open && onClose()} />}
         content={
           <div className="settings-form">
-            <TextInput label="Ngôn ngữ OCR (ảnh / PDF scan)" value={form.ocrLangs} onChange={(v: string) => set("ocrLangs", v)} placeholder="vie+eng" />
+            <TextInput
+              label="Ngôn ngữ OCR (ảnh / PDF scan)"
+              value={form.ocrLangs}
+              onChange={(v: string) => set("ocrLangs", v)}
+              placeholder="vie+eng"
+              status={errors.ocrLangs ? { type: "error", message: errors.ocrLangs } : undefined}
+            />
             <CheckboxInput label="OCR trang PDF dạng scan (ít/không có lớp text)" value={form.pdfOcr} onChange={(v: boolean) => set("pdfOcr", v)} />
             <CheckboxInput label="OCR thêm ảnh nhúng trong trang PDF có text (chậm hơn)" value={form.pdfOcrImages} onChange={(v: boolean) => set("pdfOcrImages", v)} />
             <div className="settings-grid">
-              <TextInput label="Ngôn ngữ audio" value={form.audioLang} onChange={(v: string) => set("audioLang", v)} />
-              <NumberInput label="Thread audio" value={form.audioThreads} onChange={(v: number) => set("audioThreads", v || 1)} min={1} max={32} />
+              <TextInput
+                label="Ngôn ngữ audio"
+                value={form.audioLang}
+                onChange={(v: string) => set("audioLang", v)}
+                status={errors.audioLang ? { type: "error", message: errors.audioLang } : undefined}
+              />
+              <NumberInput
+                label="Thread audio"
+                value={form.audioThreads}
+                // hasClear để onChange nhận được null khi xoá — không có nó NumberInput
+                // nuốt giá trị rỗng/sai và tự revert, validate không bao giờ thấy.
+                hasClear
+                onChange={(v: number | null) => set("audioThreads", v)}
+                min={1}
+                max={32}
+                status={errors.audioThreads ? { type: "error", message: errors.audioThreads } : undefined}
+              />
             </div>
             <div className="settings-whisper">
               <TextInput label="Model whisper (.bin) — để trống nếu không dùng audio" value={form.whisperModel ?? ""} onChange={(v: string) => set("whisperModel", v || null)} placeholder="đường dẫn tới ggml-*.bin" />
@@ -68,8 +115,9 @@ export function SettingsModal({ onClose }: { onClose: () => void }) {
         footer={
           <LayoutFooter hasDivider>
             <div className="settings-actions">
+              <Button label="Khôi phục mặc định" variant="ghost" onClick={() => setForm(DEFAULTS)} />
               <Button label="Hủy" variant="ghost" onClick={onClose} />
-              <Button label="Lưu" variant="primary" onClick={onSave} />
+              <Button label="Lưu" variant="primary" onClick={onSave} isDisabled={hasErrors} />
             </div>
           </LayoutFooter>
         }


### PR DESCRIPTION
Closes #8

## Vấn đề
Form Settings lưu thẳng mọi giá trị người dùng nhập — không kiểm tra gì trước khi Lưu,
và không có cách đưa cấu hình về mặc định.

## Giải pháp
Chỉ sửa `app/src/components/Settings.tsx` (đúng phạm vi issue).

### Validate trước khi Lưu
| Trường | Luật | Thông báo lỗi |
|---|---|---|
| Ngôn ngữ OCR | không rỗng, đúng dạng mã tesseract (`vie+eng`, `chi_sim`) | "Ngôn ngữ OCR không hợp lệ (ví dụ: vie+eng)" |
| Ngôn ngữ audio | không rỗng (đã trim) | "Ngôn ngữ audio không được để trống" |
| Thread audio | bắt buộc 1–32, bắt cả giá trị rỗng | "Thread audio phải từ 1 đến 32" |

- **Thời điểm validate: onChange** (mục "Cần tìm hiểu" của issue) — lỗi được tính lại
  mỗi lần render từ form, không cần state lỗi riêng, hiện ngay dưới input qua prop
  `status` của TextInput/NumberInput.
- Có lỗi → nút **Lưu** disabled; `onSave` có thêm guard chặn trường hợp gọi trực tiếp.

### Nút "Khôi phục mặc định"
Đặt ở footer, set form nháp về `DEFAULTS` — vẫn phải bấm Lưu mới ghi xuống,
nên bấm nhầm không mất cấu hình hiện tại.

### Fix kèm theo: `hasClear` cho NumberInput (mục "Lưu ý" của issue)
NumberInput không có `hasClear` sẽ chỉ gọi `onChange` với số hợp lệ trong min/max
và tự revert khi blur → form không bao giờ "thấy" giá trị rỗng/NaN, validate không
thể kích hoạt. Thêm `hasClear` để xoá trống truyền `null` về form và bị bắt lỗi.

## Test (tiêu chí chấp nhận)
Verify runtime bằng Playwright (headless Edge) trên vite dev server:
- **Nhập sai không lưu + báo rõ**: ocrLangs rỗng/`vie+`, audioLang rỗng/toàn space,
  threads rỗng → lỗi hiện đúng dưới input + Lưu disabled; force-click Lưu qua JS cũng bị chặn
-  **Reset trả đúng default**: từ trạng thái bẩn + đang lỗi → về đúng
  `vie+eng` / `vi` / `4` / pdfOcr bật, hết lỗi
-  **Rỗng/NaN dù có min/max**: clear threads → báo lỗi; gõ `0`/`99` → không lọt vào form
-  `tsc --noEmit` pass

## Giới hạn đã thống nhất
Validate ngôn ngữ OCR theo **dạng mã** (đúng scope issue) — mã bịa đúng dạng
(vd `gugugaga`) vẫn qua. Đã trao đổi, quyết định giữ nguyên; siết bằng whitelist
mã thật hoặc hỏi backend `tesseract --list-langs` để dành issue khác.