### PR TITLE
fix: unset empty TAURI_SIGNING_PRIVATE_KEY before tauri build in CI

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -114,9 +114,18 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$KEYCHAIN_PASSWORD" build.keychain
 
+      # Secret trống (chưa cấu hình TAURI_SIGNING_PRIVATE_KEY) vẫn được GitHub Actions
+      # export thành biến RỖNG (không phải absent) → Tauri CLI hiểu nhầm là "có key
+      # nhưng sai định dạng" và fail cứng (xác nhận bằng CI run thật:
+      # "failed to decode secret key: ... Missing comment in secret key"). unset khi
+      # rỗng để khôi phục hành vi "không có key" (bỏ qua ký updater, không lỗi).
       - name: Build Linux installers
         if: runner.os == 'Linux'
-        run: pnpm tauri build --bundles ${{ matrix.bundles }}
+        run: |
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            unset TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+          fi
+          pnpm tauri build --bundles ${{ matrix.bundles }}
         working-directory: app
 
       # `--no-sign` chỉ tắt code-signing OS-level, nhưng cũng tắt LUÔN chữ ký
@@ -136,7 +145,12 @@ jobs:
 
       - name: Build signed Windows installers
         if: runner.os == 'Windows' && vars.WINDOWS_SIGNING_ENABLED == 'true'
-        run: pnpm tauri build --bundles ${{ matrix.bundles }} --ci
+        shell: bash
+        run: |
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            unset TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+          fi
+          pnpm tauri build --bundles ${{ matrix.bundles }} --ci
         working-directory: app
 
       - name: Build macOS installer (no OS cert, no updater key)
@@ -156,7 +170,11 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: pnpm tauri build --bundles ${{ matrix.bundles }} --ci
+        run: |
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            unset TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+          fi
+          pnpm tauri build --bundles ${{ matrix.bundles }} --ci
         working-directory: app
 
       - name: Verify Windows Authenticode

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE3REUxMTJEQkZFNDFDRUEKUldUcUhPUy9MUkhlRjQvZzdWOFpWQTBKMktqbDFvU2dFRnlwRmU3N1ZMSngraFV6UzhBOS9yL3QK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEU0Q0UzNDMxMzAzODcxOQpSV1FaaHdNVFErTk1Ea2hPQ3dZb2ZGTWMxVW1JK1MyemViZE5DL3FsRVNjVGtqQlN1REYrNUtXNAo=",
       "endpoints": [
         "https://github.com/anhnth24/project-example/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Vấn đề

Run CI thật sau khi merge #30 ([run 29198889579](https://github.com/anhnth24/project-example/actions/runs/29198889579)) cho thấy job Linux fail:

```
failed to decode secret key: incorrect updater private key password: Missing comment in secret key
```

Windows và macOS build thành công, chỉ Linux fail. Nguyên nhân: khi secret `TAURI_SIGNING_PRIVATE_KEY` chưa cấu hình, GitHub Actions vẫn export biến môi trường này thành **chuỗi rỗng** (không phải absent hẳn). Tauri CLI đọc thấy biến "có" nhưng nội dung rỗng → hiểu nhầm là key thật nhưng sai định dạng, fail cứng thay vì bỏ qua ký updater như thiết kế.

Windows/macOS vô tình né được vì nhánh build "no OS cert" của 2 job đó dùng `--no-sign` (tắt luôn cả ký updater), còn Linux không có nhánh `--no-sign` tương ứng (deb/appimage không cần code-signing OS-level) nên luôn chạm bug.

## Fix

Thêm guard `unset` ngay trong step trước khi gọi `pnpm tauri build`, cho cả 3 chỗ chạy build không qua `--no-sign`:
- `Build Linux installers`
- `Build signed Windows installers`
- `Build signed and notarized macOS installer`

```bash
if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
  unset TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD
fi
```

Khi secret thật sự có giá trị, guard không đụng gì (đã test cục bộ cả 2 nhánh: rỗng → unset sạch; có giá trị → giữ nguyên).

## Kiểm chứng

- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML hợp lệ.
- Test cục bộ bash logic cho cả 2 trường hợp (rỗng/có giá trị) — đúng như mong đợi.
- Repo vừa được cấu hình `TAURI_SIGNING_PRIVATE_KEY` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` thật — merge PR này sẽ trigger lại `release-desktop.yml` trên `master` để xác nhận cả 3 OS build + ký updater artifact thành công.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnbJZN3nsANT19636Q18cP)_