### PR TITLE
Improve PDF OCR fallback quality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,14 @@ rust-version = "1.88"
 anyhow = "1"
 thiserror = "2"
 infer = "0.16"
+
+# Tauri dev otherwise runs the PDF/OCR pipeline completely unoptimized
+# (measured ~17.5s vs <1s release on the 45-page CASAN PDF).
+[profile.dev]
+opt-level = 1
+
+[profile.dev.package."*"]
+opt-level = 2
+
+[profile.dev.package.fileconv-core]
+opt-level = 2

--- a/bench/REPORT_CASAN_PDF.md
+++ b/bench/REPORT_CASAN_PDF.md
@@ -1,0 +1,58 @@
+# Báo cáo PDF CASAN — OCR false-positive và hiệu năng
+
+Ngày đo: 2026-07-10. File:
+`Phương-pháp-luận-FPT-CASAN---ver.-Alpha_đã-ký 2.pdf` (45 trang, 1.61 MB,
+Microsoft Word, tagged PDF). Build `--release`, máy sandbox 8 vCPU, PDFium local,
+Tesseract `vie+eng` và `tessdata_best`.
+
+## Chẩn đoán
+
+PDF có text-layer Unicode tốt, không phải bản scan. `pdf-inspector` 0.1.3 gắn cờ
+ba trang mục lục do font GID/symbol và dotted leader, khiến pipeline cũ render
+rồi OCR Tesseract. OCR làm sai dấu/chữ dù text gốc hoàn toàn đọc được.
+
+Một số bảng nhiều dòng/ô gộp cũng bị nhận thành quá nhiều cột Markdown, làm đảo
+thứ tự câu. Header tài liệu lặp trên cả 45 trang.
+
+File Markdown được nhắc trong commit test không có trên Git, nên phép đo nội dung
+dùng `pdftotext -raw` làm tham chiếu text-layer.
+
+## Thay đổi
+
+- Ưu tiên native PDFium text khi qua cổng chất lượng cao; trang scan thật vẫn OCR.
+- Page-filter dùng API lọc trang của `pdf-inspector`, không quét toàn bộ 45 trang.
+- Bảng lỗi được cô lập theo trang và thay bằng native text nếu bảo toàn ≥90% nội dung.
+- PDF 16–200 trang, ≤32 MB chạy tối đa 4 range song song trên máy ≥5 CPU.
+- `pdf-inspector` và PDFium chạy chồng thời gian; PDFium binding tái sử dụng an toàn
+  giữa các thread.
+- Xóa header/footer lặp nhưng không đụng dòng bảng Markdown.
+
+## Kết quả
+
+| Kịch bản | Trước | Sau |
+|---|---:|---:|
+| Full 45 trang | ~0.77 s sau fix chất lượng tuần tự | **0.51 s** |
+| Chọn 1 trang thường | ~0.40 s | **0.055 s** |
+| Chọn 1 trang bảng | ~0.44 s | **0.061 s** |
+| Chọn trang 1–10 | ~0.49 s | **0.29 s** |
+| Trang OCR nhầm | 3 | **0** |
+| Header `Mã hiệu` lặp | 45 | **0** |
+| Token recall (bỏ header lặp) | — | **99.84%** |
+| Token precision | — | **100%** |
+
+So với đường tuần tự bảo thủ, output song song giữ 99.95% token, đồng thời giữ
+nhiều heading/bảng hợp lệ hơn. PDF ảnh-only sinh từ trang 4 vẫn đi qua
+`<!-- Trang 1 (OCR) -->`.
+
+## Lệnh đo
+
+```bash
+cargo build --release -p fileconv-cli
+./target/release/fileconv one "<file.pdf>"
+./target/release/fileconv one "<file.pdf>" --pages 5
+cargo test -p fileconv-core
+cargo test -p fileconv-cli metrics
+```
+
+Hiệu năng phụ thuộc số core. Máy dưới 5 CPU, PDF >200 trang hoặc >32 MB tự dùng
+đường tuần tự để tránh oversubscribe/OOM.

--- a/bench/REPORT_CASAN_PDF.md
+++ b/bench/REPORT_CASAN_PDF.md
@@ -26,23 +26,33 @@ dùng `pdftotext -raw` làm tham chiếu text-layer.
 - `pdf-inspector` và PDFium chạy chồng thời gian; PDFium binding tái sử dụng an toàn
   giữa các thread.
 - Xóa header/footer lặp nhưng không đụng dòng bảng Markdown.
+- Desktop dev tự tìm `pdfium/` và `tessdata_best/` từ các thư mục cha/executable,
+  không phụ thuộc current working directory `app/`.
+- Profile dev tối ưu core/dependency để `pnpm tauri dev` không chạy pipeline PDF
+  hoàn toàn ở `opt-level=0`.
 
 ## Kết quả
 
 | Kịch bản | Trước | Sau |
 |---|---:|---:|
-| Full 45 trang | ~0.77 s sau fix chất lượng tuần tự | **0.51 s** |
+| Full 45 trang (CLI release) | ~0.77 s sau fix chất lượng tuần tự | **0.35 s** |
 | Chọn 1 trang thường | ~0.40 s | **0.055 s** |
-| Chọn 1 trang bảng | ~0.44 s | **0.061 s** |
-| Chọn trang 1–10 | ~0.49 s | **0.29 s** |
+| Chọn 1 trang bảng | ~0.44 s | **0.059 s** |
+| Chọn trang 1–10 | ~0.49 s | **0.27 s** |
+| Desktop Tauri dev, click `Convert ngay` → `.md` | 17.54 s | **0.403 s** |
 | Trang OCR nhầm | 3 | **0** |
 | Header `Mã hiệu` lặp | 45 | **0** |
-| Token recall (bỏ header lặp) | — | **99.84%** |
+| Token recall (bỏ header lặp) | — | **99.86%** |
 | Token precision | — | **100%** |
 
 So với đường tuần tự bảo thủ, output song song giữ 99.95% token, đồng thời giữ
 nhiều heading/bảng hợp lệ hơn. PDF ảnh-only sinh từ trang 4 vẫn đi qua
 `<!-- Trang 1 (OCR) -->`.
+
+Tauri được chạy thật trong Xvfb 1440×900 với DATA riêng: mở PDF raw, bấm
+`Convert ngay`, sidecar 107.854 ký tự được tạo trong 0.403 giây; giao diện tự
+chuyển sang chế độ Đối chiếu. Lần compile dev đầu tiên lâu hơn do dependency được
+tối ưu, các lần chạy/compile tăng dần dùng incremental cache.
 
 ## Lệnh đo
 

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -81,7 +81,8 @@ fn via_pdf_inspector(
     PDFIUM.with(|opt| -> Option<String> {
         // Chỉ mở PDFium khi thật sự cần (OCR trang scan hoặc OCR ảnh nhúng).
         let pdf_doc = if need_pdfium {
-            opt.as_ref().and_then(|p| p.load_pdf_from_file(path, None).ok())
+            opt.as_ref()
+                .and_then(|p| p.load_pdf_from_file(path, None).ok())
         } else {
             None
         };
@@ -91,8 +92,21 @@ fn via_pdf_inspector(
             let has_text = !pm.markdown.trim().is_empty();
 
             if pm.needs_ocr && ocr_enabled {
-                // Trang scan / text rác → render + OCR.
-                if let Some(text) = pdf_doc
+                // `pdf-inspector` intentionally errs on the side of OCR when
+                // *any* GID/symbol font is present. Real Word-exported PDFs can
+                // therefore be flagged because of one logo/bullet font even
+                // though PDFium decodes the main text perfectly. Prefer that
+                // native text when it passes a conservative quality gate;
+                // only render + OCR genuinely empty/garbled pages.
+                let native_text = pdf_doc
+                    .as_ref()
+                    .and_then(|d| native_page_text_at(d, pm.page))
+                    .filter(|text| native_text_is_trustworthy(text));
+
+                if let Some(text) = native_text {
+                    out.push_str(text.trim_end());
+                    out.push_str("\n\n");
+                } else if let Some(text) = pdf_doc
                     .as_ref()
                     .and_then(|d| ocr_page_at(d, pm.page, langs))
                 {
@@ -113,7 +127,8 @@ fn via_pdf_inspector(
                 if ocr_enabled && ocr_images {
                     if let Some(doc) = pdf_doc.as_ref() {
                         if let Ok(page) = doc.pages().get(pm.page as i32) {
-                            if let Some(extra) = ocr_page_images(doc, &page, langs, pm.page as usize + 1)
+                            if let Some(extra) =
+                                ocr_page_images(doc, &page, langs, pm.page as usize + 1)
                             {
                                 out.push_str(&extra);
                             }
@@ -133,7 +148,66 @@ fn via_pdf_inspector(
 /// Render + OCR một trang theo chỉ số 0-based.
 fn ocr_page_at(doc: &PdfDocument, page_0idx: u32, langs: &str) -> Option<String> {
     let page = doc.pages().get(page_0idx as i32).ok()?;
-    ocr_full_page(&page, langs).ok().filter(|t| !t.trim().is_empty())
+    ocr_full_page(&page, langs)
+        .ok()
+        .filter(|t| !t.trim().is_empty())
+}
+
+/// Extract the page's native text layer through PDFium.
+fn native_page_text_at(doc: &PdfDocument, page_0idx: u32) -> Option<String> {
+    let page = doc.pages().get(page_0idx as i32).ok()?;
+    page.text()
+        .ok()
+        .map(|text| text.all())
+        .filter(|text| !text.trim().is_empty())
+}
+
+/// Conservative trust gate for a native PDF text layer.
+///
+/// A useful page must contain enough word-like/alphanumeric content and almost
+/// no decoding sentinels or control/private-use characters. This deliberately
+/// accepts punctuation-heavy tables of contents while rejecting empty scans,
+/// `(cid:123)` output and broken font mappings.
+fn native_text_is_trustworthy(text: &str) -> bool {
+    let mut nonspace = 0usize;
+    let mut alphanumeric = 0usize;
+    let mut bad = 0usize;
+
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            continue;
+        }
+        nonspace += 1;
+        if ch.is_alphanumeric() {
+            alphanumeric += 1;
+        }
+        if ch == '\u{FFFD}'
+            || ch == '\0'
+            || ch.is_control()
+            || ('\u{E000}'..='\u{F8FF}').contains(&ch)
+        {
+            bad += 1;
+        }
+    }
+
+    if nonspace < 80 || alphanumeric < 40 || bad * 200 > nonspace {
+        return false;
+    }
+
+    let lower = text.to_ascii_lowercase();
+    if lower.contains("(cid:")
+        || lower.contains("/gid")
+        || lower.contains("<gid")
+        || lower.contains("uni+")
+    {
+        return false;
+    }
+
+    let word_like = text
+        .split_whitespace()
+        .filter(|token| token.chars().filter(|ch| ch.is_alphabetic()).count() >= 2)
+        .count();
+    word_like >= 8 && alphanumeric * 100 >= nonspace * 30
 }
 
 /// Đường fallback cũ: PDFium đếm ký tự để quyết text vs OCR.
@@ -185,7 +259,12 @@ fn via_pdfium(
 }
 
 /// OCR các ảnh nhúng đủ lớn trong một trang (cho trang trộn text + ảnh).
-fn ocr_page_images(doc: &PdfDocument, page: &PdfPage, langs: &str, page_no: usize) -> Option<String> {
+fn ocr_page_images(
+    doc: &PdfDocument,
+    page: &PdfPage,
+    langs: &str,
+    page_no: usize,
+) -> Option<String> {
     let mut out = String::new();
     for obj in page.objects().iter() {
         let Some(img_obj) = obj.as_image_object() else {
@@ -219,8 +298,12 @@ fn ocr_page_images(doc: &PdfDocument, page: &PdfPage, langs: &str, page_no: usiz
 fn ocr_full_page(page: &PdfPage, langs: &str) -> Result<String, ConvertError> {
     let w = (((page.width().value / 72.0) * OCR_DPI).round() as i32).clamp(100, 5000);
     let h = (((page.height().value / 72.0) * OCR_DPI).round() as i32).clamp(100, 7000);
-    let bitmap = page.render(w, h, None).map_err(|e| fail(format!("render: {e}")))?;
-    let img = bitmap.as_image().map_err(|e| fail(format!("as_image: {e}")))?;
+    let bitmap = page
+        .render(w, h, None)
+        .map_err(|e| fail(format!("render: {e}")))?;
+    let img = bitmap
+        .as_image()
+        .map_err(|e| fail(format!("as_image: {e}")))?;
     image_ocr::ocr_dynimage(&img, langs).map_err(fail)
 }
 
@@ -252,5 +335,37 @@ fn extract_with_pdf_extract(bytes: &[u8]) -> Result<String, ConvertError> {
         Err(_) => Err(ConvertError::Failed(
             "pdf-extract panic (PDF phức tạp/không chuẩn)".to_string(),
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::native_text_is_trustworthy;
+
+    #[test]
+    fn trusts_native_vietnamese_table_of_contents() {
+        let text = "MỤC LỤC\n\
+            PHẦN 1 - MÔ HÌNH CASAN........................................ 1\n\
+            1. BỐI CẢNH RA ĐỜI........................................... 1\n\
+            1.1. AI đã đi qua thời thử công cụ........................... 1\n\
+            2. MÔ HÌNH CASAN............................................. 2\n\
+            3. LỘ TRÌNH CHUYỂN ĐỔI GIỮA CÁC CẤP ĐỘ CASAN................ 4";
+        assert!(native_text_is_trustworthy(text));
+    }
+
+    #[test]
+    fn rejects_short_or_broken_native_text() {
+        assert!(!native_text_is_trustworthy("Mã hiệu: 123"));
+        assert!(!native_text_is_trustworthy(
+            "(cid:123) (cid:99) /GID12 \u{FFFD}\u{FFFD}\u{FFFD} broken text"
+        ));
+    }
+
+    #[test]
+    fn trusts_long_plain_english_text() {
+        let text = "This document contains a complete native text layer with enough readable \
+            words to avoid unnecessary optical character recognition. The source remains \
+            searchable, selectable, and substantially more accurate than a rendered OCR pass.";
+        assert!(native_text_is_trustworthy(text));
     }
 }

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -11,7 +11,7 @@
 //! Fallback: nếu pdf-inspector lỗi → đường PDFium (đếm ký tự); nếu vẫn không được /
 //! thiếu libpdfium → `pdf-extract`.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::Path;
 
@@ -42,6 +42,19 @@ pub fn to_markdown(
 ) -> Result<String, ConvertError> {
     let bytes = std::fs::read(path).map_err(fail)?;
 
+    // Page-filtered requests are common in the desktop/MCP token-saving flow.
+    // The per-page API below intentionally extracts the whole document for
+    // cross-page font statistics (~400 ms even for one page). The regular
+    // options API honours its page filter during extraction and is ~8× faster.
+    // Keep the slower path as fallback for OCR and malformed tables.
+    if !ocr_images {
+        if let Some(selected_pages) = pages {
+            if let Some(md) = via_pdf_inspector_filtered_fast(&bytes, selected_pages) {
+                return Ok(md);
+            }
+        }
+    }
+
     // 1) pdf-inspector: markdown có cấu trúc + needs_ocr theo trang.
     if let Some(md) = via_pdf_inspector(path, &bytes, ocr_langs, ocr_enabled, ocr_images, pages) {
         if !md.trim().is_empty() {
@@ -61,6 +74,92 @@ pub fn to_markdown(
         ));
     }
     extract_with_pdf_extract(&bytes)
+}
+
+fn parse_marked_pages(markdown: &str) -> HashMap<u32, String> {
+    let mut pages = HashMap::new();
+    let mut current_page = None;
+    let mut current_text = String::new();
+
+    for line in markdown.lines() {
+        let marker = line
+            .trim()
+            .strip_prefix("<!-- Page ")
+            .and_then(|rest| rest.strip_suffix(" -->"))
+            .and_then(|page| page.parse::<u32>().ok());
+        if let Some(page) = marker {
+            if let Some(previous) = current_page.replace(page) {
+                pages.insert(previous, current_text.trim().to_string());
+                current_text.clear();
+            }
+            continue;
+        }
+        if current_page.is_some() {
+            current_text.push_str(line);
+            current_text.push('\n');
+        }
+    }
+    if let Some(page) = current_page {
+        pages.insert(page, current_text.trim().to_string());
+    }
+    pages
+}
+
+fn remove_page_markers(markdown: &str) -> String {
+    markdown
+        .lines()
+        .filter(|line| {
+            let line = line.trim();
+            !(line.starts_with("<!-- Page ") && line.ends_with(" -->"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+/// Fast structured extraction for a sorted, page-filtered request.
+///
+/// Page markers let us independently validate every page that the detector
+/// considers suspicious. A genuine scan has an empty/low-confidence section
+/// and falls through to the normal PDFium/Tesseract path.
+fn via_pdf_inspector_filtered_fast(bytes: &[u8], pages: &[u32]) -> Option<String> {
+    let selected: Vec<u32> = pages.iter().copied().filter(|&page| page >= 1).collect();
+    if selected.is_empty() || selected.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return None;
+    }
+
+    let mut markdown_options = pdf_inspector::MarkdownOptions::default();
+    markdown_options.include_page_numbers = true;
+    let options = pdf_inspector::PdfOptions::new()
+        .pages(selected.iter().copied())
+        .markdown(markdown_options);
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        pdf_inspector::process_pdf_mem_with_options(bytes, options)
+    }))
+    .ok()?
+    .ok()?;
+    let marked = result.markdown?;
+    if marked.trim().is_empty() || markdown_has_malformed_table(&marked) {
+        return None;
+    }
+
+    let chunks = parse_marked_pages(&marked);
+    if selected.iter().any(|page| !chunks.contains_key(page)) {
+        return None;
+    }
+    for page in result.pages_needing_ocr {
+        if selected.contains(&page)
+            && !chunks
+                .get(&page)
+                .is_some_and(|text| native_text_is_high_confidence(text))
+        {
+            return None;
+        }
+    }
+
+    let clean = remove_page_markers(&marked);
+    (!clean.is_empty()).then_some(clean)
 }
 
 /// Đường chính: pdf-inspector cho text/cấu trúc + PDFium/Tesseract cho trang scan.
@@ -618,7 +717,8 @@ fn extract_with_pdf_extract(bytes: &[u8]) -> Result<String, ConvertError> {
 mod tests {
     use super::{
         markdown_has_malformed_table, native_text_covers_markdown, native_text_is_high_confidence,
-        native_text_is_trustworthy, strip_repeated_marginal_lines,
+        native_text_is_trustworthy, parse_marked_pages, remove_page_markers,
+        strip_repeated_marginal_lines,
     };
 
     #[test]
@@ -744,5 +844,25 @@ mod tests {
             .iter()
             .all(|page| page.contains("| Chỉ tiêu | Giá trị |")));
         assert!(pages.iter().all(|page| page.contains("| --- | --- |")));
+    }
+
+    #[test]
+    fn parses_and_removes_fast_path_page_markers() {
+        let marked = "<!-- Page 2 -->\n\n## Hai\n\nNội dung\n\
+            <!-- Page 5 -->\n\n## Năm\n\nNội dung khác";
+        let pages = parse_marked_pages(marked);
+
+        assert_eq!(
+            pages.get(&2).map(String::as_str),
+            Some("## Hai\n\nNội dung")
+        );
+        assert_eq!(
+            pages.get(&5).map(String::as_str),
+            Some("## Năm\n\nNội dung khác")
+        );
+        let clean = remove_page_markers(marked);
+        assert!(!clean.contains("<!-- Page"));
+        assert!(clean.contains("## Hai"));
+        assert!(clean.contains("## Năm"));
     }
 }

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -13,7 +13,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use pdfium_render::prelude::*;
 
@@ -940,15 +940,43 @@ fn load_pdfium() -> Option<Pdfium> {
     let _init_guard = PDFIUM_INIT
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let mut candidates: Vec<String> = Vec::new();
+    let mut candidates: Vec<PathBuf> = Vec::new();
     if let Ok(p) = std::env::var("FILECONV_PDFIUM_LIB") {
-        candidates.push(p);
+        let path = PathBuf::from(p);
+        candidates.push(path.clone());
+        if path.is_dir() {
+            candidates.push(Pdfium::pdfium_platform_library_name_at_path(path));
+        }
     }
-    candidates.push("pdfium/lib/libpdfium.so".to_string());
-    candidates.push("pdfium/libpdfium.so".to_string());
+
+    let mut roots = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        roots.extend(cwd.ancestors().take(4).map(Path::to_path_buf));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            roots.extend(parent.ancestors().take(4).map(Path::to_path_buf));
+        }
+    }
+    roots.extend(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .take(4)
+            .map(Path::to_path_buf),
+    );
+    for root in roots {
+        candidates.push(Pdfium::pdfium_platform_library_name_at_path(
+            root.join("pdfium/lib"),
+        ));
+        candidates.push(Pdfium::pdfium_platform_library_name_at_path(
+            root.join("pdfium"),
+        ));
+    }
+    let mut seen = HashSet::new();
+    candidates.retain(|path| seen.insert(path.clone()));
 
     for c in candidates {
-        match Pdfium::bind_to_library(&c) {
+        match Pdfium::bind_to_library(c) {
             Ok(bindings) => return Some(Pdfium::new(bindings)),
             Err(PdfiumError::PdfiumLibraryBindingsAlreadyInitialized) => {
                 return Some(Pdfium::default());

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -311,46 +311,31 @@ fn via_pdf_inspector_parallel_full(path: &Path, bytes: &[u8]) -> Option<String> 
         merged.pages_needing_ocr.extend(part.pages_needing_ocr);
     }
 
-    let mut recover: Vec<u32> = selected
+    let missing: Vec<u32> = selected
         .iter()
         .copied()
-        .filter(|page| {
-            !merged.chunks.contains_key(page)
-                || merged
-                    .chunks
-                    .get(page)
-                    .is_some_and(|text| markdown_has_malformed_table(text))
-        })
+        .filter(|page| !merged.chunks.contains_key(page))
         .collect();
-    recover.sort_unstable();
-    if !recover.is_empty() {
-        let recovery_workers = workers.min(recover.len());
-        let recovery_chunk = recover.len().div_ceil(recovery_workers);
-        let recovered = std::thread::scope(|scope| {
-            let handles: Vec<_> = recover
-                .chunks(recovery_chunk)
-                .map(|group| {
-                    scope.spawn(|| {
-                        group
-                            .iter()
-                            .map(|&page| {
-                                let mut single = extract_fast_pages_once(bytes, &[page])?;
-                                let text = single.chunks.remove(&page)?;
-                                Some((page, text, single.pages_needing_ocr))
-                            })
-                            .collect::<Option<Vec<_>>>()
-                    })
-                })
-                .collect();
-            handles
-                .into_iter()
-                .map(|handle| handle.join().ok().flatten())
-                .collect::<Option<Vec<Vec<_>>>>()
-        })?;
-        for group in recovered {
-            for (page, text, pages_needing_ocr) in group {
-                merged.chunks.insert(page, text);
-                merged.pages_needing_ocr.extend(pages_needing_ocr);
+    let missing_set: HashSet<u32> = missing.iter().copied().collect();
+    for page in missing {
+        let native = native_pages.get(&page)?;
+        if !native_text_is_high_confidence(native) {
+            return None;
+        }
+        merged.chunks.insert(page, native.trim().to_string());
+
+        // pdf-inspector 0.1.3 appends an unmarked table-only page to the
+        // preceding marked chunk. Replace that predecessor with its native
+        // page text as well, preventing duplicate/misattributed content.
+        if let Some(previous) = page.checked_sub(1).filter(|page| *page >= 1) {
+            if !missing_set.contains(&previous) && merged.chunks.contains_key(&previous) {
+                let previous_native = native_pages.get(&previous)?;
+                if !native_text_is_high_confidence(previous_native) {
+                    return None;
+                }
+                merged
+                    .chunks
+                    .insert(previous, previous_native.trim().to_string());
             }
         }
     }
@@ -647,9 +632,37 @@ fn native_text_is_high_confidence(text: &str) -> bool {
 }
 
 fn native_text_covers_markdown(native: &str, markdown: &str) -> bool {
-    let native_alnum = native.chars().filter(|ch| ch.is_alphanumeric()).count();
-    let markdown_alnum = markdown.chars().filter(|ch| ch.is_alphanumeric()).count();
-    markdown_alnum == 0 || native_alnum * 100 >= markdown_alnum * 90
+    fn capped_tokens(text: &str) -> HashMap<String, u8> {
+        let mut counts = HashMap::new();
+        let mut token = String::new();
+        let flush = |token: &mut String, counts: &mut HashMap<String, u8>| {
+            if !token.is_empty() {
+                let count = counts.entry(std::mem::take(token)).or_default();
+                *count = (*count + 1).min(2);
+            }
+        };
+        for ch in text.chars() {
+            if ch.is_alphanumeric() {
+                token.extend(ch.to_lowercase());
+            } else {
+                flush(&mut token, &mut counts);
+            }
+        }
+        flush(&mut token, &mut counts);
+        counts
+    }
+
+    let native_tokens = capped_tokens(native);
+    let markdown_tokens = capped_tokens(markdown);
+    let expected: usize = markdown_tokens.values().map(|&count| count as usize).sum();
+    if expected == 0 {
+        return true;
+    }
+    let overlap: usize = markdown_tokens
+        .iter()
+        .map(|(token, &count)| count.min(native_tokens.get(token).copied().unwrap_or(0)) as usize)
+        .sum();
+    overlap * 100 >= expected * 90
 }
 
 fn table_cells(line: &str) -> Option<Vec<&str>> {

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -112,14 +112,15 @@ fn via_pdf_inspector(
                 // though PDFium decodes the main text perfectly. Prefer that
                 // native text when it passes a conservative quality gate;
                 // only render + OCR genuinely empty/garbled pages.
-                let native_text = pm.ocr_reason.is_none().then(|| {
-                    pdf_doc
-                        .as_ref()
-                        .and_then(|d| native_page_text_at(d, pm.page))
-                        .filter(|text| native_text_is_trustworthy(text))
-                });
+                let native_text = pdf_doc
+                    .as_ref()
+                    .and_then(|d| native_page_text_at(d, pm.page))
+                    .filter(|text| {
+                        native_text_is_trustworthy(text)
+                            && (pm.ocr_reason.is_none() || native_text_is_high_confidence(text))
+                    });
 
-                if let Some(text) = native_text.flatten() {
+                if let Some(text) = native_text {
                     page_out.push_str(text.trim_end());
                 } else if let Some(text) = ocr_enabled
                     .then(|| {
@@ -262,6 +263,48 @@ fn native_text_is_trustworthy(text: &str) -> bool {
     // TOC pages can legitimately be dominated by dotted leaders; 20% still
     // requires substantial readable content while allowing those pages.
     word_like >= 8 && alphanumeric * 100 >= nonspace * 20
+}
+
+/// Stricter semantic-looking gate used when `pdf-inspector` explicitly reports
+/// garbled text. Printable GID noise often passes basic character checks but
+/// lacks natural vowel-bearing words and contains long repeated letter runs.
+fn native_text_is_high_confidence(text: &str) -> bool {
+    if !native_text_is_trustworthy(text) {
+        return false;
+    }
+
+    let vowels = "aeiouyAEIOUYăâêôơưĂÂÊÔƠƯ\
+        áàảãạắằẳẵặấầẩẫậéèẻẽẹếềểễệíìỉĩịóòỏõọốồổỗộớờởỡợúùủũụứừửữựýỳỷỹỵ\
+        ÁÀẢÃẠẮẰẲẴẶẤẦẨẪẬÉÈẺẼẸẾỀỂỄỆÍÌỈĨỊÓÒỎÕỌỐỒỔỖỘỚỜỞỠỢÚÙỦŨỤỨỪỬỮỰÝỲỶỸỴ";
+    let words: Vec<&str> = text
+        .split_whitespace()
+        .filter(|token| token.chars().filter(|ch| ch.is_alphabetic()).count() >= 2)
+        .collect();
+    let vowel_words = words
+        .iter()
+        .filter(|token| token.chars().any(|ch| vowels.contains(ch)))
+        .count();
+    let alphabetic = text.chars().filter(|ch| ch.is_alphabetic()).count();
+
+    let mut repeated_alnum_runs = 0usize;
+    let mut previous = None;
+    let mut run = 0usize;
+    for ch in text.chars().map(|ch| ch.to_ascii_lowercase()) {
+        if ch.is_alphanumeric() && Some(ch) == previous {
+            run += 1;
+            if run == 4 {
+                repeated_alnum_runs += 1;
+            }
+        } else {
+            run = 1;
+        }
+        previous = Some(ch);
+    }
+
+    alphabetic >= 250
+        && words.len() >= 40
+        && vowel_words * 100 >= words.len() * 70
+        && repeated_alnum_runs <= 3
 }
 
 fn native_text_covers_markdown(native: &str, markdown: &str) -> bool {
@@ -574,8 +617,8 @@ fn extract_with_pdf_extract(bytes: &[u8]) -> Result<String, ConvertError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        markdown_has_malformed_table, native_text_covers_markdown, native_text_is_trustworthy,
-        strip_repeated_marginal_lines,
+        markdown_has_malformed_table, native_text_covers_markdown, native_text_is_high_confidence,
+        native_text_is_trustworthy, strip_repeated_marginal_lines,
     };
 
     #[test]
@@ -588,6 +631,7 @@ mod tests {
             ));
         }
         assert!(native_text_is_trustworthy(&text));
+        assert!(native_text_is_high_confidence(&text));
     }
 
     #[test]
@@ -601,6 +645,10 @@ mod tests {
             "This otherwise readable page contains many normal words and sentences. ".repeat(8)
         );
         assert!(!native_text_is_trustworthy(&private_use));
+
+        let printable_gid_noise = "bcdfg hjklm npqrs tvwxyz BCDFG HJKLM NPQRS TVWXYZ ".repeat(20);
+        assert!(native_text_is_trustworthy(&printable_gid_noise));
+        assert!(!native_text_is_high_confidence(&printable_gid_noise));
     }
 
     #[test]

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -137,7 +137,13 @@ fn extract_fast_pages_once(bytes: &[u8], selected: &[u32]) -> Option<FastPages> 
     if marked.trim().is_empty() {
         return None;
     }
-    let chunks = parse_marked_pages(&marked);
+    let mut chunks = parse_marked_pages(&marked);
+    // Table-only pages in pdf-inspector 0.1.3 can produce Markdown without the
+    // requested page marker even when marker output is enabled. A single-page
+    // request is still unambiguous.
+    if chunks.is_empty() && selected.len() == 1 {
+        chunks.insert(selected[0], marked.trim().to_string());
+    }
     Some(FastPages {
         chunks,
         pages_needing_ocr: result.pages_needing_ocr.into_iter().collect(),

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -49,7 +49,7 @@ pub fn to_markdown(
     // Keep the slower path as fallback for OCR and malformed tables.
     if !ocr_images {
         if let Some(selected_pages) = pages {
-            if let Some(md) = via_pdf_inspector_filtered_fast(&bytes, selected_pages) {
+            if let Some(md) = via_pdf_inspector_filtered_fast(path, &bytes, selected_pages) {
                 return Ok(md);
             }
         }
@@ -105,25 +105,12 @@ fn parse_marked_pages(markdown: &str) -> HashMap<u32, String> {
     pages
 }
 
-fn remove_page_markers(markdown: &str) -> String {
-    markdown
-        .lines()
-        .filter(|line| {
-            let line = line.trim();
-            !(line.starts_with("<!-- Page ") && line.ends_with(" -->"))
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-        .trim()
-        .to_string()
-}
-
 /// Fast structured extraction for a sorted, page-filtered request.
 ///
 /// Page markers let us independently validate every page that the detector
 /// considers suspicious. A genuine scan has an empty/low-confidence section
 /// and falls through to the normal PDFium/Tesseract path.
-fn via_pdf_inspector_filtered_fast(bytes: &[u8], pages: &[u32]) -> Option<String> {
+fn via_pdf_inspector_filtered_fast(path: &Path, bytes: &[u8], pages: &[u32]) -> Option<String> {
     let selected: Vec<u32> = pages.iter().copied().filter(|&page| page >= 1).collect();
     if selected.is_empty() || selected.windows(2).any(|pair| pair[0] >= pair[1]) {
         return None;
@@ -131,6 +118,9 @@ fn via_pdf_inspector_filtered_fast(bytes: &[u8], pages: &[u32]) -> Option<String
 
     let mut markdown_options = pdf_inspector::MarkdownOptions::default();
     markdown_options.include_page_numbers = true;
+    // Keep headers in each marked chunk so our page-aware cleanup can also
+    // process native-text replacements consistently.
+    markdown_options.strip_headers_footers = false;
     let options = pdf_inspector::PdfOptions::new()
         .pages(selected.iter().copied())
         .markdown(markdown_options);
@@ -140,11 +130,11 @@ fn via_pdf_inspector_filtered_fast(bytes: &[u8], pages: &[u32]) -> Option<String
     .ok()?
     .ok()?;
     let marked = result.markdown?;
-    if marked.trim().is_empty() || markdown_has_malformed_table(&marked) {
+    if marked.trim().is_empty() {
         return None;
     }
 
-    let chunks = parse_marked_pages(&marked);
+    let mut chunks = parse_marked_pages(&marked);
     if selected.iter().any(|page| !chunks.contains_key(page)) {
         return None;
     }
@@ -158,8 +148,40 @@ fn via_pdf_inspector_filtered_fast(bytes: &[u8], pages: &[u32]) -> Option<String
         }
     }
 
-    let clean = remove_page_markers(&marked);
-    (!clean.is_empty()).then_some(clean)
+    let malformed_pages: Vec<u32> = selected
+        .iter()
+        .copied()
+        .filter(|page| {
+            chunks
+                .get(page)
+                .is_some_and(|text| markdown_has_malformed_table(text))
+        })
+        .collect();
+    if !malformed_pages.is_empty() {
+        let native_pages = native_text_for_pages(path, &malformed_pages);
+        for page in malformed_pages {
+            let native = native_pages.get(&page)?;
+            let structured = chunks.get(&page)?;
+            if !native_text_is_trustworthy(native)
+                || !native_text_covers_markdown(native, structured)
+            {
+                return None;
+            }
+            chunks.insert(page, native.trim().to_string());
+        }
+    }
+
+    let mut ordered: Vec<String> = selected
+        .iter()
+        .filter_map(|page| chunks.remove(page))
+        .collect();
+    strip_repeated_marginal_lines(&mut ordered);
+    let clean = ordered
+        .into_iter()
+        .filter(|page| !page.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    (!clean.trim().is_empty()).then_some(clean)
 }
 
 /// Đường chính: pdf-inspector cho text/cấu trúc + PDFium/Tesseract cho trang scan.
@@ -310,6 +332,25 @@ fn native_page_text_at(doc: &PdfDocument, page_0idx: u32) -> Option<String> {
         .ok()
         .map(|text| text.all())
         .filter(|text| !text.trim().is_empty())
+}
+
+fn native_text_for_pages(path: &Path, pages_1idx: &[u32]) -> HashMap<u32, String> {
+    PDFIUM.with(|opt| {
+        let Some(doc) = opt
+            .as_ref()
+            .and_then(|pdfium| pdfium.load_pdf_from_file(path, None).ok())
+        else {
+            return HashMap::new();
+        };
+        pages_1idx
+            .iter()
+            .filter_map(|&page| {
+                page.checked_sub(1)
+                    .and_then(|page_0idx| native_page_text_at(&doc, page_0idx))
+                    .map(|text| (page, text))
+            })
+            .collect()
+    })
 }
 
 /// Conservative trust gate for a native PDF text layer.
@@ -717,8 +758,7 @@ fn extract_with_pdf_extract(bytes: &[u8]) -> Result<String, ConvertError> {
 mod tests {
     use super::{
         markdown_has_malformed_table, native_text_covers_markdown, native_text_is_high_confidence,
-        native_text_is_trustworthy, parse_marked_pages, remove_page_markers,
-        strip_repeated_marginal_lines,
+        native_text_is_trustworthy, parse_marked_pages, strip_repeated_marginal_lines,
     };
 
     #[test]
@@ -847,7 +887,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_and_removes_fast_path_page_markers() {
+    fn parses_fast_path_page_markers() {
         let marked = "<!-- Page 2 -->\n\n## Hai\n\nNội dung\n\
             <!-- Page 5 -->\n\n## Năm\n\nNội dung khác";
         let pages = parse_marked_pages(marked);
@@ -860,9 +900,5 @@ mod tests {
             pages.get(&5).map(String::as_str),
             Some("## Năm\n\nNội dung khác")
         );
-        let clean = remove_page_markers(marked);
-        assert!(!clean.contains("<!-- Page"));
-        assert!(clean.contains("## Hai"));
-        assert!(clean.contains("## Năm"));
     }
 }

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -146,15 +146,23 @@ fn extract_fast_pages_once(bytes: &[u8], selected: &[u32]) -> Option<FastPages> 
 
 fn extract_fast_pages(bytes: &[u8], selected: &[u32]) -> Option<FastPages> {
     let mut extracted = extract_fast_pages_once(bytes, selected)?;
-    let missing: Vec<u32> = selected
+    let mut recover: HashSet<u32> = selected
         .iter()
         .copied()
         .filter(|page| !extracted.chunks.contains_key(page))
         .collect();
+    if selected.len() > 1 {
+        recover.extend(selected.iter().copied().filter(|page| {
+            extracted
+                .chunks
+                .get(page)
+                .is_some_and(|text| markdown_has_malformed_table(text))
+        }));
+    }
     // Multi-page table insertion in pdf-inspector 0.1.3 can omit a page marker
-    // for table-only pages. Recover only those pages individually instead of
-    // discarding the entire fast path.
-    for page in missing {
+    // or duplicate table content across page boundaries. Recover only those
+    // pages individually instead of discarding the entire fast path.
+    for page in recover {
         let mut single = extract_fast_pages_once(bytes, &[page])?;
         let text = single.chunks.remove(&page)?;
         extracted.chunks.insert(page, text);

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -945,7 +945,7 @@ fn load_pdfium() -> Option<Pdfium> {
         let path = PathBuf::from(p);
         candidates.push(path.clone());
         if path.is_dir() {
-            candidates.push(Pdfium::pdfium_platform_library_name_at_path(path));
+            candidates.push(Pdfium::pdfium_platform_library_name_at_path(&path));
         }
     }
 
@@ -966,10 +966,10 @@ fn load_pdfium() -> Option<Pdfium> {
     );
     for root in roots {
         candidates.push(Pdfium::pdfium_platform_library_name_at_path(
-            root.join("pdfium/lib"),
+            &root.join("pdfium/lib"),
         ));
         candidates.push(Pdfium::pdfium_platform_library_name_at_path(
-            root.join("pdfium"),
+            &root.join("pdfium"),
         ));
     }
     let mut seen = HashSet::new();

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -273,7 +273,7 @@ fn via_pdf_inspector_parallel_full(path: &Path, bytes: &[u8]) -> Option<String> 
     let (parts, native_pages) = std::thread::scope(|scope| {
         let handles: Vec<_> = ranges
             .iter()
-            .map(|range| scope.spawn(|| extract_fast_pages(bytes, range)))
+            .map(|range| scope.spawn(|| extract_fast_pages_once(bytes, range)))
             .collect();
         // Run PDFium on the caller thread so its thread-local instance remains
         // cached for subsequent desktop conversions.
@@ -297,6 +297,51 @@ fn via_pdf_inspector_parallel_full(path: &Path, bytes: &[u8]) -> Option<String> 
         }
         merged.pages_needing_ocr.extend(part.pages_needing_ocr);
     }
+
+    let mut recover: Vec<u32> = selected
+        .iter()
+        .copied()
+        .filter(|page| {
+            !merged.chunks.contains_key(page)
+                || merged
+                    .chunks
+                    .get(page)
+                    .is_some_and(|text| markdown_has_malformed_table(text))
+        })
+        .collect();
+    recover.sort_unstable();
+    if !recover.is_empty() {
+        let recovery_workers = workers.min(recover.len());
+        let recovery_chunk = recover.len().div_ceil(recovery_workers);
+        let recovered = std::thread::scope(|scope| {
+            let handles: Vec<_> = recover
+                .chunks(recovery_chunk)
+                .map(|group| {
+                    scope.spawn(|| {
+                        group
+                            .iter()
+                            .map(|&page| {
+                                let mut single = extract_fast_pages_once(bytes, &[page])?;
+                                let text = single.chunks.remove(&page)?;
+                                Some((page, text, single.pages_needing_ocr))
+                            })
+                            .collect::<Option<Vec<_>>>()
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().ok().flatten())
+                .collect::<Option<Vec<Vec<_>>>>()
+        })?;
+        for group in recovered {
+            for (page, text, pages_needing_ocr) in group {
+                merged.chunks.insert(page, text);
+                merged.pages_needing_ocr.extend(pages_needing_ocr);
+            }
+        }
+    }
+
     if merged.chunks.len() != selected.len() {
         return None;
     }

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -11,6 +11,7 @@
 //! Fallback: nếu pdf-inspector lỗi → đường PDFium (đếm ký tự); nếu vẫn không được /
 //! thiếu libpdfium → `pdf-extract`.
 
+use std::collections::{HashMap, HashSet};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::Path;
 
@@ -76,7 +77,8 @@ fn via_pdf_inspector(
     .ok()?
     .ok()?;
 
-    let need_pdfium = ocr_enabled && (ocr_images || res.pages.iter().any(|p| p.needs_ocr));
+    let need_pdfium = !res.pages_with_tables.is_empty()
+        || (ocr_enabled && (ocr_images || res.pages.iter().any(|p| p.needs_ocr)));
 
     PDFIUM.with(|opt| -> Option<String> {
         // Chỉ mở PDFium khi thật sự cần (OCR trang scan hoặc OCR ảnh nhúng).
@@ -87,9 +89,10 @@ fn via_pdf_inspector(
             None
         };
 
-        let mut out = String::new();
+        let mut page_chunks: Vec<String> = Vec::with_capacity(res.pages.len());
         for pm in &res.pages {
             let has_text = !pm.markdown.trim().is_empty();
+            let mut page_out = String::new();
 
             if pm.needs_ocr && ocr_enabled {
                 // `pdf-inspector` intentionally errs on the side of OCR when
@@ -104,24 +107,34 @@ fn via_pdf_inspector(
                     .filter(|text| native_text_is_trustworthy(text));
 
                 if let Some(text) = native_text {
-                    out.push_str(text.trim_end());
-                    out.push_str("\n\n");
+                    page_out.push_str(text.trim_end());
                 } else if let Some(text) = pdf_doc
                     .as_ref()
                     .and_then(|d| ocr_page_at(d, pm.page, langs))
                 {
-                    out.push_str(&format!("<!-- Trang {} (OCR) -->\n\n", pm.page + 1));
-                    out.push_str(text.trim());
-                    out.push_str("\n\n");
+                    page_out.push_str(&format!("<!-- Trang {} (OCR) -->\n\n", pm.page + 1));
+                    page_out.push_str(text.trim());
                 } else if has_text {
                     // Không OCR được (thiếu lib…) → tạm dùng text-layer dù kém.
-                    out.push_str(pm.markdown.trim_end());
-                    out.push_str("\n\n");
+                    page_out.push_str(pm.markdown.trim_end());
                 }
             } else if has_text {
                 // Trang có text tốt → dùng markdown cấu trúc của pdf-inspector.
-                out.push_str(pm.markdown.trim_end());
-                out.push_str("\n\n");
+                // Với bảng bị tách sai cột/ô rỗng, ưu tiên native text theo thứ
+                // tự đọc: ít đẹp hơn nhưng không làm mất hoặc đảo nội dung.
+                let native_table_fallback = markdown_has_malformed_table(&pm.markdown)
+                    .then(|| {
+                        pdf_doc
+                            .as_ref()
+                            .and_then(|d| native_page_text_at(d, pm.page))
+                            .filter(|text| native_text_is_trustworthy(text))
+                    })
+                    .flatten();
+                if let Some(text) = native_table_fallback {
+                    page_out.push_str(text.trim_end());
+                } else {
+                    page_out.push_str(pm.markdown.trim_end());
+                }
 
                 // Trang trộn: OCR thêm ảnh nhúng lớn (nếu bật).
                 if ocr_enabled && ocr_images {
@@ -130,13 +143,25 @@ fn via_pdf_inspector(
                             if let Some(extra) =
                                 ocr_page_images(doc, &page, langs, pm.page as usize + 1)
                             {
-                                out.push_str(&extra);
+                                if !page_out.is_empty() {
+                                    page_out.push_str("\n\n");
+                                }
+                                page_out.push_str(extra.trim_end());
                             }
                         }
                     }
                 }
             }
+            page_chunks.push(page_out);
         }
+
+        strip_repeated_marginal_lines(&mut page_chunks);
+        let out = page_chunks
+            .into_iter()
+            .filter(|page| !page.trim().is_empty())
+            .map(|page| page.trim().to_string())
+            .collect::<Vec<_>>()
+            .join("\n\n");
         if out.trim().is_empty() {
             None
         } else {
@@ -210,6 +235,157 @@ fn native_text_is_trustworthy(text: &str) -> bool {
     // TOC pages can legitimately be dominated by dotted leaders; 20% still
     // requires substantial readable content while allowing those pages.
     word_like >= 8 && alphanumeric * 100 >= nonspace * 20
+}
+
+fn table_cells(line: &str) -> Option<Vec<&str>> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('|') {
+        return None;
+    }
+    let inner = trimmed
+        .strip_prefix('|')
+        .unwrap_or(trimmed)
+        .strip_suffix('|')
+        .unwrap_or(trimmed);
+    Some(inner.split('|').map(str::trim).collect())
+}
+
+fn is_table_separator(line: &str) -> bool {
+    table_cells(line).is_some_and(|cells| {
+        !cells.is_empty()
+            && cells.iter().all(|cell| {
+                !cell.is_empty()
+                    && cell
+                        .chars()
+                        .all(|ch| ch == '-' || ch == ':' || ch.is_whitespace())
+                    && cell.chars().filter(|&ch| ch == '-').count() >= 3
+            })
+    })
+}
+
+/// `pdf-inspector` can over-segment a visually merged/multi-line table into
+/// extra empty columns. Such Markdown looks structured but scrambles sentence
+/// order. Detect those cases so the caller can preserve content as native text.
+fn markdown_has_malformed_table(markdown: &str) -> bool {
+    let lines: Vec<&str> = markdown.lines().collect();
+    for index in 0..lines.len().saturating_sub(1) {
+        let Some(header) = table_cells(lines[index]) else {
+            continue;
+        };
+        if !is_table_separator(lines[index + 1]) {
+            continue;
+        }
+        let separator = table_cells(lines[index + 1]).unwrap_or_default();
+        if header.len() < 2
+            || header.len() != separator.len()
+            || header.iter().any(|cell| cell.is_empty())
+        {
+            return true;
+        }
+
+        let mut total_cells = header.len();
+        let mut empty_cells = 0usize;
+        for row in lines
+            .iter()
+            .skip(index + 2)
+            .take_while(|line| line.trim().starts_with('|'))
+        {
+            let Some(cells) = table_cells(row) else {
+                break;
+            };
+            if cells.len() != header.len() {
+                return true;
+            }
+            total_cells += cells.len();
+            empty_cells += cells.iter().filter(|cell| cell.is_empty()).count();
+        }
+        if empty_cells * 4 > total_cells {
+            return true;
+        }
+    }
+    false
+}
+
+fn normalized_margin_line(line: &str) -> Option<String> {
+    let normalized = line
+        .chars()
+        .filter(|ch| !matches!(ch, '#' | '*' | '_' | '`'))
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+    (normalized.chars().count() >= 8 && normalized.chars().count() <= 240).then_some(normalized)
+}
+
+fn margin_indices(lines: &[&str]) -> HashSet<usize> {
+    let nonempty: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| (!line.trim().is_empty()).then_some(index))
+        .collect();
+    nonempty
+        .iter()
+        .take(6)
+        .chain(nonempty.iter().rev().take(4))
+        .copied()
+        .collect()
+}
+
+/// Remove headers/footers repeated on most pages. Matching is restricted to
+/// page margins and also handles a header represented as one combined line on
+/// structured pages but several lines on PDFium fallback pages.
+fn strip_repeated_marginal_lines(pages: &mut [String]) {
+    if pages.len() < 4 {
+        return;
+    }
+
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for page in pages.iter() {
+        let lines: Vec<&str> = page.lines().collect();
+        let margins = margin_indices(&lines);
+        let unique: HashSet<String> = margins
+            .into_iter()
+            .filter_map(|index| normalized_margin_line(lines[index]))
+            .collect();
+        for line in unique {
+            *counts.entry(line).or_default() += 1;
+        }
+    }
+
+    let threshold = (pages.len() * 3).div_ceil(5).max(3);
+    let repeated: Vec<String> = counts
+        .into_iter()
+        .filter_map(|(line, count)| (count >= threshold).then_some(line))
+        .collect();
+    if repeated.is_empty() {
+        return;
+    }
+
+    for page in pages.iter_mut() {
+        let lines: Vec<&str> = page.lines().collect();
+        let margins = margin_indices(&lines);
+        let retained = lines
+            .iter()
+            .enumerate()
+            .filter(|(index, line)| {
+                if !margins.contains(index) {
+                    return true;
+                }
+                let Some(normalized) = normalized_margin_line(line) else {
+                    return true;
+                };
+                !repeated.iter().any(|candidate| {
+                    candidate == &normalized
+                        || (normalized.chars().count() >= 12 && candidate.contains(&normalized))
+                        || (candidate.chars().count() >= 12 && normalized.contains(candidate))
+                })
+            })
+            .map(|(_, line)| *line)
+            .collect::<Vec<_>>()
+            .join("\n");
+        *page = retained;
+    }
 }
 
 /// Đường fallback cũ: PDFium đếm ký tự để quyết text vs OCR.
@@ -342,7 +518,9 @@ fn extract_with_pdf_extract(bytes: &[u8]) -> Result<String, ConvertError> {
 
 #[cfg(test)]
 mod tests {
-    use super::native_text_is_trustworthy;
+    use super::{
+        markdown_has_malformed_table, native_text_is_trustworthy, strip_repeated_marginal_lines,
+    };
 
     #[test]
     fn trusts_native_vietnamese_table_of_contents() {
@@ -370,5 +548,56 @@ mod tests {
             words to avoid unnecessary optical character recognition. The source remains \
             searchable, selectable, and substantially more accurate than a rendered OCR pass.";
         assert!(native_text_is_trustworthy(text));
+    }
+
+    #[test]
+    fn detects_malformed_markdown_tables() {
+        let valid = "| Tên | Mô tả | Trạng thái |\n\
+            | --- | --- | --- |\n\
+            | CASAN | Khung năng lực AI | Hoàn tất |";
+        assert!(!markdown_has_malformed_table(valid));
+
+        let empty_header = "| Định nghĩa |  | Đặc điểm | Mục tiêu |  |\n\
+            | --- | --- | --- | --- | --- |\n\
+            | Curious | là cấp | nội dung | chuyển cấp |  |";
+        assert!(markdown_has_malformed_table(empty_header));
+
+        let mismatched = "| Tên | Mô tả |\n\
+            | --- | --- |\n\
+            | CASAN | Khung năng lực | Dư cột |";
+        assert!(markdown_has_malformed_table(mismatched));
+    }
+
+    #[test]
+    fn strips_repeated_headers_in_combined_and_split_forms() {
+        let combined = "Mã hiệu: ALPHA/LD/HDCV/FPT **PHƯƠNG PHÁP LUẬN FPT CASAN** \
+            Lần ban hành/sửa đổi: 1/0 **TRONG CHUYỂN ĐỔI AI** Ngày hiệu lực: 19/5/2026";
+        let mut pages = vec![
+            format!("{combined}\n\nNội dung trang một"),
+            format!("{combined}\n\nNội dung trang hai"),
+            format!("{combined}\n\nNội dung trang ba"),
+            format!("{combined}\n\nNội dung trang bốn"),
+            "PHƯƠNG PHÁP LUẬN FPT CASAN\n\
+             TRONG CHUYỂN ĐỔI AI\n\
+             Mã hiệu: ALPHA/LD/HDCV/FPT\n\
+             Lần ban hành/sửa đổi: 1/0\n\
+             Ngày hiệu lực: 19/5/2026\n\
+             Nội dung trang năm"
+                .to_string(),
+        ];
+
+        strip_repeated_marginal_lines(&mut pages);
+
+        assert!(pages.iter().all(|page| !page.contains("Mã hiệu:")));
+        assert!(pages
+            .iter()
+            .all(|page| !page.contains("PHƯƠNG PHÁP LUẬN FPT CASAN")));
+        assert!(pages
+            .iter()
+            .enumerate()
+            .all(|(index, page)| page.contains(&format!(
+                "trang {}",
+                ["một", "hai", "ba", "bốn", "năm"][index]
+            ))));
     }
 }

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -11,7 +11,7 @@
 //! Fallback: nếu pdf-inspector lỗi → đường PDFium (đếm ký tự); nếu vẫn không được /
 //! thiếu libpdfium → `pdf-extract`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::Path;
 
@@ -340,25 +340,35 @@ fn strip_repeated_marginal_lines(pages: &mut [String]) {
         return;
     }
 
-    let mut counts: HashMap<String, usize> = HashMap::new();
+    let mut candidates: HashSet<String> = HashSet::new();
+    let normalized_pages: Vec<String> = pages
+        .iter()
+        .map(|page| {
+            page.lines()
+                .filter_map(normalized_margin_line)
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .collect();
     for page in pages.iter() {
         let lines: Vec<&str> = page.lines().collect();
-        // Count across the page, but removal below is still restricted to the
-        // margins. This is robust when a converter inserts blank/metadata lines
-        // before the visual header.
-        let unique: HashSet<String> = lines
-            .iter()
-            .filter_map(|line| normalized_margin_line(line))
-            .collect();
-        for line in unique {
-            *counts.entry(line).or_default() += 1;
+        for index in margin_indices(&lines) {
+            if let Some(line) = normalized_margin_line(lines[index]) {
+                candidates.insert(line);
+            }
         }
     }
 
     let threshold = (pages.len() * 3).div_ceil(5).max(3);
-    let repeated: Vec<String> = counts
+    let repeated: Vec<String> = candidates
         .into_iter()
-        .filter_map(|(line, count)| (count >= threshold).then_some(line))
+        .filter(|line| {
+            normalized_pages
+                .iter()
+                .filter(|page| page.contains(line))
+                .count()
+                >= threshold
+        })
         .collect();
     if repeated.is_empty() {
         return;

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -32,6 +32,8 @@ const PAGE_TEXT_MIN_CHARS: usize = 10;
 const MIN_IMG_AREA: i64 = 200 * 200;
 /// DPI render trang khi OCR (cao hơn = OCR tốt hơn, chậm hơn).
 const OCR_DPI: f32 = 300.0;
+const PARALLEL_MIN_PAGES: u32 = 16;
+const PARALLEL_MAX_PDF_BYTES: usize = 32 * 1024 * 1024;
 
 pub fn to_markdown(
     path: &Path,
@@ -48,9 +50,16 @@ pub fn to_markdown(
     // options API honours its page filter during extraction and is ~8× faster.
     // Keep the slower path as fallback for OCR and malformed tables.
     if !ocr_images {
-        if let Some(selected_pages) = pages {
-            if let Some(md) = via_pdf_inspector_filtered_fast(path, &bytes, selected_pages) {
-                return Ok(md);
+        match pages {
+            Some(selected_pages) => {
+                if let Some(md) = via_pdf_inspector_filtered_fast(path, &bytes, selected_pages) {
+                    return Ok(md);
+                }
+            }
+            None => {
+                if let Some(md) = via_pdf_inspector_parallel_full(path, &bytes) {
+                    return Ok(md);
+                }
             }
         }
     }
@@ -105,17 +114,12 @@ fn parse_marked_pages(markdown: &str) -> HashMap<u32, String> {
     pages
 }
 
-/// Fast structured extraction for a sorted, page-filtered request.
-///
-/// Page markers let us independently validate every page that the detector
-/// considers suspicious. A genuine scan has an empty/low-confidence section
-/// and falls through to the normal PDFium/Tesseract path.
-fn via_pdf_inspector_filtered_fast(path: &Path, bytes: &[u8], pages: &[u32]) -> Option<String> {
-    let selected: Vec<u32> = pages.iter().copied().filter(|&page| page >= 1).collect();
-    if selected.is_empty() || selected.windows(2).any(|pair| pair[0] >= pair[1]) {
-        return None;
-    }
+struct FastPages {
+    chunks: HashMap<u32, String>,
+    pages_needing_ocr: HashSet<u32>,
+}
 
+fn extract_fast_pages(bytes: &[u8], selected: &[u32]) -> Option<FastPages> {
     let mut markdown_options = pdf_inspector::MarkdownOptions::default();
     markdown_options.include_page_numbers = true;
     // Keep headers in each marked chunk so our page-aware cleanup can also
@@ -133,15 +137,27 @@ fn via_pdf_inspector_filtered_fast(path: &Path, bytes: &[u8], pages: &[u32]) -> 
     if marked.trim().is_empty() {
         return None;
     }
-
-    let mut chunks = parse_marked_pages(&marked);
+    let chunks = parse_marked_pages(&marked);
     if selected.iter().any(|page| !chunks.contains_key(page)) {
         return None;
     }
-    for page in result.pages_needing_ocr {
-        if selected.contains(&page)
-            && !chunks
-                .get(&page)
+    Some(FastPages {
+        chunks,
+        pages_needing_ocr: result.pages_needing_ocr.into_iter().collect(),
+    })
+}
+
+fn finalize_fast_pages(
+    path: &Path,
+    selected: &[u32],
+    mut extracted: FastPages,
+    prefetched_native: Option<HashMap<u32, String>>,
+) -> Option<String> {
+    for page in &extracted.pages_needing_ocr {
+        if selected.contains(page)
+            && !extracted
+                .chunks
+                .get(page)
                 .is_some_and(|text| native_text_is_high_confidence(text))
         {
             return None;
@@ -152,28 +168,29 @@ fn via_pdf_inspector_filtered_fast(path: &Path, bytes: &[u8], pages: &[u32]) -> 
         .iter()
         .copied()
         .filter(|page| {
-            chunks
+            extracted
+                .chunks
                 .get(page)
                 .is_some_and(|text| markdown_has_malformed_table(text))
         })
         .collect();
-    if !malformed_pages.is_empty() {
-        let native_pages = native_text_for_pages(path, &malformed_pages);
-        for page in malformed_pages {
-            let native = native_pages.get(&page)?;
-            let structured = chunks.get(&page)?;
-            if !native_text_is_trustworthy(native)
-                || !native_text_covers_markdown(native, structured)
-            {
-                return None;
-            }
-            chunks.insert(page, native.trim().to_string());
+    let native_pages = match prefetched_native {
+        Some(native) => native,
+        None if malformed_pages.is_empty() => HashMap::new(),
+        None => native_text_for_pages(path, &malformed_pages),
+    };
+    for page in malformed_pages {
+        let native = native_pages.get(&page)?;
+        let structured = extracted.chunks.get(&page)?;
+        if !native_text_is_trustworthy(native) || !native_text_covers_markdown(native, structured) {
+            return None;
         }
+        extracted.chunks.insert(page, native.trim().to_string());
     }
 
     let mut ordered: Vec<String> = selected
         .iter()
-        .filter_map(|page| chunks.remove(page))
+        .filter_map(|page| extracted.chunks.remove(page))
         .collect();
     strip_repeated_marginal_lines(&mut ordered);
     let clean = ordered
@@ -182,6 +199,81 @@ fn via_pdf_inspector_filtered_fast(path: &Path, bytes: &[u8], pages: &[u32]) -> 
         .collect::<Vec<_>>()
         .join("\n\n");
     (!clean.trim().is_empty()).then_some(clean)
+}
+
+/// Fast structured extraction for a sorted, page-filtered request.
+///
+/// Page markers let us independently validate every page that the detector
+/// considers suspicious. A genuine scan has an empty/low-confidence section
+/// and falls through to the normal PDFium/Tesseract path.
+fn via_pdf_inspector_filtered_fast(path: &Path, bytes: &[u8], pages: &[u32]) -> Option<String> {
+    let selected: Vec<u32> = pages.iter().copied().filter(|&page| page >= 1).collect();
+    if selected.is_empty() || selected.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return None;
+    }
+
+    let extracted = extract_fast_pages(bytes, &selected)?;
+    finalize_fast_pages(path, &selected, extracted, None)
+}
+
+/// Split a larger full-document extraction into a few page-filtered workers.
+///
+/// `pdf-inspector`'s filtered pipeline parses font/layout data only for its
+/// requested range. Four medium-sized ranges preserve enough context for
+/// heading classification while reducing wall time substantially on normal
+/// multicore desktops. Every page is validated and merged in document order;
+/// any suspicious/missing page falls back to the conservative sequential path.
+fn via_pdf_inspector_parallel_full(path: &Path, bytes: &[u8]) -> Option<String> {
+    if bytes.len() > PARALLEL_MAX_PDF_BYTES {
+        return None;
+    }
+    let page_count = catch_unwind(AssertUnwindSafe(|| pdf_inspector::detect_pdf_mem(bytes)))
+        .ok()?
+        .ok()?
+        .page_count;
+    if page_count < PARALLEL_MIN_PAGES {
+        return None;
+    }
+    let available = std::thread::available_parallelism().ok()?.get();
+    let workers = available.min(4).min(page_count.div_ceil(8) as usize);
+    if workers < 2 {
+        return None;
+    }
+
+    let selected: Vec<u32> = (1..=page_count).collect();
+    let chunk_size = page_count.div_ceil(workers as u32) as usize;
+    let ranges: Vec<&[u32]> = selected.chunks(chunk_size).collect();
+    let (parts, native_pages) = std::thread::scope(|scope| {
+        let handles: Vec<_> = ranges
+            .iter()
+            .map(|range| scope.spawn(|| extract_fast_pages(bytes, range)))
+            .collect();
+        // Run PDFium on the caller thread so its thread-local instance remains
+        // cached for subsequent desktop conversions.
+        let native_pages = native_text_for_requested_pages(path, None);
+        let parts = handles
+            .into_iter()
+            .map(|handle| handle.join().ok().flatten())
+            .collect::<Option<Vec<_>>>()?;
+        Some((parts, native_pages))
+    })?;
+
+    let mut merged = FastPages {
+        chunks: HashMap::new(),
+        pages_needing_ocr: HashSet::new(),
+    };
+    for part in parts {
+        for (page, text) in part.chunks {
+            if merged.chunks.insert(page, text).is_some() {
+                return None;
+            }
+        }
+        merged.pages_needing_ocr.extend(part.pages_needing_ocr);
+    }
+    if merged.chunks.len() != selected.len() {
+        return None;
+    }
+    finalize_fast_pages(path, &selected, merged, Some(native_pages))
 }
 
 /// Đường chính: pdf-inspector cho text/cấu trúc + PDFium/Tesseract cho trang scan.

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -119,7 +119,7 @@ struct FastPages {
     pages_needing_ocr: HashSet<u32>,
 }
 
-fn extract_fast_pages(bytes: &[u8], selected: &[u32]) -> Option<FastPages> {
+fn extract_fast_pages_once(bytes: &[u8], selected: &[u32]) -> Option<FastPages> {
     let mut markdown_options = pdf_inspector::MarkdownOptions::default();
     markdown_options.include_page_numbers = true;
     // Keep headers in each marked chunk so our page-aware cleanup can also
@@ -138,13 +138,32 @@ fn extract_fast_pages(bytes: &[u8], selected: &[u32]) -> Option<FastPages> {
         return None;
     }
     let chunks = parse_marked_pages(&marked);
-    if selected.iter().any(|page| !chunks.contains_key(page)) {
-        return None;
-    }
     Some(FastPages {
         chunks,
         pages_needing_ocr: result.pages_needing_ocr.into_iter().collect(),
     })
+}
+
+fn extract_fast_pages(bytes: &[u8], selected: &[u32]) -> Option<FastPages> {
+    let mut extracted = extract_fast_pages_once(bytes, selected)?;
+    let missing: Vec<u32> = selected
+        .iter()
+        .copied()
+        .filter(|page| !extracted.chunks.contains_key(page))
+        .collect();
+    // Multi-page table insertion in pdf-inspector 0.1.3 can omit a page marker
+    // for table-only pages. Recover only those pages individually instead of
+    // discarding the entire fast path.
+    for page in missing {
+        let mut single = extract_fast_pages_once(bytes, &[page])?;
+        let text = single.chunks.remove(&page)?;
+        extracted.chunks.insert(page, text);
+        extracted.pages_needing_ocr.extend(single.pages_needing_ocr);
+    }
+    selected
+        .iter()
+        .all(|page| extracted.chunks.contains_key(page))
+        .then_some(extracted)
 }
 
 fn finalize_fast_pages(

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -25,6 +25,8 @@ thread_local! {
     static PDFIUM: Option<Pdfium> = load_pdfium();
 }
 
+static PDFIUM_INIT: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Trang có ít hơn ngưỡng này ký tự (không tính khoảng trắng) → coi là trang scan → OCR.
 /// (Chỉ dùng ở đường fallback PDFium.)
 const PAGE_TEXT_MIN_CHARS: usize = 10;
@@ -33,7 +35,9 @@ const MIN_IMG_AREA: i64 = 200 * 200;
 /// DPI render trang khi OCR (cao hơn = OCR tốt hơn, chậm hơn).
 const OCR_DPI: f32 = 300.0;
 const PARALLEL_MIN_PAGES: u32 = 16;
+const PARALLEL_MAX_PAGES: u32 = 200;
 const PARALLEL_MAX_PDF_BYTES: usize = 32 * 1024 * 1024;
+const PARALLEL_MIN_CPUS: usize = 5;
 
 pub fn to_markdown(
     path: &Path,
@@ -264,11 +268,14 @@ fn via_pdf_inspector_parallel_full(path: &Path, bytes: &[u8]) -> Option<String> 
         .ok()?
         .ok()?
         .page_count;
-    if page_count < PARALLEL_MIN_PAGES {
+    if !(PARALLEL_MIN_PAGES..=PARALLEL_MAX_PAGES).contains(&page_count) {
         return None;
     }
     let available = std::thread::available_parallelism().ok()?.get();
-    let workers = available.min(4).min(page_count.div_ceil(8) as usize);
+    if available < PARALLEL_MIN_CPUS {
+        return None;
+    }
+    let workers = 4.min(page_count.div_ceil(8) as usize);
     if workers < 2 {
         return None;
     }
@@ -917,6 +924,9 @@ fn ocr_full_page(page: &PdfPage, langs: &str) -> Result<String, ConvertError> {
 
 /// Bind libpdfium (nếu có).
 fn load_pdfium() -> Option<Pdfium> {
+    let _init_guard = PDFIUM_INIT
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let mut candidates: Vec<String> = Vec::new();
     if let Ok(p) = std::env::var("FILECONV_PDFIUM_LIB") {
         candidates.push(p);
@@ -925,11 +935,19 @@ fn load_pdfium() -> Option<Pdfium> {
     candidates.push("pdfium/libpdfium.so".to_string());
 
     for c in candidates {
-        if let Ok(b) = Pdfium::bind_to_library(&c) {
-            return Some(Pdfium::new(b));
+        match Pdfium::bind_to_library(&c) {
+            Ok(bindings) => return Some(Pdfium::new(bindings)),
+            Err(PdfiumError::PdfiumLibraryBindingsAlreadyInitialized) => {
+                return Some(Pdfium::default());
+            }
+            Err(_) => {}
         }
     }
-    Pdfium::bind_to_system_library().ok().map(Pdfium::new)
+    match Pdfium::bind_to_system_library() {
+        Ok(bindings) => Some(Pdfium::new(bindings)),
+        Err(PdfiumError::PdfiumLibraryBindingsAlreadyInitialized) => Some(Pdfium::default()),
+        Err(_) => None,
+    }
 }
 
 /// Fallback cuối: pdf-extract (có thể panic → bắt bằng catch_unwind).

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -55,6 +55,11 @@ pub fn to_markdown(
         }
     }
     // 3) Cuối cùng: pdf-extract (không hỗ trợ lọc trang).
+    if pages.is_some() {
+        return Err(fail(
+            "không thể trích đúng các trang đã chọn (pdf-inspector/PDFium thất bại)",
+        ));
+    }
     extract_with_pdf_extract(&bytes)
 }
 
@@ -77,8 +82,13 @@ fn via_pdf_inspector(
     .ok()?
     .ok()?;
 
-    let need_pdfium = !res.pages_with_tables.is_empty()
-        || (ocr_enabled && (ocr_images || res.pages.iter().any(|p| p.needs_ocr)));
+    let has_malformed_tables = res
+        .pages
+        .iter()
+        .any(|page| markdown_has_malformed_table(&page.markdown));
+    let need_pdfium = has_malformed_tables
+        || res.pages.iter().any(|page| page.needs_ocr)
+        || (ocr_enabled && ocr_images);
 
     PDFIUM.with(|opt| -> Option<String> {
         // Chỉ mở PDFium khi thật sự cần (OCR trang scan hoặc OCR ảnh nhúng).
@@ -90,33 +100,42 @@ fn via_pdf_inspector(
         };
 
         let mut page_chunks: Vec<String> = Vec::with_capacity(res.pages.len());
+        let mut unresolved_page = false;
         for pm in &res.pages {
             let has_text = !pm.markdown.trim().is_empty();
             let mut page_out = String::new();
 
-            if pm.needs_ocr && ocr_enabled {
+            if pm.needs_ocr {
                 // `pdf-inspector` intentionally errs on the side of OCR when
                 // *any* GID/symbol font is present. Real Word-exported PDFs can
                 // therefore be flagged because of one logo/bullet font even
                 // though PDFium decodes the main text perfectly. Prefer that
                 // native text when it passes a conservative quality gate;
                 // only render + OCR genuinely empty/garbled pages.
-                let native_text = pdf_doc
-                    .as_ref()
-                    .and_then(|d| native_page_text_at(d, pm.page))
-                    .filter(|text| native_text_is_trustworthy(text));
+                let native_text = pm.ocr_reason.is_none().then(|| {
+                    pdf_doc
+                        .as_ref()
+                        .and_then(|d| native_page_text_at(d, pm.page))
+                        .filter(|text| native_text_is_trustworthy(text))
+                });
 
-                if let Some(text) = native_text {
+                if let Some(text) = native_text.flatten() {
                     page_out.push_str(text.trim_end());
-                } else if let Some(text) = pdf_doc
-                    .as_ref()
-                    .and_then(|d| ocr_page_at(d, pm.page, langs))
+                } else if let Some(text) = ocr_enabled
+                    .then(|| {
+                        pdf_doc
+                            .as_ref()
+                            .and_then(|d| ocr_page_at(d, pm.page, langs))
+                    })
+                    .flatten()
                 {
                     page_out.push_str(&format!("<!-- Trang {} (OCR) -->\n\n", pm.page + 1));
                     page_out.push_str(text.trim());
                 } else if has_text {
                     // Không OCR được (thiếu lib…) → tạm dùng text-layer dù kém.
                     page_out.push_str(pm.markdown.trim_end());
+                } else {
+                    unresolved_page = true;
                 }
             } else if has_text {
                 // Trang có text tốt → dùng markdown cấu trúc của pdf-inspector.
@@ -127,7 +146,10 @@ fn via_pdf_inspector(
                         pdf_doc
                             .as_ref()
                             .and_then(|d| native_page_text_at(d, pm.page))
-                            .filter(|text| native_text_is_trustworthy(text))
+                            .filter(|text| {
+                                native_text_is_trustworthy(text)
+                                    && native_text_covers_markdown(text, &pm.markdown)
+                            })
                     })
                     .flatten();
                 if let Some(text) = native_table_fallback {
@@ -155,6 +177,9 @@ fn via_pdf_inspector(
             page_chunks.push(page_out);
         }
 
+        if unresolved_page {
+            return None;
+        }
         strip_repeated_marginal_lines(&mut page_chunks);
         let out = page_chunks
             .into_iter()
@@ -210,6 +235,8 @@ fn native_text_is_trustworthy(text: &str) -> bool {
             || ch == '\0'
             || ch.is_control()
             || ('\u{E000}'..='\u{F8FF}').contains(&ch)
+            || ('\u{F0000}'..='\u{FFFFD}').contains(&ch)
+            || ('\u{100000}'..='\u{10FFFD}').contains(&ch)
         {
             bad += 1;
         }
@@ -235,6 +262,12 @@ fn native_text_is_trustworthy(text: &str) -> bool {
     // TOC pages can legitimately be dominated by dotted leaders; 20% still
     // requires substantial readable content while allowing those pages.
     word_like >= 8 && alphanumeric * 100 >= nonspace * 20
+}
+
+fn native_text_covers_markdown(native: &str, markdown: &str) -> bool {
+    let native_alnum = native.chars().filter(|ch| ch.is_alphanumeric()).count();
+    let markdown_alnum = markdown.chars().filter(|ch| ch.is_alphanumeric()).count();
+    markdown_alnum == 0 || native_alnum * 100 >= markdown_alnum * 90
 }
 
 fn table_cells(line: &str) -> Option<Vec<&str>> {
@@ -276,15 +309,19 @@ fn markdown_has_malformed_table(markdown: &str) -> bool {
             continue;
         }
         let separator = table_cells(lines[index + 1]).unwrap_or_default();
+        let empty_headers = header.iter().filter(|cell| cell.is_empty()).count();
+        let joined_header = header.join(" ").to_lowercase();
         if header.len() < 2
             || header.len() != separator.len()
-            || header.iter().any(|cell| cell.is_empty())
+            || empty_headers >= 2
+            || (empty_headers > 0
+                && (joined_header.contains("mã hiệu")
+                    || joined_header.contains("lần ban hành")
+                    || joined_header.contains("ngày hiệu lực")))
         {
             return true;
         }
 
-        let mut total_cells = header.len();
-        let mut empty_cells = 0usize;
         for row in lines
             .iter()
             .skip(index + 2)
@@ -296,20 +333,24 @@ fn markdown_has_malformed_table(markdown: &str) -> bool {
             if cells.len() != header.len() {
                 return true;
             }
-            total_cells += cells.len();
-            empty_cells += cells.iter().filter(|cell| cell.is_empty()).count();
-        }
-        if empty_cells * 4 > total_cells {
-            return true;
         }
     }
     false
 }
 
 fn normalized_margin_line(line: &str) -> Option<String> {
-    let normalized = line
+    use unicode_normalization::UnicodeNormalization;
+
+    let trimmed = line.trim();
+    if trimmed.starts_with('|') || trimmed.starts_with("```") || is_table_separator(trimmed) {
+        return None;
+    }
+    let filtered = trimmed
         .chars()
         .filter(|ch| !matches!(ch, '#' | '*' | '_' | '`'))
+        .collect::<String>();
+    let normalized = filtered
+        .nfc()
         .collect::<String>()
         .split_whitespace()
         .collect::<Vec<_>>()
@@ -326,8 +367,8 @@ fn margin_indices(lines: &[&str]) -> HashSet<usize> {
         .collect();
     nonempty
         .iter()
-        .take(8)
-        .chain(nonempty.iter().rev().take(4))
+        .take(5)
+        .chain(nonempty.iter().rev().take(3))
         .copied()
         .collect()
 }
@@ -341,11 +382,13 @@ fn strip_repeated_marginal_lines(pages: &mut [String]) {
     }
 
     let mut candidates: HashSet<String> = HashSet::new();
-    let normalized_pages: Vec<String> = pages
+    let normalized_margins: Vec<String> = pages
         .iter()
         .map(|page| {
-            page.lines()
-                .filter_map(normalized_margin_line)
+            let lines: Vec<&str> = page.lines().collect();
+            margin_indices(&lines)
+                .into_iter()
+                .filter_map(|index| normalized_margin_line(lines[index]))
                 .collect::<Vec<_>>()
                 .join(" ")
         })
@@ -363,9 +406,9 @@ fn strip_repeated_marginal_lines(pages: &mut [String]) {
     let repeated: Vec<String> = candidates
         .into_iter()
         .filter(|line| {
-            normalized_pages
+            normalized_margins
                 .iter()
-                .filter(|page| page.contains(line))
+                .filter(|margin| margin.contains(line))
                 .count()
                 >= threshold
         })
@@ -531,7 +574,8 @@ fn extract_with_pdf_extract(bytes: &[u8]) -> Result<String, ConvertError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        markdown_has_malformed_table, native_text_is_trustworthy, strip_repeated_marginal_lines,
+        markdown_has_malformed_table, native_text_covers_markdown, native_text_is_trustworthy,
+        strip_repeated_marginal_lines,
     };
 
     #[test]
@@ -549,9 +593,14 @@ mod tests {
     #[test]
     fn rejects_short_or_broken_native_text() {
         assert!(!native_text_is_trustworthy("Mã hiệu: 123"));
-        assert!(!native_text_is_trustworthy(
-            "(cid:123) (cid:99) /GID12 \u{FFFD}\u{FFFD}\u{FFFD} broken text"
-        ));
+        let cid_garbage = "(cid:123) readable looking words repeated many times ".repeat(20);
+        assert!(!native_text_is_trustworthy(&cid_garbage));
+        let private_use = format!(
+            "{} {}",
+            '\u{F0000}'.to_string().repeat(4),
+            "This otherwise readable page contains many normal words and sentences. ".repeat(8)
+        );
+        assert!(!native_text_is_trustworthy(&private_use));
     }
 
     #[test]
@@ -574,10 +623,28 @@ mod tests {
             | Curious | là cấp | nội dung | chuyển cấp |  |";
         assert!(markdown_has_malformed_table(empty_header));
 
+        let valid_sparse = "|  | Quý 1 | Quý 2 |\n\
+            | --- | --- | --- |\n\
+            | Doanh thu |  | 100 |";
+        assert!(!markdown_has_malformed_table(valid_sparse));
+
         let mismatched = "| Tên | Mô tả |\n\
             | --- | --- |\n\
             | CASAN | Khung năng lực | Dư cột |";
         assert!(markdown_has_malformed_table(mismatched));
+    }
+
+    #[test]
+    fn native_fallback_must_cover_structured_content() {
+        assert!(native_text_covers_markdown(
+            "CASAN là khung năng lực chuyển đổi trí tuệ nhân tạo cho doanh nghiệp.",
+            "## CASAN\n\nCASAN là khung năng lực chuyển đổi trí tuệ nhân tạo."
+        ));
+        assert!(!native_text_covers_markdown(
+            "CASAN có nội dung ngắn.",
+            "## CASAN\n\nCASAN là khung năng lực chuyển đổi trí tuệ nhân tạo với rất nhiều \
+             nội dung chi tiết không được phép biến mất khi fallback."
+        ));
     }
 
     #[test]
@@ -611,5 +678,23 @@ mod tests {
                 "trang {}",
                 ["một", "hai", "ba", "bốn", "năm"][index]
             ))));
+    }
+
+    #[test]
+    fn repeated_table_headers_are_not_stripped() {
+        let mut pages = (1..=5)
+            .map(|page| {
+                format!(
+                    "| Chỉ tiêu | Giá trị |\n| --- | --- |\n| Trang {page} | {page}00 |\nNội dung {page}"
+                )
+            })
+            .collect::<Vec<_>>();
+
+        strip_repeated_marginal_lines(&mut pages);
+
+        assert!(pages
+            .iter()
+            .all(|page| page.contains("| Chỉ tiêu | Giá trị |")));
+        assert!(pages.iter().all(|page| page.contains("| --- | --- |")));
     }
 }

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -196,20 +196,30 @@ fn via_pdf_inspector(
     // pages 1-indexed từ người dùng → 0-indexed cho pdf-inspector.
     let pages0: Option<Vec<u32>> =
         pages.map(|ps| ps.iter().filter(|&&p| p >= 1).map(|&p| p - 1).collect());
-    // pdf-inspector dùng lopdf bên trong → bọc catch_unwind cho chắc.
-    let res = catch_unwind(AssertUnwindSafe(|| {
-        pdf_inspector::extract_pages_markdown_mem(bytes, pages0.as_deref())
-    }))
-    .ok()?
-    .ok()?;
+    // lopdf structure extraction and PDFium native-text extraction are
+    // independent. Run them concurrently so documents that need native table
+    // rescue pay the slower stage, not the sum of both stages.
+    let (res, native_pages) = std::thread::scope(|scope| {
+        let inspector = scope.spawn(|| {
+            catch_unwind(AssertUnwindSafe(|| {
+                pdf_inspector::extract_pages_markdown_mem(bytes, pages0.as_deref())
+            }))
+            .ok()?
+            .ok()
+        });
+        let native_pages = native_text_for_requested_pages(path, pages);
+        let res = inspector.join().ok().flatten()?;
+        Some((res, native_pages))
+    })?;
 
-    let has_malformed_tables = res
-        .pages
-        .iter()
-        .any(|page| markdown_has_malformed_table(&page.markdown));
-    let need_pdfium = has_malformed_tables
-        || res.pages.iter().any(|page| page.needs_ocr)
-        || (ocr_enabled && ocr_images);
+    let needs_rendered_ocr = res.pages.iter().any(|page| {
+        page.needs_ocr
+            && !native_pages.get(&(page.page + 1)).is_some_and(|text| {
+                native_text_is_trustworthy(text)
+                    && (page.ocr_reason.is_none() || native_text_is_high_confidence(text))
+            })
+    });
+    let need_pdfium = ocr_enabled && (ocr_images || needs_rendered_ocr);
 
     PDFIUM.with(|opt| -> Option<String> {
         // Chỉ mở PDFium khi thật sự cần (OCR trang scan hoặc OCR ảnh nhúng).
@@ -233,13 +243,10 @@ fn via_pdf_inspector(
                 // though PDFium decodes the main text perfectly. Prefer that
                 // native text when it passes a conservative quality gate;
                 // only render + OCR genuinely empty/garbled pages.
-                let native_text = pdf_doc
-                    .as_ref()
-                    .and_then(|d| native_page_text_at(d, pm.page))
-                    .filter(|text| {
-                        native_text_is_trustworthy(text)
-                            && (pm.ocr_reason.is_none() || native_text_is_high_confidence(text))
-                    });
+                let native_text = native_pages.get(&(pm.page + 1)).filter(|text| {
+                    native_text_is_trustworthy(text)
+                        && (pm.ocr_reason.is_none() || native_text_is_high_confidence(text))
+                });
 
                 if let Some(text) = native_text {
                     page_out.push_str(text.trim_end());
@@ -265,13 +272,10 @@ fn via_pdf_inspector(
                 // tự đọc: ít đẹp hơn nhưng không làm mất hoặc đảo nội dung.
                 let native_table_fallback = markdown_has_malformed_table(&pm.markdown)
                     .then(|| {
-                        pdf_doc
-                            .as_ref()
-                            .and_then(|d| native_page_text_at(d, pm.page))
-                            .filter(|text| {
-                                native_text_is_trustworthy(text)
-                                    && native_text_covers_markdown(text, &pm.markdown)
-                            })
+                        native_pages.get(&(pm.page + 1)).filter(|text| {
+                            native_text_is_trustworthy(text)
+                                && native_text_covers_markdown(text, &pm.markdown)
+                        })
                     })
                     .flatten();
                 if let Some(text) = native_table_fallback {
@@ -334,7 +338,10 @@ fn native_page_text_at(doc: &PdfDocument, page_0idx: u32) -> Option<String> {
         .filter(|text| !text.trim().is_empty())
 }
 
-fn native_text_for_pages(path: &Path, pages_1idx: &[u32]) -> HashMap<u32, String> {
+fn native_text_for_requested_pages(
+    path: &Path,
+    pages_1idx: Option<&[u32]>,
+) -> HashMap<u32, String> {
     PDFIUM.with(|opt| {
         let Some(doc) = opt
             .as_ref()
@@ -342,15 +349,30 @@ fn native_text_for_pages(path: &Path, pages_1idx: &[u32]) -> HashMap<u32, String
         else {
             return HashMap::new();
         };
-        pages_1idx
-            .iter()
-            .filter_map(|&page| {
-                page.checked_sub(1)
-                    .and_then(|page_0idx| native_page_text_at(&doc, page_0idx))
-                    .map(|text| (page, text))
-            })
-            .collect()
+        match pages_1idx {
+            Some(pages) => pages
+                .iter()
+                .filter_map(|&page| {
+                    page.checked_sub(1)
+                        .and_then(|page_0idx| native_page_text_at(&doc, page_0idx))
+                        .map(|text| (page, text))
+                })
+                .collect(),
+            None => doc
+                .pages()
+                .iter()
+                .enumerate()
+                .filter_map(|(page_0idx, _)| {
+                    native_page_text_at(&doc, page_0idx as u32)
+                        .map(|text| (page_0idx as u32 + 1, text))
+                })
+                .collect(),
+        }
     })
+}
+
+fn native_text_for_pages(path: &Path, pages_1idx: &[u32]) -> HashMap<u32, String> {
+    native_text_for_requested_pages(path, Some(pages_1idx))
 }
 
 /// Conservative trust gate for a native PDF text layer.

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -315,7 +315,7 @@ fn normalized_margin_line(line: &str) -> Option<String> {
         .collect::<Vec<_>>()
         .join(" ")
         .to_lowercase();
-    (normalized.chars().count() >= 8 && normalized.chars().count() <= 240).then_some(normalized)
+    (normalized.chars().count() >= 8 && normalized.chars().count() <= 400).then_some(normalized)
 }
 
 fn margin_indices(lines: &[&str]) -> HashSet<usize> {
@@ -326,7 +326,7 @@ fn margin_indices(lines: &[&str]) -> HashSet<usize> {
         .collect();
     nonempty
         .iter()
-        .take(6)
+        .take(8)
         .chain(nonempty.iter().rev().take(4))
         .copied()
         .collect()
@@ -343,10 +343,12 @@ fn strip_repeated_marginal_lines(pages: &mut [String]) {
     let mut counts: HashMap<String, usize> = HashMap::new();
     for page in pages.iter() {
         let lines: Vec<&str> = page.lines().collect();
-        let margins = margin_indices(&lines);
-        let unique: HashSet<String> = margins
-            .into_iter()
-            .filter_map(|index| normalized_margin_line(lines[index]))
+        // Count across the page, but removal below is still restricted to the
+        // margins. This is robust when a converter inserts blank/metadata lines
+        // before the visual header.
+        let unique: HashSet<String> = lines
+            .iter()
+            .filter_map(|line| normalized_margin_line(line))
             .collect();
         for line in unique {
             *counts.entry(line).or_default() += 1;

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -207,7 +207,9 @@ fn native_text_is_trustworthy(text: &str) -> bool {
         .split_whitespace()
         .filter(|token| token.chars().filter(|ch| ch.is_alphabetic()).count() >= 2)
         .count();
-    word_like >= 8 && alphanumeric * 100 >= nonspace * 30
+    // TOC pages can legitimately be dominated by dotted leaders; 20% still
+    // requires substantial readable content while allowing those pages.
+    word_like >= 8 && alphanumeric * 100 >= nonspace * 20
 }
 
 /// Đường fallback cũ: PDFium đếm ký tự để quyết text vs OCR.
@@ -344,13 +346,14 @@ mod tests {
 
     #[test]
     fn trusts_native_vietnamese_table_of_contents() {
-        let text = "MỤC LỤC\n\
-            PHẦN 1 - MÔ HÌNH CASAN........................................ 1\n\
-            1. BỐI CẢNH RA ĐỜI........................................... 1\n\
-            1.1. AI đã đi qua thời thử công cụ........................... 1\n\
-            2. MÔ HÌNH CASAN............................................. 2\n\
-            3. LỘ TRÌNH CHUYỂN ĐỔI GIỮA CÁC CẤP ĐỘ CASAN................ 4";
-        assert!(native_text_is_trustworthy(text));
+        let mut text = String::from("MỤC LỤC\n");
+        for page in 1..=35 {
+            text.push_str(&format!(
+                "{page}. Nội dung phương pháp luận chuyển đổi AI{} {page}\n",
+                ".".repeat(90)
+            ));
+        }
+        assert!(native_text_is_trustworthy(&text));
     }
 
     #[test]

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -967,8 +967,9 @@ fn extract_with_pdf_extract(bytes: &[u8]) -> Result<String, ConvertError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        markdown_has_malformed_table, native_text_covers_markdown, native_text_is_high_confidence,
-        native_text_is_trustworthy, parse_marked_pages, strip_repeated_marginal_lines,
+        load_pdfium, markdown_has_malformed_table, native_text_covers_markdown,
+        native_text_is_high_confidence, native_text_is_trustworthy, parse_marked_pages,
+        strip_repeated_marginal_lines,
     };
 
     #[test]
@@ -1110,5 +1111,18 @@ mod tests {
             pages.get(&5).map(String::as_str),
             Some("## Năm\n\nNội dung khác")
         );
+    }
+
+    #[test]
+    fn reuses_initialized_pdfium_bindings_across_threads() {
+        if load_pdfium().is_none() {
+            return; // PDFium is an optional runtime dependency.
+        }
+        let handles: Vec<_> = (0..4)
+            .map(|_| std::thread::spawn(|| load_pdfium().is_some()))
+            .collect();
+        assert!(handles
+            .into_iter()
+            .all(|handle| handle.join().unwrap_or(false)));
     }
 }

--- a/crates/core/src/image_ocr.rs
+++ b/crates/core/src/image_ocr.rs
@@ -98,9 +98,27 @@ fn tessdata_dir() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("FILECONV_TESSDATA") {
         return Some(PathBuf::from(p));
     }
-    let local = PathBuf::from("tessdata_best");
-    if local.join("vie.traineddata").exists() {
-        return Some(local);
+
+    let mut roots = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        roots.extend(cwd.ancestors().take(4).map(Path::to_path_buf));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            roots.extend(parent.ancestors().take(4).map(Path::to_path_buf));
+        }
+    }
+    roots.extend(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .take(4)
+            .map(Path::to_path_buf),
+    );
+    for root in roots {
+        let candidate = root.join("tessdata_best");
+        if candidate.join("vie.traineddata").exists() {
+            return Some(candidate);
+        }
     }
     None
 }

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -66,9 +66,10 @@ convert pdf
  pdf_ocr_images (mặc định tắt) → OCR thêm ảnh nhúng ≥200×200px
 ```
 
-Đánh đổi (đo thực): pdf-inspector **~18ms/trang** (có cấu trúc + đa cột) vs PDFium **~5.67ms/trang** (chỉ text).
-> Ghi chú: `CLAUDE.md` ghi "~35ms/trang" cho pdf-inspector — **số đo thực trong các REPORT là ~18ms/trang** (cấu trúc) /
-> ~5.67ms (text). Dùng số đo; con số 35ms đã cũ.
+Đánh đổi (đo thực): corpus cũ pdf-inspector **~18ms/trang** (có cấu trúc + đa cột)
+vs PDFium **~5.67ms/trang** (chỉ text). Đường range song song mới đo **~11.4ms/trang**
+trên PDF CASAN 45 trang/8 vCPU; chọn riêng một trang ~55–61ms thay vì ~400–440ms.
+Chi tiết: [`../bench/REPORT_CASAN_PDF.md`](../bench/REPORT_CASAN_PDF.md).
 
 ### Mỗi converter (tóm tắt)
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -67,8 +67,10 @@ convert pdf
 ```
 
 Đánh đổi (đo thực): corpus cũ pdf-inspector **~18ms/trang** (có cấu trúc + đa cột)
-vs PDFium **~5.67ms/trang** (chỉ text). Đường range song song mới đo **~11.4ms/trang**
-trên PDF CASAN 45 trang/8 vCPU; chọn riêng một trang ~55–61ms thay vì ~400–440ms.
+vs PDFium **~5.67ms/trang** (chỉ text). Đường range song song mới đo **~7.8ms/trang**
+trên PDF CASAN 45 trang/8 vCPU; chọn riêng một trang ~55–59ms thay vì ~400–440ms.
+Tauri dev tối ưu tạo sidecar cùng file trong ~0.40s (trước đó 17.54s do core opt-level 0
+và không tìm thấy PDFium khi working directory là `app/`).
 Chi tiết: [`../bench/REPORT_CASAN_PDF.md`](../bench/REPORT_CASAN_PDF.md).
 
 ### Mỗi converter (tóm tắt)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- avoid false OCR by preferring high-confidence native PDF text while retaining Tesseract for true scans
- repair malformed/table-only pages with validated native text and remove recurring headers
- accelerate selected pages through the filtered inspector API (~7–8× faster)
- accelerate full 16–200 page documents with bounded parallel ranges and overlapped PDFium extraction
- safely reuse process-global PDFium bindings across worker threads
- discover PDFium/tessdata from desktop working-directory/executable ancestors
- optimize the Cargo dev profile so Tauri dev runs conversion code optimized instead of `opt-level=0`
- fail explicitly rather than leaking unrequested pages when filtered fallbacks are unavailable

## Root cause
`Phương-pháp-luận-FPT-CASAN---ver.-Alpha_đã-ký 2.pdf` is a 45-page tagged Word PDF with a good Unicode text layer, not a scan. The old pipeline OCRed the first three TOC pages because of GID/symbol and dotted-leader heuristics. In Tauri dev, CWD=`app/` also prevented `./pdfium` discovery, then unoptimized debug code made conversion take 17.54s.

The Markdown mentioned in commit `09b8729` was not present, so native `pdftotext -raw` is the content reference.

## Benchmark (8 vCPU)
- false OCR pages: **3 → 0**
- original OCR-heavy full conversion: **~11.5s → ~0.35s release**
- conservative quality-safe full path: **~0.77s → ~0.35s**
- one TOC/normal page: **~0.40s → ~0.055s**
- one complex-table page: **~0.44s → ~0.059s**
- pages 1–10: **~0.49s → ~0.27s**
- actual Tauri dev click `Convert ngay` → sidecar: **17.54s → 0.403s**
- recurring `Mã hiệu` header: **45 → 0**
- native-token recall: **99.86%**, precision: **100%**
- parallel vs conservative sequential token recall: **99.95%**

## Desktop end-to-end verification
Ran the real Tauri app under Xvfb 1440×900 with isolated DATA:
1. opened the raw 45-page PDF in Source view
2. clicked `Convert ngay`
3. observed the `.pdf.md` sidecar created in **0.403s**
4. verified 107,854 characters, no OCR markers, no repeated metadata header, 8 retained Markdown tables
5. observed the UI automatically switch to linked-block Compare view

Artifact: `<img alt="Markhand desktop after PDF conversion" src="/opt/cursor/artifacts/markhand-desktop-pdf-converted.png" />`

## Verification
- `cargo test -p fileconv-core` — 25 passed
- `cargo test -p fileconv-cli metrics` — 3 passed
- changed Rust files pass rustfmt
- cross-thread PDFium binding reuse test passes
- generated image-only PDF still uses OCR
- low-core, >200-page, or >32MB inputs use conservative path
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

