### PR TITLE
fix: stop console windows flashing when spawning subprocesses on Windows

### DIFF
--- a/crates/core/src/image_ocr.rs
+++ b/crates/core/src/image_ocr.rs
@@ -14,7 +14,6 @@
 use std::cell::Cell;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use image::{imageops, DynamicImage, GrayImage};
@@ -348,7 +347,7 @@ fn run_paddle(path: &Path, langs: &str) -> io::Result<String> {
     } else {
         "en"
     };
-    let output = Command::new("python3")
+    let output = crate::proc::background_command("python3")
         .arg(script)
         .arg("--image")
         .arg(path)
@@ -396,7 +395,7 @@ fn run_tesseract(path: &Path, langs: &str) -> io::Result<String> {
 }
 
 fn run_tesseract_psm(path: &Path, langs: &str, psm: u8) -> io::Result<String> {
-    let mut cmd = Command::new("tesseract");
+    let mut cmd = crate::proc::background_command("tesseract");
     cmd.arg(path)
         .arg("stdout")
         .arg("-l")
@@ -466,7 +465,7 @@ fn ocr_text_score(text: &str) -> i64 {
 
 /// Kiểm tra tesseract có sẵn không.
 pub fn tesseract_available() -> bool {
-    Command::new("tesseract")
+    crate::proc::background_command("tesseract")
         .arg("--version")
         .output()
         .map(|o| o.status.success())

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod llm;
 pub mod llm_cli;
 pub mod pptx_preview;
 pub mod probe;
+mod proc;
 pub mod tables;
 pub mod viet_legacy;
 mod viet_legacy_maps;

--- a/crates/core/src/llm_cli.rs
+++ b/crates/core/src/llm_cli.rs
@@ -89,7 +89,7 @@ fn binary_for(config: &LlmConfig) -> Result<OsString, ConvertError> {
 }
 
 fn command_for(config: &LlmConfig) -> Result<Command, ConvertError> {
-    let mut command = Command::new(binary_for(config)?);
+    let mut command = crate::proc::background_command(binary_for(config)?);
     // Subscription bridges must use the official CLI login, not API-key env vars.
     command
         .env_remove("CURSOR_API_KEY")
@@ -317,7 +317,7 @@ pub fn subscription_status(config: &LlmConfig) -> Result<CliSubscriptionStatus, 
 
 pub fn start_login(config: &LlmConfig) -> Result<(), ConvertError> {
     let binary = binary_for(config)?;
-    let mut command = Command::new(binary);
+    let mut command = crate::proc::background_command(binary);
     command
         .arg("login")
         .env_remove("CURSOR_API_KEY")

--- a/crates/core/src/proc.rs
+++ b/crates/core/src/proc.rs
@@ -1,0 +1,36 @@
+//! Tiện ích spawn tiến trình con.
+
+use std::ffi::OsStr;
+use std::process::Command;
+
+/// Tạo `Command` không mở cửa sổ console trên Windows.
+///
+/// App desktop (GUI, không có console) spawn tesseract/python/CLI: Windows sẽ
+/// cấp console mới cho tiến trình con và cửa sổ đen nháy lên mỗi lần convert.
+/// `CREATE_NO_WINDOW` chặn việc đó; stdout/stderr vẫn capture qua pipe như thường.
+pub(crate) fn background_command(program: impl AsRef<OsStr>) -> Command {
+    #[allow(unused_mut)]
+    let mut command = Command::new(program);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    // CREATE_NO_WINDOW chỉ được ẩn cửa sổ, không được phá spawn/capture.
+    #[cfg(windows)]
+    #[test]
+    fn background_command_still_spawns_and_captures_output() {
+        let output = super::background_command("cmd")
+            .args(["/C", "echo hi"])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("hi"));
+    }
+}


### PR DESCRIPTION
## Vấn đề

Trên Windows, mỗi lần convert PDF có trang OCR là một cửa sổ console đen (tesseract) nháy lên rồi tắt — rất khó chịu (ảnh chụp người dùng báo). Nguyên nhân: Markhand là app GUI (không có console), nên khi spawn tiến trình con qua `std::process::Command`, Windows tự cấp console mới cho tiến trình con.

## Thay đổi

Helper mới `crates/core/src/proc.rs::background_command` — tạo `Command` với cờ `CREATE_NO_WINDOW` (0x08000000) trên Windows, no-op trên OS khác — và thay vào mọi điểm spawn chạy trong tiến trình GUI:

- `image_ocr.rs`: tesseract OCR mỗi trang (thủ phạm chính), probe `tesseract --version`, PaddleOCR python bridge
- `llm_cli.rs`: Cursor/Codex subscription CLI (chat + login)

Không đổi: `crates/cli` (fileconv là console app, có sẵn terminal), site `/bin/sh` trong test cfg(unix).

`CREATE_NO_WINDOW` chỉ ẩn console; stdout/stderr vẫn capture qua pipe như cũ — có test Windows-only trong `proc.rs` chứng minh spawn + capture còn nguyên.

## Kiểm chứng

- `cargo test -p fileconv-core`: 88 pass; `--features llm`: 101 pass (khớp CI), gồm test mới `background_command_still_spawns_and_captures_output` chạy trên chính Windows 11 + tesseract 5.4.0 thật.
- `cargo fmt --check` sạch.