### PR TITLE
Thêm sort và filter cho cây file

### DIFF
--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import {
   FilePlus2,
+  Filter,
   Folder,
   FolderCog,
   FolderInput,
@@ -12,11 +13,11 @@ import {
   Settings,
   Upload,
 } from "lucide-react";
-import { useStore } from "../state/store";
+import { useStore, type SortOption } from "../state/store";
 import { api } from "../lib/ipc";
 import { findByRel, isWithinRel, parentRel } from "../lib/tree";
 import type { FsNode } from "../lib/types";
-import { Tree } from "./Tree";
+import { Tree, sortChildren, hasVisibleDescendant } from "./Tree";
 import { Button, IconButton, Modal, SelectControl } from "./ui";
 
 type DialogState =
@@ -27,28 +28,41 @@ type DialogState =
   | { kind: "delete"; node: FsNode }
   | null;
 
+function isSortOption(val: string): val is SortOption {
+  return [
+    "name_asc",
+    "name_desc",
+    "type_asc",
+    "type_desc",
+    "converted_first",
+    "unconverted_first",
+  ].includes(val);
+}
+
 export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
-  const {
-    dataRoot,
-    tree,
-    projects,
-    activeProjectId,
-    activeFolder,
-    supportedExts,
-    sessions,
-    jobs,
-    activeImports,
-    workspaceChanging,
-    refreshTree,
-    refreshProjects,
-    setActiveProject,
-    changeDataRoot,
-    importSources,
-    openNode,
-    closeTabsWithin,
-    setActiveFolder,
-    setError,
-  } = useStore();
+  const dataRoot = useStore((state) => state.dataRoot);
+  const tree = useStore((state) => state.tree);
+  const projects = useStore((state) => state.projects);
+  const activeProjectId = useStore((state) => state.activeProjectId);
+  const activeFolder = useStore((state) => state.activeFolder);
+  const supportedExts = useStore((state) => state.supportedExts);
+  const sessions = useStore((state) => state.sessions);
+  const jobs = useStore((state) => state.jobs);
+  const activeImports = useStore((state) => state.activeImports);
+  const workspaceChanging = useStore((state) => state.workspaceChanging);
+  const refreshTree = useStore((state) => state.refreshTree);
+  const refreshProjects = useStore((state) => state.refreshProjects);
+  const setActiveProject = useStore((state) => state.setActiveProject);
+  const changeDataRoot = useStore((state) => state.changeDataRoot);
+  const importSources = useStore((state) => state.importSources);
+  const openNode = useStore((state) => state.openNode);
+  const closeTabsWithin = useStore((state) => state.closeTabsWithin);
+  const setActiveFolder = useStore((state) => state.setActiveFolder);
+  const setError = useStore((state) => state.setError);
+  const sortBy = useStore((state) => state.sortBy);
+  const setSortBy = useStore((state) => state.setSortBy);
+  const filterUnconvertedOnly = useStore((state) => state.filterUnconvertedOnly);
+  const setFilterUnconvertedOnly = useStore((state) => state.setFilterUnconvertedOnly);
   const [query, setQuery] = useState("");
   const [dialog, setDialog] = useState<DialogState>(null);
   const [name, setName] = useState("");
@@ -73,14 +87,18 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
     activeProject?.rootRel && tree
       ? findByRel(tree, activeProject.rootRel)
       : tree;
-  const projectChildren = (projectNode?.children ?? []).filter(
-    (child) =>
-      activeProject?.rootRel !== "" ||
-      !projects.some(
-        (project) =>
-          project.rootRel !== "" &&
-          project.rootRel.toLowerCase() === child.relPath.toLowerCase(),
-      ),
+  const projectChildren = sortChildren(
+    (projectNode?.children ?? []).filter(
+      (child) =>
+        (activeProject?.rootRel !== "" ||
+          !projects.some(
+            (project) =>
+              project.rootRel !== "" &&
+              project.rootRel.toLowerCase() === child.relPath.toLowerCase(),
+          )) &&
+        hasVisibleDescendant(child, query, filterUnconvertedOnly),
+    ),
+    sortBy,
   );
 
   function openCreate(
@@ -309,9 +327,41 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
         </IconButton>
       </div>
 
-      <div className="drawer-section-label">
+      <div className="drawer-section-label" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <span>DATA</span>
-        <span title={`File mới sẽ vào ${folderLabel}`}>Đích: {folderLabel}</span>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <span title={`File mới sẽ vào ${folderLabel}`}>Đích: {folderLabel}</span>
+          <div style={{ display: "inline-flex", alignItems: "center", gap: "4px" }}>
+            <IconButton
+              label={filterUnconvertedOnly ? "Hiển thị tất cả file" : "Chỉ hiện file chưa convert"}
+              active={filterUnconvertedOnly}
+              onClick={() => setFilterUnconvertedOnly(!filterUnconvertedOnly)}
+            >
+              <Filter size={14} />
+            </IconButton>
+            <div title="Phân loại file theo" style={{ display: "inline-flex" }}>
+              <SelectControl
+                value={sortBy}
+                onChange={(val) => {
+                  if (isSortOption(val)) {
+                    setSortBy(val);
+                  }
+                }}
+                ariaLabel="Sắp xếp"
+                placeholder="Phân loại file theo"
+                compact
+                options={[
+                  { value: "name_asc", label: "Tên (A-Z)" },
+                  { value: "name_desc", label: "Tên (Z-A)" },
+                  { value: "type_asc", label: "Loại file (A-Z)" },
+                  { value: "type_desc", label: "Loại file (Z-A)" },
+                  { value: "converted_first", label: "Đã convert trước" },
+                  { value: "unconverted_first", label: "Chưa convert trước" },
+                ]}
+              />
+            </div>
+          </div>
+        </div>
       </div>
 
       <div className="tree-scroll">

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -87,16 +87,20 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
     activeProject?.rootRel && tree
       ? findByRel(tree, activeProject.rootRel)
       : tree;
+
+  const baseChildren = (projectNode?.children ?? []).filter(
+    (child) =>
+      activeProject?.rootRel !== "" ||
+      !projects.some(
+        (project) =>
+          project.rootRel !== "" &&
+          project.rootRel.toLowerCase() === child.relPath.toLowerCase(),
+      )
+  );
+
   const projectChildren = sortChildren(
-    (projectNode?.children ?? []).filter(
-      (child) =>
-        (activeProject?.rootRel !== "" ||
-          !projects.some(
-            (project) =>
-              project.rootRel !== "" &&
-              project.rootRel.toLowerCase() === child.relPath.toLowerCase(),
-          )) &&
-        hasVisibleDescendant(child, query, filterUnconvertedOnly),
+    baseChildren.filter((child) =>
+      hasVisibleDescendant(child, query, filterUnconvertedOnly)
     ),
     sortBy,
   );
@@ -365,7 +369,17 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
       </div>
 
       <div className="tree-scroll">
-        {projectChildren.length ? (
+        {!baseChildren.length ? (
+          <div className="drawer-empty">
+            {activeProject
+              ? "Dự án trống — import folder, tải file hoặc tạo thư mục."
+              : "Tạo dự án đầu tiên để bắt đầu."}
+          </div>
+        ) : !projectChildren.length ? (
+          <div className="drawer-empty">
+            Không có file khớp bộ lọc/tìm kiếm.
+          </div>
+        ) : (
           projectChildren.map((child) => (
             <Tree
               key={child.relPath}
@@ -376,12 +390,6 @@ export function Sidebar({ onOpenSettings }: { onOpenSettings: () => void }) {
               onDelete={openDelete}
             />
           ))
-        ) : (
-          <div className="drawer-empty">
-            {activeProject
-              ? "Dự án trống — import folder, tải file hoặc tạo thư mục."
-              : "Tạo dự án đầu tiên để bắt đầu."}
-          </div>
         )}
       </div>
 

--- a/app/src/components/Tree.tsx
+++ b/app/src/components/Tree.tsx
@@ -1,10 +1,80 @@
 import { useState } from "react";
 import { ChevronRight, Folder, FolderOpen, Pencil, Trash2 } from "lucide-react";
-import { useStore } from "../state/store";
+import { useStore, type SortOption } from "../state/store";
 import { fileIcon } from "../lib/icons";
-import { nodeMatches } from "../lib/tree";
 import type { FsNode } from "../lib/types";
 import { IconButton } from "./ui";
+
+export function hasVisibleDescendant(
+  node: FsNode,
+  query: string,
+  filterUnconvertedOnly: boolean
+): boolean {
+  if (!node.isDir) {
+    const matchesQuery =
+      !query.trim() || node.name.toLowerCase().includes(query.toLowerCase());
+    const matchesFilter =
+      !filterUnconvertedOnly || !!(node.supported && !node.mdRelPath);
+    return matchesQuery && matchesFilter;
+  }
+  return node.children.some((child) =>
+    hasVisibleDescendant(child, query, filterUnconvertedOnly)
+  );
+}
+
+export function hasUnconvertedDescendant(node: FsNode): boolean {
+  return hasVisibleDescendant(node, "", true);
+}
+
+export function sortChildren(children: FsNode[], sortBy: SortOption): FsNode[] {
+  return [...children].sort((a, b) => {
+    if (a.isDir !== b.isDir) {
+      return a.isDir ? -1 : 1;
+    }
+
+    const nameComp = a.name.localeCompare(b.name, "vi", { sensitivity: "base", numeric: true });
+
+    if (sortBy === "name_asc") {
+      return nameComp;
+    }
+    if (sortBy === "name_desc") {
+      return -nameComp;
+    }
+
+    if (sortBy === "type_asc") {
+      const kindA = a.kind || "";
+      const kindB = b.kind || "";
+      const comp = kindA.localeCompare(kindB, "vi");
+      return comp !== 0 ? comp : nameComp;
+    }
+    if (sortBy === "type_desc") {
+      const kindA = a.kind || "";
+      const kindB = b.kind || "";
+      const comp = kindB.localeCompare(kindA, "vi");
+      return comp !== 0 ? comp : nameComp;
+    }
+
+    if (sortBy === "converted_first") {
+      const unconvA = !a.isDir && a.supported && !a.mdRelPath;
+      const unconvB = !b.isDir && b.supported && !b.mdRelPath;
+      if (unconvA !== unconvB) {
+        return unconvA ? 1 : -1;
+      }
+      return nameComp;
+    }
+
+    if (sortBy === "unconverted_first") {
+      const unconvA = !a.isDir && a.supported && !a.mdRelPath;
+      const unconvB = !b.isDir && b.supported && !b.mdRelPath;
+      if (unconvA !== unconvB) {
+        return unconvA ? -1 : 1;
+      }
+      return nameComp;
+    }
+
+    return nameComp;
+  });
+}
 
 export function Tree({
   node,
@@ -24,8 +94,11 @@ export function Tree({
   const activeFolder = useStore((state) => state.activeFolder);
   const view = useStore((state) => state.view);
   const openNode = useStore((state) => state.openNode);
+  const sortBy = useStore((state) => state.sortBy);
+  const filterUnconvertedOnly = useStore((state) => state.filterUnconvertedOnly);
 
-  if (!nodeMatches(node, query)) return null;
+  if (!hasVisibleDescendant(node, query, filterUnconvertedOnly)) return null;
+
   const expanded = query.trim() ? true : open;
   const isSelected = node.isDir
     ? activeFolder === node.relPath
@@ -76,7 +149,10 @@ export function Tree({
       </div>
       {node.isDir && expanded && node.children.length > 0 && (
         <div className="children">
-          {node.children.map((c) => (
+          {sortChildren(
+            node.children.filter((c) => hasVisibleDescendant(c, query, filterUnconvertedOnly)),
+            sortBy
+          ).map((c) => (
             <Tree
               key={c.relPath}
               node={c}

--- a/app/src/components/Tree.tsx
+++ b/app/src/components/Tree.tsx
@@ -4,19 +4,25 @@ import { useStore, type SortOption } from "../state/store";
 import { fileIcon } from "../lib/icons";
 import type { FsNode } from "../lib/types";
 import { IconButton } from "./ui";
+import { normalizeSearch } from "../lib/tree";
 
 export function hasVisibleDescendant(
   node: FsNode,
   query: string,
   filterUnconvertedOnly: boolean
 ): boolean {
+  const q = normalizeSearch(query);
   if (!node.isDir) {
-    const matchesQuery =
-      !query.trim() || node.name.toLowerCase().includes(query.toLowerCase());
+    const matchesQuery = !q || normalizeSearch(node.name).includes(q);
     const matchesFilter =
       !filterUnconvertedOnly || !!(node.supported && !node.mdRelPath);
     return matchesQuery && matchesFilter;
   }
+  // Folder: tên khớp query → hiện (kể cả trống / không có file match)
+  if (q && normalizeSearch(node.name).includes(q)) return true;
+  // Không query + không filter → hiện mọi folder (kể cả trống)
+  if (!q && !filterUnconvertedOnly) return true;
+  // Còn lại: hiện folder nếu có descendant còn visible
   return node.children.some((child) =>
     hasVisibleDescendant(child, query, filterUnconvertedOnly)
   );

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -51,6 +51,14 @@ function defaultSession(relPath: string): DocumentSession {
   };
 }
 
+export type SortOption =
+  | "name_asc"
+  | "name_desc"
+  | "type_asc"
+  | "type_desc"
+  | "converted_first"
+  | "unconverted_first";
+
 interface AppStore {
   dataRoot: string;
   tree: FsNode | null;
@@ -60,6 +68,8 @@ interface AppStore {
   projects: Project[];
   activeProjectId: string | null;
   error: string | null;
+  sortBy: SortOption;
+  filterUnconvertedOnly: boolean;
 
   view: AppView;
   openTabs: string[];
@@ -83,6 +93,8 @@ interface AppStore {
   closeTab: (relPath: string) => void;
   closeTabsWithin: (relPath: string) => void;
   setActiveFolder: (relPath: string) => void;
+  setSortBy: (sortBy: SortOption) => void;
+  setFilterUnconvertedOnly: (filterUnconvertedOnly: boolean) => void;
 
   loadSession: (relPath: string, conversionBaseline?: boolean) => Promise<void>;
   updateDraft: (relPath: string, draft: string) => void;
@@ -108,6 +120,8 @@ export const useStore = create<AppStore>((set, get) => ({
   projects: [],
   activeProjectId: null,
   error: null,
+  sortBy: "name_asc",
+  filterUnconvertedOnly: false,
 
   view: "home",
   openTabs: [],
@@ -275,6 +289,8 @@ export const useStore = create<AppStore>((set, get) => ({
   },
 
   setActiveFolder: (activeFolder) => set({ activeFolder }),
+  setSortBy: (sortBy) => set({ sortBy }),
+  setFilterUnconvertedOnly: (filterUnconvertedOnly) => set({ filterUnconvertedOnly }),
 
   loadSession: async (relPath, conversionBaseline = false) => {
     const existing = get().sessions[relPath];

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -694,7 +694,7 @@ kbd {
 
 .ui-button-sm {
   min-height: 32px;
-  padding: 0 13px;
+  padding: 0 12px;
   font-size: 11.5px;
 }
 
@@ -934,7 +934,7 @@ kbd {
   justify-content: center;
   gap: 6px;
   min-height: 28px;
-  padding: 0 12px;
+  padding: 0 3px;
   border: 0;
   border-radius: var(--radius-pill);
   color: var(--color-text-muted);


### PR DESCRIPTION
Fixes #11
Thêm 2 nút là sắp xếp (theo tên, loại, hoặc trạng thái convert) và lọc (chỉ hiện file chưa convert) vào cây file.
Sửa thêm lỗi tìm kiếm + lọc file có thể hiện thư mục trống, và "replaced setSortBy(val as any) with a typed conversion or guard to preserve strict TypeScript checks".