### PR TITLE
Thêm sort và filter cho cây file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ pdfium/
 /bench/edge/
 /bench/sample10/
 /bench/corpus10/
+/.venv
+.aider*
+.env
+/tao_file_test.py

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -16,7 +16,7 @@ import { useStore } from "../state/store";
 import { api } from "../lib/ipc";
 import { findByRel, isWithinRel, parentRel } from "../lib/tree";
 import type { FsNode } from "../lib/types";
-import { Tree } from "./Tree";
+import { Tree, sortChildren } from "./Tree";
 import { Button, IconButton, Modal, SelectControl } from "./ui";
 
 type DialogState =
@@ -48,6 +48,8 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
     closeTabsWithin,
     setActiveFolder,
     setError,
+    sortBy,
+    setSortBy,
   } = useStore();
   const [query, setQuery] = useState("");
   const [dialog, setDialog] = useState<DialogState>(null);
@@ -73,14 +75,17 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
     activeProject?.rootRel && tree
       ? findByRel(tree, activeProject.rootRel)
       : tree;
-  const projectChildren = (projectNode?.children ?? []).filter(
-    (child) =>
-      activeProject?.rootRel !== "" ||
-      !projects.some(
-        (project) =>
-          project.rootRel !== "" &&
-          project.rootRel.toLowerCase() === child.relPath.toLowerCase(),
-      ),
+  const projectChildren = sortChildren(
+    (projectNode?.children ?? []).filter(
+      (child) =>
+        activeProject?.rootRel !== "" ||
+        !projects.some(
+          (project) =>
+            project.rootRel !== "" &&
+            project.rootRel.toLowerCase() === child.relPath.toLowerCase(),
+        ),
+    ),
+    sortBy,
   );
 
   function openCreate(
@@ -309,9 +314,22 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
         </IconButton>
       </div>
 
-      <div className="drawer-section-label">
+      <div className="drawer-section-label" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <span>DATA</span>
-        <span title={`File mới sẽ vào ${folderLabel}`}>Đích: {folderLabel}</span>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <span title={`File mới sẽ vào ${folderLabel}`}>Đích: {folderLabel}</span>
+          <SelectControl
+            value={sortBy}
+            onChange={(val) => setSortBy(val as any)}
+            ariaLabel="Sắp xếp"
+            compact
+            options={[
+              { value: "name", label: "Tên" },
+              { value: "type", label: "Loại file" },
+              { value: "converted", label: "Chưa convert" },
+            ]}
+          />
+        </div>
       </div>
 
       <div className="tree-scroll">

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import {
   FilePlus2,
+  Filter,
   Folder,
   FolderCog,
   FolderInput,
@@ -16,7 +17,7 @@ import { useStore } from "../state/store";
 import { api } from "../lib/ipc";
 import { findByRel, isWithinRel, parentRel } from "../lib/tree";
 import type { FsNode } from "../lib/types";
-import { Tree, sortChildren } from "./Tree";
+import { Tree, sortChildren, hasUnconvertedDescendant } from "./Tree";
 import { Button, IconButton, Modal, SelectControl } from "./ui";
 
 type DialogState =
@@ -28,29 +29,29 @@ type DialogState =
   | null;
 
 export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
-  const {
-    dataRoot,
-    tree,
-    projects,
-    activeProjectId,
-    activeFolder,
-    supportedExts,
-    sessions,
-    jobs,
-    activeImports,
-    workspaceChanging,
-    refreshTree,
-    refreshProjects,
-    setActiveProject,
-    changeDataRoot,
-    importSources,
-    openNode,
-    closeTabsWithin,
-    setActiveFolder,
-    setError,
-    sortBy,
-    setSortBy,
-  } = useStore();
+  const dataRoot = useStore((state) => state.dataRoot);
+  const tree = useStore((state) => state.tree);
+  const projects = useStore((state) => state.projects);
+  const activeProjectId = useStore((state) => state.activeProjectId);
+  const activeFolder = useStore((state) => state.activeFolder);
+  const supportedExts = useStore((state) => state.supportedExts);
+  const sessions = useStore((state) => state.sessions);
+  const jobs = useStore((state) => state.jobs);
+  const activeImports = useStore((state) => state.activeImports);
+  const workspaceChanging = useStore((state) => state.workspaceChanging);
+  const refreshTree = useStore((state) => state.refreshTree);
+  const refreshProjects = useStore((state) => state.refreshProjects);
+  const setActiveProject = useStore((state) => state.setActiveProject);
+  const changeDataRoot = useStore((state) => state.changeDataRoot);
+  const importSources = useStore((state) => state.importSources);
+  const openNode = useStore((state) => state.openNode);
+  const closeTabsWithin = useStore((state) => state.closeTabsWithin);
+  const setActiveFolder = useStore((state) => state.setActiveFolder);
+  const setError = useStore((state) => state.setError);
+  const sortBy = useStore((state) => state.sortBy);
+  const setSortBy = useStore((state) => state.setSortBy);
+  const filterUnconvertedOnly = useStore((state) => state.filterUnconvertedOnly);
+  const setFilterUnconvertedOnly = useStore((state) => state.setFilterUnconvertedOnly);
   const [query, setQuery] = useState("");
   const [dialog, setDialog] = useState<DialogState>(null);
   const [name, setName] = useState("");
@@ -78,12 +79,13 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
   const projectChildren = sortChildren(
     (projectNode?.children ?? []).filter(
       (child) =>
-        activeProject?.rootRel !== "" ||
-        !projects.some(
-          (project) =>
-            project.rootRel !== "" &&
-            project.rootRel.toLowerCase() === child.relPath.toLowerCase(),
-        ),
+        (activeProject?.rootRel !== "" ||
+          !projects.some(
+            (project) =>
+              project.rootRel !== "" &&
+              project.rootRel.toLowerCase() === child.relPath.toLowerCase(),
+          )) &&
+        (!filterUnconvertedOnly || hasUnconvertedDescendant(child)),
     ),
     sortBy,
   );
@@ -318,17 +320,32 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
         <span>DATA</span>
         <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
           <span title={`File mới sẽ vào ${folderLabel}`}>Đích: {folderLabel}</span>
-          <SelectControl
-            value={sortBy}
-            onChange={(val) => setSortBy(val as any)}
-            ariaLabel="Sắp xếp"
-            compact
-            options={[
-              { value: "name", label: "Tên" },
-              { value: "type", label: "Loại file" },
-              { value: "converted", label: "Chưa convert" },
-            ]}
-          />
+          <div style={{ display: "inline-flex", alignItems: "center", gap: "4px" }}>
+            <IconButton
+              label={filterUnconvertedOnly ? "Hiển thị tất cả file" : "Chỉ hiện file chưa convert"}
+              active={filterUnconvertedOnly}
+              onClick={() => setFilterUnconvertedOnly(!filterUnconvertedOnly)}
+            >
+              <Filter size={14} />
+            </IconButton>
+            <div title="Phân loại file theo" style={{ display: "inline-flex" }}>
+              <SelectControl
+                value={sortBy}
+                onChange={(val) => setSortBy(val as any)}
+                ariaLabel="Sắp xếp"
+                placeholder="Phân loại file theo"
+                compact
+                options={[
+                  { value: "name_asc", label: "Tên (A-Z)" },
+                  { value: "name_desc", label: "Tên (Z-A)" },
+                  { value: "type_asc", label: "Loại file (A-Z)" },
+                  { value: "type_desc", label: "Loại file (Z-A)" },
+                  { value: "converted_first", label: "Đã convert trước" },
+                  { value: "unconverted_first", label: "Chưa convert trước" },
+                ]}
+              />
+            </div>
+          </div>
         </div>
       </div>
 

--- a/app/src/components/Tree.tsx
+++ b/app/src/components/Tree.tsx
@@ -1,10 +1,31 @@
 import { useState } from "react";
 import { ChevronRight, Folder, FolderOpen, Pencil, Trash2 } from "lucide-react";
-import { useStore } from "../state/store";
+import { useStore, type SortOption } from "../state/store";
 import { fileIcon } from "../lib/icons";
 import { nodeMatches } from "../lib/tree";
 import type { FsNode } from "../lib/types";
 import { IconButton } from "./ui";
+
+export function sortChildren(children: FsNode[], sortBy: SortOption): FsNode[] {
+  return [...children].sort((a, b) => {
+    if (a.isDir !== b.isDir) {
+      return a.isDir ? -1 : 1;
+    }
+    if (sortBy === "type") {
+      const kindA = a.kind || "";
+      const kindB = b.kind || "";
+      const comp = kindA.localeCompare(kindB, "vi");
+      if (comp !== 0) return comp;
+    } else if (sortBy === "converted") {
+      const unconvA = !a.isDir && a.supported && !a.mdRelPath;
+      const unconvB = !b.isDir && b.supported && !b.mdRelPath;
+      if (unconvA !== unconvB) {
+        return unconvA ? -1 : 1;
+      }
+    }
+    return a.name.localeCompare(b.name, "vi", { sensitivity: "base", numeric: true });
+  });
+}
 
 export function Tree({
   node,
@@ -24,6 +45,7 @@ export function Tree({
   const activeFolder = useStore((state) => state.activeFolder);
   const view = useStore((state) => state.view);
   const openNode = useStore((state) => state.openNode);
+  const sortBy = useStore((state) => state.sortBy);
 
   if (!nodeMatches(node, query)) return null;
   const expanded = query.trim() ? true : open;
@@ -76,7 +98,7 @@ export function Tree({
       </div>
       {node.isDir && expanded && node.children.length > 0 && (
         <div className="children">
-          {node.children.map((c) => (
+          {sortChildren(node.children, sortBy).map((c) => (
             <Tree
               key={c.relPath}
               node={c}

--- a/app/src/components/Tree.tsx
+++ b/app/src/components/Tree.tsx
@@ -6,24 +6,60 @@ import { nodeMatches } from "../lib/tree";
 import type { FsNode } from "../lib/types";
 import { IconButton } from "./ui";
 
+export function hasUnconvertedDescendant(node: FsNode): boolean {
+  if (!node.isDir) {
+    return !!(node.supported && !node.mdRelPath);
+  }
+  return node.children.some(child => hasUnconvertedDescendant(child));
+}
+
 export function sortChildren(children: FsNode[], sortBy: SortOption): FsNode[] {
   return [...children].sort((a, b) => {
     if (a.isDir !== b.isDir) {
       return a.isDir ? -1 : 1;
     }
-    if (sortBy === "type") {
+
+    const nameComp = a.name.localeCompare(b.name, "vi", { sensitivity: "base", numeric: true });
+
+    if (sortBy === "name_asc") {
+      return nameComp;
+    }
+    if (sortBy === "name_desc") {
+      return -nameComp;
+    }
+
+    if (sortBy === "type_asc") {
       const kindA = a.kind || "";
       const kindB = b.kind || "";
       const comp = kindA.localeCompare(kindB, "vi");
-      if (comp !== 0) return comp;
-    } else if (sortBy === "converted") {
+      return comp !== 0 ? comp : nameComp;
+    }
+    if (sortBy === "type_desc") {
+      const kindA = a.kind || "";
+      const kindB = b.kind || "";
+      const comp = kindB.localeCompare(kindA, "vi");
+      return comp !== 0 ? comp : nameComp;
+    }
+
+    if (sortBy === "converted_first") {
+      const unconvA = !a.isDir && a.supported && !a.mdRelPath;
+      const unconvB = !b.isDir && b.supported && !b.mdRelPath;
+      if (unconvA !== unconvB) {
+        return unconvA ? 1 : -1;
+      }
+      return nameComp;
+    }
+
+    if (sortBy === "unconverted_first") {
       const unconvA = !a.isDir && a.supported && !a.mdRelPath;
       const unconvB = !b.isDir && b.supported && !b.mdRelPath;
       if (unconvA !== unconvB) {
         return unconvA ? -1 : 1;
       }
+      return nameComp;
     }
-    return a.name.localeCompare(b.name, "vi", { sensitivity: "base", numeric: true });
+
+    return nameComp;
   });
 }
 
@@ -46,8 +82,11 @@ export function Tree({
   const view = useStore((state) => state.view);
   const openNode = useStore((state) => state.openNode);
   const sortBy = useStore((state) => state.sortBy);
+  const filterUnconvertedOnly = useStore((state) => state.filterUnconvertedOnly);
 
   if (!nodeMatches(node, query)) return null;
+  if (filterUnconvertedOnly && !hasUnconvertedDescendant(node)) return null;
+
   const expanded = query.trim() ? true : open;
   const isSelected = node.isDir
     ? activeFolder === node.relPath
@@ -98,7 +137,10 @@ export function Tree({
       </div>
       {node.isDir && expanded && node.children.length > 0 && (
         <div className="children">
-          {sortChildren(node.children, sortBy).map((c) => (
+          {sortChildren(
+            node.children.filter((c) => !filterUnconvertedOnly || hasUnconvertedDescendant(c)),
+            sortBy
+          ).map((c) => (
             <Tree
               key={c.relPath}
               node={c}

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -51,6 +51,8 @@ function defaultSession(relPath: string): DocumentSession {
   };
 }
 
+export type SortOption = "name" | "type" | "converted";
+
 interface AppStore {
   dataRoot: string;
   tree: FsNode | null;
@@ -60,6 +62,7 @@ interface AppStore {
   projects: Project[];
   activeProjectId: string | null;
   error: string | null;
+  sortBy: SortOption;
 
   view: AppView;
   openTabs: string[];
@@ -83,6 +86,7 @@ interface AppStore {
   closeTab: (relPath: string) => void;
   closeTabsWithin: (relPath: string) => void;
   setActiveFolder: (relPath: string) => void;
+  setSortBy: (sortBy: SortOption) => void;
 
   loadSession: (relPath: string, conversionBaseline?: boolean) => Promise<void>;
   updateDraft: (relPath: string, draft: string) => void;
@@ -108,6 +112,7 @@ export const useStore = create<AppStore>((set, get) => ({
   projects: [],
   activeProjectId: null,
   error: null,
+  sortBy: "name",
 
   view: "home",
   openTabs: [],
@@ -275,6 +280,7 @@ export const useStore = create<AppStore>((set, get) => ({
   },
 
   setActiveFolder: (activeFolder) => set({ activeFolder }),
+  setSortBy: (sortBy) => set({ sortBy }),
 
   loadSession: async (relPath, conversionBaseline = false) => {
     const existing = get().sessions[relPath];

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -51,7 +51,13 @@ function defaultSession(relPath: string): DocumentSession {
   };
 }
 
-export type SortOption = "name" | "type" | "converted";
+export type SortOption =
+  | "name_asc"
+  | "name_desc"
+  | "type_asc"
+  | "type_desc"
+  | "converted_first"
+  | "unconverted_first";
 
 interface AppStore {
   dataRoot: string;
@@ -63,6 +69,7 @@ interface AppStore {
   activeProjectId: string | null;
   error: string | null;
   sortBy: SortOption;
+  filterUnconvertedOnly: boolean;
 
   view: AppView;
   openTabs: string[];
@@ -87,6 +94,7 @@ interface AppStore {
   closeTabsWithin: (relPath: string) => void;
   setActiveFolder: (relPath: string) => void;
   setSortBy: (sortBy: SortOption) => void;
+  setFilterUnconvertedOnly: (filterUnconvertedOnly: boolean) => void;
 
   loadSession: (relPath: string, conversionBaseline?: boolean) => Promise<void>;
   updateDraft: (relPath: string, draft: string) => void;
@@ -112,7 +120,8 @@ export const useStore = create<AppStore>((set, get) => ({
   projects: [],
   activeProjectId: null,
   error: null,
-  sortBy: "name",
+  sortBy: "name_asc",
+  filterUnconvertedOnly: false,
 
   view: "home",
   openTabs: [],
@@ -281,6 +290,7 @@ export const useStore = create<AppStore>((set, get) => ({
 
   setActiveFolder: (activeFolder) => set({ activeFolder }),
   setSortBy: (sortBy) => set({ sortBy }),
+  setFilterUnconvertedOnly: (filterUnconvertedOnly) => set({ filterUnconvertedOnly }),
 
   loadSession: async (relPath, conversionBaseline = false) => {
     const existing = get().sessions[relPath];

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -694,7 +694,7 @@ kbd {
 
 .ui-button-sm {
   min-height: 32px;
-  padding: 0 13px;
+  padding: 0 12px;
   font-size: 11.5px;
 }
 
@@ -934,7 +934,7 @@ kbd {
   justify-content: center;
   gap: 6px;
   min-height: 28px;
-  padding: 0 12px;
+  padding: 0 3px;
   border: 0;
   border-radius: var(--radius-pill);
   color: var(--color-text-muted);


### PR DESCRIPTION
Fixes #11
Thêm 2 nút là sắp xếp (theo tên, loại, hoặc trạng thái convert) và lọc (chỉ hiện file chưa convert) vào cây file.