### PR TITLE
Thêm subcommand 'fileconv info'

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -144,7 +144,11 @@ fn main() -> Result<()> {
                 ("Tesseract data", base_dir.join("tessdata_best")),
                 ("Whisper models", base_dir.join("models")),
             ] {
-                let status = if path.exists() { "Có tồn tại file" } else { "Chưa có file" };
+                let status = if path.exists() {
+                    "Có tồn tại file"
+                } else {
+                    "Chưa có file"
+                };
                 println!("{label}: {status} ({})", path.display());
             }
             if let Ok(entries) = fs::read_dir(base_dir.join("models")) {
@@ -152,7 +156,8 @@ fn main() -> Result<()> {
                     .filter_map(Result::ok)
                     .filter_map(|e| {
                         let p = e.path();
-                        (p.extension().and_then(|ext| ext.to_str()) == Some("bin")).then_some(p.display().to_string())
+                        (p.extension().and_then(|ext| ext.to_str()) == Some("bin"))
+                            .then_some(p.display().to_string())
                     })
                     .collect();
                 if bins.is_empty() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,7 +3,10 @@
 //! Lệnh:
 //!   fileconv speed <corpus_dir> [report.md]   - đo tốc độ theo file & page
 //!   fileconv accuracy <manifest> [report.md]  - đo độ chính xác CER/WER vs ground truth
-//!   fileconv one <file>                        - convert 1 file, in markdown ra stdout
+//!   fileconv one <file>                       - convert 1 file, in markdown ra stdout
+//!   fileconv info                             - hiển thị định dạng file hỗ trợ, 
+//!                                               đường dẫn pdfium/tessdata (có tồn tại không),
+//!                                               và model whisper tìm thấy trong models/
 //!
 //! Manifest accuracy: mỗi dòng "<đường_dẫn_file>\t<đường_dẫn_text_chuẩn>\t<nhãn_kịch_bản>".
 
@@ -34,7 +37,7 @@ fn main() -> Result<()> {
 
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
-        eprintln!("dùng: fileconv <speed|accuracy|audio|one|handoff|pptx-preview> ...");
+        eprintln!("dùng: fileconv <speed|accuracy|audio|one|handoff|pptx-preview|info> ...");
         std::process::exit(2);
     }
     match args[1].as_str() {
@@ -126,6 +129,39 @@ fn main() -> Result<()> {
                     "slides": slides
                 }))?
             );
+            Ok(())
+        }
+        "info" => {
+            println!("Danh sách định dạng hỗ trợ:");
+            for ext in FormatKind::supported_extensions() {
+                println!("  .{ext}");
+            }
+
+            let base_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .unwrap_or_else(|| Path::new("."));
+            for (label, path) in [
+                ("PDFium lib", base_dir.join("pdfium").join("lib")),
+                ("Tesseract data", base_dir.join("tessdata_best")),
+                ("Whisper models", base_dir.join("models")),
+            ] {
+                let status = if path.exists() { "Có tồn tại file" } else { "Chưa có file" };
+                println!("{label}: {status} ({})", path.display());
+            }
+            if let Ok(entries) = fs::read_dir(base_dir.join("models")) {
+                let mut bins: Vec<_> = entries
+                    .filter_map(Result::ok)
+                    .filter_map(|e| {
+                        let p = e.path();
+                        (p.extension().and_then(|ext| ext.to_str()) == Some("bin")).then_some(p.display().to_string())
+                    })
+                    .collect();
+                bins.sort();
+                for bin in bins {
+                    println!("  model: {bin}");
+                }
+            }
             Ok(())
         }
         other => bail!("lệnh không hợp lệ: {other}"),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -158,8 +158,12 @@ fn main() -> Result<()> {
                     })
                     .collect();
                 bins.sort();
-                for bin in bins {
-                    println!("  model: {bin}");
+                if bins.is_empty() {
+                    println!("  (chưa có model .bin trong models/)");
+                } else {
+                    for bin in bins {
+                        println!("  model: {bin}");
+                    }
                 }
             }
             Ok(())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,9 +4,7 @@
 //!   fileconv speed <corpus_dir> [report.md]   - đo tốc độ theo file & page
 //!   fileconv accuracy <manifest> [report.md]  - đo độ chính xác CER/WER vs ground truth
 //!   fileconv one <file>                       - convert 1 file, in markdown ra stdout
-//!   fileconv info                             - hiển thị định dạng file hỗ trợ, 
-//!                                               đường dẫn pdfium/tessdata (có tồn tại không),
-//!                                               và model whisper tìm thấy trong models/
+//!   fileconv info                             - hiển thị định dạng file hỗ trợ, đường dẫn pdfium/tessdata (có tồn tại không), và model whisper tìm thấy trong models/
 //!
 //! Manifest accuracy: mỗi dòng "<đường_dẫn_file>\t<đường_dẫn_text_chuẩn>\t<nhãn_kịch_bản>".
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -155,10 +155,10 @@ fn main() -> Result<()> {
                         (p.extension().and_then(|ext| ext.to_str()) == Some("bin")).then_some(p.display().to_string())
                     })
                     .collect();
-                bins.sort();
                 if bins.is_empty() {
-                    println!("  (chưa có model .bin trong models/)");
+                    println!("  (Chưa có model .bin trong models/)");
                 } else {
+                    bins.sort();
                     for bin in bins {
                         println!("  model: {bin}");
                     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -88,7 +88,7 @@ impl FormatKind {
         &[
             "pdf", "docx", "pptx", "xlsx", "xls", "xlsb", "ods", "csv", "html", "htm",
             "png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff", "gif", "wav", "mp3",
-            "m4a", "flac", "ogg",
+            "m4a", "flac", "ogg"
         ]
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -83,6 +83,14 @@ impl FormatKind {
             Self::Unknown => "unknown",
         }
     }
+
+    pub fn supported_extensions() -> &'static [&'static str] {
+        &[
+            "pdf", "docx", "pptx", "xlsx", "xls", "xlsb", "ods", "csv", "html", "htm",
+            "png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff", "gif", "wav", "mp3",
+            "m4a", "flac", "ogg",
+        ]
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -87,8 +87,8 @@ impl FormatKind {
     pub fn supported_extensions() -> &'static [&'static str] {
         &[
             "pdf", "docx", "pptx", "xlsx", "xls", "xlsb", "ods", "csv", "html", "htm",
-            "png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff", "gif", "wav", "mp3",
-            "m4a", "flac", "ogg"
+            "png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff", "gif", "wav", "mp3", 
+            "m4a", "ogg", "flac"
         ]
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -88,7 +88,7 @@ impl FormatKind {
         &[
             "pdf", "docx", "pptx", "xlsx", "xls", "xlsb", "ods", "csv", "html", "htm",
             "png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff", "gif", "wav", "mp3", 
-            "m4a", "ogg", "flac", "txt", "log"
+            "m4a", "flac", "ogg", "txt", "log"
         ]
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -86,9 +86,9 @@ impl FormatKind {
 
     pub fn supported_extensions() -> &'static [&'static str] {
         &[
-            "pdf", "docx", "pptx", "xlsx", "xls", "xlsb", "ods", "csv", "html", "htm",
-            "png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff", "gif", "wav", "mp3", 
-            "m4a", "flac", "ogg", "txt", "log"
+            "pdf", "docx", "pptx", "xlsx", "xls", "xlsb", "ods", "csv", "html", "htm", "png",
+            "jpg", "jpeg", "webp", "bmp", "tif", "tiff", "gif", "wav", "mp3", "m4a", "flac", "ogg",
+            "txt", "log",
         ]
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -88,7 +88,7 @@ impl FormatKind {
         &[
             "pdf", "docx", "pptx", "xlsx", "xls", "xlsb", "ods", "csv", "html", "htm",
             "png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff", "gif", "wav", "mp3", 
-            "m4a", "ogg", "flac"
+            "m4a", "ogg", "flac", "txt", "log"
         ]
     }
 }


### PR DESCRIPTION
Fixes #14 
Thêm subcommand 'fileconv info' chạy tức thời và in đủ 3 mục: danh sách định dạng hỗ trợ, đường dẫn pdfium/tessdata (có tồn tại không), và các model whisper được tìm thấy trong models/. Nếu thiếu file/model thì in rõ là chưa có (không panic).