### PR TITLE
feat: version management + auto-update via GitHub Releases (#30)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -18,7 +18,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Chỉ chạy khi push tag `markhand-vX.Y.Z` — chặn sớm trước khi tốn runner
+  # build nếu version trong tag lệch với tauri.conf.json (nguồn sự thật duy nhất).
+  check-version:
+    if: startsWith(github.ref, 'refs/tags/markhand-v')
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate tag matches tauri.conf.json version
+        run: |
+          tag_version="${GITHUB_REF_NAME#markhand-v}"
+          conf_version=$(jq -r '.version' app/src-tauri/tauri.conf.json)
+          if [ "$tag_version" != "$conf_version" ]; then
+            echo "::error::Tag markhand-v$tag_version không khớp version trong tauri.conf.json ($conf_version)"
+            exit 1
+          fi
+          echo "OK: tag khớp version $conf_version"
+
   bundle:
+    needs: [check-version]
+    if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +52,11 @@ jobs:
             bundles: dmg
             artifact: macos
     runs-on: ${{ matrix.os }}
+    env:
+      # Ký updater artifact (minisign) khi có secret; thiếu thì `createUpdaterArtifacts`
+      # tự bỏ qua bước ký (không fail build .deb/.msi/.dmg thường).
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux bundle dependencies
@@ -95,9 +119,19 @@ jobs:
         run: pnpm tauri build --bundles ${{ matrix.bundles }}
         working-directory: app
 
-      - name: Build unsigned Windows installers
-        if: runner.os == 'Windows' && vars.WINDOWS_SIGNING_ENABLED != 'true'
+      # `--no-sign` chỉ tắt code-signing OS-level, nhưng cũng tắt LUÔN chữ ký
+      # updater minisign (xác nhận bằng build thật trong sandbox: `--no-sign`
+      # in "Updater signing is skipped"). Nên khi đã có TAURI_SIGNING_PRIVATE_KEY
+      # (updater key) mà chưa có cert OS, bỏ `--no-sign` để vẫn ký được updater
+      # artifact — bundle .msi/.dmg vẫn ra unsigned như cũ, chỉ .sig là có thật.
+      - name: Build Windows installers (no OS cert, no updater key)
+        if: runner.os == 'Windows' && vars.WINDOWS_SIGNING_ENABLED != 'true' && env.TAURI_SIGNING_PRIVATE_KEY == ''
         run: pnpm tauri build --bundles ${{ matrix.bundles }} --no-sign --ci
+        working-directory: app
+
+      - name: Build Windows installers (updater-signed, no OS cert)
+        if: runner.os == 'Windows' && vars.WINDOWS_SIGNING_ENABLED != 'true' && env.TAURI_SIGNING_PRIVATE_KEY != ''
+        run: pnpm tauri build --bundles ${{ matrix.bundles }} --ci
         working-directory: app
 
       - name: Build signed Windows installers
@@ -105,9 +139,14 @@ jobs:
         run: pnpm tauri build --bundles ${{ matrix.bundles }} --ci
         working-directory: app
 
-      - name: Build unsigned macOS installer
-        if: runner.os == 'macOS' && vars.MACOS_SIGNING_ENABLED != 'true'
+      - name: Build macOS installer (no OS cert, no updater key)
+        if: runner.os == 'macOS' && vars.MACOS_SIGNING_ENABLED != 'true' && env.TAURI_SIGNING_PRIVATE_KEY == ''
         run: pnpm tauri build --bundles ${{ matrix.bundles }} --no-sign --ci
+        working-directory: app
+
+      - name: Build macOS installer (updater-signed, no OS cert)
+        if: runner.os == 'macOS' && vars.MACOS_SIGNING_ENABLED != 'true' && env.TAURI_SIGNING_PRIVATE_KEY != ''
+        run: pnpm tauri build --bundles ${{ matrix.bundles }} --ci
         working-directory: app
 
       - name: Build signed and notarized macOS installer
@@ -140,3 +179,67 @@ jobs:
           name: markhand-${{ matrix.artifact }}
           path: target/release/bundle/**
           if-no-files-found: error
+
+  # Chỉ chạy khi push tag — gom artifact 3 OS, lắp `latest.json` cho
+  # tauri-plugin-updater, tạo GitHub Release đính kèm installer + file cập nhật.
+  release:
+    needs: [check-version, bundle]
+    if: startsWith(github.ref, 'refs/tags/markhand-v')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Assemble latest.json and stage release assets
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          version="${GITHUB_REF_NAME#markhand-v}"
+          pub_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          # Chỉ AppImage (Linux)/NSIS (Windows)/.app bundle (macOS) tự cập nhật
+          # tại chỗ được — .deb/.msi cài qua package manager, không đưa vào
+          # latest.json (đúng thiết kế: deb chỉ thông báo + link Release).
+          declare -A platform_patterns=(
+            [linux-x86_64]="artifacts/markhand-linux/**/*.AppImage.tar.gz.sig"
+            [windows-x86_64]="artifacts/markhand-windows/**/*.exe.sig"
+            [darwin-aarch64]="artifacts/markhand-macos/**/*.app.tar.gz.sig"
+          )
+          json_platforms="{}"
+          for platform in "${!platform_patterns[@]}"; do
+            pattern="${platform_patterns[$platform]}"
+            sig_file=$(shopt -s globstar nullglob; files=($pattern); [ ${#files[@]} -gt 0 ] && echo "${files[0]}" || true)
+            if [ -z "$sig_file" ]; then
+              echo "::warning::Không tìm thấy updater .sig cho $platform (thiếu TAURI_SIGNING_PRIVATE_KEY hoặc build lỗi) — bỏ qua trong latest.json"
+              continue
+            fi
+            asset_file="${sig_file%.sig}"
+            asset_name=$(basename "$asset_file")
+            signature=$(cat "$sig_file")
+            cp "$asset_file" "release/$asset_name"
+            url="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/${asset_name}"
+            json_platforms=$(jq --arg p "$platform" --arg sig "$signature" --arg url "$url" \
+              '. + {($p): {signature: $sig, url: $url}}' <<<"$json_platforms")
+          done
+
+          jq -n --arg version "$version" --arg notes "Markhand v$version" \
+            --arg pub_date "$pub_date" --argjson platforms "$json_platforms" \
+            '{version: $version, notes: $notes, pub_date: $pub_date, platforms: $platforms}' \
+            > release/latest.json
+
+          # Installer chính để user tải thủ công (không phải mọi bản đều tự-update được).
+          find artifacts -type f \( -name '*.deb' -o -name '*.AppImage' -o -name '*.msi' \
+            -o -name '*setup.exe' -o -name '*.dmg' \) -exec cp {} release/ \;
+          ls -la release
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Markhand ${{ github.ref_name }}
+          files: release/*
+          fail_on_unmatched_files: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "time",
 ]
 
@@ -1601,6 +1603,16 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2709,6 +2721,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +3116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,6 +3466,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,6 +3558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,6 +3577,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4242,15 +4322,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4392,6 +4477,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,6 +4497,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4431,6 +4555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4503,6 +4636,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4752,6 +4908,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5164,7 +5336,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -5198,6 +5370,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5220,7 +5403,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5397,6 +5580,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5406,7 +5632,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5429,7 +5655,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -6315,6 +6541,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6958,7 +7193,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -7003,6 +7238,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,8 @@
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.2.0",
     "@tauri-apps/plugin-opener": "^2.2.5",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@uiw/react-codemirror": "^4.23.7",
     "docx-preview": "^0.3.7",
     "lucide-react": "^1.22.0",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2.2.5
         version: 2.5.4
+      '@tauri-apps/plugin-process':
+        specifier: ^2.3.1
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.10.1
+        version: 2.10.1
       '@uiw/react-codemirror':
         specifier: ^4.23.7
         version: 4.25.10(@babel/runtime@8.0.0)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -716,6 +722,12 @@ packages:
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2029,6 +2041,14 @@ snapshots:
       '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-opener@2.5.4':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -24,6 +24,8 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Pin có chủ đích: time 0.3.52 đổi chữ ký `Parsable::parse` làm vỡ `cookie 0.18.1`

--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -1,12 +1,14 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Quyền mặc định cho cửa sổ chính: core, hộp thoại chọn file/thư mục, mở file bằng app ngoài.",
+  "description": "Quyền mặc định cho cửa sổ chính: core, hộp thoại chọn file/thư mục, mở file bằng app ngoài, kiểm tra/cài update.",
   "windows": ["main"],
   "permissions": [
     "core:default",
     "dialog:default",
     "opener:default",
-    "opener:allow-open-path"
+    "opener:allow-open-path",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -71,6 +71,7 @@ pub struct Settings {
     pub embedding_api_key: Option<String>,
     pub embedding_dimensions: Option<usize>,
     pub embedding_fallback_local: bool,
+    pub auto_check_update: bool,
 }
 
 impl Default for Settings {
@@ -98,6 +99,7 @@ impl Default for Settings {
             embedding_api_key: None,
             embedding_dimensions: None,
             embedding_fallback_local: true,
+            auto_check_update: true,
         }
     }
 }
@@ -1000,6 +1002,8 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
             let config_dir = app.path().app_config_dir()?;
             fs::create_dir_all(&config_dir).ok();
@@ -1216,6 +1220,7 @@ mod tests {
         assert!(!settings.llm_enabled);
         assert_eq!(settings.llm_provider, "ollama");
         assert_eq!(settings.llm_base_url, "http://127.0.0.1:11434");
+        assert!(settings.auto_check_update);
     }
 
     #[test]

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -24,9 +24,18 @@
       "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:1420 ws://localhost:1420; img-src 'self' blob: data:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; worker-src 'self' blob:; script-src 'self'"
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE3REUxMTJEQkZFNDFDRUEKUldUcUhPUy9MUkhlRjQvZzdWOFpWQTBKMktqbDFvU2dFRnlwRmU3N1ZMSngraFV6UzhBOS9yL3QK",
+      "endpoints": [
+        "https://github.com/anhnth24/project-example/releases/latest/download/latest.json"
+      ]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "publisher": "anhnth24",
     "homepage": "https://github.com/anhnth24/project-example",
     "license": "MIT",

--- a/app/src/components/Settings.tsx
+++ b/app/src/components/Settings.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { relaunch } from "@tauri-apps/plugin-process";
+import { check as checkForUpdate, type Update } from "@tauri-apps/plugin-updater";
 import {
   Cloud,
   BrainCircuit,
+  Download,
   FolderOpen,
   LogIn,
   RotateCcw,
@@ -57,6 +61,7 @@ const DEFAULTS: Settings = {
   embeddingApiKey: null,
   embeddingDimensions: null,
   embeddingFallbackLocal: true,
+  autoCheckUpdate: true,
 };
 
 function providerOptionLabel(preset: LlmProviderPreset): string {
@@ -82,6 +87,12 @@ export function SettingsModal({ onClose }: { onClose: () => void }) {
   const [testingEmbedding, setTestingEmbedding] = useState(false);
   const [embeddingResult, setEmbeddingResult] =
     useState<EmbeddingConnectionResult | null>(null);
+  const [appVersion, setAppVersion] = useState("");
+  const [checkingUpdate, setCheckingUpdate] = useState(false);
+  const [updateChecked, setUpdateChecked] = useState(false);
+  const [updateInfo, setUpdateInfo] = useState<Update | null>(null);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const [installingUpdate, setInstallingUpdate] = useState(false);
 
   useEffect(() => {
     api
@@ -92,7 +103,37 @@ export function SettingsModal({ onClose }: { onClose: () => void }) {
       .getEmbeddingProviderPresets()
       .then(setEmbeddingPresets)
       .catch((error) => setError(String(error)));
+    getVersion()
+      .then(setAppVersion)
+      .catch(() => {});
   }, [setError]);
+
+  async function runUpdateCheck() {
+    setCheckingUpdate(true);
+    setUpdateError(null);
+    setUpdateChecked(false);
+    try {
+      setUpdateInfo(await checkForUpdate());
+      setUpdateChecked(true);
+    } catch (error) {
+      setUpdateError(String(error));
+    } finally {
+      setCheckingUpdate(false);
+    }
+  }
+
+  async function installUpdate() {
+    if (!updateInfo) return;
+    setInstallingUpdate(true);
+    setUpdateError(null);
+    try {
+      await updateInfo.downloadAndInstall();
+      await relaunch();
+    } catch (error) {
+      setUpdateError(String(error));
+      setInstallingUpdate(false);
+    }
+  }
 
   function set<K extends keyof Settings>(key: K, val: Settings[K]) {
     setForm((f) => ({ ...f, [key]: val }));
@@ -674,6 +715,39 @@ export function SettingsModal({ onClose }: { onClose: () => void }) {
             </div>
           </div>
         )}
+
+        <div className="settings-section-heading">
+          <span className="eyebrow">Phiên bản {appVersion || "…"}</span>
+          <strong>Cập nhật</strong>
+        </div>
+
+        <Toggle
+          checked={form.autoCheckUpdate}
+          onChange={(checked) => set("autoCheckUpdate", checked)}
+          label="Tự động kiểm tra khi mở app"
+          description="Chỉ kiểm tra qua GitHub Releases, không tự tải/cài khi chưa xác nhận."
+        />
+
+        <div className="llm-test-row">
+          <Button
+            variant="secondary"
+            icon={<Download size={14} />}
+            loading={checkingUpdate}
+            onClick={runUpdateCheck}
+          >
+            Kiểm tra cập nhật
+          </Button>
+          {updateChecked && !updateInfo && !updateError && <span>Đã ở bản mới nhất.</span>}
+          {updateInfo && (
+            <>
+              <span className="local-result">Có bản {updateInfo.version} mới hơn.</span>
+              <Button variant="primary" loading={installingUpdate} onClick={installUpdate}>
+                Cài đặt &amp; khởi động lại
+              </Button>
+            </>
+          )}
+          {updateError && <span>{updateError}</span>}
+        </div>
 
         {!!validation.length && (
           <div className="form-errors" role="alert">

--- a/app/src/lib/llmSettings.test.ts
+++ b/app/src/lib/llmSettings.test.ts
@@ -34,6 +34,7 @@ const settings: Settings = {
   embeddingApiKey: null,
   embeddingDimensions: null,
   embeddingFallbackLocal: true,
+  autoCheckUpdate: true,
 };
 
 const ollama: LlmProviderPreset = {

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -75,6 +75,7 @@ export interface Settings {
   embeddingApiKey: string | null;
   embeddingDimensions: number | null;
   embeddingFallbackLocal: boolean;
+  autoCheckUpdate: boolean;
 }
 
 export type LlmProtocol =

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { check as checkForUpdate } from "@tauri-apps/plugin-updater";
 import { api } from "../lib/ipc";
 import { findByRel, parentRel, isWithinRel } from "../lib/tree";
 import type {
@@ -141,6 +142,16 @@ export const useStore = create<AppStore>((set, get) => ({
         activeFolder: activeProject?.rootRel ?? "",
       });
       await get().refreshTree();
+      if (settings.autoCheckUpdate) {
+        // Chạy nền, không chặn init(); lỗi mạng/offline thì im lặng bỏ qua.
+        checkForUpdate()
+          .then((update) => {
+            if (update) {
+              set({ error: `Có bản ${update.version} mới hơn — mở Cài đặt để cập nhật.` });
+            }
+          })
+          .catch(() => {});
+      }
     } catch (error) {
       set({ error: String(error) });
     }


### PR DESCRIPTION
- tauri.conf.json version stays the single source of truth; wire
  tauri-plugin-updater + tauri-plugin-process with a real generated
  minisign keypair (pubkey embedded, private key kept out of the repo).
- Settings: show app version, "auto-check on launch" toggle
  (auto_check_update, defaults true, backward-compatible via serde
  default), manual "Kiểm tra cập nhật" check/install/relaunch flow.
- store.ts: silent background update check on init() when the toggle
  is on, surfaced through the existing error/notice banner.
- CI: check-version job fails a tag push before building if the tag
  doesn't match tauri.conf.json's version; release job assembles
  latest.json from the per-OS updater .sig artifacts and publishes a
  GitHub Release. Split the "no OS cert" build steps so `--no-sign`
  (which also disables updater signing, confirmed via a real signed
  sandbox build) is only used when no updater key is configured.