### PR TITLE
ci: build desktop installers for linux, windows, macos on master pushes

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -3,11 +3,19 @@ name: Build desktop installers
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
     tags:
       - "markhand-v*"
 
 permissions:
   contents: read
+
+# Mỗi push master build lại từ đầu; hủy run cũ đang chạy của cùng ref để khỏi
+# đốt runner macOS (giá 10×) cho commit đã bị vượt qua.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   bundle:


### PR DESCRIPTION
## Vấn đề

`release-desktop.yml` có sẵn matrix 3 OS (deb/appimage, msi/nsis, dmg) nhưng chỉ trigger bằng tag `markhand-v*` hoặc bấm tay — **chưa từng chạy lần nào** (không có run history, chưa có tag). Tức là installer Windows/macOS chưa bao giờ được build thật; `ci.yml` hằng ngày chỉ build `.deb` Linux. Đây là lỗ hổng roadmap 'Desktop release foundation'.

## Thay đổi

- Thêm trigger `push: branches: [master]` — mỗi push vào master build installer cho cả 3 OS và upload artifact (giữ nguyên tag + workflow_dispatch).
- Thêm `concurrency` cancel-in-progress theo ref — push liên tiếp không đốt runner macOS (giá 10×) cho commit đã bị vượt.
- Không đổi logic build/signing: vẫn unsigned khi thiếu secrets, signed+notarized khi bật vars/secrets như thiết kế cũ.

## Kiểm chứng

Đã dispatch workflow từ chính branch này để build thật trên cả 3 OS (lần chạy đầu tiên của workflow): https://github.com/anhnth24/project-example/actions/runs/29159261916 — sẽ cập nhật kết quả vào PR khi hoàn tất.