### PR TITLE
docs: add detailed Markhand Web phase plans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ permissions:
   contents: read
 
 jobs:
+  roadmap:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check generated roadmap
+        run: python3 scripts/build-roadmap.py --check
+
   rust:
     runs-on: ubuntu-22.04
     steps:

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -33,8 +33,9 @@ Issue-level backlog (101 issues):
 
 ```text
 Phase 0 ──────────────┐
-                      ├─> Phase 1B ─> Phase 1C ─> Phase 2 ─> Phase 3 ─> Phase 4
-Phase 1A ─────────────┘
+                      ├─> Phase 1B ─> Phase 1C ────────> Phase 2 complete
+Phase 1A ─────────────┘         └─> stable OpenAPI ─> Phase 2 UI/mock
+                                                 Phase 2 complete ─> Phase 3 ─> Phase 4
 ```
 
 - Phase 0 và 1A có thể làm song song.

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -21,8 +21,10 @@ Roadmap dashboard tương tác:
 [`roadmap.html`](roadmap.html) — lọc/tìm kiếm, cập nhật trạng thái, lưu local và
 export/import JSON.
 
-Roadmap là generated artifact từ `backlog/*/issues/README.md`. Chạy các lệnh sau từ
-repository root sau khi đổi tiêu đề hoặc `**Status:**` của issue:
+File HTML nằm ngay trong repo. Generator bắt đầu từ phase registry ở bảng trên,
+theo link tới từng phase plan và issue catalog, rồi đọc tiêu đề/`**Status:**` của
+từng issue. Chạy các lệnh sau từ repository root sau khi đổi registry, tiêu đề hoặc
+trạng thái issue:
 
 ```bash
 python3 scripts/build-roadmap.py
@@ -35,16 +37,16 @@ không bị local override cũ che mất.
 
 ## Phạm vi các phase
 
-| Phase | Kết quả chính | Tài liệu |
-|---|---|---|
-| F | Engineering rules, skeleton, local dev environment và CI foundation | [`phase-f-engineering-foundation.md`](phase-f-engineering-foundation.md) |
-| 0 | Chốt bằng số liệu: scale, retrieval, bảo mật upload, SLA/RPO/RTO | [`phase-0-discovery-and-gates.md`](phase-0-discovery-and-gates.md) |
-| 1A | Tách logic RAG dùng chung thành `crates/knowledge`, desktop không đổi hành vi | [`phase-1a-knowledge-extraction.md`](phase-1a-knowledge-extraction.md) |
-| 1B | POC single-org hoàn chỉnh: upload → convert → index → Q&A citation | [`phase-1b-single-org-poc.md`](phase-1b-single-org-poc.md) |
-| 1C | Multi-org, RBAC/ACL, quota atomic và denial test | [`phase-1c-multi-org-security.md`](phase-1c-multi-org-security.md) |
-| 2 | Web SPA MVP: login, library, Q&A, admin tối thiểu | [`phase-2-web-spa.md`](phase-2-web-spa.md) |
-| 3 | Port intelligence: BRD/PRD, quality, PII, bảng, version, export | [`phase-3-intelligence.md`](phase-3-intelligence.md) |
-| 4 | OIDC/SSO, hardening production, DR và onboarding/help | [`phase-4-production-hardening.md`](phase-4-production-hardening.md) |
+| Phase | Kết quả chính | Phase plan | Issue catalog |
+|---|---|---|---|
+| F | Engineering rules, skeleton, local dev environment và CI foundation | [Phase plan](phase-f-engineering-foundation.md) | [12 issues](backlog/phase-f/issues/README.md) |
+| 0 | Chốt bằng số liệu: scale, retrieval, bảo mật upload, SLA/RPO/RTO | [Phase plan](phase-0-discovery-and-gates.md) | [10 issues](backlog/phase-0/issues/README.md) |
+| 1A | Tách logic RAG dùng chung thành `crates/knowledge`, desktop không đổi hành vi | [Phase plan](phase-1a-knowledge-extraction.md) | [10 issues](backlog/phase-1a/issues/README.md) |
+| 1B | POC single-org hoàn chỉnh: upload → convert → index → Q&A citation | [Phase plan](phase-1b-single-org-poc.md) | [24 issues](backlog/phase-1b/issues/README.md) |
+| 1C | Multi-org, RBAC/ACL, quota atomic và denial test | [Phase plan](phase-1c-multi-org-security.md) | [13 issues](backlog/phase-1c/issues/README.md) |
+| 2 | Web SPA MVP: login, library, Q&A, admin tối thiểu | [Phase plan](phase-2-web-spa.md) | [16 issues](backlog/phase-2/issues/README.md) |
+| 3 | Port intelligence: BRD/PRD, quality, PII, bảng, version, export | [Phase plan](phase-3-intelligence.md) | [14 issues](backlog/phase-3/issues/README.md) |
+| 4 | OIDC/SSO, hardening production, DR và onboarding/help | [Phase plan](phase-4-production-hardening.md) | [14 issues](backlog/phase-4/issues/README.md) |
 
 ## Dependency và đường găng
 

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -14,13 +14,14 @@ Kế hoạch này biến report kiến trúc thành các gói việc có depende
 test và gate đo được. Không dùng thời gian lịch làm tiêu chí; chỉ chuyển phase khi
 gate kỹ thuật của phase trước đã đạt.
 
-Issue-level backlog (101 issues):
+Issue-level backlog (113 issues):
 [`backlog/README.md`](backlog/README.md).
 
 ## Phạm vi các phase
 
 | Phase | Kết quả chính | Tài liệu |
 |---|---|---|
+| F | Engineering rules, skeleton, local dev environment và CI foundation | [`phase-f-engineering-foundation.md`](phase-f-engineering-foundation.md) |
 | 0 | Chốt bằng số liệu: scale, retrieval, bảo mật upload, SLA/RPO/RTO | [`phase-0-discovery-and-gates.md`](phase-0-discovery-and-gates.md) |
 | 1A | Tách logic RAG dùng chung thành `crates/knowledge`, desktop không đổi hành vi | [`phase-1a-knowledge-extraction.md`](phase-1a-knowledge-extraction.md) |
 | 1B | POC single-org hoàn chỉnh: upload → convert → index → Q&A citation | [`phase-1b-single-org-poc.md`](phase-1b-single-org-poc.md) |
@@ -32,13 +33,14 @@ Issue-level backlog (101 issues):
 ## Dependency và đường găng
 
 ```text
-Phase 0 ──────────────┐
-                      ├─> Phase 1B ─> Phase 1C ────────> Phase 2 complete
-Phase 1A ─────────────┘         └─> stable OpenAPI ─> Phase 2 UI/mock
+Phase F ─┬─> Phase 0 ─┐
+         └─> Phase 1A ┴─> Phase 1B ─> Phase 1C ────────> Phase 2 complete
+                                  └─> stable OpenAPI ─> Phase 2 UI/mock
                                                  Phase 2 complete ─> Phase 3 ─> Phase 4
 ```
 
-- Phase 0 và 1A có thể làm song song.
+- Phase F phải pass trước khi activate Phase 0/1A.
+- Sau Phase F, Phase 0 và 1A có thể làm song song.
 - 1B không được fork/copy logic RAG desktop; phải dùng kết quả 1A.
 - 1B dùng một org nhưng mọi repository, object key, job, vector và event bắt buộc
   mang `OrgContext`; 1C mở nhiều org và hoàn thiện chính sách, không retrofit tenancy.

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -17,6 +17,10 @@ gate kỹ thuật của phase trước đã đạt.
 Issue-level backlog (113 issues):
 [`backlog/README.md`](backlog/README.md).
 
+Roadmap dashboard tương tác:
+[`roadmap.html`](roadmap.html) — lọc/tìm kiếm, cập nhật trạng thái, lưu local và
+export/import JSON.
+
 ## Phạm vi các phase
 
 | Phase | Kết quả chính | Tài liệu |

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -23,8 +23,9 @@ export/import JSON.
 
 File HTML nằm ngay trong repo. Generator bắt đầu từ phase registry ở bảng trên,
 theo link tới từng phase plan và issue catalog, rồi đọc tiêu đề/`**Status:**` của
-từng issue. Chạy các lệnh sau từ repository root sau khi đổi registry, tiêu đề hoặc
-trạng thái issue:
+từng issue. Generator cũng đọc bảng **Technology stack** để dựng tab cùng tên.
+Chạy các lệnh sau từ repository root sau khi đổi registry, stack, tiêu đề hoặc trạng
+thái issue:
 
 ```bash
 python3 scripts/build-roadmap.py
@@ -84,6 +85,28 @@ crates/core: convert, chunk, deterministic intelligence, LLM/embedding clients
 
 PostgreSQL luôn là nguồn sự thật. Qdrant có thể rebuild từ chunk trong PostgreSQL;
 MinIO cần backup riêng vì file gốc không thể tái tạo từ index.
+
+## Technology stack
+
+Bảng này là nguồn dữ liệu cho tab **Tech stack** trong
+[`roadmap.html`](roadmap.html).
+
+<!-- roadmap-tech-stack-start -->
+| Lớp | Công nghệ | Trách nhiệm | Delivery |
+|---|---|---|---|
+| Web client | React + Vite + TypeScript | SPA cho library, upload, search, Q&A và admin | Phase 2 |
+| API | Rust + axum + OpenAPI | REST API, SSE progress, auth middleware và OrgContext | Phase 1B |
+| Shared knowledge | Rust crate knowledge | Hybrid rank/merge, grounding, citation và index signature | Phase 1A |
+| Document engine | fileconv-core | Convert, OCR, chunk và deterministic intelligence | Existing core |
+| System of record | PostgreSQL + FTS | Metadata, ACL, auth, jobs, quota, audit và lexical search | Phase 1B |
+| Vector retrieval | Qdrant | Vector candidates; kết quả luôn được hydrate và kiểm ACL lại | Phase 1B |
+| Object storage | MinIO | File gốc, quarantine, Markdown và derived artifacts | Phase 1B |
+| Embeddings | vLLM GPU endpoint | Batch embedding với model/dimension/normalize được pin | Phase 0 → 1B |
+| Chat and extraction | GLM via LLM client | Grounded Q&A, summarize và structured extraction theo policy | Phase 1B → 3 |
+| Identity | JWT + rotating refresh + OIDC | Session cho POC; SSO/OIDC và key rotation cho production | Phase 1B → 4 |
+| Observability | OpenTelemetry + structured logs | Trace, metrics, audit correlation và redacted diagnostics | Phase F → 4 |
+| Runtime | Docker Compose → production orchestrator | Local/POC reproducible; Kubernetes hoặc nền tảng on-prem tương đương được chốt ở Phase 4 | Phase F → 4 |
+<!-- roadmap-tech-stack-end -->
 
 ## Invariant xuyên suốt
 

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -21,6 +21,18 @@ Roadmap dashboard tương tác:
 [`roadmap.html`](roadmap.html) — lọc/tìm kiếm, cập nhật trạng thái, lưu local và
 export/import JSON.
 
+Roadmap là generated artifact từ `backlog/*/issues/README.md`. Chạy các lệnh sau từ
+repository root sau khi đổi tiêu đề hoặc `**Status:**` của issue:
+
+```bash
+python3 scripts/build-roadmap.py
+python3 scripts/build-roadmap.py --check
+```
+
+Mỗi catalog có `roadmap-default-status`; `**Status:**` trong issue sẽ override giá
+trị mặc định. Source hash mới tạo namespace local riêng nên trạng thái Markdown mới
+không bị local override cũ che mất.
+
 ## Phạm vi các phase
 
 | Phase | Kết quả chính | Tài liệu |

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -1,6 +1,6 @@
 # Markhand Web — kế hoạch triển khai theo phase
 
-Ngày lập: 2026-07-16  
+Ngày lập: 2026-07-16
 Nguồn thiết kế đã duyệt:
 [`../reports/brainstorm-260713-1656-markhand-web-rag-multi-org-report.md`](../reports/brainstorm-260713-1656-markhand-web-rag-multi-org-report.md)
 

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -1,0 +1,111 @@
+# Markhand Web — kế hoạch triển khai theo phase
+
+Ngày lập: 2026-07-16  
+Nguồn thiết kế đã duyệt:
+[`../reports/brainstorm-260713-1656-markhand-web-rag-multi-org-report.md`](../reports/brainstorm-260713-1656-markhand-web-rag-multi-org-report.md)
+
+## Mục tiêu
+
+Xây Markhand Web on-prem trên nền `fileconv-core`: quản lý tài liệu, chuyển đổi,
+index, tìm kiếm hybrid, hỏi đáp có citation và bộ công cụ intelligence; hỗ trợ
+multi-org, multi-user, RBAC và quota.
+
+Kế hoạch này biến report kiến trúc thành các gói việc có dependency, deliverable,
+test và gate đo được. Không dùng thời gian lịch làm tiêu chí; chỉ chuyển phase khi
+gate kỹ thuật của phase trước đã đạt.
+
+## Phạm vi các phase
+
+| Phase | Kết quả chính | Tài liệu |
+|---|---|---|
+| 0 | Chốt bằng số liệu: scale, retrieval, bảo mật upload, SLA/RPO/RTO | [`phase-0-discovery-and-gates.md`](phase-0-discovery-and-gates.md) |
+| 1A | Tách logic RAG dùng chung thành `crates/knowledge`, desktop không đổi hành vi | [`phase-1a-knowledge-extraction.md`](phase-1a-knowledge-extraction.md) |
+| 1B | POC single-org hoàn chỉnh: upload → convert → index → Q&A citation | [`phase-1b-single-org-poc.md`](phase-1b-single-org-poc.md) |
+| 1C | Multi-org, RBAC/ACL, quota atomic và denial test | [`phase-1c-multi-org-security.md`](phase-1c-multi-org-security.md) |
+| 2 | Web SPA MVP: login, library, Q&A, admin tối thiểu | [`phase-2-web-spa.md`](phase-2-web-spa.md) |
+| 3 | Port intelligence: BRD/PRD, quality, PII, bảng, version, export | [`phase-3-intelligence.md`](phase-3-intelligence.md) |
+| 4 | OIDC/SSO, hardening production, DR và onboarding/help | [`phase-4-production-hardening.md`](phase-4-production-hardening.md) |
+
+## Dependency và đường găng
+
+```text
+Phase 0 ──────────────┐
+                      ├─> Phase 1B ─> Phase 1C ─> Phase 2 ─> Phase 3 ─> Phase 4
+Phase 1A ─────────────┘
+```
+
+- Phase 0 và 1A có thể làm song song.
+- 1B không được fork/copy logic RAG desktop; phải dùng kết quả 1A.
+- 1B dùng một org nhưng mọi repository, object key, job, vector và event bắt buộc
+  mang `OrgContext`; 1C mở nhiều org và hoàn thiện chính sách, không retrofit tenancy.
+- Phase 2 có thể phát triển UI với OpenAPI mock khi API 1B ổn định, nhưng chỉ đạt
+  gate sau khi backend 1C qua denial suite.
+- Phase 3 chỉ port intelligence sau khi auth, ACL, artifact model và audit đã ổn định.
+
+## Kiến trúc đích
+
+```text
+web/ (React + Vite)
+        │ REST + SSE
+crates/server (axum)
+        ├── PostgreSQL: system of record, FTS, auth, jobs, quota, audit
+        ├── Qdrant: vector candidates
+        ├── MinIO: file gốc, Markdown và artifact
+        └── workers: convert / embed / delete / reconcile
+              │
+crates/knowledge: rank, merge, citation, grounding, index signature
+              │
+crates/core: convert, chunk, deterministic intelligence, LLM/embedding clients
+```
+
+PostgreSQL luôn là nguồn sự thật. Qdrant có thể rebuild từ chunk trong PostgreSQL;
+MinIO cần backup riêng vì file gốc không thể tái tạo từ index.
+
+## Invariant xuyên suốt
+
+1. Không endpoint, repository hay adapter nào chạy khi thiếu org context.
+2. Candidate retrieval luôn được hydrate và kiểm quyền lại từ PostgreSQL trước khi
+   trả text/citation.
+3. Xóa/revoke có hiệu lực tức thời ở read path; dọn Qdrant/MinIO chạy idempotent sau.
+4. File upload đi qua quarantine và converter cô lập trước khi trở thành tài liệu tin cậy.
+5. Job dùng lease, checkpoint, idempotency key; retry không tạo chunk/artifact trùng.
+6. Không log nội dung tài liệu, prompt, token, API key, signed URL hay PII.
+7. Model, dimension, normalize, chunking version và index signature được pin.
+8. Derived artifacts kế thừa ACL nguồn; redaction không ghi đè bản gốc.
+9. Migration dùng expand/cutover/contract; rollback ứng dụng không yêu cầu rollback DB.
+10. Desktop tiếp tục build/test trong mọi phase.
+
+## Definition of done chung
+
+- Unit, integration, contract, E2E và denial tests tương ứng đều xanh.
+- Migration chạy được từ DB rỗng và từ release được hỗ trợ.
+- Có metrics/traces/audit phù hợp, không chứa dữ liệu nhạy cảm.
+- Tài liệu vận hành và rollback được cập nhật cùng thay đổi.
+- Không còn finding mức high/critical chưa có owner và quyết định rõ ràng.
+
+## Quyết định còn mở — Phase 0 phải chốt
+
+- GPU/VRAM, model embedding và throughput thực tế.
+- SLA/SLO, RPO/RTO và retention backup.
+- Format/giới hạn upload của POC.
+- Qdrant shared collection hay phân cohort.
+- PostgreSQL partition strategy và việc bắt buộc RLS.
+- Canonical storage của Markdown/derived artifacts.
+- Chính sách GLM cloud theo phân loại dữ liệu.
+- JWT signing/key rotation/session/MFA.
+- ACL chi tiết cho private/org/groups.
+- License PhoWhisper khi deploy server.
+
+## Phạm vi POC
+
+POC được coi là hoàn thành sau **Phase 1B**, không phải chỉ dựng API:
+
+- Một org và vài account test.
+- Mỗi format đã allowlist có ít nhất một file chạy end-to-end.
+- Search/Q&A trả citation đã kiểm quyền.
+- Worker bị kill có thể resume từ checkpoint.
+- Corpus upload độc hại bị chặn hoặc chứa trong sandbox.
+- Backup/restore trên môi trường sạch đã chạy thành công.
+
+Phase 1C là gate bắt buộc trước khi mở hệ thống cho nhiều org hoặc người dùng không
+thuộc cùng một nhóm tin cậy.

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -14,6 +14,9 @@ Kế hoạch này biến report kiến trúc thành các gói việc có depende
 test và gate đo được. Không dùng thời gian lịch làm tiêu chí; chỉ chuyển phase khi
 gate kỹ thuật của phase trước đã đạt.
 
+Issue-level backlog (101 issues):
+[`backlog/README.md`](backlog/README.md).
+
 ## Phạm vi các phase
 
 | Phase | Kết quả chính | Tài liệu |
@@ -81,7 +84,8 @@ MinIO cần backup riêng vì file gốc không thể tái tạo từ index.
 - Migration chạy được từ DB rỗng và từ release được hỗ trợ.
 - Có metrics/traces/audit phù hợp, không chứa dữ liệu nhạy cảm.
 - Tài liệu vận hành và rollback được cập nhật cùng thay đổi.
-- Không còn finding mức high/critical chưa có owner và quyết định rõ ràng.
+- Zero unresolved high/critical findings; accepted risk phải có approver,
+  compensating controls, expiry và retest date.
 
 ## Quyết định còn mở — Phase 0 phải chốt
 

--- a/plans/markhand-web/backlog/ISSUE_TEMPLATE.md
+++ b/plans/markhand-web/backlog/ISSUE_TEMPLATE.md
@@ -1,0 +1,87 @@
+# [ID] Tiêu đề kết quả cần đạt
+
+## Metadata
+
+- Milestone:
+- Labels:
+- Status: `Ready | Blocked | Backlog`
+- Parent epic:
+- Owner:
+- Gate registry keys:
+
+## Objective
+
+Mô tả một kết quả có thể review/verify độc lập. Không mô tả bằng hoạt động chung
+chung như “làm backend” hoặc “cải thiện security”.
+
+## Context
+
+- Hiện trạng và bằng chứng trong repo.
+- Vì sao issue cần thiết.
+- Contract/invariant phải giữ.
+
+## Implementation plan
+
+1. Các bước theo thứ tự dependency.
+2. Data/API/state transitions cần thêm hoặc thay đổi.
+3. Error/fallback/cancellation/idempotency behavior.
+4. Observability/audit cần emit.
+5. Documentation/runbook cần cập nhật.
+
+## Files/modules
+
+Liệt kê đường dẫn từ repository root. Với file chưa tồn tại, đánh dấu `(new)`.
+
+- `path/to/existing.rs`
+- `path/to/new.rs` (new)
+
+## Dependencies / blocks
+
+- Depends on:
+- External decision/hardware:
+- Blocks:
+- Điều kiện chuyển `Blocked` → `Ready`:
+
+Diagram milestone chỉ là critical path; phần này là dependency authority.
+
+## Acceptance criteria
+
+- [ ] Outcome quan sát được, không chỉ “code đã merge”.
+- [ ] Backward compatibility/desktop invariant đạt.
+- [ ] Error và degraded mode đạt.
+- [ ] Numeric gate trỏ tới gate registry.
+- [ ] Docs/runbook/API contract cập nhật.
+
+## Required tests / evidence
+
+- [ ] Unit tests:
+- [ ] Integration/contract tests:
+- [ ] Denial/security tests:
+- [ ] Migration/upgrade/rollback tests:
+- [ ] Performance/evaluation:
+- [ ] Manual/deployed evidence:
+
+Ghi command, fixture/workload, environment và vị trí artifact/report.
+
+## Security and migration notes
+
+- Tenant/ACL behavior:
+- Sensitive data/logging:
+- Secret/egress behavior:
+- Migration strategy:
+- Rollback/compatibility:
+
+Nếu không áp dụng, ghi rõ `N/A` và lý do; không xóa section.
+
+## Out of scope
+
+Liệt kê rõ các hạng mục dễ bị hiểu nhầm là thuộc issue này.
+
+## Definition of done
+
+- [ ] Acceptance checklist hoàn tất.
+- [ ] Required tests/evidence hoàn tất.
+- [ ] Dependency/blocker đã cập nhật.
+- [ ] Không còn high/critical finding chưa disposition.
+- [ ] PR đã merge nhưng chỉ đóng issue sau khi deployed/gate evidence đạt nếu issue
+      yêu cầu deployment.

--- a/plans/markhand-web/backlog/README.md
+++ b/plans/markhand-web/backlog/README.md
@@ -13,17 +13,9 @@ Phase F là prerequisite cho backlog bốn bước:
 
 ## Milestones
 
-| Milestone | Catalog | Issue | Trạng thái ban đầu | Exit gate |
-|---|---|---:|---|---|
-| Phase F | [`phase-f/issues/README.md`](phase-f/issues/README.md) | 12 | Ready/Blocked theo dependency | Engineering foundation |
-| Phase 0 | [`phase-0/issues/README.md`](phase-0/issues/README.md) | 10 | Blocked bởi Phase F/hardware | Decision gates |
-| Phase 1A | [`phase-1a/issues/README.md`](phase-1a/issues/README.md) | 10 | Blocked bởi Phase F/dependency | Desktop parity |
-| Phase 1B | [`phase-1b/issues/README.md`](phase-1b/issues/README.md) | 24 | Blocked | Single-org POC |
-| Phase 1C | [`phase-1c/issues/README.md`](phase-1c/issues/README.md) | 13 | Backlog | Multi-org denial |
-| Phase 2 | [`phase-2/issues/README.md`](phase-2/issues/README.md) | 16 | Backlog | Web E2E |
-| Phase 3 | [`phase-3/issues/README.md`](phase-3/issues/README.md) | 14 | Backlog | Intelligence quality/security |
-| Phase 4 | [`phase-4/issues/README.md`](phase-4/issues/README.md) | 14 | Backlog | Production go-live |
-| **Tổng** | | **113** | | |
+Phase registry, phase-plan links, issue-catalog links và issue counts chỉ được khai báo
+tại [`../README.md`](../README.md). Roadmap generator dùng registry đó làm nguồn sự thật,
+tránh duy trì một bảng milestone trùng lặp tại đây.
 
 ## Trạng thái
 

--- a/plans/markhand-web/backlog/README.md
+++ b/plans/markhand-web/backlog/README.md
@@ -1,6 +1,8 @@
 # Markhand Web — milestone và issue backlog
 
-Backlog này triển khai tuần tự bốn bước:
+Phase F là prerequisite cho backlog bốn bước:
+
+0. Dựng engineering foundation: rules, skeleton, dev environment và CI.
 
 1. Phase 0 + 1A được break thành issue có thể bắt đầu.
 2. Phase 1B được tổ chức thành epic/dependency graph.
@@ -13,14 +15,15 @@ Backlog này triển khai tuần tự bốn bước:
 
 | Milestone | Catalog | Issue | Trạng thái ban đầu | Exit gate |
 |---|---|---:|---|---|
-| Phase 0 | [`phase-0/issues/README.md`](phase-0/issues/README.md) | 10 | Ready/Blocked theo hardware | Decision gates |
-| Phase 1A | [`phase-1a/issues/README.md`](phase-1a/issues/README.md) | 10 | Ready theo dependency | Desktop parity |
+| Phase F | [`phase-f/issues/README.md`](phase-f/issues/README.md) | 12 | Ready/Blocked theo dependency | Engineering foundation |
+| Phase 0 | [`phase-0/issues/README.md`](phase-0/issues/README.md) | 10 | Blocked bởi Phase F/hardware | Decision gates |
+| Phase 1A | [`phase-1a/issues/README.md`](phase-1a/issues/README.md) | 10 | Blocked bởi Phase F/dependency | Desktop parity |
 | Phase 1B | [`phase-1b/issues/README.md`](phase-1b/issues/README.md) | 24 | Blocked | Single-org POC |
 | Phase 1C | [`phase-1c/issues/README.md`](phase-1c/issues/README.md) | 13 | Backlog | Multi-org denial |
 | Phase 2 | [`phase-2/issues/README.md`](phase-2/issues/README.md) | 16 | Backlog | Web E2E |
 | Phase 3 | [`phase-3/issues/README.md`](phase-3/issues/README.md) | 14 | Backlog | Intelligence quality/security |
 | Phase 4 | [`phase-4/issues/README.md`](phase-4/issues/README.md) | 14 | Backlog | Production go-live |
-| **Tổng** | | **101** | | |
+| **Tổng** | | **113** | | |
 
 ## Trạng thái
 
@@ -35,7 +38,7 @@ Không chuyển `Done` chỉ vì code đã merge.
 
 ## Nhãn đề xuất
 
-- Milestone: `web-p0`, `web-p1a`, `web-p1b`, `web-p1c`, `web-p2`, `web-p3`,
+- Milestone: `web-foundation`, `web-p0`, `web-p1a`, `web-p1b`, `web-p1c`, `web-p2`, `web-p3`,
   `web-p4`.
 - Type: `epic`, `feature`, `security`, `benchmark`, `infra`, `migration`,
   `test`, `docs`.
@@ -77,15 +80,16 @@ của từng issue là nguồn sự thật đầy đủ khi tạo tracker depend
 ## Dependency cấp milestone
 
 ```text
-Phase 0 ───────────┐
-                   ├─> Phase 1B ─> Phase 1C ────────> Phase 2 complete
-Phase 1A ──────────┘         └─> stable OpenAPI ─> Phase 2 UI/mock
+Phase F ─┬─> Phase 0 ─┐
+         └─> Phase 1A ┴─> Phase 1B ─> Phase 1C ────────> Phase 2 complete
+                                  └─> stable OpenAPI ─> Phase 2 UI/mock
                                                 Phase 2 complete ─> Phase 3 ─> Phase 4
 ```
 
+Phase F phải pass trước Phase 0/1A. Sau đó hai phase này chạy song song.
 Phase 2 có **start gate**: UI/mock bắt đầu khi OpenAPI 1B ổn định. Integration trên
 backend thật và **completion gate** vẫn phụ thuộc 1C-12/1C-13. Phase 0 và 1A có thể
-chạy song song.
+chạy song song sau foundation gate.
 
 ## Quy tắc triển khai
 

--- a/plans/markhand-web/backlog/README.md
+++ b/plans/markhand-web/backlog/README.md
@@ -1,0 +1,97 @@
+# Markhand Web — milestone và issue backlog
+
+Backlog này triển khai tuần tự bốn bước:
+
+1. Phase 0 + 1A được break thành issue có thể bắt đầu.
+2. Phase 1B được tổ chức thành epic/dependency graph.
+3. Issue implementation 1B chỉ chuyển `Blocked` → `Ready` khi gate Phase 0/1A
+   tương ứng đã đạt.
+4. Phase 1C–4 được chuẩn bị ở trạng thái `Backlog`; start/completion gate được tách
+   rõ để UI mock có thể chạy song song mà không bỏ qua security gate.
+
+## Milestones
+
+| Milestone | Catalog | Issue | Trạng thái ban đầu | Exit gate |
+|---|---|---:|---|---|
+| Phase 0 | [`phase-0/issues/README.md`](phase-0/issues/README.md) | 10 | Ready/Blocked theo hardware | Decision gates |
+| Phase 1A | [`phase-1a/issues/README.md`](phase-1a/issues/README.md) | 10 | Ready theo dependency | Desktop parity |
+| Phase 1B | [`phase-1b/issues/README.md`](phase-1b/issues/README.md) | 24 | Blocked | Single-org POC |
+| Phase 1C | [`phase-1c/issues/README.md`](phase-1c/issues/README.md) | 13 | Backlog | Multi-org denial |
+| Phase 2 | [`phase-2/issues/README.md`](phase-2/issues/README.md) | 16 | Backlog | Web E2E |
+| Phase 3 | [`phase-3/issues/README.md`](phase-3/issues/README.md) | 14 | Backlog | Intelligence quality/security |
+| Phase 4 | [`phase-4/issues/README.md`](phase-4/issues/README.md) | 14 | Backlog | Production go-live |
+| **Tổng** | | **101** | | |
+
+## Trạng thái
+
+- `Ready`: đủ thông tin và dependency để bắt đầu.
+- `Blocked`: đã định nghĩa nhưng gate/dependency chưa đạt.
+- `Backlog`: chưa activate milestone.
+- `In progress`: đã có owner/branch và đang triển khai.
+- `Review`: implementation và evidence đã sẵn sàng review.
+- `Done`: acceptance criteria, required tests và gate evidence đều đạt.
+
+Không chuyển `Done` chỉ vì code đã merge.
+
+## Nhãn đề xuất
+
+- Milestone: `web-p0`, `web-p1a`, `web-p1b`, `web-p1c`, `web-p2`, `web-p3`,
+  `web-p4`.
+- Type: `epic`, `feature`, `security`, `benchmark`, `infra`, `migration`,
+  `test`, `docs`.
+- Area: `core`, `knowledge`, `server`, `worker`, `storage`, `auth`, `web`,
+  `intelligence`, `ops`.
+- State helper: `blocked`, `needs-decision`, `needs-hardware`.
+
+## Quy tắc issue
+
+Catalog dùng card rút gọn nhưng phải chứa thông tin tương đương. Khi tạo issue trên
+tracker, dùng [`ISSUE_TEMPLATE.md`](ISSUE_TEMPLATE.md) và mở rộng thành đúng tám
+section:
+
+1. Objective.
+2. Implementation plan.
+3. Files/modules.
+4. Dependencies/blocks.
+5. Acceptance criteria.
+6. Required tests/evidence.
+7. Security/migration notes.
+8. Out of scope.
+
+Nếu card gộp `Acceptance/tests`, `Security/migration` hoặc dùng tiêu đề làm objective,
+người tạo issue phải tách lại theo template; trường không áp dụng ghi rõ
+`N/A — không thay đổi persisted contract/schema`. Đường dẫn rút gọn trong card được
+hiểu tương đối với namespace đầu tiên đã nêu; tracker issue phải dùng đường dẫn từ
+repo root.
+
+Issue chỉ được activate khi:
+
+- dependency issue đã `Done`;
+- quyết định/gate liên quan có evidence;
+- numeric threshold lấy từ gate registry, không tự đặt trong implementation PR;
+- không có thay đổi scope ẩn.
+
+Các diagram trong catalog là **critical path rút gọn**. Trường `Dependencies/blocks`
+của từng issue là nguồn sự thật đầy đủ khi tạo tracker dependency.
+
+## Dependency cấp milestone
+
+```text
+Phase 0 ───────────┐
+                   ├─> Phase 1B ─> Phase 1C ────────> Phase 2 complete
+Phase 1A ──────────┘         └─> stable OpenAPI ─> Phase 2 UI/mock
+                                                Phase 2 complete ─> Phase 3 ─> Phase 4
+```
+
+Phase 2 có **start gate**: UI/mock bắt đầu khi OpenAPI 1B ổn định. Integration trên
+backend thật và **completion gate** vẫn phụ thuộc 1C-12/1C-13. Phase 0 và 1A có thể
+chạy song song.
+
+## Quy tắc triển khai
+
+- Mỗi issue tương ứng một logical PR nếu không có lý do kỹ thuật để gộp.
+- Migration và code sử dụng migration có thể tách PR theo expand/cutover/contract.
+- Security denial test nên viết exploit fixture trước hoặc cùng implementation.
+- Benchmark PR phải commit harness/config/report schema; raw data lớn lưu artifact.
+- Không đưa credential, model binary, corpus nhạy cảm hoặc benchmark hostname vào Git.
+- Mọi PR server phải giữ desktop CI xanh.

--- a/plans/markhand-web/backlog/README.md
+++ b/plans/markhand-web/backlog/README.md
@@ -46,8 +46,8 @@ Không chuyển `Done` chỉ vì code đã merge.
 ## Quy tắc issue
 
 Catalog dùng card rút gọn nhưng phải chứa thông tin tương đương. Khi tạo issue trên
-tracker, dùng [`ISSUE_TEMPLATE.md`](ISSUE_TEMPLATE.md) và mở rộng thành đúng tám
-section:
+tracker, dùng [`ISSUE_TEMPLATE.md`](ISSUE_TEMPLATE.md) và mở rộng thành ít nhất tám
+section bắt buộc:
 
 1. Objective.
 2. Implementation plan.

--- a/plans/markhand-web/backlog/phase-0/issues/README.md
+++ b/plans/markhand-web/backlog/phase-0/issues/README.md
@@ -1,0 +1,182 @@
+# Phase 0 issues — Discovery và decision gates
+
+Parent plan: [`../../../phase-0-discovery-and-gates.md`](../../../phase-0-discovery-and-gates.md)
+
+## Dependency
+
+```text
+P0-01 ─┬─> P0-02 ─> P0-03 ─────────────┐
+       ├─> P0-04 ─┬─> P0-05 ─> P0-06 ─┤
+       │          ├─> P0-07 ───────────┤
+       │          └─> P0-08 ───────────┤
+       └─> P0-09 ──────────────────────┤
+                                       └─> P0-10
+```
+
+## P0-01 — Khóa workload, hardware và gate registry
+
+- **Status:** Ready.
+- **Objective:** Thay giả định scale/SLA bằng workload envelope, hardware profile và
+  gate schema được duyệt.
+- **Plan:** Ghi org/collection/document/vector, ingest/query/recovery load; CPU/RAM/
+  disk/GPU/network; tạo registry gồm metric, workload, threshold, command,
+  environment, approver và failure disposition.
+- **Files:** `bench/markhand_web/{README.md,workload-profile.yaml,gates.yaml}`,
+  `bench/markhand_web/environments/`, `docs/adr/README.md`.
+- **Dependencies/blocks:** Cần input sản phẩm/vận hành; block mọi benchmark.
+- **Acceptance:** Normal/peak/recovery/aggregate load đầy đủ; mọi open decision có
+  owner; gate thiếu trường bị schema validator từ chối.
+- **Tests/evidence:** Validate YAML/schema; mọi report sau emit environment
+  fingerprint.
+- **Security/migration:** Không ghi credential, hostname nội bộ hoặc tên khách hàng.
+- **Out of scope:** Chọn model và tuyên bố đạt SLA.
+
+## P0-02 — Golden corpus tiếng Việt và adversarial corpus
+
+- **Status:** Blocked bởi P0-01.
+- **Objective:** Dataset tái lập cho conversion, retrieval, citation và upload attack.
+- **Plan:** Thêm mọi format; 200–500 query với expected document/source span/
+  relevance/no-answer; sample spoof/bomb/malformed/traversal/prompt injection; pin
+  checksum và provenance/license.
+- **Files:** `bench/markhand_web/golden/`, `adversarial/`,
+  `manifest.lock.json`, `scripts/validate_corpus.py`.
+- **Dependencies/blocks:** P0-01; fixture phải redistributable.
+- **Acceptance:** Coverage đủ category; source span ổn định; validator bắt checksum,
+  duplicate ID, invalid span và missing license; mỗi attack có expected disposition.
+- **Tests/evidence:** Clean-checkout reproducibility; dual review + adjudication.
+- **Security/migration:** Synthetic/de-identified; bomb fixture chỉ chạy trong limits.
+- **Out of scope:** Customer data và expected chunk ID trước khi chốt chunking.
+
+## P0-03 — Mở rộng desktop baseline trên corpus Phase 0
+
+- **Status:** Blocked bởi P0-02.
+- **Objective:** Mở rộng parity baseline P1A-01 lên corpus/metrics Phase 0; P1A-01 là
+  baseline authoritative để việc extraction không phải đợi toàn bộ corpus.
+- **Plan:** Tái dùng fixtures/harness P1A-01; chạy release conversion; snapshot top-k,
+  scores, anchors, answer modes,
+  warnings, stats, provider fallback và signature mismatch.
+- **Files:** `bench/markhand_web/scripts/run_desktop_baseline.sh`,
+  `baselines/desktop-v1/`, `reports/desktop-baseline.md`.
+- **Dependencies/blocks:** P0-02; provider run cần config/model pin.
+- **Acceptance:** Mọi format/query có raw machine-readable result; offline chạy không
+  cần LLM; đủ dữ liệu so parity 1A.
+- **Tests/evidence:** CER/WER/time, Recall@5/10, MRR, nDCG, citation correctness;
+  deterministic rerun.
+- **Security/migration:** Redact key/prompt/absolute path.
+- **Out of scope:** Sửa defect ranking/performance.
+
+## P0-04 — Spike infrastructure tái lập
+
+- **Status:** Blocked bởi P0-01; scaffold có thể chuẩn bị nhưng không đóng issue.
+- **Objective:** Stack disposable PG/Qdrant/MinIO/vLLM/telemetry cho benchmark.
+- **Plan:** Pin image/digest; health/init/seed/reset; tách quarantine/main; GPU
+  optional để CPU validation vẫn chạy.
+- **Files:** `deploy/compose.spike.yml`, `deploy/spike/`,
+  `bench/markhand_web/scripts/spike-{health,reset}.sh`.
+- **Dependencies/blocks:** P0-01 cho profile; có thể scaffold trước hardware.
+- **Acceptance:** Một command boot từ empty volumes; không thao tác console; restart/
+  reset đúng semantics.
+- **Tests/evidence:** Clean-machine startup, service health, version/GPU/telemetry
+  fingerprint.
+- **Security/migration:** Bind private/localhost; non-production secrets ngoài Git.
+- **Out of scope:** HA/TLS/production orchestration.
+
+## P0-05 — Đánh giá embedding tiếng Việt
+
+- **Status:** Blocked bởi P0-01, P0-02, P0-04 và target GPU.
+- **Objective:** Chọn model/revision/dimension/normalization theo quality + capacity.
+- **Plan:** So `bge-m3` và multilingual-e5; pin tokenizer/batch/truncation; đo theo
+  category, queue depth, cold/warm.
+- **Files:** `bench/markhand_web/embedding/`, `scripts/run_embedding_eval.py`,
+  `reports/embedding-evaluation.md`, ADR model.
+- **Dependencies/blocks:** Corpus, spike, GPU, approved model download.
+- **Acceptance:** ≥2 model family cùng corpus/hardware; model chọn đạt gate và không
+  kém best vượt margin đã duyệt; config immutable trong report.
+- **Tests/evidence:** Recall/MRR/nDCG, P50/P95/P99, vectors/s, VRAM, saturation,
+  failure rate; ≥3 runs.
+- **Security/migration:** Restricted corpus không ra cloud; license trước bundle.
+- **Out of scope:** Autoscaling và đổi desktop embedding.
+
+## P0-06 — Chunking, hybrid tuning và index signature
+
+- **Status:** Blocked bởi P0-03, P0-05.
+- **Objective:** Chốt chunking/hybrid parameters và canonical signature.
+- **Plan:** So chunk sizes; FTS/vector/hybrid; tune RRF; định nghĩa length-delimited
+  signature gồm model/revision/dim/normalize/chunk/text-normalization version.
+- **Files:** `bench/markhand_web/retrieval/`, `expected-chunks.tsv`,
+  `reports/retrieval-evaluation.md`, ADR index signature.
+- **Dependencies/blocks:** Desktop baseline + embedding result.
+- **Acceptance:** So sánh identical candidates; source span vẫn resolve; signature
+  test vector ổn định; chunk ID có version.
+- **Tests/evidence:** Recall/MRR/nDCG/citation/no-answer + variance; cross-run signature.
+- **Security/migration:** Signature đổi tạo index generation mới, không trộn vector.
+- **Out of scope:** Server adapters/ACL.
+
+## P0-07 — PG/Qdrant target-scale topology
+
+- **Status:** Blocked bởi P0-01, P0-04, P0-05 và target resources.
+- **Objective:** Chọn Qdrant topology và PG partition strategy bằng mixed-load evidence.
+- **Plan:** Generate realistic tenants; test max/org và aggregate production scale;
+  shared/cohort collection; PG no-partition/hash; query+ingest+delete+snapshot.
+- **Files:** `bench/markhand_web/scale/`, `reports/scale-topology.md`, ADR Qdrant/PG.
+- **Dependencies/blocks:** Hardware/storage scale thật; không chấp nhận extrapolation nhỏ.
+- **Acceptance:** Filtered P95/P99/recall đạt gate; ADR ghi measured limits; snapshot/
+  restore chạy được.
+- **Tests/evidence:** Latency, throughput, quantized recall, RAM/disk, compaction,
+  noisy-neighbor, FTS.
+- **Security/migration:** Synthetic tenant; mọi query vẫn có tenant filter.
+- **Out of scope:** Production RLS.
+
+## P0-08 — Sizing converter và ingest backpressure
+
+- **Status:** Blocked bởi P0-01, P0-02, P0-04 và worker hardware.
+- **Objective:** Chốt worker count, limits, timeout, queue và recovery headroom.
+- **Plan:** Benchmark từng format native/scan/audio; single/concurrent; CPU/RAM/temp;
+  PDFium serialization; converter-vs-GPU bottleneck.
+- **Files:** `bench/markhand_web/ingest/`, `scripts/run_ingest_capacity.sh`,
+  `reports/ingest-capacity.md`.
+- **Dependencies/blocks:** Golden files + native deps + hardware.
+- **Acceptance:** Mọi POC format có sizing/timeout; ≥30% resource headroom; recovery
+  2× load không tăng queue vô hạn.
+- **Tests/evidence:** Time/file/page, throughput, peaks, timeout/failure, queue age.
+- **Security/migration:** Malformed input chỉ chạy dưới limits.
+- **Out of scope:** Production job engine.
+
+## P0-09 — Upload threat model, sandbox và license inventory
+
+- **Status:** Blocked bởi P0-02/P0-08; draft threat model có thể bắt đầu sớm.
+- **Objective:** Security policy thực thi được trước khi nhận upload.
+- **Plan:** Threat model spoof/bomb/parser/SSRF/exhaustion/traversal/injection/token/
+  quota/tenant/compromised worker; chốt allowlist/limits/quarantine/sandbox; inventory
+  source/version/checksum/license.
+- **Files:** `docs/markhand-web-{upload-threat-model,upload-policy}.md`,
+  `docs/markhand-web-model-license-inventory.md`, adversarial disposition YAML.
+- **Dependencies/blocks:** P0-02/P0-08 evidence.
+- **Acceptance:** Mỗi threat có prevention/detection/owner; sandbox non-root,
+  read-only, no egress, resource/process/wall limits; unresolved model bị exclude.
+- **Tests/evidence:** Policy linter; sandbox blocks egress/traversal/fork/timeout.
+- **Security/migration:** GLM policy theo data classification.
+- **Out of scope:** Production malware scanner.
+
+## P0-10 — ADR, SLO/RPO/RTO và Phase 0 gate
+
+- **Status:** Blocked bởi P0-05…P0-09.
+- **Objective:** Chuyển evidence thành quyết định và clean restore proof.
+- **Plan:** ADR document/artifact, tenancy/RLS, partition, Qdrant, auth/session,
+  index migration, backup order; chốt SLO; backup/restore ba hệ; close registry.
+- **Files:** `docs/adr/`, `docs/markhand-web-{sla-targets,risk-register}.md`,
+  `bench/markhand_web/reports/restore-drill.md`.
+- **Dependencies/blocks:** Toàn bộ Phase 0 + approvers.
+- **Acceptance:** Mọi decision được duyệt hoặc block 1B; clean restore đạt RPO/RTO;
+  gate link raw evidence; không high/critical/license issue thiếu disposition.
+- **Tests/evidence:** Independent gate rerun; component-loss restore; checksum/
+  query-ready/full-rebuild timing.
+- **Security/migration:** PG authority; MinIO originals không reconstruct được;
+  migration expand/cutover/contract.
+- **Out of scope:** Production HA và user onboarding.
+
+## Exit gate
+
+P0-10 chỉ đóng khi quality, target-scale mixed load, capacity headroom, adversarial
+disposition, clean restore, architecture decisions và license inventory đều đạt
+numeric gate trong registry.

--- a/plans/markhand-web/backlog/phase-0/issues/README.md
+++ b/plans/markhand-web/backlog/phase-0/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-0-discovery-and-gates.md`](../../../phase-0-discovery-and-gates.md)
 
+<!-- roadmap-default-status: blocked -->
+
 Toàn milestone blocked bởi Phase F exit gate.
 
 ## Dependency

--- a/plans/markhand-web/backlog/phase-0/issues/README.md
+++ b/plans/markhand-web/backlog/phase-0/issues/README.md
@@ -67,7 +67,8 @@ P0-01 ─┬─> P0-02 ─> P0-03 ─────────────┐
 
 ## P0-04 — Spike infrastructure tái lập
 
-- **Status:** Blocked bởi P0-01; scaffold có thể chuẩn bị nhưng không đóng issue.
+- **Status:** Blocked bởi P0-01; chỉ ghi research note ngoài issue trước khi unblock,
+  không bắt đầu implementation.
 - **Objective:** Stack disposable PG/Qdrant/MinIO/vLLM/telemetry cho benchmark.
 - **Plan:** Pin image/digest; health/init/seed/reset; tách quarantine/main; GPU
   optional để CPU validation vẫn chạy.
@@ -144,7 +145,8 @@ P0-01 ─┬─> P0-02 ─> P0-03 ─────────────┐
 
 ## P0-09 — Upload threat model, sandbox và license inventory
 
-- **Status:** Blocked bởi P0-02/P0-08; draft threat model có thể bắt đầu sớm.
+- **Status:** Blocked bởi P0-02/P0-08; chỉ ghi research note ngoài issue trước khi
+  unblock, không bắt đầu implementation.
 - **Objective:** Security policy thực thi được trước khi nhận upload.
 - **Plan:** Threat model spoof/bomb/parser/SSRF/exhaustion/traversal/injection/token/
   quota/tenant/compromised worker; chốt allowlist/limits/quarantine/sandbox; inventory

--- a/plans/markhand-web/backlog/phase-0/issues/README.md
+++ b/plans/markhand-web/backlog/phase-0/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-0-discovery-and-gates.md`](../../../phase-0-discovery-and-gates.md)
 
+Toàn milestone blocked bởi Phase F exit gate.
+
 ## Dependency
 
 ```text
@@ -11,11 +13,12 @@ P0-01 ─┬─> P0-02 ─> P0-03 ─────────────┐
        │          └─> P0-08 ───────────┤
        └─> P0-09 ──────────────────────┤
                                        └─> P0-10
+P1A-01 ──────────> P0-03
 ```
 
 ## P0-01 — Khóa workload, hardware và gate registry
 
-- **Status:** Ready.
+- **Status:** Blocked bởi Phase F.
 - **Objective:** Thay giả định scale/SLA bằng workload envelope, hardware profile và
   gate schema được duyệt.
 - **Plan:** Ghi org/collection/document/vector, ingest/query/recovery load; CPU/RAM/
@@ -49,7 +52,7 @@ P0-01 ─┬─> P0-02 ─> P0-03 ─────────────┐
 
 ## P0-03 — Mở rộng desktop baseline trên corpus Phase 0
 
-- **Status:** Blocked bởi P0-02.
+- **Status:** Blocked bởi P0-02 và P1A-01.
 - **Objective:** Mở rộng parity baseline P1A-01 lên corpus/metrics Phase 0; P1A-01 là
   baseline authoritative để việc extraction không phải đợi toàn bộ corpus.
 - **Plan:** Tái dùng fixtures/harness P1A-01; chạy release conversion; snapshot top-k,
@@ -57,7 +60,8 @@ P0-01 ─┬─> P0-02 ─> P0-03 ─────────────┐
   warnings, stats, provider fallback và signature mismatch.
 - **Files:** `bench/markhand_web/scripts/run_desktop_baseline.sh`,
   `baselines/desktop-v1/`, `reports/desktop-baseline.md`.
-- **Dependencies/blocks:** P0-02; provider run cần config/model pin.
+- **Dependencies/blocks:** P0-02 + P1A-01 authoritative parity harness; provider run
+  cần config/model pin.
 - **Acceptance:** Mọi format/query có raw machine-readable result; offline chạy không
   cần LLM; đủ dữ liệu so parity 1A.
 - **Tests/evidence:** CER/WER/time, Recall@5/10, MRR, nDCG, citation correctness;
@@ -70,11 +74,12 @@ P0-01 ─┬─> P0-02 ─> P0-03 ─────────────┐
 - **Status:** Blocked bởi P0-01; chỉ ghi research note ngoài issue trước khi unblock,
   không bắt đầu implementation.
 - **Objective:** Stack disposable PG/Qdrant/MinIO/vLLM/telemetry cho benchmark.
-- **Plan:** Pin image/digest; health/init/seed/reset; tách quarantine/main; GPU
-  optional để CPU validation vẫn chạy.
-- **Files:** `deploy/compose.spike.yml`, `deploy/spike/`,
+- **Plan:** Tái dùng compose/services/scripts base từ F-08; thêm benchmark-specific
+  override với isolated volumes/data, vLLM/GPU profile, workload sizing, image digest
+  và environment fingerprint. Không fork dev stack.
+- **Files:** `deploy/compose.spike.yml`, `deploy/spike/`, base `deploy/dev/`,
   `bench/markhand_web/scripts/spike-{health,reset}.sh`.
-- **Dependencies/blocks:** P0-01 cho profile; có thể scaffold trước hardware.
+- **Dependencies/blocks:** Phase F/F-08 + P0-01; target hardware để đóng issue.
 - **Acceptance:** Một command boot từ empty volumes; không thao tác console; restart/
   reset đúng semantics.
 - **Tests/evidence:** Clean-machine startup, service health, version/GPU/telemetry
@@ -168,7 +173,7 @@ P0-01 ─┬─> P0-02 ─> P0-03 ─────────────┐
   index migration, backup order; chốt SLO; backup/restore ba hệ; close registry.
 - **Files:** `docs/adr/`, `docs/markhand-web-{sla-targets,risk-register}.md`,
   `bench/markhand_web/reports/restore-drill.md`.
-- **Dependencies/blocks:** Toàn bộ Phase 0 + approvers.
+- **Dependencies/blocks:** P0-01…P0-09 + approvers.
 - **Acceptance:** Mọi decision được duyệt hoặc block 1B; clean restore đạt RPO/RTO;
   gate link raw evidence; không high/critical/license issue thiếu disposition.
 - **Tests/evidence:** Independent gate rerun; component-loss restore; checksum/

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-1a-knowledge-extraction.md`](../../../phase-1a-knowledge-extraction.md)
 
+<!-- roadmap-default-status: blocked -->
+
 Toàn milestone blocked bởi Phase F exit gate.
 
 ## Dependency

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-1a-knowledge-extraction.md`](../../../phase-1a-knowledge-extraction.md)
 
+Toàn milestone blocked bởi Phase F exit gate.
+
 ## Dependency
 
 ```text
@@ -13,7 +15,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 
 ## P1A-01 — Freeze desktop RAG và IPC contracts
 
-- **Status:** Ready.
+- **Status:** Blocked bởi Phase F.
 - **Objective:** Baseline parity trước khi move code.
 - **Plan:** Inventory tests; fixtures top-k/score/snippet/anchor/answer/fallback/stats/
   incremental; canonical JSON cho 4 hybrid commands; offline + mock-provider flows.
@@ -26,12 +28,14 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 - **Security/migration:** Synthetic content/path, không credential.
 - **Out of scope:** Sửa ranking/concurrency.
 
-## P1A-02 — Scaffold crate và dependency boundaries
+## P1A-02 — Populate knowledge skeleton và enforce dependency boundaries
 
 - **Status:** Blocked bởi P1A-01.
-- **Objective:** Tạo reusable crate, typed errors và optional desktop features.
-- **Plan:** Add workspace member; modules types/embedding/query/rank/citation/ask;
-  features `desktop-sqlite`, `desktop-hnsw`; CI deny-list.
+- **Objective:** Hoàn thiện skeleton `crates/knowledge` do F-02 tạo thành reusable
+  crate có typed errors và optional desktop features.
+- **Plan:** Populate modules types/embedding/query/rank/citation/ask; features
+  `desktop-sqlite`, `desktop-hnsw`; mở rộng CI deny-list theo boundary F-01. Không
+  tạo lại workspace member hoặc convention.
 - **Files:** `Cargo.toml`, `crates/knowledge/**`, `.github/workflows/ci.yml`.
 - **Dependencies/blocks:** Baseline committed.
 - **Acceptance:** Build no-feature/all-feature; default tree không SQLite/HNSW; không

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -1,0 +1,164 @@
+# Phase 1A issues — Extract `fileconv-knowledge`
+
+Parent plan: [`../../../phase-1a-knowledge-extraction.md`](../../../phase-1a-knowledge-extraction.md)
+
+## Dependency
+
+```text
+P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
+                            ├→ P1A-05 → P1A-06
+                            ├→ P1A-07 ─┐
+                            └→ P1A-08 ─┴→ P1A-09 → P1A-10
+```
+
+## P1A-01 — Freeze desktop RAG và IPC contracts
+
+- **Status:** Ready.
+- **Objective:** Baseline parity trước khi move code.
+- **Plan:** Inventory tests; fixtures top-k/score/snippet/anchor/answer/fallback/stats/
+  incremental; canonical JSON cho 4 hybrid commands; offline + mock-provider flows.
+- **Files:** `app/src-tauri/src/{knowledge,vector_index}.rs`,
+  `app/src/lib/{types,ipc}.ts`, backend/frontend contract fixtures.
+- **Dependencies/blocks:** Không.
+- **Acceptance:** CamelCase/answer modes/warnings/tolerance được khóa; undesirable
+  current behavior cũng được ghi rõ.
+- **Tests:** Desktop/core/frontend tests; fixture generation deterministic.
+- **Security/migration:** Synthetic content/path, không credential.
+- **Out of scope:** Sửa ranking/concurrency.
+
+## P1A-02 — Scaffold crate và dependency boundaries
+
+- **Status:** Blocked bởi P1A-01.
+- **Objective:** Tạo reusable crate, typed errors và optional desktop features.
+- **Plan:** Add workspace member; modules types/embedding/query/rank/citation/ask;
+  features `desktop-sqlite`, `desktop-hnsw`; CI deny-list.
+- **Files:** `Cargo.toml`, `crates/knowledge/**`, `.github/workflows/ci.yml`.
+- **Dependencies/blocks:** Baseline committed.
+- **Acceptance:** Build no-feature/all-feature; default tree không SQLite/HNSW; không
+  Tauri/axum/desktop; API không có DATA-root.
+- **Tests:** `cargo check/test/tree` feature matrix.
+- **Security/migration:** Minimal dependency review.
+- **Out of scope:** PG/Qdrant/server.
+
+## P1A-03 — Shared DTO và serde contract
+
+- **Status:** Blocked bởi P1A-01/02.
+- **Objective:** Di chuyển index/search/ask types mà không đổi JSON.
+- **Plan:** Index request/result/stats, hit/anchor/grounded answer/metadata; serde
+  fixtures; temporary desktop re-export.
+- **Files:** `crates/knowledge/src/types.rs`, serde fixtures/tests,
+  `app/src/lib/types.ts`.
+- **Dependencies/blocks:** Scaffold + frozen JSON.
+- **Acceptance:** Canonical JSON equivalent; no desktop path/state type; TypeScript
+  không cần behavior change.
+- **Tests:** Rust round-trip + TS fixture tests.
+- **Security/migration:** Errors không expose provider secrets.
+- **Out of scope:** OpenAPI generation.
+
+## P1A-04 — Durable identities và index signatures
+
+- **Status:** Blocked bởi P1A-03.
+- **Objective:** Deterministic server identities, desktop compatibility.
+- **Plan:** Versioned length-delimited encoding; BLAKE3/SHA-256 document/chunk/index;
+  signature model/revision/dim/normalize/chunk/text version; fixed vectors; legacy
+  `DefaultHasher` compatibility.
+- **Files:** `crates/knowledge/src/{identity,embedding}.rs`, identity fixtures.
+- **Dependencies/blocks:** Shared metadata; production values tới từ Phase 0.
+- **Acceptance:** Cross-platform stable; no concatenation ambiguity; server không
+  dùng DefaultHasher; legacy index mở hoặc explicit rebuild.
+- **Tests:** Unicode/boundary/order/version/cross-process + legacy fixture.
+- **Security/migration:** Hash là identity, không phải access control; không mix version.
+- **Out of scope:** Chọn model.
+
+## P1A-05 — Query, local vectors và embedding plan
+
+- **Status:** Blocked bởi P1A-03; tích hợp signature phụ thuộc P1A-04.
+- **Objective:** Tách pure query/embedding preparation.
+- **Plan:** Normalization, feature hash/vector norm, provider plan, dimension check,
+  FTS escape; HTTP client vẫn ở core; giữ local fallback semantics.
+- **Files:** `crates/knowledge/src/{query,embedding}.rs`, tests; source desktop module.
+- **Dependencies/blocks:** Shared types.
+- **Acceptance:** Output parity; query rỗng/punctuation safe; mismatch/fallback không
+  đổi; không Tauri/settings/filesystem.
+- **Tests:** Vietnamese/punctuation/determinism/provider mock/dim mismatch.
+- **Security/migration:** Credential-bearing URL không vào signature/error.
+- **Out of scope:** Async client/new tokenizer.
+
+## P1A-06 — Rank, citation và grounded answer
+
+- **Status:** Blocked bởi P1A-03/05.
+- **Objective:** Reusable hybrid merge, anchors và grounding.
+- **Plan:** Cosine/RRF/rerank/sort; snippet/page-slide-sheet anchor; extractive answer;
+  citation validator; separate LLM calls.
+- **Files:** `crates/knowledge/src/{rank,citation,ask}.rs`, golden tests.
+- **Dependencies/blocks:** DTO/query.
+- **Acceptance:** Top-k/citation/answer parity trong tolerance; invented citation
+  fallback; server caller không kéo desktop features.
+- **Tests:** Tie/NaN/overlap/anchor/snippet/grounding/golden.
+- **Security/migration:** Untrusted passages không thành instruction.
+- **Out of scope:** Learned reranker/streaming.
+
+## P1A-07 — SQLite desktop storage feature
+
+- **Status:** Blocked bởi P1A-03…06.
+- **Objective:** Move SQLite persistence, bỏ reverse dependency vào Tauri.
+- **Plan:** Schema/metadata/vector/incremental/FTS/hydration; API nhận DB path +
+  caller-supplied corpus; Tauri giữ path jail/load.
+- **Files:** `crates/knowledge/src/desktop/sqlite.rs`, legacy DB fixture,
+  `app/src-tauri/src/{knowledge,intelligence}.rs`.
+- **Dependencies/blocks:** Shared APIs stable.
+- **Acceptance:** Legacy DB parity; incremental/scope/signature/fallback giữ nguyên;
+  không gọi data_root/load_documents/resolve_within; optional rusqlite.
+- **Tests:** Empty/legacy/changed/scope/corrupt-dim/persistence.
+- **Security/migration:** Caller chịu path jail; schema additive hoặc explicit rebuild.
+- **Out of scope:** PostgreSQL/perf redesign.
+
+## P1A-08 — Persistent HNSW desktop feature
+
+- **Status:** Blocked bởi P1A-02/04/05.
+- **Objective:** Move optional ANN cache, SQLite vẫn authority.
+- **Plan:** Manifest/partition/rebuild/search/clear; legacy signature compatibility;
+  corrupt/mismatch fallback exact cosine.
+- **Files:** `crates/knowledge/src/desktop/hnsw.rs`, legacy HNSW fixture,
+  source `vector_index.rs`.
+- **Dependencies/blocks:** Feature scaffold + vectors/identity.
+- **Acceptance:** Round-trip parity; corruption không mất data; location/threshold
+  không đổi; `hnsw_rs` optional.
+- **Tests:** Corrupt/count/signature/atomic replacement/feature matrix.
+- **Security/migration:** Validate manifest bounds/path.
+- **Out of scope:** HNSW tuning/Qdrant.
+
+## P1A-09 — Thin Tauri adapters
+
+- **Status:** Blocked bởi P1A-06/07/08.
+- **Objective:** Desktop commands delegate shared crate, IPC giữ nguyên.
+- **Plan:** Tauri giữ state/settings/path load/spawn_blocking/error mapping; delegate
+  rebuild/stats/search/ask; retain legacy commands; remove duplicate only sau parity.
+- **Files:** `app/src-tauri/src/{knowledge,vector_index,intelligence,lib}.rs`,
+  Cargo manifests.
+- **Dependencies/blocks:** Pure logic + stores.
+- **Acceptance:** Command/payload/result unchanged; source adapter mỏng; legacy index
+  behavior documented; no duplicate algorithm.
+- **Tests:** Backend/frontend contract + manual rebuild/search/offline/LLM fallback.
+- **Security/migration:** Path jail và secret-safe errors giữ ở desktop.
+- **Out of scope:** UI/IPC rename/async redesign.
+
+## P1A-10 — CI parity và extraction gate
+
+- **Status:** Blocked bởi P1A-09.
+- **Objective:** Chứng minh desktop equivalence và server usability.
+- **Plan:** Full feature/contract/golden matrix; no-feature server consumer test;
+  dependency deny-list; docs compatibility; file perf/concurrency defects riêng.
+- **Files:** CI, `crates/knowledge/tests/`, desktop integration tests,
+  architecture/compatibility docs.
+- **Dependencies/blocks:** Adapter cutover.
+- **Acceptance:** Tất cả test xanh; golden trong tolerance; IPC unchanged; legacy
+  index path tested; server consumer không desktop deps.
+- **Tests:** `cargo test` core/knowledge/desktop, `cargo tree`, `pnpm test/build`.
+- **Security/migration:** Synthetic fixtures; explicit index rebuild notice.
+- **Out of scope:** Server/storage/auth.
+
+## Exit gate
+
+P1A-10 chỉ đóng khi desktop parity, IPC contract, legacy index handling, optional
+dependency boundaries và pure server-consumer test đều đạt.

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-1b-single-org-poc.md`](../../../phase-1b-single-org-poc.md)
 
+<!-- roadmap-default-status: blocked -->
+
 Tất cả issue bắt đầu ở **Blocked**. Chỉ chuyển `Ready` khi external gate và predecessor
 ghi trong issue đã `Done`.
 

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -1,0 +1,292 @@
+# Phase 1B issues — Secure single-org POC
+
+Parent plan: [`../../../phase-1b-single-org-poc.md`](../../../phase-1b-single-org-poc.md)
+
+Tất cả issue bắt đầu ở **Blocked**. Chỉ chuyển `Ready` khi external gate và predecessor
+ghi trong issue đã `Done`.
+
+## External gates
+
+| Gate | Evidence bắt buộc |
+|---|---|
+| G0-ARCH | ADR document/artifact, tenancy/RLS, partition, Qdrant, auth, migration, recovery |
+| G0-RET | Model/dimension/normalize/chunk/signature/hybrid thresholds |
+| G0-SEC | Upload allowlist/limits/quarantine/sandbox/GLM policy |
+| G0-CAP | Worker/queue/concurrency/timeout/headroom |
+| G0-SLO | Latency/throughput/RPO/RTO/soak numeric gates |
+| G0-LIC | Model/native license inventory |
+| G1A | `fileconv-knowledge` parity/extraction gate |
+
+## Foundation
+
+### P1B-F01 — Server workspace và validated config
+
+- **Plan:** Tạo API/worker binaries, typed config/state/error, secret references,
+  graceful shutdown và fail-fast validation.
+- **Files:** `crates/server/{Cargo.toml,src/{lib,main,config,error,state}.rs}`,
+  `src/bin/worker.rs`.
+- **Depends:** G0-ARCH.
+- **Acceptance/tests:** API/worker compile độc lập; invalid URL/secret/limit/issuer/
+  signature không start; config/env/shutdown/table tests; secrets không `Debug`.
+- **Security/migration:** Unsafe defaults chỉ dev mode. **Out:** business routes/HA.
+
+### P1B-F02 — POC deployment và isolation scaffold
+
+- **Plan:** Pinned API/converter/index images, compose services, health/init, non-root,
+  read-only, tmpfs, dropped caps, converter no-egress, resource/secret limits.
+- **Files:** `deploy/{Dockerfile.server,Dockerfile.worker,compose.poc.yml,.env.example}`.
+- **Depends:** F01 + G0-CAP/G0-SEC/G0-LIC.
+- **Acceptance/tests:** Clean host boot tự động; API/worker image tách; isolation/
+  UID/cap/egress/native format smoke tests.
+- **Security/migration:** Narrow MinIO credentials, no bundled unlicensed model.
+  **Out:** Kubernetes/HA.
+
+### P1B-F03 — Multi-org-ready schema và immutable migrations
+
+- **Plan:** Migrations org/auth/RBAC/groups/collections, versions/artifacts, chunks/
+  FTS, jobs/outbox, quota/audit/index; seed POC riêng.
+- **Files:** `crates/server/migrations/000*.sql`, `src/db/models.rs`.
+- **Depends:** F01 + G0-ARCH.
+- **Acceptance/tests:** Mọi business row có org; immutable versions; checks/indexes;
+  fresh + supported-upgrade migration/schema introspection.
+- **Security/migration:** Files immutable sau merge; RLS theo ADR. **Out:** custom role UI.
+
+### P1B-F04 — OrgContext, repositories và state machine
+
+- **Plan:** Tenant-scoped repos, transaction helpers, legal document transitions;
+  transaction-local RLS context nếu chọn.
+- **Files:** `src/auth/context.rs`, `src/db/{orgs,collections,documents,chunks}.rs`,
+  `src/services/document_state.rs`.
+- **Depends:** F03 + G0-ARCH.
+- **Acceptance/tests:** Không public business method thiếu context; cross-org deny;
+  invalid/concurrent transition atomic; pool leakage test.
+- **Security/migration:** Empty scope fail closed. **Out:** Full ACL semantics 1C.
+
+### P1B-F05 — Password auth, rotating sessions và browser refresh transport
+
+- **Plan:** Argon2; pinned JWT issuer/audience/alg/KID; short access; hashed rotating
+  refresh family; provider interface; POC guards/audit; chốt transport theo auth ADR.
+  Nếu dùng browser cookie: issue/rotate/clear `HttpOnly Secure SameSite`, CSRF token
+  binding + Origin validation và OpenAPI cookie contract.
+- **Files:** `src/auth/{password,jwt,session,provider,permissions,middleware}.rs`,
+  `routes/auth.rs`.
+- **Depends:** F03/F04 + auth ADR.
+- **Acceptance/tests:** Login/refresh/logout/me; reuse revokes family; disabled user
+  blocked; alg/issuer/audience/expiry/race/permission/audit tests; cookie attributes,
+  CSRF missing/mismatch, cross-origin refresh/logout và cookie clearing tests nếu ADR
+  chọn cookie.
+- **Security/migration:** No token/password logs. **Out:** OIDC/MFA/recovery.
+
+### P1B-F06 — Fail-closed PG/Qdrant/MinIO adapters
+
+- **Plan:** Pools, opaque key builder, quarantine/trusted namespace, deterministic
+  points, versioned collection, mandatory org/collection filters, typed errors.
+- **Files:** `src/storage/{keys,minio,qdrant}.rs`, `src/db/pool.rs`,
+  `services/index_signature.rs`.
+- **Depends:** F02/F04 + G0-ARCH/G0-RET/G1A.
+- **Acceptance/tests:** Missing/empty filter rejected; no filename in key; payload has
+  all identities; real-service contracts, traversal/fuzz, deterministic vectors.
+- **Security/migration:** No public key, least privilege. **Out:** generic backend trait.
+
+## Ingest và jobs
+
+### P1B-I01 — Streaming quarantine upload validation
+
+- **Plan:** Multipart stream+hash; magic/extension canonical format; OOXML limits;
+  PDF/audio limits; retention disposition.
+- **Files:** `routes/uploads.rs`, `services/upload/{stream,sniff,archive,limits}.rs`.
+- **Depends:** F04/F06 + G0-SEC/G0-CAP.
+- **Acceptance/tests:** Spoof/bomb/oversize/malformed/traversal/interruption rejected
+  hoặc safely quarantined; bounded memory; adversarial/property tests.
+- **Security/migration:** Filename metadata only. **Out:** resumable upload/malware service.
+
+### P1B-I02 — Atomic quota admission
+
+- **Plan:** Transactional reserve/finalize/refund, expiry, concurrent-job admission,
+  quota headers/errors.
+- **Files:** `src/db/quota.rs`, `services/quota.rs`, quota middleware.
+- **Depends:** F03/F04/I01 + G0-CAP.
+- **Acceptance/tests:** Concurrent requests không over-reserve; every terminal path
+  settles; expiry/retry/crash/overflow tests.
+- **Security/migration:** Checked arithmetic, client không sửa counter. **Out:** billing.
+
+### P1B-I03 — Durable jobs, outbox và event log
+
+- **Plan:** Versioned payload, transactional outbox, leased SKIP LOCKED claims,
+  heartbeat/retry/checkpoint/cancel/dead-letter/idempotency/sequenced events.
+- **Files:** `src/jobs/**`, `src/db/jobs.rs`.
+- **Depends:** F03/F04 + G0-CAP.
+- **Acceptance/tests:** Commit/enqueue không split; lease reclaimed; duplicate harmless;
+  kill/checkpoint/claim/dead-letter/cancel/outbox replay.
+- **Security/migration:** IDs only, no content/secrets; backward-readable payloads.
+  **Out:** Kafka/Redis queue.
+
+### P1B-I04 — Isolated converter worker
+
+- **Plan:** Download quarantine; materialize server-derived canonical extension;
+  process/cgroup limits and kill descendants; ephemeral cleanup/heartbeat/cancel.
+- **Files:** `src/workers/{convert,sandbox,limits}.rs`, worker image/config.
+- **Depends:** F02/I03 + G0-SEC/G0-CAP/G0-LIC.
+- **Acceptance/tests:** No network/host FS; timeout kills tree; cleanup all outcomes;
+  fork/disk/RAM/malformed/cancel/all-format smoke.
+- **Security/migration:** Unapproved model excluded, narrow credentials. **Out:** VM sandbox.
+
+### P1B-I05 — Idempotent conversion promotion saga
+
+- **Plan:** Checkpoint download/convert/stage/promote/DB/cleanup; immutable version;
+  index outbox; compensation/refund.
+- **Files:** `workers/convert.rs`, `services/{conversion,promotion,artifacts}.rs`,
+  `db/document_versions.rs`.
+- **Depends:** I01–I04/F06/G1A.
+- **Acceptance/tests:** Retry tạo một visible version/job; trusted chỉ sau success;
+  fault injection mọi cross-store step; immutable checks.
+- **Security/migration:** Never overwrite original; ACL inherited. **Out:** user merge.
+
+### P1B-I06 — Chunk/embedding/index worker
+
+- **Plan:** Core chunking + knowledge identity/signature; PG chunks/FTS; separate
+  embedding batches; blocking client off async executor; deterministic Qdrant upsert.
+- **Files:** `workers/{index,embedding}.rs`, `services/{chunking,embedding,indexing}.rs`.
+- **Depends:** I03/I05/F06 + G0-RET/G0-CAP/G1A.
+- **Acceptance/tests:** Approved signature; ≤1 replay batch; no duplicate; mismatch
+  before publish; golden/mock/backpressure/kill/consistency tests.
+- **Security/migration:** Local approved embedding only; new signature=new generation.
+  **Out:** user-selected models.
+
+### P1B-I07 — Tombstone delete và reconcile
+
+- **Plan:** PG tombstone first; idempotent vector/object cleanup; dry-run/repair
+  missing/orphan/stale across three stores.
+- **Files:** `workers/{delete,reconcile}.rs`, `services/{deletion,reconciliation}.rs`.
+- **Depends:** I03/I06/F06 + recovery ADR.
+- **Acceptance/tests:** Immediate read suppression; drift safely repaired; repeated
+  repair, race, kill/resume matrix.
+- **Security/migration:** Scoped destructive audit. **Out:** legal hold/full ACL revoke.
+
+## Retrieval và API
+
+### P1B-R01 — Tenant-scoped hybrid retrieval
+
+- **Plan:** Resolve scope; query embed; parallel Qdrant/FTS; knowledge merge/rerank;
+  PG hydration/recheck state/ACL.
+- **Files:** `services/retrieval/{vector,fts,hydrate}.rs`, `db/search.rs`.
+- **Depends:** F04/F06/I06 + G0-RET/G1A.
+- **Acceptance/tests:** Empty scope deny; stale vector no text; golden quality/
+  cross-scope/deleted/one-leg outage/latency tests.
+- **Security/migration:** Text only after authorized hydration. **Out:** new reranker.
+
+### P1B-R02 — Citation, preview và download authorization
+
+- **Plan:** Stable anchors/version; fresh auth per resolve; trusted Markdown fetch;
+  short single-purpose download capability.
+- **Files:** `services/{citation,preview,download}.rs`, document routes.
+- **Depends:** F05/F06/R01.
+- **Acceptance/tests:** Source/version/anchor valid; delete/suspend/removal deny;
+  IDOR, expiry/replay, PDF/PPTX/XLSX anchor tests.
+- **Security/migration:** No raw bucket credential/key. **Out:** rich rendering.
+
+### P1B-R03 — Grounded Q&A, stream và fallback
+
+- **Plan:** Policy-separated prompt, untrusted passage framing, GLM, citation
+  validation, token stream, deterministic extractive fallback.
+- **Files:** `services/qa/{prompt,provider,grounding,stream}.rs`.
+- **Depends:** R01/R02 + G0-RET/G0-SEC/G1A.
+- **Acceptance/tests:** Citation subset only; injection không tool/scope change;
+  provider outage fallback; fabricated citation, timeout, delete-during-stream tests.
+- **Security/migration:** Audit metadata only. **Out:** agents/memory/web browse.
+
+### P1B-R04 — Collection/document/job REST API
+
+- **Plan:** `/api/v1` collection POC; upload/list/get/preview/delete/reindex; job status;
+  pagination/idempotency/error schema.
+- **Files:** `routes/{collections,documents,jobs}.rs`, `api/{types,error,pagination}.rs`.
+- **Depends:** F04/F05/I01/I03/I07/R02.
+- **Acceptance/tests:** Org context + permissions; stable errors; idempotent reindex;
+  HTTP contract/pagination/IDOR/malformed tests.
+- **Security/migration:** Bounded body/page, no internals. **Out:** admin membership API.
+
+### P1B-R05 — Search/ask/resumable SSE API
+
+- **Plan:** Search/ask/stream routes; versioned sequence; Last-Event-ID replay;
+  heartbeat/bounded buffering; auth expiry/revoke close.
+- **Files:** `routes/{search,ask,events}.rs`, `api/sse.rs`.
+- **Depends:** F05/I03/R01/R03/R04.
+- **Acceptance/tests:** No lost acknowledged/duplicate sequence; bounded slow client;
+  reconnect/order/expiry/revoke/worker restart.
+- **Security/migration:** Scoped per user/org/job, no cache. **Out:** WebSocket.
+
+### P1B-R06 — OpenAPI, rate limit và readiness
+
+- **Plan:** Complete OpenAPI/fixtures; request IDs; CORS; IP auth/user limits; quota
+  metadata; live/ready/start checks.
+- **Files:** `api/openapi.rs`, OpenAPI YAML, middleware, `routes/health.rs`.
+- **Depends:** R04/R05/F05 + G0-SLO.
+- **Acceptance/tests:** Every route represented; readiness detects required deps/
+  signature/reconciliation; 429 metadata; snapshots/rate/trusted-proxy/outage tests.
+- **Security/migration:** Conservative CORS/proxy trust. **Out:** distributed limiter.
+
+## Operations và release
+
+### P1B-O01 — End-to-end telemetry và safe audit
+
+- **Plan:** Traces API→jobs→convert/embed/retrieval/GLM; latency/queue/conversion/
+  embedding/retrieval/drift/quota/backup metrics; append-only audit.
+- **Files:** `src/telemetry/**`, `services/audit.rs`, `db/audit.rs`, OTel config.
+- **Depends:** F01/F05/I03 + G0-SLO.
+- **Acceptance/tests:** Correlation qua async; action/deny coverage; canary secret/
+  content absent; trace/cardinality/redaction/audit tests.
+- **Security/migration:** Allowlist log fields. **Out:** SIEM.
+
+### P1B-O02 — Dashboards, alerts và runbooks
+
+- **Plan:** SLO/queue/disk/dependency alerts; runbooks jobs/parser/outage/rebuild/disk/
+  GLM/key rotation.
+- **Files:** `deploy/observability/**`, `docs/runbooks/**`.
+- **Depends:** F02/F06/I03/O01 + G0-SLO.
+- **Acceptance/tests:** Trigger từng alert; runbook detection→contain→recover→verify;
+  rule validation/fault/tabletop evidence.
+- **Security/migration:** No tenant/document high-cardinality labels. **Out:** staffing.
+
+### P1B-O03 — Backup/restore và migration safety
+
+- **Plan:** PG PITR, MinIO version inventory, Qdrant snapshot, consistency fence/
+  manifest, restore order, reconcile-before-ready, vector rebuild.
+- **Files:** `deploy/backup/**`, restore/migration runbooks, restore guard.
+- **Depends:** F02/F03/F06/I07 + G0-ARCH/G0-SLO.
+- **Acceptance/tests:** Clean restore đạt RPO/RTO; missing/orphan detect; readiness
+  false until reconcile; PG rebuild; corrupt manifest/upgrade tests.
+- **Security/migration:** Encrypted narrow credentials; expand/cutover/contract.
+  **Out:** multi-region DR.
+
+### P1B-O04 — Vertical-slice/security release suite
+
+- **Plan:** Clean stack, seed org/accounts; every format upload→citation; suspend/
+  membership remove/delete; adversarial + fault injection.
+- **Files:** `crates/server/tests/e2e/**`, POC manifest, deploy test script.
+- **Depends:** F01–R06 + G0-SEC/G1A.
+- **Acceptance/tests:** All formats pass; unauthorized gets no text; malicious
+  rejected/contained; worker kill consistent; evidence redacted.
+- **Security/migration:** High/critical blocks release. **Out:** full 1C matrix.
+
+### P1B-O05 — Mixed-load soak và POC qualification
+
+- **Plan:** Ingest/query/delete/reconcile mixed load + failures; monitor leaks/queue;
+  restore; aggregate gate report.
+- **Files:** `bench/markhand_web/{soak,workloads,reports/phase-1b-gate}*`.
+- **Depends:** O02/O03/O04 + G0-CAP/G0-SLO.
+- **Acceptance/tests:** Numeric gates pass; no unbounded memory/temp/connection/queue;
+  recovery/worker/dependency/restore/post-restore retrieval evidence.
+- **Security/migration:** Synthetic/redacted, exact versions recorded.
+  **Out:** production/multi-org.
+
+## Critical path và release gate
+
+```text
+Phase 0 + 1A → F03/F04/F06 → I01/I03/I04 → I05 → I06
+→ R01/R02/R03 → R04/R05/R06 → O04/O03 → O05
+```
+
+Phase 1B chỉ đóng khi 24 issue, mọi external gate, per-format vertical slice,
+checkpoint replay, adversarial containment, immediate delete/suspend suppression,
+OrgContext/fail-closed filters, reconciliation, clean restore, soak và secret-safe
+telemetry đều đạt. Release phải được ghi rõ là **trusted single-org POC**.

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -19,10 +19,11 @@ ghi trong issue đã `Done`.
 
 ## Foundation
 
-### P1B-F01 — Server workspace và validated config
+### P1B-F01 — Extend server skeleton với runtime POC
 
-- **Plan:** Tạo API/worker binaries, typed config/state/error, secret references,
-  graceful shutdown và fail-fast validation.
+- **Plan:** Mở rộng `crates/server` API/worker skeleton từ F-02/F-07 với runtime
+  dependencies, application state, graceful shutdown và các config fields đã được
+  Phase 0 phê duyệt. Không tạo lại workspace/config conventions.
 - **Files:** `crates/server/{Cargo.toml,src/{lib,main,config,error,state}.rs}`,
   `src/bin/worker.rs`.
 - **Depends:** G0-ARCH.

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -3,6 +3,7 @@
 Parent plan: [`../../../phase-1b-single-org-poc.md`](../../../phase-1b-single-org-poc.md)
 
 <!-- roadmap-default-status: blocked -->
+<!-- roadmap-groups: F,I,R,O -->
 
 Tất cả issue bắt đầu ở **Blocked**. Chỉ chuyển `Ready` khi external gate và predecessor
 ghi trong issue đã `Done`.

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-1c-multi-org-security.md`](../../../phase-1c-multi-org-security.md)
 
+<!-- roadmap-default-status: backlog -->
+
 Mọi issue ở trạng thái **Backlog**, activate sau Phase 1B gate.
 
 ## Dependency

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -1,0 +1,128 @@
+# Phase 1C issues — Multi-org security
+
+Parent plan: [`../../../phase-1c-multi-org-security.md`](../../../phase-1c-multi-org-security.md)
+
+Mọi issue ở trạng thái **Backlog**, activate sau Phase 1B gate.
+
+## Dependency
+
+```text
+1C-01 → 1C-02 → 1C-05 → 1C-06 → 1C-07 ─┐
+   └──→ 1C-03 → 1C-04 ──────────────────┤
+ADR RLS ───────→ 1C-08 ─────────────────┤
+1C-09 → 1C-10 → 1C-11 ─────────────────┴→ 1C-12 → 1C-13
+```
+
+## 1C-01 — Organization lifecycle và validated context
+
+- **Plan/files:** Org create/list/detail/switch, service/repo/middleware; issue new
+  context/session after verified membership.
+- **Depends:** Phase 1B auth/schema. **Acceptance/tests:** Chỉ thấy org của mình;
+  forged/stale header deny; two-org resolver/integration tests.
+- **Security/migration:** Không global org state; audit switch. **Out:** billing/OIDC.
+
+## 1C-02 — Membership, invites và last-owner invariant
+
+- **Plan/files:** Hashed single-use invite; membership state; transactional last-owner;
+  membership version; session revoke. MVP chưa có mail dùng invite URL/token hiển thị
+  đúng một lần cho admin copy qua kênh được tổ chức phê duyệt; expiry/revoke/audit
+  bắt buộc.
+- **Depends:** 1C-01. **Acceptance/tests:** Không remove/downgrade last owner; admin
+  không quản owner; concurrent owner removal, invite replay/expiry, escalation tests.
+- **Security/migration:** Row lock, expand/backfill version; plaintext invite không
+  lưu DB/log. **Out:** automated email delivery/SCIM/MFA.
+
+## 1C-03 — Canonical RBAC seed
+
+- **Plan/files:** Permission constants + DB seed owner/admin/editor/viewer; immutable
+  system roles; OpenAPI fixture.
+- **Depends:** Phase 1B role schema. **Acceptance/tests:** Matrix đúng/idempotent,
+  duplicate/missing/immutable mutation tests; UI không hard-code matrix.
+- **Security/migration:** Stable keys, expand/backfill. **Out:** custom role builder.
+
+## 1C-04 — Route/service guards và service identities
+
+- **Plan/files:** Deny-by-default `authorize`; apply route+service+worker/reconcile;
+  least-privilege identities.
+- **Depends:** 1C-01/03. **Acceptance/tests:** Allow/deny mỗi permission cả hai layer;
+  missing-guard inventory, direct-service và worker misuse tests.
+- **Security/migration:** Không `internal=true` bypass. **Out:** generic ABAC.
+
+## 1C-05 — Collection ACL resolver/cache
+
+- **Plan/files:** Private/org/groups grants; ACL/version snapshot; cache key org/user/
+  membership/ACL version; invalidation APIs.
+- **Depends:** 1C-02/03. **Acceptance/tests:** Semantics đúng, empty/error fail closed;
+  grants/status/cache/revoke tests.
+- **Security/migration:** Backfill ACL version. **Out:** nested/time-based groups.
+
+## 1C-06 — PostgreSQL ACL enforcement
+
+- **Plan/files:** Tenant+ACL predicates cho list/count/autocomplete/FTS/hydration.
+- **Depends:** 1C-05. **Acceptance/tests:** Không path thiếu context; no existence/count
+  leak; SQL join/subquery/missing-predicate tests.
+- **Security/migration:** PG authority, prepared queries. **Out:** vector/object path.
+
+## 1C-07 — Qdrant/storage/jobs fail-closed enforcement
+
+- **Plan/files:** Mandatory org+non-empty collection filter; PG payload validation;
+  authorize preview/download/export/job/SSE; abort in-flight on ACL change.
+- **Depends:** 1C-05/06. **Acceptance/tests:** Missing/malformed/timeout/mismatch deny;
+  Qdrant failure, forged payload, job ID, stream revoke, signed URL replay tests.
+- **Security/migration:** No signed URL logs. **Out:** public sharing/CDN.
+
+## 1C-08 — RLS và pool defense
+
+- **Plan/files:** Nếu ADR chọn: FORCE RLS, non-owner app role, transaction-local context,
+  worker role, pool reset/verification.
+- **Depends:** ADR + 1C-01/06. **Acceptance/tests:** No owner/BYPASSRLS; wrong/missing/
+  pooled-context/worker misuse/migration tests.
+- **Security/migration:** Expand policy trước force; nếu không chọn, close bằng ADR
+  + repository evidence. **Out:** thay app guards bằng RLS.
+
+## 1C-09 — Atomic quota lifecycle
+
+- **Plan/files:** Reserve/finalize/refund, idempotency/expiry/sweeper/reconcile cho
+  storage/token/jobs.
+- **Depends:** Phase 1B jobs + 1C-01. **Acceptance/tests:** 100 concurrent reservations
+  không over-limit; crash/retry/cancel/timeout/actual-usage tests.
+- **Security/migration:** Checked arithmetic, org/resource unique key. **Out:** billing.
+
+## 1C-10 — Rate limit và per-org fairness
+
+- **Plan/files:** User/IP/auth limits, per-org worker/GPU scheduler/semaphore, headers,
+  privacy-safe metrics.
+- **Depends:** 1C-09 + Phase 0 SLO/capacity. **Acceptance/tests:** Noisy org không phá
+  SLO org khác; burst/window/fair-load/crash-release/proxy tests.
+- **Security/migration:** Chỉ trusted proxy IP, bounded state. **Out:** multi-region.
+
+## 1C-11 — Audit/admin APIs
+
+- **Plan/files:** Member/role/ACL/config/quota/data/cloud events; read-only pagination/
+  filter/retention; owner-only controls.
+- **Depends:** 1C-02…10. **Acceptance/tests:** Mọi mutation có actor/org/action/target/
+  result/request ID; coverage/access/pagination/redaction/retention tests.
+- **Security/migration:** No document/prompt/token/PII/URL. **Out:** SIEM archive.
+
+## 1C-12 — Multi-org denial suite
+
+- **Plan/files:** Fixture 2 org, ≥3 users, duplicate names, private/org/groups, stale
+  token; phủ list/count/FTS/vector/Q&A/citation/preview/download/export/jobs/SSE/
+  cache/audit/worker/reconcile/in-flight revoke.
+- **Depends:** 1C-01…11. **Acceptance/tests:** Zero content/metadata/existence leak,
+  route + direct service, CI + deployed environment.
+- **Security/migration:** Deployment-like roles, exploit-first regression.
+  **Out:** external pentest.
+
+## 1C-13 — Security/revoke/load gate
+
+- **Plan/files:** Token/revoke/cache/Qdrant partial/reconcile/quota/noisy-neighbor/
+  supply-chain suite + gate report.
+- **Depends:** 1C-10/11/12. **Acceptance/tests:** Leakage 0; revoke bound; quota recovery;
+  fairness SLO; audit complete; no undispositioned high/critical.
+- **Security/migration:** Record environment/threshold/approver. **Out:** SPA/OIDC.
+
+## Exit gate
+
+Chỉ đóng Phase 1C khi 1C-12 và 1C-13 xanh cả CI lẫn deployed environment. Đây là
+gate trước khi cho nhiều org khác trust boundary và trước khi Phase 2 hoàn tất.

--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -1,0 +1,150 @@
+# Phase 2 issues — Web SPA MVP
+
+Parent plan: [`../../../phase-2-web-spa.md`](../../../phase-2-web-spa.md)
+
+Issue ở **Backlog**. UI/mock có thể chạy sau OpenAPI 1B; final gate phụ thuộc Phase 1C.
+
+## Dependency
+
+```text
+P2-01 → P2-02 → P2-03 → P2-04
+                    └→ P2-05 → P2-06 → P2-07 → P2-08 → P2-09
+                                      ├→ P2-10
+                                      ├→ P2-11
+                                      └→ P2-12
+P2-01 + P2-07/10 → P2-13
+P2-05 + P2-07..12 → P2-14
+P2-02..14 → P2-15
+P2-15 + Phase 1C gate → P2-16
+```
+
+## P2-01 — React/Vite workspace và UI foundations
+
+- **Plan/files:** Tạo `web/` scripts/layout; copy browser-safe tokens/icons/primitives.
+- **Depends:** Không. **Acceptance/tests:** Build/test độc lập; no Tauri import;
+  typecheck/lint/unit/dependency-boundary; desktop vẫn xanh.
+- **Security:** Dependency/license scan. **Out:** shared package/redesign desktop.
+
+## P2-02 — OpenAPI contracts và mock server
+
+- **Plan/files:** Pin generator; generated types; drift check; auth/org/library/job/
+  Q&A/admin/error/SSE fixtures và mock scenarios.
+- **Depends:** Stable 1B OpenAPI. **Acceptance/tests:** Drift fails CI; generated files
+  immutable; fixture/schema/breaking-change tests; mock excluded production.
+- **Out:** Chờ toàn bộ 1C mới làm UI.
+
+## P2-03 — Typed HTTP client/session refresh
+
+- **Plan/files:** Fetch wrapper, access token memory, refresh single-flight, one retry,
+  normalized errors/request ID/quota, abort.
+- **Depends:** P2-02. **Acceptance/tests:** Concurrent 401 một refresh; revoked refresh
+  logout; race/loop/malformed/403/429/network/abort tests.
+- **Security:** No token storage/log. **Out:** offline queue/Tauri IPC.
+
+## P2-04 — Fetch-based SSE transport
+
+- **Plan/files:** Streaming parser với bearer, Last-Event-ID, dedupe/gap, refresh/
+  reconnect/backoff/snapshot, abort on scope change.
+- **Depends:** P2-02/03. **Acceptance/tests:** Không native EventSource/token URL;
+  chunk boundary/reconnect/order/revoke/cancel tests.
+- **Security:** Bounded buffer/backoff, no content logs. **Out:** WebSocket.
+
+## P2-05 — Login/session/application shell
+
+- **Plan/files:** Router, auth bootstrap/login/protected shell/guards/logout/help stub.
+- **Depends:** P2-01/03 + P1B-F05 browser refresh contract. **Acceptance/tests:**
+  Intended route, expiry, guard matrix, login/refresh/logout component tests và
+  integration CSRF/cookie-origin contract theo auth ADR.
+- **Security:** HttpOnly/Secure/SameSite refresh + CSRF policy; server authority.
+  **Out:** signup/reset/MFA/OIDC.
+
+## P2-06 — Org switch và scope-safe state
+
+- **Plan/files:** Org-scoped cache keys; atomic switch; abort REST/SSE; clear stores;
+  scope generation ignores late response.
+- **Depends:** P2-03…05 + backend 1C org APIs. **Acceptance/tests:** No old-org render;
+  delayed/active-stream/rapid-switch/stale-membership tests.
+- **Security:** No unapproved persisted tenant cache. **Out:** simultaneous org view.
+
+## P2-07 — Library/list/sanitized preview
+
+- **Plan/files:** Adapt browser-safe LibraryView; collection navigation, filter/page,
+  status, preview states + SafeMarkdown.
+- **Depends:** P2-02/03/05/06. **Acceptance/tests:** Stable URL/pagination; API-only
+  preview; unsafe markdown, 403/404, switch-race tests.
+- **Security:** No local path/public key. **Out:** desktop editor/compare.
+
+## P2-08 — Upload progress và job lifecycle
+
+- **Plan/files:** Multipart/progress/cancel; job SSE; reconnect snapshot; accessible
+  status for uploaded→indexed/failed.
+- **Depends:** P2-04/07. **Acceptance/tests:** Client/server progress distinct; recover
+  refresh; success/cancel/loss/gap/413/415/429/filename tests.
+- **Security:** No client conversion queue. **Out:** folder/watch/resumable protocol.
+
+## P2-09 — Download/delete/reindex/retry
+
+- **Plan/files:** Authorized actions, permission/confirm/conflict/idempotency handling.
+- **Depends:** P2-07/08 + backend 1C guards. **Acceptance/tests:** Delete closes preview;
+  server deny wins; confirm/concurrency/stale/signed-route tests.
+- **Security:** No client-built object URLs; CSRF/idempotency. **Out:** purge policy.
+
+## P2-10 — Streaming search/Q&A/citations
+
+- **Plan/files:** Search/ask panel, index readiness, stream reducer, fallback warnings,
+  citation deep-link, abort scope change.
+- **Depends:** P2-04…07 + backend ACL. **Acceptance/tests:** `aria-live`; current source
+  citation; sequence/fallback/no-answer/revoke/switch-mid-answer tests.
+- **Security:** Sanitized Markdown/server route IDs. **Out:** intelligence/conversation memory.
+
+## P2-11 — Member/role admin
+
+- **Plan/files:** Member table/invite/suspend/role selector; owner restrictions from API.
+- **Depends:** P2-02/03/05 + backend 1C-02…04. **Acceptance/tests:** Owner/admin matrix,
+  last-owner conflict, invite/suspend/role/403/409/stale-update tests.
+- **Security:** UI không hard-code matrix hay thay enforcement. **Out:** custom/group/SSO.
+
+## P2-12 — Usage/quota/reservations
+
+- **Plan/files:** Usage cards, limits, active reservations/jobs, actionable 429.
+- **Depends:** P2-03/05 + backend 1C-09…11. **Acceptance/tests:** API numbers match;
+  unit/timezone/403/429/stale tests.
+- **Security:** No client-derived authority/cross-org usage. **Out:** billing.
+
+## P2-13 — Browser/SafeMarkdown hardening
+
+- **Plan/files:** CSP-compatible app, protocol allowlist, raw HTML/SVG/data URL denial,
+  content bounds, header checks.
+- **Depends:** P2-01/07/10. **Acceptance/tests:** Malicious corpus không execute; CSP
+  browser/OWASP/dependency tests; no inline eval.
+- **Security:** CSP/frame/nosniff/referrer/HSTS proxy. **Out:** WAF/pentest.
+
+## P2-14 — Accessibility/interaction quality
+
+- **Plan/files:** Skip/landmark/focus/keyboard/progress labels/contrast/reduced motion.
+- **Depends:** P2-05/07…12. **Acceptance/tests:** No axe critical; keyboard primary
+  flows; focus/reduced-motion/screen reader tests.
+- **Security:** Error không đọc internal/token. **Out:** formal certification/i18n.
+
+## P2-15 — Contract/integration/E2E suite
+
+- **Plan/files:** Unit API/SSE/cache; component auth/library/Q&A/admin; Playwright full
+  flows, org switch, deny/quota; CI artifacts redacted.
+- **Depends:** P2-02…14; deployed integration cần 1C endpoints.
+- **Acceptance/tests:** Mock deterministic + real deployment E2E; no stale-scope render;
+  desktop regression.
+- **Security:** Ephemeral users/credentials. **Out:** thay backend denial suite.
+
+## P2-16 — Production build/static serving/final gate
+
+- **Plan/files:** Hashed Vite assets; server/image dist; UI-only history fallback;
+  API 404; HTML revalidate, immutable assets, headers.
+- **Depends:** P2-13/15 + 1C-12/13.
+- **Acceptance/tests:** Deep-link, cache/header/API404, packaged E2E, SLO, scans,
+  desktop test/build.
+- **Security:** Mock/source map policy; rollbackable immutable assets. **Out:** CDN/HA.
+
+## Exit gate
+
+Phase 2 chỉ đóng khi P2-16 đạt trên backend deploy thật và Phase 1C denial/security
+gate đã pass; mock E2E không thay thế integration.

--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-2-web-spa.md`](../../../phase-2-web-spa.md)
 
+<!-- roadmap-default-status: backlog -->
+
 Issue ở **Backlog**. UI/mock có thể chạy sau OpenAPI 1B; final gate phụ thuộc Phase 1C.
 
 ## Dependency

--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -31,6 +31,8 @@ P2-15 + Phase 1C gate → P2-16
   Q&A/admin/error/SSE fixtures và mock scenarios.
 - **Depends:** Stable 1B OpenAPI. **Acceptance/tests:** Drift fails CI; generated files
   immutable; fixture/schema/breaking-change tests; mock excluded production.
+- **Security/migration:** N/A — không thay đổi persisted schema; fixtures synthetic,
+  không chứa token/PII thật.
 - **Out:** Chờ toàn bộ 1C mới làm UI.
 
 ## P2-03 — Typed HTTP client/session refresh
@@ -55,8 +57,9 @@ P2-15 + Phase 1C gate → P2-16
 - **Depends:** P2-01/03 + P1B-F05 browser refresh contract. **Acceptance/tests:**
   Intended route, expiry, guard matrix, login/refresh/logout component tests và
   integration CSRF/cookie-origin contract theo auth ADR.
-- **Security:** HttpOnly/Secure/SameSite refresh + CSRF policy; server authority.
-  **Out:** signup/reset/MFA/OIDC.
+- **Security:** Transport theo auth ADR. Nếu chọn cookie: HttpOnly/Secure/SameSite +
+  CSRF/Origin contract; nếu chọn bearer refresh: không cookie/CSRF nhưng token không
+  được persist/log. Server luôn là authority. **Out:** signup/reset/MFA/OIDC.
 
 ## P2-06 — Org switch và scope-safe state
 

--- a/plans/markhand-web/backlog/phase-3/issues/README.md
+++ b/plans/markhand-web/backlog/phase-3/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-3-intelligence.md`](../../../phase-3-intelligence.md)
 
+<!-- roadmap-default-status: backlog -->
+
 Mọi issue ở **Backlog**, blocked bởi Phase 2 gate trừ khi ghi khác.
 
 ## Dependency

--- a/plans/markhand-web/backlog/phase-3/issues/README.md
+++ b/plans/markhand-web/backlog/phase-3/issues/README.md
@@ -1,0 +1,140 @@
+# Phase 3 issues — Document Intelligence
+
+Parent plan: [`../../../phase-3-intelligence.md`](../../../phase-3-intelligence.md)
+
+Mọi issue ở **Backlog**, blocked bởi Phase 2 gate trừ khi ghi khác.
+
+## Dependency
+
+```text
+P3-01 → P3-02 → P3-03 ─┬→ P3-04 → P3-05
+                        ├→ P3-06
+                        ├→ P3-07
+                        ├→ P3-08
+                        ├→ P3-09
+                        └→ P3-10
+P3-01 + policy/quota → P3-11
+P3-04..10 → P3-12
+P3-04..11 → P3-13
+P3-03..13 → P3-14
+```
+
+## P3-01 — Reusable intelligence service boundary
+
+- **Plan/files:** Service nhận OrgContext, immutable versions, artifact store, LLM
+  policy, jobs/audit; core deterministic algorithms không copy; desktop/web adapters.
+- **Depends:** Phase 2 + existing jobs/storage/audit. **Acceptance/tests:** Không route
+  gọi core trực tiếp; every call scoped; parity/adapter/missing-org/desktop tests.
+- **Security:** No document logs. **Out:** watch folder/rewrite core algorithms.
+
+## P3-02 — Versioned derived-artifact schema
+
+- **Plan/files:** Artifact type/status/schema/hash/signature/creator/job/model/template;
+  source-version joins, citations, versions/supersede/revision, source ACL/policy
+  snapshot chỉ để provenance; opaque MinIO.
+- **Depends:** P3-01 + ACL model. **Acceptance/tests:** Full provenance; retry no
+  duplicate; fresh/upgrade/tenancy/reconcile/idempotency/conflict tests.
+- **Security/migration:** Expand/backfill/cutover, no object key; ACL snapshot tuyệt
+  đối không dùng để authorize. **Out:** mutable/shared artifact.
+
+## P3-03 — Current-source ACL mỗi artifact access
+
+- **Plan/files:** Resolve current intersection ACL/state on list/read/preview/download/
+  export/citation; cache by ACL/membership version; invalidation only cleanup.
+- **Depends:** P3-02 + 1C denial suite. **Acceptance/tests:** Revoke bất kỳ source deny
+  ngay; cross-scope/revoke-race/cache/signed-url/existence tests.
+- **Security:** Timeout fail closed; snapshot không authorize. **Out:** public links.
+
+## P3-04 — Deterministic BRD/PRD job
+
+- **Plan/files:** Authorized corpus → core handoff → validate IDs/citations/traceability/
+  assumptions → checkpoint/persist artifacts.
+- **Depends:** P3-01…03. **Acceptance/tests:** Đủ 10 artifacts; factual requirement có
+  citation; không evidence→question; offline/empty/kill/retry/NFC tests.
+- **Security:** Versioned payload/schema, content-safe audit. **Out:** third-party publish.
+
+## P3-05 — Handoff edit/validate/ZIP export
+
+- **Plan/files:** List/read/save/validate/export APIs; optimistic revision; streaming ZIP
+  + hashes; reauthorize start/delivery.
+- **Depends:** P3-03/04. **Acceptance/tests:** No overwrite; manifest round-trip/tamper/
+  concurrent/revoke/large export tests.
+- **Security:** Safe archive names, no public URL. **Out:** direct Jira/Confluence import.
+
+## P3-06 — Quality và immutable reprocess
+
+- **Plan/files:** Persist quality/recommendations; new native/OCR/VLM jobs/version;
+  before/after/provenance; quota/sandbox/egress.
+- **Depends:** P3-01…03 + converter. **Acceptance/tests:** Source immutable; policy deny
+  no cloud; OCR/VLM/fallback/quota/cancel/retry tests.
+- **Security:** VLM deny-by-default. **Out:** fake unsupported success.
+
+## P3-07 — Citation-backed summarization
+
+- **Plan/files:** Document/collection/corpus summary; audience/length/language;
+  extractive fallback; LLM authorized passages only.
+- **Depends:** P3-01…03 + retrieval. **Acceptance/tests:** Every fact attributable;
+  fallback/insufficient/timeout/revoke/factuality golden tests.
+- **Security:** Provider metadata only, no prompt logs. **Out:** web research.
+
+## P3-08 — PII detection/reviewed redaction
+
+- **Plan/files:** Extensible rules, `pii.manage`, sensitive reports, review before
+  derived version/export, full audit.
+- **Depends:** P3-02/03 + RBAC. **Acceptance/tests:** Original hash unchanged; findings
+  authorized; precision/recall/completeness/overlap/Unicode/permission tests.
+- **Security:** No PII logs; prohibited data no GLM. **Out:** legal completeness guarantee.
+
+## P3-09 — Schema/table edit và safe CSV
+
+- **Plan/files:** Stable table/cell IDs, source revision, patch surrounding-safe,
+  optimistic conflict, formula neutralization.
+- **Depends:** P3-02/03. **Acceptance/tests:** Byte-preserving round trip; escaped pipes/
+  multiline/stable ID/formula/ACL tests.
+- **Security:** Source hash binding. **Out:** spreadsheet formulas/merged edit/realtime.
+
+## P3-10 — Versions, diff và three-way merge
+
+- **Plan/files:** List/read/diff, base/parent provenance, merge conflicts, expected
+  revision saves.
+- **Depends:** P3-02/03. **Acceptance/tests:** Unrelated merge, exact conflicts, no
+  stale overwrite; Unicode/CRLF/concurrent/revoked-base tests.
+- **Security:** Immutable rows/opaque keys. **Out:** collaborative editing.
+
+## P3-11 — Prompt/model/quota/cloud policy
+
+- **Plan/files:** Separate system/untrusted text; no tool/scope change; classification
+  and token caps; version templates; timeout/cancel/circuit/fallback.
+- **Depends:** P3-01 + quota/classification. **Acceptance/tests:** Injection/egress deny/
+  token race/provider failure/template rollback tests.
+- **Security:** Secret manager, metadata-only audit. **Out:** general agents/tools.
+
+## P3-12 — Intelligence web workspace
+
+- **Plan/files:** Corpus/Handoff/Quality/Versions/Tables/Privacy/Export panels; typed
+  state, permissions, browser downloads, deep links, cancel/clear on scope change.
+- **Depends:** P3-04…10 APIs. **Acceptance/tests:** Independent panels; no stale PII/
+  artifact state; component/a11y/Playwright flows.
+- **Security:** No storage-key URL. **Out:** Q&A panel/watch/native dialogs.
+
+## P3-13 — Task-specific golden evaluation
+
+- **Plan/files:** Separate datasets/runners for citation, requirements/traceability,
+  summary factuality, PII, redaction, table and merge; version all inputs.
+- **Depends:** P3-04…11. **Acceptance/tests:** Independent numeric thresholds/regression
+  budgets; reproducible case-level failures; retrieval score không thay task metrics.
+- **Security:** Licensed/de-identified corpus. **Out:** blended “AI quality” score.
+
+## P3-14 — Intelligence denial/audit/reconcile/release gate
+
+- **Plan/files:** Extend denial to artifacts/routes; object-row reconcile; audit
+  coverage; realistic corpus/fallback E2E.
+- **Depends:** P3-03…13. **Acceptance/tests:** Zero leakage; current ACL/revoke races;
+  no canonical mutation; provider outage; desktop regression.
+- **Security:** Reconcile không restore revoked visibility. **Out:** OIDC/production infra.
+
+## Exit gate
+
+Phase 3 cần current-source authorization, BRD/PRD citation validity, independent
+quality thresholds, immutable originals, safe table/version/export, deterministic
+fallback và complete audit/denial evidence.

--- a/plans/markhand-web/backlog/phase-4/issues/README.md
+++ b/plans/markhand-web/backlog/phase-4/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-4-production-hardening.md`](../../../phase-4-production-hardening.md)
 
+<!-- roadmap-default-status: backlog -->
+
 Mọi issue ở **Backlog**, blocked bởi P3-14. Threat-model notes có thể được ghi ở
 phase trước nhưng không activate issue Phase 4 trước gate.
 

--- a/plans/markhand-web/backlog/phase-4/issues/README.md
+++ b/plans/markhand-web/backlog/phase-4/issues/README.md
@@ -1,0 +1,138 @@
+# Phase 4 issues — Production hardening
+
+Parent plan: [`../../../phase-4-production-hardening.md`](../../../phase-4-production-hardening.md)
+
+Mọi issue ở **Backlog**, blocked bởi P3-14. Threat-model notes có thể được ghi ở
+phase trước nhưng không activate issue Phase 4 trước gate.
+
+## Dependency
+
+```text
+P4-01 → P4-02 → P4-03 → P4-04 ──────────┐
+P4-05 → P4-06 ───────────────────────────┤
+P4-07 + P4-05 → P4-08 → P4-09 → P4-10 ─┤
+                         └→ P4-11 ───────┤
+P4-07..11 → P4-12 ──────────────────────┤
+P4-01..12 → P4-13 ──────────────────────┤
+                                         └→ P4-14
+```
+
+## P4-01 — OIDC Authorization Code + PKCE
+
+- **Plan/files:** Discovery/auth/callback/PKCE/state/nonce/issuer/audience/JWKS/cache/
+  rotation; web callback/error.
+- **Depends:** Existing provider/session framework. **Acceptance/tests:** Identity
+  `(issuer,subject)`, never email; invalid/replay/rotated-key/multi-issuer mock+staging.
+- **Security/migration:** No code/token logs, separate identity linkage. **Out:** SAML.
+
+## P4-02 — JIT provisioning và account linking
+
+- **Plan/files:** Domain/claim allowlist, JIT policy, confirmation link, collision/
+  recovery, federated identity migration.
+- **Depends:** P4-01. **Acceptance/tests:** Ambiguous mapping fail closed; email change
+  không transfer; spoof/duplicate/disabled-JIT/link/unlink tests.
+- **Security/migration:** Unique immutable issuer+subject audit. **Out:** user policy DSL.
+
+## P4-03 — Group/role sync và bounded deprovision
+
+- **Plan/files:** Chọn SCIM/webhook/back-channel/periodic sync; map groups; cursor/
+  status; suspend/revoke sessions/SSE/cache; max session age + alerts.
+- **Depends:** P4-01/02 + IdP capability. **Acceptance/tests:** Measured revoke bound
+  kể cả missed sync/outage; replay/order/group removal/in-flight tests.
+- **Security:** Signed webhook/least SCIM token/audit. **Out:** document-driven identity.
+
+## P4-04 — Session UI và break-glass
+
+- **Plan/files:** Linked identities/session list, per-session/logout-all; MFA-protected
+  restricted break-glass + alert/runbook.
+- **Depends:** P4-01…03. **Acceptance/tests:** Revoked REST/SSE denied; IdP outage
+  break-glass/rotation/race drill.
+- **Security:** Emergency use always high-signal audit. **Out:** social login.
+
+## P4-05 — Platform security/supply chain/secrets
+
+- **Plan/files:** CSP/CSRF/CORS/TLS/proxy, SSRF/egress, sandbox, secret rotation,
+  SBOM/dependency/image/license, audit tamper/retention.
+- **Depends:** Deployment target; có thể song song OIDC. **Acceptance/tests:** No static
+  secret; compromise drill; policy-enforced scans/security probes/rotation.
+- **Security/migration:** Staged dual-key rotation. **Out:** custom crypto.
+
+## P4-06 — Threat review/external pentest/remediation
+
+- **Plan/files:** Update threat/data flow; scope tenancy/upload/parser/artifact/OIDC/
+  egress/admin/deploy; remediate + regression + retest.
+- **Depends:** P4-01…05 + stable staging. **Acceptance/tests:** Zero unresolved
+  high/critical; risk được formally accepted phải có approver, compensating controls,
+  expiry và retest date; external retest evidence.
+- **Security:** Restricted report handling. **Out:** self-review thay pentest.
+
+## P4-07 — HA/degraded modes/distributed limiting
+
+- **Plan/files:** Stateless replicas, worker fairness, PG/MinIO/Qdrant HA, vLLM/GLM
+  circuits, extractive mode, pause ingest, shared global limiter.
+- **Depends:** SLA/deployment ADR. **Acceptance/tests:** Aggregate limits survive
+  replica restart; authorized degraded behavior; fault/failover/load tests.
+- **Security:** Auth/storage failure fail closed. **Out:** multi-site active-active.
+
+## P4-08 — Reproducible production deployment
+
+- **Plan/files:** One supported Helm/Kubernetes target, pinned images, ingress/TLS,
+  secrets, network/egress, PV/backup, limits/autoscaling/PDB, topology profiles.
+- **Depends:** P4-05/07. **Acceptance/tests:** Clean install; clear POC-vs-HA; lint/
+  policy/install/upgrade/rollback/uninstall/pressure tests.
+- **Security:** Least service accounts, no public data services. **Out:** Compose as prod.
+
+## P4-09 — Backup/PITR/restore tooling
+
+- **Plan/files:** Ordered/fenced PG+MinIO+Qdrant backup; signed manifest inventory/
+  versions; reconcile readiness; rebuild path.
+- **Depends:** P4-08 + RPO/RTO. **Acceptance/tests:** Detect missing/orphan/corrupt/
+  incompatible before ready; scheduled restore/checksum/key tests.
+- **Security:** Encrypt/isolate/audit backup credentials. **Out:** Qdrant-only backup.
+
+## P4-10 — Clean DR/destructive failure drills
+
+- **Plan/files:** Restore/rebuild, integrity/denial/golden suite; timed query-ready/full
+  index; Qdrant/MinIO loss, corrupt migration, key compromise, tenant deletion.
+- **Depends:** P4-08/09. **Acceptance/tests:** Approved RPO/RTO on clean environment,
+  scenario evidence.
+- **Security:** Isolated restored staging; rotate compromised keys. **Out:** paper drill.
+
+## P4-11 — Migration/canary/rollback discipline
+
+- **Plan/files:** Immutable lock; fresh/N-1/realistic duration; expand/backfill/dual/
+  cutover/contract; versioned index/shadow/alias; payload compatibility; flags/canary.
+- **Depends:** P4-08 + schema features. **Acceptance/tests:** Upgrade/rollback every
+  supported release; mixed workers; long backfill; shadow quality; trigger simulation.
+- **Security:** Isolation incident immediate stop/rollback. **Out:** destructive down migration.
+
+## P4-12 — SRE dashboards/alerts/runbooks
+
+- **Plan/files:** SLO/auth/queue/saturation/retrieval/drift/quota/restore/storage
+  dashboards; ownership; executable runbooks.
+- **Depends:** P4-07…11. **Acceptance/tests:** Controlled alerts; operators resolve
+  jobs/parser/outage/quota/credential/tenant/disk game days.
+- **Security:** No content/prompt/token/URL/PII telemetry. **Out:** staffing policy.
+
+## P4-13 — Onboarding/help/accessibility/operator docs
+
+- **Plan/files:** Create/join→collection→upload→Q&A wizard; Vietnamese help/admin
+  checklist; user/admin/operator/security/API/license docs; WCAG fixes.
+- **Depends:** Stable P4 UI/APIs. **Acceptance/tests:** New users finish unaided;
+  WCAG 2.1 AA critical flows; usability/axe/keyboard/screen-reader/docs dry run.
+- **Security:** Accurate privacy/egress/RBAC/quota guidance. **Out:** billing docs.
+
+## P4-14 — Production go-live gate
+
+- **Plan/files:** Full E2E/denial/load/soak/chaos/recovery/OIDC/pentest/accessibility/
+  browser/upgrade/rollback/desktop/license matrix + signed checklist.
+- **Depends:** P4-03…13. **Acceptance/tests:** Mandatory failures block release; zero
+  unresolved high/critical (accepted risk phải đủ approver/control/expiry/retest);
+  deprovision/RPO/RTO/HA/rollback/operator/onboarding gates all pass.
+- **Security/migration:** Isolation incident luôn hard blocker. **Out:** post-P4 roadmap.
+
+## Exit gate
+
+Go-live cần OIDC/deprovision bound, no high/critical findings, reproducible production
+install, HA/distributed limits, clean DR, safe upgrade/rollback, executable operations,
+accessible onboarding và toàn bộ denial/license/desktop regression evidence.

--- a/plans/markhand-web/backlog/phase-4/issues/README.md
+++ b/plans/markhand-web/backlog/phase-4/issues/README.md
@@ -133,6 +133,7 @@ P4-01..12 → P4-13 ────────────────────
 
 ## Exit gate
 
-Go-live cần OIDC/deprovision bound, no high/critical findings, reproducible production
-install, HA/distributed limits, clean DR, safe upgrade/rollback, executable operations,
+Go-live cần OIDC/deprovision bound, zero unresolved high/critical findings (accepted
+risk phải có approver/controls/expiry/retest), reproducible production install,
+HA/distributed limits, clean DR, safe upgrade/rollback, executable operations,
 accessible onboarding và toàn bộ denial/license/desktop regression evidence.

--- a/plans/markhand-web/backlog/phase-f/issues/README.md
+++ b/plans/markhand-web/backlog/phase-f/issues/README.md
@@ -2,6 +2,8 @@
 
 Parent plan: [`../../../phase-f-engineering-foundation.md`](../../../phase-f-engineering-foundation.md)
 
+<!-- roadmap-default-status: blocked -->
+
 ## Dependency
 
 ```text

--- a/plans/markhand-web/backlog/phase-f/issues/README.md
+++ b/plans/markhand-web/backlog/phase-f/issues/README.md
@@ -1,0 +1,226 @@
+# Phase F issues — Engineering foundation
+
+Parent plan: [`../../../phase-f-engineering-foundation.md`](../../../phase-f-engineering-foundation.md)
+
+## Dependency
+
+```text
+F-01 → F-02 ─┬→ F-03
+             ├→ F-04
+             ├→ F-05
+             ├→ F-06
+             └→ F-07 → F-08
+F-03..08 ───────→ F-10 → F-09
+F-01 + F-06 + F-07 + F-09 → F-11
+F-01..11 ─────────────────────→ F-12
+```
+
+Diagram là critical path rút gọn; trường `Dependencies/blocks` là authority.
+
+## F-01 — Architecture boundaries và dependency rules
+
+- **Status:** Ready.
+- **Objective:** Khóa dependency direction và module responsibilities trước scaffold.
+- **Implementation plan:** Viết architecture boundary ADR; define allowed/forbidden
+  dependencies; route→service→repository; tenant context rule; browser/Tauri split;
+  automated `cargo tree`/import checks. Bootstrap minimum CODEOWNERS, issue/PR
+  template, Definition of Ready/Done và security-review triggers để govern chính
+  Phase F; F-12 hoàn thiện và kiểm chứng workflow.
+- **Files/modules:** `docs/adr/0001-web-boundaries.md` (new),
+  `docs/conventions/dependencies.md` (new), `.github/CODEOWNERS`,
+  `.github/{ISSUE_TEMPLATE,PULL_REQUEST_TEMPLATE}.md`, CI boundary scripts.
+- **Dependencies/blocks:** Không; blocks F-02 và mọi crate/web implementation.
+- **Acceptance criteria:** Core không framework/storage; knowledge pure mặc định;
+  server không reverse-depend desktop; web không Tauri; vendor không dependency.
+- **Required tests/evidence:** Positive/negative sample boundary checks trong CI;
+  architecture diagram và approver.
+- **Security/migration:** Tenant context bắt buộc ở repository rule; migration N/A.
+- **Out of scope:** Storage trait tổng quát và business implementation.
+
+## F-02 — Workspace và folder skeleton
+
+- **Status:** Blocked bởi F-01.
+- **Objective:** Tạo khung compile được cho knowledge/server/web/deploy/docs/bench.
+- **Implementation plan:** Add workspace members với minimal libraries/binaries; module
+  READMEs/ownership; Vite web shell; deploy/dev placeholders; không copy business
+  logic. Chốt root pnpm workspace/lockfile policy cho `app/` + `web/`; pin Node,
+  pnpm, task runner và Compose requirements; thêm bootstrap/version-check command.
+- **Files/modules:** `Cargo.toml`, `crates/{knowledge,server}/`, `web/`, `deploy/dev/`,
+  `docs/{adr,conventions,runbooks}/`, `bench/markhand_web/`.
+- **Dependencies/blocks:** F-01; blocks coding/tooling/dev environment issues.
+- **Acceptance criteria:** Cargo workspace và web build; server API/worker binaries start
+  help/config validation only; no cyclic/forbidden deps; JS workspace/lockfile policy
+  và host tool versions được máy kiểm tra.
+- **Required tests/evidence:** `cargo metadata/check`, bootstrap/version check,
+  `pnpm install --frozen-lockfile`, app+web build, tree/import boundary.
+- **Security/migration:** No credential/default public bind; no DB migration.
+- **Out of scope:** Auth/schema/routes/jobs.
+
+## F-03 — Rust coding và crate conventions
+
+- **Status:** Blocked bởi F-02.
+- **Objective:** Một chuẩn Rust bắt buộc cho core/knowledge/server/workers.
+- **Implementation plan:** Rustfmt/clippy policy; error/context; async vs blocking;
+  cancellation/timeouts; panic/unwrap/unsafe/public docs; naming/module visibility.
+- **Files/modules:** `rustfmt.toml`, `clippy.toml` nếu cần,
+  `docs/conventions/rust.md`, root lint task, CI.
+- **Dependencies/blocks:** F-02; blocks Rust feature issues.
+- **Acceptance criteria:** Convention có enforceable rule + justified exceptions;
+  existing code có migration plan thay vì bật deny phá toàn repo ngay.
+- **Required tests/evidence:** Format check, clippy selected warnings-as-errors,
+  forbidden-pattern baseline/delta.
+- **Security/migration:** Request/worker path không panic; secret-safe errors; N/A schema.
+- **Out of scope:** Refactor toàn bộ warning cũ trong cùng issue.
+
+## F-04 — TypeScript/React conventions
+
+- **Status:** Blocked bởi F-02.
+- **Objective:** Chuẩn strict TS, component/hook/state và accessibility cho web.
+- **Implementation plan:** TS strict policy; generated API immutable; naming/import
+  boundaries; state ownership; loading/error/empty; abort cleanup; a11y checklist.
+- **Files/modules:** `web/tsconfig*.json`, ESLint/Prettier config,
+  `docs/conventions/typescript-react.md`, web test setup.
+- **Dependencies/blocks:** F-02; blocks Phase 2 implementation.
+- **Acceptance criteria:** No Tauri imports; generated code separated; hooks clean up
+  requests/streams; component patterns documented.
+- **Required tests/evidence:** Typecheck/lint/format/unit sample/a11y smoke.
+- **Security/migration:** No token/content logging or unsafe HTML by default; N/A schema.
+- **Out of scope:** Full design system và Phase 2 pages.
+
+## F-05 — SQL/data/migration conventions
+
+- **Status:** Blocked bởi F-01/F-02.
+- **Objective:** Ngăn schema/tenant/migration conventions bị phát minh theo từng PR.
+- **Implementation plan:** Naming/types/time/UUID/FK/check/index; `org_id`; transaction/
+  locking/idempotency; immutable migration; expand/backfill/cutover/contract; rollback.
+- **Files/modules:** `docs/conventions/sql-migrations.md`,
+  `crates/server/migrations/README.md`, migration test harness skeleton.
+- **Dependencies/blocks:** F-01/02; blocks Phase 1B schema.
+- **Acceptance criteria:** Example migration/repository query hợp conventions; policy
+  fresh/upgrade/mixed-version rõ.
+- **Required tests/evidence:** Empty DB apply, migration checksum/immutability,
+  rollback-compat sample.
+- **Security/migration:** Tenant predicate/RLS review checklist bắt buộc.
+- **Out of scope:** Business tables và RLS decision.
+
+## F-06 — REST/OpenAPI/SSE/error conventions
+
+- **Status:** Blocked bởi F-01/F-02.
+- **Objective:** Contract thống nhất để backend/web không drift.
+- **Implementation plan:** `/api/v1`; resources/pagination/idempotency; canonical error;
+  date/UUID/enum/null; OpenAPI authority; SSE envelope/version/sequence/reconnect;
+  deprecation policy.
+- **Files/modules:** `docs/conventions/api.md`, `crates/server/openapi/`,
+  sample DTO/error/SSE types và fixtures.
+- **Dependencies/blocks:** F-01/02; blocks 1B routes và Phase 2 client.
+- **Acceptance criteria:** Sample contract generate TS; error/SSE fixtures round-trip;
+  compatibility rules có examples.
+- **Required tests/evidence:** OpenAPI validation/snapshot, Rust↔TS fixture,
+  SSE parser sequence sample.
+- **Security/migration:** Errors không leak internal; SSE auth/revocation requirements;
+  persisted migration N/A.
+- **Out of scope:** Business endpoints.
+
+## F-07 — Configuration, secrets và environment profiles
+
+- **Status:** Blocked bởi F-02.
+- **Objective:** Typed, fail-fast, secret-safe config cho local/test/prod.
+- **Implementation plan:** Define precedence; profile schema; mounted secret/env
+  references; validation/redacted Debug; `.env.example`; unsafe dev defaults isolated.
+- **Files/modules:** `crates/server/src/config.rs`, `deploy/dev/.env.example`,
+  `docs/conventions/config-secrets.md`, config tests.
+- **Dependencies/blocks:** F-02; blocks dev stack/server issues.
+- **Acceptance criteria:** Missing/invalid config fails startup; no secret in errors;
+  prod cannot use dev credentials/profile.
+- **Required tests/evidence:** Table/env/file precedence, redaction canary, profile deny.
+- **Security/migration:** No committed secrets; rotation contract documented; N/A schema.
+- **Out of scope:** Production secret-manager implementation.
+
+## F-08 — Reproducible local development environment
+
+- **Status:** Blocked bởi F-02/F-07.
+- **Objective:** One-command CPU-only dev stack, optional GPU profile.
+- **Implementation plan:** Pin PG/Qdrant/MinIO/OTel; init buckets/extensions; health/
+  seed/reset; named volumes/private network; mock embedding; optional vLLM profile.
+- **Files/modules:** `deploy/dev/compose.yml`, init/health/seed/reset scripts,
+  `docs/runbooks/local-development.md`.
+- **Dependencies/blocks:** F-02/07; blocks Phase 0 spike and server development.
+- **Acceptance criteria:** Clean machine up/health/seed/reset/down không console action;
+  restart preserves intended data; reset only dev resources.
+- **Required tests/evidence:** CI compose smoke, service versions, cold setup transcript.
+- **Security/migration:** Non-production credentials/private binds/no secret Git.
+- **Out of scope:** Benchmark evidence và production orchestration.
+
+## F-09 — Root task runner, quality tools và CI baseline
+
+- **Status:** Blocked bởi F-03…F-08 và F-10.
+- **Objective:** Cùng command local/CI cho format/lint/test/build/dev/migrate.
+- **Implementation plan:** Add `just`/equivalent root tasks theo test conventions
+  F-10; Rust/TS/SQL checks; dependency/license/security baseline cho cả `app/` và
+  `web/`; changed-path optimization nhưng giữ full required gate; pin/bootstrap host
+  tools và native Rust/Tauri prerequisites.
+- **Files/modules:** `Justfile` hoặc task runner, CI workflows, tool configs,
+  `docs/conventions/ci.md`.
+- **Dependencies/blocks:** F-03…08 + F-10; blocks all implementation PRs.
+- **Acceptance criteria:** Documented commands identical local/CI; failures actionable;
+  desktop existing CI vẫn chạy.
+- **Required tests/evidence:** Clean checkout full task, cache miss/hit, intentional
+  format/lint/test failure fixtures.
+- **Security/migration:** Least-privilege CI, pinned actions/tools, no secret artifact.
+- **Out of scope:** Production release workflow.
+
+## F-10 — Test pyramid, fixtures và golden-data conventions
+
+- **Status:** Blocked bởi F-03…F-08.
+- **Objective:** Chuẩn test/evidence dùng chung trước Phase 0/1A.
+- **Implementation plan:** Define unit/integration/contract/denial/E2E/benchmark/
+  migration/restore layers; fixture IDs/time/checksum/license; CI artifact retention.
+- **Files/modules:** `docs/conventions/testing-fixtures.md`, `tests/fixtures/README.md`,
+  sample fixture validators.
+- **Dependencies/blocks:** F-03…08; blocks F-09, P0-02 và P1A-01.
+- **Acceptance criteria:** Mỗi layer có owner/location/command; fixture synthetic/
+  deterministic; large artifacts policy rõ.
+- **Required tests/evidence:** Fixture validator catches checksum, absolute path,
+  secret canary, duplicate ID.
+- **Security/migration:** De-identification/license required; migration evidence format.
+- **Out of scope:** Viết toàn bộ golden corpus.
+
+## F-11 — Observability/audit conventions
+
+- **Status:** Blocked bởi F-01/F-06/F-07/F-09.
+- **Objective:** Correlation/metrics/log/audit schema ổn định trước business services.
+- **Implementation plan:** Field names; request/job/version/signature propagation;
+  metric units/cardinality; log allowlist/redaction; audit envelope; sample middleware.
+- **Files/modules:** `docs/conventions/observability-audit.md`,
+  `crates/server/src/telemetry/`, sample tests/config.
+- **Dependencies/blocks:** F-01/06/07/09; blocks 1B telemetry/business routes.
+- **Acceptance criteria:** Synthetic in-memory request→job fixture chứng minh field
+  propagation/redaction; không thêm durable queue, business route hoặc persisted
+  audit trong Phase F; metric naming valid; seeded content/token/key absent.
+- **Required tests/evidence:** Trace propagation, cardinality lint, redaction canaries,
+  audit fixture.
+- **Security/migration:** No document/prompt/token/key/URL/PII; audit schema versioned.
+- **Out of scope:** Production dashboards/SIEM.
+
+## F-12 — Contributor workflow, setup docs và foundation gate
+
+- **Status:** Blocked bởi F-01…F-11.
+- **Objective:** Chứng minh contributor mới có thể setup và tuân conventions.
+- **Implementation plan:** ADR/RFC templates/index; ownership/CODEOWNERS; issue/PR
+  templates; Definition of Ready/Done; security triggers; setup/troubleshooting.
+- **Files/modules:** `docs/adr/{README,TEMPLATE}.md`, `.github/CODEOWNERS`,
+  `.github/{ISSUE_TEMPLATE,PULL_REQUEST_TEMPLATE}.md`, contributor/runbook docs.
+- **Dependencies/blocks:** F-01…F-11; blocks Phase 0/1A activation.
+- **Acceptance criteria:** Clean-checkout onboarding không tribal knowledge; ownership/
+  approval rõ; Phase 0/1A không cần tạo convention riêng.
+- **Required tests/evidence:** Independent setup dry run gồm pinned Node/pnpm/Rust/
+  task-runner/Compose/native prerequisites; full local/CI task cho app+web; dev stack;
+  sample contract/config/telemetry/fixture checks.
+- **Security/migration:** Security review triggers và secret incident contact documented.
+- **Out of scope:** Benchmark/business implementation/production runbooks.
+
+## Exit gate
+
+Phase F chỉ đóng khi F-12 có clean-checkout evidence, skeleton build, dev stack health,
+local/CI quality parity, dependency checks, convention fixtures và contributor setup
+độc lập. Sau đó Phase 0 và 1A mới chuyển issue đầu tiên sang `Ready`.

--- a/plans/markhand-web/phase-0-discovery-and-gates.md
+++ b/plans/markhand-web/phase-0-discovery-and-gates.md
@@ -1,0 +1,179 @@
+# Phase 0 — Discovery, benchmark và decision gates
+
+## Outcome
+
+Biến các giả định kiến trúc thành quyết định có số liệu trên phần cứng on-prem dự
+kiến. Phase này không tạo production server; đầu ra là corpus, benchmark, threat
+model, ADR và ngưỡng chấp nhận dùng để khóa thiết kế 1B.
+
+## P0.1 — Baseline và corpus đánh giá
+
+Tạo `bench/markhand_web/`:
+
+- `golden/documents/`: tài liệu tiếng Việt đại diện cho PDF native/scan, DOCX,
+  PPTX, XLSX, CSV, HTML, ảnh OCR, audio và TXT legacy.
+- `golden/queries.tsv`: 200–500 câu hỏi đã adjudicate, gồm expected document,
+  stable source span/citation và relevance grade. Expected chunk ID chỉ được sinh
+  sau khi chốt chunking và phải mang chunking-version.
+- Phủ biến thể dấu tiếng Việt, từ viết tắt, tên riêng, bảng, truy vấn dài và câu
+  hỏi không có đáp án.
+- `adversarial/`: extension giả, MIME mismatch, archive bomb, PDF/page bomb,
+  audio dài, path traversal, malformed OOXML và prompt injection.
+- Manifest pin SHA-256/BLAKE3 để corpus tái lập được.
+
+Baseline phải ghi lại chất lượng và tốc độ desktop hiện tại để 1A có regression
+reference.
+
+## P0.2 — Hạ tầng spike có thể tái lập
+
+Tạo `deploy/compose.spike.yml` và `.env.example` cho:
+
+- PostgreSQL 16 với FTS/unaccent;
+- Qdrant với telemetry và snapshot volume;
+- MinIO với bucket quarantine/main;
+- vLLM embedding endpoint trên GPU dự kiến;
+- collector Prometheus/OpenTelemetry tối thiểu.
+
+Không commit credential. Container pin version/digest; script health-check và seed
+không phụ thuộc thao tác tay.
+
+## P0.3 — Embedding và retrieval evaluation
+
+So sánh ít nhất `bge-m3` và một model multilingual-e5 phù hợp VRAM:
+
+- Recall@5/10, MRR, nDCG;
+- chất lượng theo từng loại tài liệu và truy vấn;
+- dimension, normalization, batch size, token truncation;
+- throughput, VRAM, queue saturation;
+- hybrid PG FTS + vector so với từng leg riêng.
+
+Kết quả chốt:
+
+- model + revision;
+- dimension;
+- normalization;
+- chunking version/size;
+- index signature canonical;
+- hybrid weights/rerank baseline.
+
+Không chọn model chỉ theo latency. Chất lượng tiếng Việt là ưu tiên.
+
+## P0.4 — Qdrant/PG scale spike
+
+Benchmark trên phân bố org/collection gần thực tế:
+
+- 10–20M vector hoặc quy mô tối đa/org đã thống nhất;
+- tổng vector và tenant distribution ở quy mô aggregate production dự kiến nếu
+  chọn shared collection (không chỉ benchmark một org);
+- query đồng thời ingest/delete;
+- filter `org_id` + tập `collection_id` hẹp và rộng;
+- P50/P95/P99, recall sau quantization, RAM, disk, compaction;
+- delete/update payload, noisy neighbor;
+- snapshot và restore;
+- PG FTS latency/recall trên cùng chunk corpus.
+
+So sánh:
+
+- một shared Qdrant collection;
+- collection theo cohort nếu shared collection không đạt isolation/performance;
+- PG no-partition, bounded hash partition; không mặc định partition-per-org.
+
+Kết quả nhỏ rồi extrapolate không được coi là bằng chứng cho scale 20M.
+
+## P0.5 — Ingest capacity
+
+Chạy converter release trên worker hardware:
+
+- thời gian/file và trang theo format;
+- OCR native/scan, audio transcription, Office archive;
+- CPU/RAM/temp disk peak;
+- throughput khi nhiều worker;
+- tác động của PDFium global serialization;
+- embedding queue khi converter nhanh hơn GPU và ngược lại.
+
+Đầu ra là sizing worker pool, queue limits, timeout và headroom. Mục tiêu tối thiểu:
+30% CPU/RAM/disk headroom và khả năng xử lý gấp đôi tải bình thường trong recovery.
+
+## P0.6 — Threat model và upload policy
+
+Tạo `docs/markhand-web-upload-threat-model.md`, phân tích:
+
+- spoof MIME/extension, archive bomb, parser exploit, SSRF;
+- tài nguyên cạn kiệt, path/object-key traversal;
+- prompt injection và nội dung độc hại;
+- cross-tenant access, token theft, quota race;
+- compromised converter/embedding worker.
+
+Chốt:
+
+- allowlist format POC;
+- max bytes/pages/duration/entries/uncompressed ratio;
+- quarantine lifecycle;
+- sandbox profile: unprivileged UID, read-only root, no egress mặc định, giới hạn
+  CPU/RAM/file/process/wall-clock, process-group kill;
+- policy GLM cloud theo phân loại dữ liệu.
+
+Lập inventory model/native dependency gồm nguồn, version, checksum, license và
+redistribution constraints. Model chưa rõ license, gồm PhoWhisper, không được bundle
+vào image Phase 1B.
+
+## P0.7 — ADR và SLA/DR
+
+Viết ADR cho:
+
+1. canonical document/version/artifact model;
+2. tenant isolation và RLS;
+3. PG partition strategy;
+4. Qdrant topology;
+5. auth/session lifecycle;
+6. model/index migration;
+7. backup authority và recovery order.
+
+Chốt SLA/SLO:
+
+- retrieval P95/P99;
+- time-to-first-token;
+- ingest throughput/worker;
+- queue age;
+- availability/degraded modes;
+- RPO/RTO.
+
+Chạy restore spike gồm PostgreSQL + MinIO + Qdrant; đo cả thời điểm service query
+được và thời điểm vector rebuild hoàn tất.
+
+Tạo gate registry cho mọi phase, mỗi gate ghi:
+
+- metric và corpus/workload;
+- numeric threshold;
+- command/harness đo;
+- hardware/environment;
+- approver;
+- failure disposition.
+
+## Deliverables
+
+- `bench/markhand_web/*` và các report benchmark.
+- `deploy/compose.spike.yml`, health/seed scripts.
+- Upload threat model.
+- ADRs và `docs/markhand-web-sla-targets.md`.
+- Capacity sheet và index signature đã pin.
+- Danh sách risk có owner/mitigation.
+
+## Test và gate
+
+Phase 0 chỉ pass khi:
+
+- golden set đủ coverage và review thủ công;
+- model được chọn đạt threshold đã duyệt, không kém model tốt nhất quá biên cho phép;
+- filtered retrieval đạt SLA dưới mixed load;
+- converter/embedding capacity có headroom;
+- malicious corpus có disposition rõ ràng;
+- restore sạch đạt RTO/RPO đề xuất;
+- mọi quyết định mở trong README đã được chốt hoặc ghi rõ là blocker.
+- model/dependency bundle đã qua license gate.
+
+## Không thuộc phase
+
+- Không xây API production.
+- Không đưa user thật lên spike.
+- Không xem compose spike là manifest production.

--- a/plans/markhand-web/phase-0-discovery-and-gates.md
+++ b/plans/markhand-web/phase-0-discovery-and-gates.md
@@ -6,6 +6,9 @@ Biến các giả định kiến trúc thành quyết định có số liệu tr
 kiến. Phase này không tạo production server; đầu ra là corpus, benchmark, threat
 model, ADR và ngưỡng chấp nhận dùng để khóa thiết kế 1B.
 
+Prerequisite: Phase F engineering foundation đã pass. Phase 0 không tự tạo coding,
+fixture, environment hoặc CI conventions riêng.
+
 ## P0.1 — Baseline và corpus đánh giá
 
 Tạo `bench/markhand_web/`:
@@ -24,7 +27,10 @@ Tạo `bench/markhand_web/`:
 Baseline phải ghi lại chất lượng và tốc độ desktop hiện tại để 1A có regression
 reference.
 
-## P0.2 — Hạ tầng spike có thể tái lập
+## P0.2 — Benchmark overrides trên dev infrastructure
+
+Tái dùng service definitions/health/init conventions của Phase F dev environment;
+không fork một stack khác. Tạo benchmark-specific overrides và isolated volumes/data:
 
 Tạo `deploy/compose.spike.yml` và `.env.example` cho:
 

--- a/plans/markhand-web/phase-1a-knowledge-extraction.md
+++ b/plans/markhand-web/phase-1a-knowledge-extraction.md
@@ -6,6 +6,9 @@ Tách thuật toán RAG dùng chung khỏi Tauri để desktop và server dùng 
 thật. Desktop phải giữ nguyên IPC/JSON/hành vi; chưa thêm PG/Qdrant hay port toàn bộ
 intelligence.
 
+Prerequisite: Phase F engineering foundation đã pass; crate skeleton, Rust/test/CI
+conventions và dependency rules là đầu vào, không được tái định nghĩa trong 1A.
+
 ## Boundary đích
 
 ```text
@@ -29,9 +32,9 @@ fileconv-desktop      fileconv-server (Phase 1B)
   khóa camelCase contract với `app/src/lib/types.ts`.
 - Chạy baseline desktop index → search → ask offline và LLM fallback.
 
-## P1A.2 — Scaffold crate và types
+## P1A.2 — Populate crate skeleton và types
 
-Thêm `crates/knowledge` vào workspace, cấu trúc:
+Phase F đã thêm `crates/knowledge` vào workspace. Phase 1A populate skeleton:
 
 ```text
 src/

--- a/plans/markhand-web/phase-1a-knowledge-extraction.md
+++ b/plans/markhand-web/phase-1a-knowledge-extraction.md
@@ -1,0 +1,170 @@
+# Phase 1A — Tách `crates/knowledge`
+
+## Outcome
+
+Tách thuật toán RAG dùng chung khỏi Tauri để desktop và server dùng một nguồn sự
+thật. Desktop phải giữ nguyên IPC/JSON/hành vi; chưa thêm PG/Qdrant hay port toàn bộ
+intelligence.
+
+## Boundary đích
+
+```text
+fileconv-core
+    ↑
+fileconv-knowledge
+    ↑                 ↑
+fileconv-desktop      fileconv-server (Phase 1B)
+```
+
+`fileconv-knowledge` không phụ thuộc Tauri, axum, filesystem DATA root hoặc desktop.
+
+## P1A.1 — Freeze baseline
+
+- Ghi snapshot tên/kết quả các test trong:
+  - `app/src-tauri/src/knowledge.rs`;
+  - `app/src-tauri/src/vector_index.rs`;
+  - `crates/core/src/intelligence_tests.rs`.
+- Tạo golden fixtures cho top-k, rerank score, anchor/page và grounded answer.
+- Ghi JSON fixtures cho `HybridSearchResponse`, `GroundedAnswer`, `IndexStats` để
+  khóa camelCase contract với `app/src/lib/types.ts`.
+- Chạy baseline desktop index → search → ask offline và LLM fallback.
+
+## P1A.2 — Scaffold crate và types
+
+Thêm `crates/knowledge` vào workspace, cấu trúc:
+
+```text
+src/
+├── lib.rs
+├── types.rs
+├── embedding.rs
+├── query.rs
+├── rank.rs
+├── citation.rs
+├── ask.rs
+└── desktop/
+    ├── sqlite.rs
+    └── hnsw.rs
+```
+
+Types dùng chung:
+
+- index request/result/stats;
+- hybrid request/response/hit;
+- source anchor;
+- ask request/grounded answer;
+- embedding/index metadata.
+
+Public API trả error typed; Tauri wrapper chuyển thành `String` để không phá IPC.
+
+## P1A.3 — Tách logic thuần
+
+Di chuyển từ `app/src-tauri/src/knowledge.rs`:
+
+- token normalization và local hash vector;
+- FTS query escaping;
+- cosine/RRF/rerank;
+- snippet;
+- anchor inference;
+- extractive answer và grounding validation;
+- embedding plan/signature validation.
+
+`fileconv-core` tiếp tục sở hữu:
+
+- heading-aware chunking;
+- `CorpusDocument`/`build_corpus`;
+- LLM/embedding HTTP clients;
+- deterministic handoff/quality/PII.
+
+Không duplicate các phần trên.
+
+## P1A.4 — Storage desktop sau feature
+
+Giữ SQLite + persistent HNSW cho desktop dưới feature:
+
+- `desktop-sqlite`;
+- `desktop-hnsw`.
+
+Storage API nhận corpus/document data từ caller. Nó không gọi ngược
+`desktop::load_documents`, `resolve_within` hay Tauri state. Desktop adapter chịu
+trách nhiệm load filesystem và truyền dữ liệu vào.
+
+Không đổi trong phase này:
+
+- incremental skip semantics;
+- local fallback khi provider embedding lỗi;
+- dimension/signature mismatch behavior;
+- index file location;
+- HNSW threshold;
+- frontend answer mode.
+
+Các vấn đề perf/concurrency hiện hữu được ghi ticket riêng; không lén thay đổi trong
+refactor nếu chưa có fixture chứng minh tương đương.
+
+## P1A.5 — Tauri thin adapter
+
+`app/src-tauri/src/knowledge.rs` chỉ còn:
+
+- `#[tauri::command]`;
+- lấy `AppState`, data root, settings;
+- load tài liệu đã path-jail;
+- `spawn_blocking`;
+- map request/result/error.
+
+Giữ nguyên command:
+
+- `rebuild_knowledge_index`;
+- `knowledge_index_stats`;
+- `hybrid_search`;
+- `hybrid_ask`.
+
+Không xóa legacy `search_intelligence`/`ask_intelligence`; chỉ đánh dấu deprecation
+nội bộ vì UI hiện dùng hybrid path.
+
+## P1A.6 — Stable identities
+
+Định nghĩa canonical byte encoding + BLAKE3/SHA-256 cho server document/chunk/index
+identity trong crate dùng chung. Desktop có thể giữ hash cũ trong compatibility
+mode để không rebuild ngoài ý muốn. Không dùng `DefaultHasher` cho dữ liệu durable
+của server.
+
+Index signature phải bao gồm:
+
+- embedding provider/model/revision/dimension/normalization;
+- chunking algorithm/version;
+- text normalization version.
+
+## Tests
+
+- Unit: normalization, vectors, query escaping, cosine/RRF, grounding, anchors.
+- Storage: SQLite incremental/persistence, scope, dimension mismatch, provider
+  fallback.
+- HNSW persistent round-trip.
+- Serde contract fixture với TypeScript.
+- Golden retrieval parity trước/sau refactor.
+- Desktop manual smoke: rebuild → search → ask.
+
+Commands:
+
+```bash
+cargo test -p fileconv-knowledge --all-features
+cargo test -p fileconv-core --features llm
+cargo test -p fileconv-desktop
+cd app && pnpm test && pnpm build
+```
+
+## Gate
+
+- Tất cả test cũ và test mới xanh.
+- Golden top-k/citation không regression ngoài tolerance đã ghi.
+- `cargo tree -p fileconv-knowledge` không có `tauri`, `axum` hay
+  `fileconv-desktop`.
+- Desktop IPC JSON không đổi.
+- Desktop index hiện hữu mở được hoặc migration/rebuild được thông báo rõ.
+- Server có thể gọi pure rank/citation API mà không kéo SQLite/HNSW.
+
+## Không thuộc phase
+
+- PG/Qdrant/MinIO adapters.
+- JWT/RBAC/job queue.
+- Port handoff, quality, PII, versions, tables, watch/export — thuộc Phase 3.

--- a/plans/markhand-web/phase-1b-single-org-poc.md
+++ b/plans/markhand-web/phase-1b-single-org-poc.md
@@ -1,0 +1,288 @@
+# Phase 1B — Secure single-org vertical slice
+
+## Outcome
+
+Một POC chạy on-prem cho một org và vài account:
+
+```text
+login → upload/quarantine → convert → index → search/Q&A → citation
+```
+
+POC phải có nền tenancy, isolation worker, durable jobs, observability,
+reconciliation và restore; không phải server demo chỉ chạy happy path.
+
+## P1B.1 — Server và deployment scaffold
+
+Tạo:
+
+```text
+crates/server/
+├── src/{auth,config,db,storage,jobs,routes,services,telemetry}
+├── migrations/
+└── tests/
+deploy/
+├── Dockerfile.server
+├── Dockerfile.worker
+├── compose.poc.yml
+└── .env.example
+```
+
+Runtime:
+
+- axum + tokio;
+- sqlx/PostgreSQL;
+- Qdrant client;
+- S3-compatible client cho MinIO;
+- OpenTelemetry/tracing;
+- API và worker deploy độc lập.
+
+Configuration validate lúc startup, secret qua mounted secret/env; không lưu
+credential vào DB hoặc commit.
+
+## P1B.2 — Multi-org-ready schema
+
+Migration đầu tạo:
+
+- `orgs`, `users`, `org_memberships`, `refresh_tokens`;
+- `org_invites` với token hash, single-use và expiry;
+- `roles`, `role_permissions`;
+- `groups`, `group_memberships`;
+- `collections` với `owner_user_id`, `collection_access` với principal
+  user/group/role rõ ràng;
+- `documents`, `document_versions`, `derived_artifacts`;
+- `chunks` + FTS;
+- `jobs`, `outbox_events`;
+- `org_quotas`, `usage_counters`, `quota_reservations`;
+- `audit_log`, `index_metadata`.
+
+Mọi bảng nghiệp vụ có `org_id`. POC seed một org nhưng mọi repository method bắt
+buộc nhận:
+
+```rust
+OrgContext {
+    org_id,
+    user_id,
+    permissions,
+    allowed_collection_ids,
+}
+```
+
+Không expose query repository thiếu context. Đánh giá RLS từ Phase 0; nếu dùng,
+test connection-pool không rò session org.
+
+Document state:
+
+```text
+uploaded → converting → converted → indexing → indexed
+                         └───────────────┴──────→ failed
+indexed/deleted → tombstoned → purged
+```
+
+Version là immutable; original, Markdown và artifact dùng opaque key có
+org/document-version identity.
+
+## P1B.3 — Auth/session POC
+
+- Dùng thư viện chuẩn cho Argon2 và JWT; không tự viết crypto.
+- Pin algorithm, issuer, audience, expiry, clock skew và key ID.
+- Access token ngắn hạn.
+- Refresh token hash trong DB, rotate mỗi lần dùng, revoke cả family khi phát hiện
+  reuse.
+- Auth provider interface tách riêng để Phase 4 thêm OIDC.
+- Seed owner/admin/editor/viewer; POC có thể chỉ expose owner/editor nhưng schema và
+  permission constants đầy đủ.
+- Audit login thành công/thất bại mà không log token/password.
+
+## P1B.4 — Upload quarantine và validation
+
+Pipeline:
+
+1. Stream multipart với size limit; không buffer toàn file trong RAM.
+2. Ghi MinIO quarantine bằng opaque key.
+3. Kiểm magic bytes + extension allowlist.
+4. Với OOXML: entry count, single-entry size, total uncompressed size, compression
+   ratio và nested archive policy.
+5. Kiểm page/duration/format limits.
+6. Reserve quota trong transaction.
+7. Tạo `documents(uploaded)` và outbox convert job; object vẫn ở quarantine.
+8. Worker convert đọc quarantine. Khi convert thành công, saga idempotent
+   copy/promote original + Markdown vào trusted prefixes, commit document version
+   và outbox index job, rồi mới xóa quarantine bất đồng bộ.
+9. Mỗi cross-system step có compensation; reject/failure thì giữ hoặc xóa quarantine
+   theo retention policy và refund reservation.
+
+File name chỉ là metadata đã sanitize; không dùng làm path/object key.
+
+## P1B.5 — Isolated converter worker
+
+Worker convert chạy tách API:
+
+- unprivileged UID, read-only root filesystem;
+- ephemeral working directory;
+- no network egress mặc định;
+- CPU/RAM/temp/file/process/wall-clock limits;
+- kill process group/cgroup khi timeout;
+- download object quarantine → convert → upload Markdown;
+- không mount bucket credential có quyền ngoài prefix cần thiết.
+
+Vì `Converter::convert_path` định dạng theo extension, worker materialize file bằng
+canonical extension do server suy ra từ magic-byte + allowlist đã validate, không
+dùng extension hoặc tên do người dùng cung cấp.
+
+`Converter::convert_path` vẫn là engine. Wrapper worker chịu lease, timeout,
+cancellation và cleanup. PDF/OCR/audio native dependency được đóng gói rõ trong
+worker image.
+
+## P1B.6 — Durable job engine
+
+Job types:
+
+- `convert`;
+- `index`;
+- `delete`;
+- `reconcile`;
+- `embedding_batch`.
+
+Mỗi job có payload version, lease owner/expiry, heartbeat, attempts, retry class,
+checkpoint, idempotency key, cancellation và dead-letter state. Claim bằng
+`FOR UPDATE SKIP LOCKED`.
+
+Outbox bảo đảm DB commit và enqueue không bị tách rời. Conversion và embedding dùng
+queue/concurrency riêng để OCR không làm nghẽn GPU và ngược lại. Index checkpoint
+theo batch; replay tối đa một batch và upsert không tạo duplicate.
+
+## P1B.7 — Storage adapters và consistency
+
+### PostgreSQL
+
+- System of record cho metadata, chunk text, FTS, ACL, job, audit.
+- BLAKE3/SHA-256 deterministic identities.
+- Candidate hydration luôn kiểm document state và org.
+
+### Qdrant
+
+- Topology theo ADR Phase 0.
+- Payload gồm org, collection, document, version và chunk.
+- Adapter từ chối search khi thiếu org/filter collection.
+- Point ID deterministic; collection versioned theo index signature.
+
+### MinIO
+
+- Prefix/bucket policy tách quarantine/original/markdown/artifact.
+- Versioning và encryption theo deployment policy.
+- Không trả public object key; download qua endpoint đã authorize hoặc signed URL
+  TTL ngắn, single-purpose.
+
+Consistency:
+
+- PostgreSQL là nguồn sự thật.
+- Delete/revoke tombstone trước; read path không trả nội dung ngay lập tức.
+- Reconcile phát hiện và sửa orphan/stale giữa ba hệ.
+
+## P1B.8 — Index, retrieval và Q&A
+
+Index:
+
+- chunk heading-aware từ `fileconv-core`;
+- batch embedding qua vLLM;
+- pin index signature;
+- ghi chunk/FTS vào PG và vector vào Qdrant idempotently.
+
+Query:
+
+1. Resolve org và allowed collections.
+2. Embed query.
+3. Chạy Qdrant và PG FTS song song.
+4. Merge/rerank bằng `fileconv-knowledge`.
+5. Hydrate text từ PG, kiểm lại state/ACL.
+6. Tạo citation.
+7. GLM trả lời chỉ trên retrieved passages.
+8. Provider lỗi → extractive answer.
+
+Citation endpoint luôn authorize lại. Prompt injection trong tài liệu không được
+gọi tool, thay system policy hoặc mở rộng scope.
+
+## P1B.9 — API và SSE
+
+API tối thiểu:
+
+- `POST /api/v1/auth/login|refresh|logout`;
+- `GET /api/v1/me`;
+- CRUD collection POC;
+- upload/list/get/preview/delete/reindex document;
+- job status và SSE job events;
+- `POST /api/v1/search`;
+- `POST /api/v1/ask`;
+- `POST /api/v1/ask/stream`;
+- health/readiness.
+
+SSE event có version và sequence; reconnect dùng last-event ID hoặc snapshot +
+resume. Stream bị đóng khi auth hết hạn/revoke. Error response có
+`code/message/requestId`, không lộ nội bộ.
+
+Định nghĩa OpenAPI và contract fixtures; Phase 2 dùng chúng làm mock.
+
+## P1B.10 — Observability, audit và operations
+
+Từ phase này phải có:
+
+- trace API → job → converter → embedding → PG/Qdrant → GLM;
+- request/job/document-version/index-signature correlation;
+- metrics request latency, queue depth/age, conversion, timeout, embedding batch,
+  retrieval legs, reconciliation drift, quota reservation, backup age;
+- alert SLO burn, queue growth, disk, backup failure, drift và auth anomaly;
+- audit upload/delete/ask/config/deny, không ghi document/prompt content.
+
+Runbook:
+
+- stuck/dead jobs;
+- converter outbreak;
+- vLLM/Qdrant/PG/MinIO outage;
+- rebuild vector;
+- disk exhaustion;
+- GLM fallback;
+- leaked credential/key rotation.
+
+## P1B.11 — Backup, restore và migration
+
+- PostgreSQL encrypted backup + PITR.
+- MinIO versioning + backup/replication.
+- Qdrant snapshot để restore nhanh; vẫn rebuild được từ PG chunks.
+- Backup manifest ghi PG recovery point, MinIO marker, Qdrant snapshot,
+  app/migration/index version.
+- Backup định nghĩa consistency window/fence và ordering. Sau restore phải chạy
+  reconciliation trước readiness; manifest chứa object/version inventory đủ để
+  phát hiện missing/orphan.
+- Migration immutable, lock khi chạy; CI test DB rỗng và upgrade path.
+- Application rollback không yêu cầu DB rollback.
+
+## Tests
+
+- Upload: spoof, bomb, oversize, malformed và interrupted stream.
+- State machine: invalid transition bị từ chối.
+- Job: kill ở từng checkpoint, lease expiry, retry/dead-letter, cancel.
+- Adapter: thiếu org/filter phải fail closed.
+- Vertical slice mỗi format POC.
+- Citation: deleted/revoked doc không xuất hiện.
+- Reconciliation: orphan/stale cả PG/Qdrant/MinIO.
+- Restore trên environment sạch.
+- Mixed ingest/query soak, kiểm memory/temp/connection/queue growth.
+
+## Gate
+
+- Mỗi format allowlist chạy upload → indexed → query/citation thành công.
+- Worker kill chỉ replay tối đa một batch, không duplicate visible data.
+- Malicious corpus bị reject hoặc contained.
+- Delete biến mất tức thời khỏi mọi read path. Minimum POC revoke gồm suspend user
+  và remove collection membership; ACL chi tiết và in-flight revoke thuộc 1C.
+- Reconcile sửa được drift có chủ đích.
+- Clean restore đạt RPO/RTO.
+- Soak test không có tăng trưởng tài nguyên vô hạn.
+- Không API/repository/adapter nào chạy thiếu org context.
+
+## Không thuộc phase
+
+- Mở nhiều org cho người dùng thật.
+- UI web hoàn chỉnh.
+- BRD/PRD/PII trên web.
+- OIDC/SSO.

--- a/plans/markhand-web/phase-1b-single-org-poc.md
+++ b/plans/markhand-web/phase-1b-single-org-poc.md
@@ -11,9 +11,10 @@ login → upload/quarantine → convert → index → search/Q&A → citation
 POC phải có nền tenancy, isolation worker, durable jobs, observability,
 reconciliation và restore; không phải server demo chỉ chạy happy path.
 
-## P1B.1 — Server và deployment scaffold
+## P1B.1 — Extend server skeleton và POC deployment
 
-Tạo:
+Phase F đã tạo compileable skeleton và dev environment. Phase 1B mở rộng bằng
+runtime/business modules và deployment POC:
 
 ```text
 crates/server/

--- a/plans/markhand-web/phase-1c-multi-org-security.md
+++ b/plans/markhand-web/phase-1c-multi-org-security.md
@@ -1,0 +1,181 @@
+# Phase 1C — Multi-org, RBAC/ACL và quota
+
+## Outcome
+
+Mở kiến trúc single-org POC thành multi-org an toàn. Phase này hoàn thiện policy,
+fairness và denial suite; không retrofit `org_id` vì tenancy primitives đã có từ 1B.
+
+## P1C.1 — Organization và membership
+
+- Tạo/join/switch org.
+- Invite, activate, suspend và remove member.
+- Role assignment owner/admin/editor/viewer.
+- Quy tắc owner cuối cùng không thể tự xóa/hạ role.
+- Membership version tăng khi role/ACL đổi để invalidate cache/session.
+- Org context lấy từ route/header đã validate với membership, không tin claim do
+  client tự chọn.
+
+API gồm org list/detail, members CRUD và org switch/session refresh.
+
+## P1C.2 — RBAC level 2
+
+Permission constants:
+
+- `doc.upload`, `doc.delete`;
+- `qa.query`;
+- `member.manage`, `settings.manage`;
+- `intel.use`, `pii.manage`, `export.run`;
+- `audit.view`.
+
+Role→permission lưu DB, system role immutable; schema cho custom role tương lai nhưng
+chưa cần UI editor phức tạp. Mỗi route và service operation có explicit guard.
+Worker/admin/reconcile cũng dùng service identity với permission tối thiểu.
+
+Canonical built-in matrix:
+
+| Permission | Owner | Admin | Editor | Viewer |
+|---|---:|---:|---:|---:|
+| `doc.upload` | ✓ | ✓ | ✓ | |
+| `doc.delete` | ✓ | ✓ | own/explicit policy | |
+| `qa.query` | ✓ | ✓ | ✓ | ✓ |
+| `member.manage` | ✓ | ✓, không quản owner | | |
+| `settings.manage` | ✓ | ✓, trừ owner/security | | |
+| `intel.use` | ✓ | ✓ | ✓ | theo org policy |
+| `pii.manage` | ✓ | ✓ | | |
+| `export.run` | ✓ | ✓ | ✓ | theo org policy |
+| `audit.view` | ✓ | ✓ | | |
+
+Chỉ owner được assign/remove owner, đổi security/SSO policy, xóa org và thay quota
+hard limit. Admin không được nâng chính mình hoặc người khác lên owner. Test allow/
+deny phải phủ mỗi permission ở route lẫn service layer; matrix có migration seed và
+fixture duy nhất, không hard-code bản thứ hai trong UI.
+
+## P1C.3 — Collection ACL
+
+Chốt semantics từ ADR:
+
+- `private`: owner + principal được grant;
+- `org`: thành viên org có permission tương ứng;
+- `groups`: principal group/user được grant.
+
+Enforce tại:
+
+- document list/count/autocomplete;
+- PG FTS;
+- Qdrant filter;
+- citation hydration;
+- preview/download/export;
+- job status/SSE/reindex/delete;
+- cache key.
+
+Qdrant adapter fail closed khi:
+
+- thiếu org;
+- thiếu/empty allowed collections;
+- filter malformed;
+- ACL resolution timeout;
+- payload tenant không khớp PG.
+
+## P1C.4 — RLS và repository defense
+
+Nếu ADR Phase 0 chọn RLS:
+
+- bật và `FORCE ROW LEVEL SECURITY` cho bảng tenant;
+- application role không own/bypass policy;
+- set org context theo transaction, reset khi trả pool;
+- worker role tách riêng, audit mọi cross-scope operation.
+
+Dù có RLS, repository vẫn bắt buộc `OrgContext`; RLS là lớp thứ hai, không thay
+application authorization.
+
+## P1C.5 — Atomic quota và fairness
+
+Flow transaction:
+
+```text
+reserve → finalize(actual) | refund
+```
+
+Resource:
+
+- upload/storage bytes;
+- LLM/embedding tokens;
+- concurrent convert/embed/intelligence jobs;
+- request rate.
+
+Yêu cầu:
+
+- reservation có expiry/sweeper;
+- crash/retry/cancel không leak quota;
+- LLM finalize bằng usage thật;
+- 429 trả quota headers và retry hint;
+- semaphore/scheduler per-org để noisy neighbor không chiếm toàn worker/GPU;
+- rate limit per-user, per-IP cho unauthenticated và chặt hơn ở auth endpoints.
+
+## P1C.6 — Audit/admin APIs
+
+- Member/role/ACL/config/quota changes.
+- Upload/delete/export/PII/cloud-LLM use.
+- Authorization deny và quota exceed.
+- Read-only audit endpoint có pagination/filter và `audit.view`.
+- Retention được config; log không chứa document text, prompt, token hoặc PII.
+
+## P1C.7 — Denial suite
+
+Fixture tối thiểu:
+
+- 2 org;
+- ít nhất 3 user/org;
+- private/org/groups collections;
+- document/collection trùng tên giữa org;
+- token cũ trước khi revoke.
+
+Chứng minh không rò qua:
+
+- list, count, search, FTS, Qdrant;
+- Q&A và citation;
+- preview, download, export;
+- reindex/delete/job/SSE;
+- autocomplete, error và existence side-channel;
+- cache sau org switch;
+- signed URL;
+- audit;
+- worker/reconcile/admin code path;
+- in-flight Q&A sau ACL revoke.
+
+Database test:
+
+- thiếu/sai org;
+- join/subquery thiếu tenant predicate;
+- pool connection context leakage;
+- RLS bypass;
+- privileged worker role misuse.
+
+Quota race test chạy ít nhất 100 concurrent reservations ở sát limit và chứng minh
+finalized usage không vượt policy.
+
+## P1C.8 — Security/load validation
+
+- Noisy-neighbor: một org ingest nặng, org khác vẫn đạt latency/fairness budget.
+- Token rotation/reuse/revoke.
+- ACL cache invalidation.
+- Qdrant timeout/partial failure phải fail closed.
+- Reconciliation không vượt scope.
+- Dependency/container vulnerability scan.
+
+## Gate
+
+- Denial suite pass trong CI và environment deploy thật.
+- Cross-tenant leakage bằng 0.
+- Quota reconcile đúng sau crash, timeout, retry và cancellation.
+- Membership/ACL revoke có hiệu lực trong bound đã chốt.
+- Noisy-neighbor vẫn trong SLO.
+- Mọi administrative action có audit.
+- Chỉ sau gate này mới cho nhiều org/người dùng không cùng trust boundary.
+
+## Không thuộc phase
+
+- Web SPA hoàn chỉnh.
+- Custom-role builder nâng cao.
+- OIDC/group sync.
+- Billing thương mại.

--- a/plans/markhand-web/phase-2-web-spa.md
+++ b/plans/markhand-web/phase-2-web-spa.md
@@ -1,0 +1,167 @@
+# Phase 2 — Web SPA MVP
+
+## Outcome
+
+React/Vite SPA cho login, thư viện, upload/preview/reindex/delete, Q&A streaming có
+citation và admin member/role/usage tối thiểu.
+
+## P2.1 — Web workspace và shared UI
+
+Tạo:
+
+```text
+web/src/
+├── api/
+├── auth/
+├── components/
+├── hooks/
+├── pages/
+├── state/
+├── types/
+└── lib/
+```
+
+Tái dùng có chọn lọc từ desktop:
+
+- `SafeMarkdown.tsx`;
+- primitives trong `components/ui.tsx`;
+- icons, design tokens, focus/reduced-motion styles;
+- pure `intelligenceUtils`.
+
+Không import Tauri vào web. Chưa tách `packages/ui` nếu mới có một consumer web;
+copy có kiểm soát trước, chỉ shared package khi API giữa hai app ổn định.
+
+## P2.2 — Typed HTTP/SSE client
+
+`web/src/api/client.ts` thay `app/src/lib/ipc.ts`:
+
+- typed request/response theo OpenAPI;
+- bearer/access token injection;
+- refresh single-flight;
+- normalized `{code,message,requestId,details?}` errors;
+- quota headers;
+- request cancellation;
+- fetch-based SSE có bearer header (không dùng native `EventSource`), token refresh,
+  reconnect/`Last-Event-ID`, sequence và revocation handling cho jobs/Q&A.
+
+Contract generation/check phải phát hiện Rust/TypeScript drift trong CI.
+
+## P2.3 — Auth và application shell
+
+Routes:
+
+- `/login`;
+- `/library/:collectionId?`;
+- `/qa/:collectionId?`;
+- `/admin/members`;
+- `/admin/usage`;
+- `/help` stub.
+
+Yêu cầu:
+
+- access token trong memory;
+- rotating refresh token trong `HttpOnly`, `Secure`, `SameSite` cookie nếu deployment
+  dùng cookie refresh;
+- CSRF protection cho mutation dựa trên cookie;
+- route và control guards theo permission;
+- org switch hủy request/SSE cũ và clear scope cache;
+- session/org/role hiển thị rõ.
+
+## P2.4 — Library
+
+Adapt `app/src/components/LibraryView.tsx`:
+
+- collection navigation;
+- document list/filter/pagination;
+- multipart upload với progress;
+- trạng thái `uploaded|converting|converted|indexing|indexed|failed`;
+- job SSE;
+- Markdown preview đã sanitize;
+- delete confirm;
+- reindex/retry failed job.
+
+Không dùng filesystem tree, native dialog, local path hoặc client-side convert queue.
+Preview/download luôn qua API authorize.
+
+## P2.5 — Q&A
+
+Tách ask/search panel từ `IntelligenceView.tsx`:
+
+- collection/document scope;
+- index status;
+- hybrid search results;
+- streaming answer;
+- citation deep-link về document/heading/page;
+- offline/extractive fallback và warning provider;
+- abort khi đổi org/scope;
+- answer region `aria-live`.
+
+Client không tự tin cậy citation URL; dùng route ID do server cấp.
+
+## P2.6 — Admin tối thiểu
+
+- Member list/invite/suspend.
+- Role select owner/admin/editor/viewer.
+- Usage/quota summary và trạng thái reservation/job.
+- Error 403/429 rõ ràng.
+- Chỉ render theo permission nhưng server vẫn là nguồn authorization.
+
+## P2.7 — Browser security và accessibility
+
+Headers:
+
+- strict CSP;
+- frame denial;
+- `nosniff`;
+- referrer policy;
+- HSTS ở reverse proxy production.
+
+Markdown tests phủ raw HTML, dangerous link, SVG/data URL và oversized content.
+
+Accessibility:
+
+- skip link và semantic landmarks;
+- focus sau route change/modal;
+- keyboard upload/search/ask;
+- progressbar cho upload/job;
+- axe không có critical violations;
+- contrast và reduced-motion.
+
+## P2.8 — Tests
+
+- Unit: API error/refresh/SSE parser, scope cache, pure utilities.
+- Component: login, library state, Q&A stream/citations, member role.
+- Contract: OpenAPI fixtures.
+- Playwright:
+  - login/refresh/logout;
+  - upload → indexed;
+  - preview/delete/reindex;
+  - ask → citation;
+  - org switch không hiển thị response cũ;
+  - permission deny và quota exceed.
+- OWASP baseline/dependency/license scan.
+
+## P2.9 — Build và serve SPA
+
+- Build Vite tạo hashed immutable assets.
+- `crates/server` serve `web/dist` hoặc image/runtime layer chứa dist theo ADR deploy.
+- History fallback chỉ cho route UI, không nuốt `/api/*`.
+- HTML dùng no-cache/revalidate; hashed assets dùng immutable long cache.
+- Security headers áp dụng cả HTML và static assets.
+- Packaged-server E2E xác minh deep-link refresh, API 404 và asset cache policy.
+
+## Gate
+
+- Golden browser flow end-to-end qua backend deploy thật.
+- Expired/revoked token và org switch xử lý đúng.
+- Không render dữ liệu từ scope cũ.
+- Q&A đạt first-token/retrieval SLO và citation mở đúng nguồn.
+- Browser/a11y/security gates xanh.
+- Desktop `app/` vẫn test/build bình thường.
+
+## Không thuộc phase
+
+- Desktop editor/compare/source fidelity đầy đủ.
+- Watch folder.
+- Intelligence ngoài search/Q&A.
+- OIDC/SSO.

--- a/plans/markhand-web/phase-3-intelligence.md
+++ b/plans/markhand-web/phase-3-intelligence.md
@@ -1,0 +1,169 @@
+# Phase 3 — Document Intelligence trên web
+
+## Outcome
+
+Port các chức năng intelligence đã có ở desktop sang service/artifact model của
+web: BRD/PRD handoff, quality, PII/redaction, schema/tables, versions và export.
+
+## P3.1 — Extract service boundary
+
+Tái dùng deterministic logic trong `crates/core/src/intelligence.rs`; không copy
+thuật toán sang server. Tách orchestration đang nằm ở
+`app/src-tauri/src/intelligence.rs` thành service nhận:
+
+- `OrgContext`;
+- immutable document versions;
+- artifact store;
+- optional LLM policy/config;
+- job/audit handles.
+
+Desktop giữ thin filesystem adapter. Web adapter dùng PostgreSQL/MinIO.
+
+## P3.2 — Derived artifact model
+
+Mỗi output là artifact versioned:
+
+- type, status và schema version;
+- source document-version IDs;
+- source ACL snapshot/policy;
+- content hash/index signature;
+- creator/job/model/prompt template version;
+- citations;
+- audit metadata.
+
+Artifact kế thừa intersection ACL của nguồn theo policy đã chốt. Mỗi lần
+read/download/export phải tính hoặc validate **current** intersection ACL và trạng
+thái của mọi source; invalidation job chỉ cleanup cache, không phải security
+boundary. Không dùng public MinIO URL.
+
+## P3.3 — BRD/PRD handoff studio
+
+Server jobs:
+
+- generate deterministic pack;
+- optional LLM enhancement chỉ trên corpus đã authorize;
+- validate citation/ID/traceability;
+- save/edit artifact version;
+- export ZIP.
+
+Pack:
+
+- README;
+- BRD;
+- PRD;
+- user stories;
+- acceptance criteria;
+- glossary;
+- test cases;
+- traceability;
+- assumptions/open questions;
+- manifest/validation.
+
+Invariant:
+
+- không có API key vẫn sinh được;
+- factual requirement phải có citation;
+- thiếu dữ liệu → assumption/open question, không bịa.
+
+## P3.4 — Quality và hard reprocess
+
+- Quality report per document/block.
+- Recommendation cho OCR/reconvert.
+- Reprocess tạo version/job mới, không ghi đè canonical.
+- Optional hard OCR/VLM qua worker policy, quota và egress control.
+- So sánh trước/sau bằng quality metrics và lưu provenance.
+
+## P3.5 — Summarization
+
+- Tóm tắt theo document, collection hoặc selected corpus.
+- Deterministic extractive fallback không cần LLM.
+- LLM summary chỉ dùng retrieved/authorized passages và giữ citation.
+- Length/audience/language là explicit options; không thêm fact không có nguồn.
+- Golden test phủ factuality, citation coverage và câu hỏi không đủ dữ liệu.
+
+## P3.6 — PII và redaction
+
+- Scan email, phone, CCCD/CMND, bank-like values và rule mở rộng.
+- Permission riêng `pii.manage`.
+- Report và export được audit.
+- Redaction tạo derived document/version mới.
+- Original immutable.
+- UI buộc review trước publish/export.
+
+Không gửi tài liệu có classification cấm ra GLM cloud.
+
+## P3.7 — Schema, tables và versions
+
+- Extract document schema.
+- List/edit Markdown table bằng stable table/cell IDs.
+- Export CSV có phòng formula injection.
+- Snapshot/version list.
+- Diff và three-way merge; conflict rõ ràng.
+- Optimistic concurrency khi save artifact/table.
+
+Các tính năng schema/table/version/export là scope desktop intelligence đã có trong
+`plans/260710-document-intelligence-suite.md`; Phase 3 port tương thích, không mở
+thêm workflow mới.
+
+## P3.8 — Intelligence UI decomposition
+
+Tách `IntelligenceView.tsx` thành:
+
+- `CorpusPanel`;
+- `HandoffStudio`;
+- `QualityPanel`;
+- `VersionsPanel`;
+- `TablesPanel`;
+- `PrivacyPanel`;
+- `ExportPanel`.
+
+Q&A panel đã thuộc Phase 2. Không port watch-folder desktop. Browser download thay
+native save dialog; citation deep-link qua document route.
+
+## P3.9 — Prompt/LLM security
+
+- System instruction và retrieved text phân ranh rõ.
+- Document text không được gọi tool, đổi ACL hoặc scope.
+- Per-org cloud egress policy và token cap.
+- Audit provider/model/classification/usage, không log prompt body.
+- Timeout/cancel/fallback deterministic.
+- Model/prompt rollout dùng versioned template và golden eval.
+
+## P3.10 — Quality evaluation
+
+Golden sets riêng:
+
+- citation coverage và validity;
+- requirement extraction/traceability;
+- PII precision/recall;
+- redaction completeness;
+- table round-trip;
+- merge conflict correctness.
+
+Retrieval metric không thay thế task-specific intelligence metric.
+
+## Tests
+
+- Handoff offline, LLM fallback và citation invariant.
+- Artifact ACL/revoke/cross-org denial.
+- PII original không đổi.
+- Table edit không phá surrounding text.
+- Version diff/merge và optimistic conflict.
+- Export manifest/ACL/formula safety.
+- Prompt injection và cloud-policy deny.
+- Component/E2E cho từng panel.
+
+## Gate
+
+- BRD/PRD pack hoàn chỉnh từ corpus thực, mọi factual requirement có citation.
+- Zero cross-scope derived artifacts.
+- PII/redaction đạt threshold đã duyệt; canonical không bị mutate.
+- Table/version/export round-trip đúng.
+- Deterministic fallback hoạt động khi provider lỗi.
+- Audit coverage đầy đủ cho intelligence/PII/export/cloud egress.
+
+## Không thuộc phase
+
+- Server-side watch folder.
+- Custom agent/tool execution từ nội dung tài liệu.
+- OIDC/group synchronization.

--- a/plans/markhand-web/phase-4-production-hardening.md
+++ b/plans/markhand-web/phase-4-production-hardening.md
@@ -1,0 +1,188 @@
+# Phase 4 — SSO, production hardening và onboarding
+
+## Outcome
+
+Đưa hệ thống từ sản phẩm nội bộ đã đủ tính năng thành deployment production có
+federated identity, hardening, DR đã diễn tập, vận hành/audit và hướng dẫn đầy đủ.
+
+## P4.1 — OIDC/SSO
+
+- Authorization Code + PKCE.
+- Validate issuer, audience, nonce, state, signature và key rotation.
+- Identity key là `(issuer, subject)`, không dùng email làm khóa duy nhất.
+- JIT provisioning theo policy.
+- Org/domain mapping.
+- Group/role sync và deprovision.
+- Chốt cơ chế deprovision: SCIM, IdP webhook/back-channel logout, hoặc periodic sync
+  có bounded interval + maximum session age; gate đo đúng revocation bound.
+- Link local account với IdP có confirmation, tránh account takeover.
+- Break-glass account và quy trình audit.
+- Session revoke khi IdP/membership thay đổi.
+
+UI:
+
+- SSO button;
+- callback/error;
+- org picker;
+- linked identity/account sessions;
+- logout all sessions.
+
+## P4.2 — Security hardening
+
+- External penetration test và remediation.
+- Threat model review sau implementation.
+- Dependency/container/SBOM/license scanning.
+- Secret manager, key rotation và compromised-token drill.
+- CSP/CSRF/CORS/reverse-proxy/TLS review.
+- SSRF/egress allowlist.
+- Parser sandbox escape review.
+- Audit tamper evidence, retention và export.
+- Privacy/data-classification review cho GLM cloud.
+
+Không go-live nếu còn high/critical finding chưa được chấp nhận chính thức.
+
+## P4.3 — HA và degraded modes
+
+Theo SLA/ADR đã chốt:
+
+- API replicas và stateless routing;
+- worker scaling/fair queue;
+- PG HA/PITR;
+- MinIO replication;
+- Qdrant topology/snapshot;
+- vLLM failover hoặc extractive degraded mode;
+- GLM outage fallback;
+- query vẫn phục vụ khi ingest tạm pause.
+
+Mỗi dependency có readiness và circuit breaker phù hợp. Không trả stale unauthorized
+cache khi auth/storage lỗi.
+
+Rate limit phải dùng shared distributed state hoặc thiết kế global tương đương khi
+có nhiều API replica; test tổng limit qua replica và sau restart, không dùng limiter
+in-memory độc lập.
+
+## P4.4 — Production deployment package
+
+Chốt một deployment target được hỗ trợ (Kubernetes hoặc orchestrator on-prem tương
+đương), cung cấp:
+
+- reproducible manifests/chart và pinned images;
+- reverse proxy/ingress + TLS;
+- secret injection và rotation;
+- namespace/network/egress policies;
+- persistent volumes, backup hooks và resource limits;
+- API/worker autoscaling;
+- install, upgrade, rollback và uninstall validation;
+- topology single-node POC và production HA được phân biệt rõ.
+
+Compose POC Phase 1B không được quảng bá là production manifest.
+
+## P4.5 — Backup/DR exercise
+
+Thực hiện trên môi trường sạch:
+
+1. Restore PG về recovery point.
+2. Restore MinIO objects/versions.
+3. Restore Qdrant snapshot hoặc rebuild từ PG chunks.
+4. Verify backup manifest/app/migration/index compatibility.
+5. Chạy integrity + denial + golden retrieval suite.
+6. Đo service-queryable RTO và full-index RTO.
+
+Diễn tập thêm:
+
+- mất Qdrant;
+- mất MinIO;
+- corrupt migration/index;
+- key compromise;
+- accidental tenant delete.
+
+## P4.6 — Migration và rollout discipline
+
+- Immutable versioned migrations + lock.
+- CI test fresh install, supported upgrades và realistic-data duration.
+- Expand → backfill → dual read/write nếu cần → cutover → contract.
+- Qdrant index versioned, shadow query, alias switch và giữ bản trước để rollback.
+- Worker khai báo schema/job payload compatibility.
+- API và worker canary độc lập.
+- Feature flag cho format, cloud GLM, intelligence và index signature.
+
+Rollout:
+
+```text
+dev → restored staging → internal org → allowlisted POC org → broader rollout
+```
+
+Định nghĩa rollback trigger trước release: error, latency, queue age, retrieval
+regression, reconciliation drift hoặc bất kỳ isolation incident nào.
+
+## P4.7 — Observability/SRE completion
+
+Dashboard và alert:
+
+- SLO burn;
+- auth anomaly;
+- queue age/capacity;
+- converter/GPU saturation;
+- retrieval quality/latency;
+- reconciliation drift;
+- quota leak;
+- backup/restore-test age;
+- disk/object/vector growth.
+
+Runbook bắt buộc:
+
+- stuck jobs/dead letters;
+- parser outbreak;
+- PG/Qdrant/MinIO/vLLM/GLM outage;
+- rebuild/rollback model;
+- quota discrepancy;
+- credential rotation;
+- tenant-access incident;
+- disk exhaustion.
+
+## P4.8 — Help và onboarding
+
+Web:
+
+- onboarding create/join org → collection → upload → first Q&A;
+- help tiếng Việt về format/limit, citation, privacy, quota, RBAC;
+- admin setup checklist;
+- contextual empty/error states;
+- searchable help;
+- accessibility WCAG 2.1 AA cho critical flows.
+
+Docs:
+
+- user guide;
+- org admin guide;
+- operator install/upgrade/backup/restore;
+- security/data-flow overview;
+- API/OpenAPI;
+- model/license inventory.
+
+## P4.9 — Final validation
+
+- Full E2E, denial, load, soak, chaos và recovery.
+- OIDC mock + IdP staging.
+- Pentest retest.
+- Accessibility audit.
+- Browser compatibility.
+- Upgrade/rollback rehearsal.
+- Desktop regression suite.
+- License review, đặc biệt model audio/OCR.
+
+## Gate
+
+- OIDC, deprovision và break-glass flow pass.
+- Không high/critical security finding mở.
+- DR đạt RPO/RTO đã duyệt.
+- HA/degraded modes hoạt động đúng.
+- Upgrade và rollback rehearsal thành công.
+- Operator có thể cài, backup, restore và xử lý incident bằng runbook.
+- Người dùng mới hoàn thành upload → Q&A qua onboarding mà không cần hỗ trợ trực tiếp.
+
+## Sau Phase 4
+
+Chỉ mở roadmap mới dựa trên telemetry và nhu cầu thật, ví dụ custom roles, billing,
+advanced workflow approval, server-side connectors/watch hoặc HA đa site. Không đưa
+các hạng mục này ngược vào scope production đầu tiên.

--- a/plans/markhand-web/phase-4-production-hardening.md
+++ b/plans/markhand-web/phase-4-production-hardening.md
@@ -39,7 +39,9 @@ UI:
 - Audit tamper evidence, retention và export.
 - Privacy/data-classification review cho GLM cloud.
 
-Không go-live nếu còn high/critical finding chưa được chấp nhận chính thức.
+Không go-live nếu còn high/critical finding chưa được giải quyết. Risk được chấp
+nhận chính thức phải có approver, compensating controls, expiry và retest date mới
+được xem là đã disposition; không được ghi nhận chung chung để bỏ qua gate.
 
 ## P4.3 — HA và degraded modes
 
@@ -174,7 +176,8 @@ Docs:
 ## Gate
 
 - OIDC, deprovision và break-glass flow pass.
-- Không high/critical security finding mở.
+- Zero unresolved high/critical security findings; mọi accepted risk có approver,
+  controls, expiry và retest date.
 - DR đạt RPO/RTO đã duyệt.
 - HA/degraded modes hoạt động đúng.
 - Upgrade và rollback rehearsal thành công.

--- a/plans/markhand-web/phase-f-engineering-foundation.md
+++ b/plans/markhand-web/phase-f-engineering-foundation.md
@@ -1,0 +1,207 @@
+# Phase F — Engineering foundation và developer platform
+
+## Outcome
+
+Dựng khung kỹ thuật thống nhất trước khi benchmark/refactor/server implementation:
+
+- architecture boundaries và folder skeleton;
+- coding/API/data conventions;
+- reproducible local development environment;
+- formatter/linter/CI/test baseline;
+- configuration/secrets/observability conventions;
+- contributor documentation và foundation gate.
+
+Phase F không quyết định model, Qdrant topology, SLA hoặc production HA. Các quyết
+định cần benchmark vẫn thuộc Phase 0; production deployment vẫn thuộc Phase 4.
+
+## F.1 — Architecture boundaries
+
+Chốt dependency direction:
+
+```text
+fileconv-core
+    ↑
+fileconv-knowledge
+    ↑                ↑
+desktop adapters    server services
+                         ↑
+                    axum routes/workers
+
+web → generated API client → server
+```
+
+Rules:
+
+- core không biết Tauri/axum/storage;
+- knowledge pure mặc định, desktop SQLite/HNSW sau optional features;
+- routes không truy cập DB/storage trực tiếp, phải qua service;
+- repository business method bắt buộc tenant context;
+- web không import Tauri;
+- `vendor/markitdown-rs` chỉ tham khảo, không dependency.
+
+## F.2 — Workspace và folder skeleton
+
+Tạo skeleton compile được nhưng không thêm business implementation:
+
+```text
+crates/
+├── core/
+├── knowledge/
+└── server/
+web/
+deploy/
+├── dev/
+└── scripts/
+docs/
+├── adr/
+├── conventions/
+└── runbooks/
+bench/markhand_web/
+```
+
+Mỗi boundary có README/module ownership. Không tạo generic abstraction khi mới có
+một consumer.
+
+## F.3 — Coding conventions
+
+### Rust
+
+- `rustfmt`, clippy policy, error/context rules;
+- async/blocking boundary và cancellation;
+- no panic/unwrap trong request/worker path;
+- DTO/domain/repository/service naming;
+- public API docs và unsafe policy.
+
+### TypeScript/React
+
+- strict TypeScript;
+- generated API types không sửa tay;
+- component/hook/state ownership;
+- accessibility, error/loading/empty states;
+- browser/Tauri boundary.
+
+### SQL
+
+- naming, UUID/time/enum/check/FK/index;
+- tenant column/predicate;
+- immutable migrations;
+- expand/backfill/cutover/contract;
+- transaction/idempotency/locking conventions.
+
+## F.4 — API/event/error conventions
+
+Chốt:
+
+- `/api/v1`, resource naming, pagination/filter/idempotency;
+- error `{code,message,requestId,details?}`;
+- OpenAPI là contract authority;
+- SSE envelope/version/sequence/reconnect;
+- date/time/UUID/enum/nullable conventions;
+- backward compatibility và deprecation policy.
+
+## F.5 — Configuration và secrets
+
+- typed config, precedence và environment profiles;
+- `.env.example` không secret;
+- mounted secret/env references;
+- redact `Debug`/logs;
+- startup fail-fast;
+- dev/test/prod không dùng unsafe default lẫn nhau.
+
+## F.6 — Local development environment
+
+Dev stack reproducible cho PostgreSQL, Qdrant, MinIO và telemetry. vLLM/GPU là
+optional profile; fake/mock embedding dùng cho CPU-only development.
+
+Yêu cầu:
+
+- one-command up/down/reset/health/seed;
+- pinned versions;
+- named volumes;
+- non-production credentials;
+- service ports/private network rõ ràng;
+- setup không phụ thuộc thao tác console.
+
+Spike benchmark Phase 0 dùng config riêng, không dùng dev data làm evidence.
+
+## F.7 — Quality tooling và CI
+
+- root task runner cho format/lint/test/build/dev;
+- rustfmt/clippy;
+- ESLint/Prettier/TypeScript/Vitest;
+- SQL migration lint/test;
+- dependency/license/security checks baseline;
+- cache và changed-path jobs nhưng vẫn có full required gate;
+- branch protection checklist.
+
+## F.8 — Test conventions
+
+Định nghĩa test pyramid:
+
+- pure unit;
+- repository/adapter integration;
+- API contract;
+- multi-tenant denial;
+- E2E;
+- benchmark/golden;
+- migration/upgrade/rollback;
+- restore/chaos.
+
+Fixture rules:
+
+- synthetic/de-identified;
+- deterministic IDs/time;
+- checksum/version;
+- no secret/absolute machine path;
+- large raw results lưu CI artifact, không commit bừa.
+
+## F.9 — Observability/audit conventions
+
+Trước khi thêm service:
+
+- trace/correlation field names;
+- metric naming/unit/cardinality;
+- structured log allowlist/redaction;
+- audit event envelope;
+- request/job/document-version/index signature propagation;
+- tuyệt đối không log document, prompt, token, key, signed URL hoặc PII.
+
+## F.10 — ADR/RFC và ownership workflow
+
+- ADR template và index;
+- khi nào cần ADR, ai approve, supersede thế nào;
+- CODEOWNERS/module ownership;
+- issue/PR templates;
+- Definition of Ready/Done;
+- security review trigger.
+
+## Deliverables
+
+- Compileable workspace skeleton.
+- Convention documents và automated checks.
+- Reproducible CPU-only local dev stack.
+- CI foundation và task runner.
+- Test/fixture/observability standards.
+- ADR/issue/PR workflow.
+- Developer setup/runbook.
+
+## Gate
+
+Phase F chỉ pass khi:
+
+- clean checkout setup chạy theo docs;
+- workspace skeleton build/test;
+- local services up/health/seed/reset;
+- formatter/linter/typecheck/test/migration checks chạy cả local và CI;
+- dependency boundary tests pass;
+- sample API error/SSE/config/telemetry fixtures tuân conventions;
+- không secret/PII trong repository hoặc CI artifact mẫu;
+- Phase 0 và 1A có thể bắt đầu mà không tự tạo convention riêng.
+
+## Không thuộc phase
+
+- Benchmark/model/topology/SLA decisions.
+- Business schema đầy đủ.
+- Auth/upload/job/retrieval implementation.
+- Production Kubernetes/HA/DR.
+- Refactor toàn bộ desktop vào skeleton.

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -1,0 +1,1171 @@
+<!doctype html>
+<html lang="vi">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark">
+  <title>Markhand Web — Roadmap</title>
+  <style>
+    :root {
+      --bg: #090b0f;
+      --surface: #11141a;
+      --surface-raised: #171b22;
+      --surface-hover: #1d222b;
+      --border: #2b313c;
+      --border-strong: #3c4553;
+      --text: #f4f6f8;
+      --text-muted: #a4adba;
+      --text-dim: #778190;
+      --brand: #f97316;
+      --brand-soft: rgba(249, 115, 22, 0.14);
+      --brand-ring: rgba(249, 115, 22, 0.35);
+      --ready: #38bdf8;
+      --ready-soft: rgba(56, 189, 248, 0.13);
+      --blocked: #fb7185;
+      --blocked-soft: rgba(251, 113, 133, 0.13);
+      --backlog: #94a3b8;
+      --backlog-soft: rgba(148, 163, 184, 0.12);
+      --progress: #fbbf24;
+      --progress-soft: rgba(251, 191, 36, 0.13);
+      --review: #a78bfa;
+      --review-soft: rgba(167, 139, 250, 0.13);
+      --done: #34d399;
+      --done-soft: rgba(52, 211, 153, 0.13);
+      --shadow: 0 18px 50px rgba(0, 0, 0, 0.3);
+      --radius: 14px;
+      --sidebar: 260px;
+    }
+
+    * { box-sizing: border-box; }
+
+    html {
+      scroll-behavior: smooth;
+      background: var(--bg);
+    }
+
+    body {
+      margin: 0;
+      min-width: 320px;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 80% -10%, rgba(249, 115, 22, 0.10), transparent 30rem),
+        var(--bg);
+      font: 15px/1.55 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    button, input, select { font: inherit; }
+    button, select { cursor: pointer; }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .skip-link {
+      position: fixed;
+      z-index: 1000;
+      top: 8px;
+      left: 8px;
+      padding: 10px 14px;
+      color: #111;
+      background: #fff;
+      border-radius: 8px;
+      transform: translateY(-150%);
+    }
+
+    .skip-link:focus { transform: translateY(0); }
+
+    :focus-visible {
+      outline: 3px solid var(--brand);
+      outline-offset: 2px;
+    }
+
+    .app {
+      display: grid;
+      grid-template-columns: var(--sidebar) minmax(0, 1fr);
+      min-height: 100dvh;
+    }
+
+    .sidebar {
+      position: sticky;
+      top: 0;
+      height: 100dvh;
+      overflow-y: auto;
+      padding: 24px 18px;
+      background: rgba(13, 16, 21, 0.94);
+      border-right: 1px solid var(--border);
+      backdrop-filter: blur(16px);
+    }
+
+    .brand {
+      display: flex;
+      gap: 11px;
+      align-items: center;
+      margin: 0 6px 28px;
+    }
+
+    .brand-mark {
+      display: grid;
+      place-items: center;
+      width: 36px;
+      height: 36px;
+      color: #111827;
+      background: var(--brand);
+      border-radius: 10px;
+      box-shadow: 0 8px 24px var(--brand-ring);
+    }
+
+    .brand-mark svg { width: 20px; height: 20px; }
+    .brand-name { font-weight: 750; letter-spacing: -0.02em; }
+    .brand-subtitle { color: var(--text-dim); font-size: 12px; }
+
+    .nav-label {
+      margin: 0 8px 8px;
+      color: var(--text-dim);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.11em;
+      text-transform: uppercase;
+    }
+
+    .phase-nav {
+      display: grid;
+      gap: 6px;
+      margin-bottom: 24px;
+    }
+
+    .phase-nav button {
+      display: grid;
+      grid-template-columns: 30px 1fr auto;
+      gap: 9px;
+      align-items: center;
+      width: 100%;
+      min-height: 46px;
+      padding: 7px 10px;
+      color: var(--text-muted);
+      text-align: left;
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 10px;
+      transition: 160ms ease;
+    }
+
+    .phase-nav button:hover {
+      color: var(--text);
+      background: var(--surface-hover);
+    }
+
+    .phase-nav button.active {
+      color: var(--text);
+      background: var(--brand-soft);
+      border-color: var(--brand-ring);
+    }
+
+    .phase-code {
+      display: grid;
+      place-items: center;
+      width: 28px;
+      height: 28px;
+      color: var(--text);
+      font-size: 11px;
+      font-weight: 800;
+      background: var(--surface-raised);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+    }
+
+    .phase-nav button.active .phase-code {
+      color: #111827;
+      background: var(--brand);
+      border-color: var(--brand);
+    }
+
+    .phase-nav-name { font-size: 13px; font-weight: 650; }
+    .phase-nav-count { color: var(--text-dim); font-size: 12px; font-variant-numeric: tabular-nums; }
+
+    .sidebar-note {
+      margin-top: 24px;
+      padding: 14px;
+      color: var(--text-muted);
+      font-size: 12px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+    }
+
+    .sidebar-note strong { display: block; margin-bottom: 4px; color: var(--text); }
+
+    .main {
+      min-width: 0;
+      padding: 28px clamp(18px, 4vw, 58px) 64px;
+    }
+
+    .topbar {
+      display: flex;
+      gap: 20px;
+      align-items: flex-start;
+      justify-content: space-between;
+      max-width: 1460px;
+      margin: 0 auto 26px;
+    }
+
+    .eyebrow {
+      margin: 0 0 6px;
+      color: var(--brand);
+      font-size: 12px;
+      font-weight: 750;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(28px, 4vw, 44px);
+      line-height: 1.12;
+      letter-spacing: -0.045em;
+    }
+
+    .lead {
+      max-width: 720px;
+      margin: 9px 0 0;
+      color: var(--text-muted);
+      font-size: 15px;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+
+    .button {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      min-height: 44px;
+      padding: 9px 13px;
+      color: var(--text);
+      background: var(--surface-raised);
+      border: 1px solid var(--border);
+      border-radius: 9px;
+      transition: 160ms ease;
+    }
+
+    .button:hover { background: var(--surface-hover); border-color: var(--border-strong); }
+    .button.danger:hover { color: #fecdd3; border-color: var(--blocked); }
+    .button svg { width: 16px; height: 16px; }
+
+    .dashboard {
+      max-width: 1460px;
+      margin: 0 auto;
+    }
+
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 18px;
+    }
+
+    .stat {
+      min-height: 118px;
+      padding: 18px;
+      background: linear-gradient(150deg, var(--surface-raised), var(--surface));
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+    }
+
+    .stat-label { color: var(--text-muted); font-size: 12px; font-weight: 650; }
+    .stat-value { margin-top: 4px; font-size: 32px; font-weight: 760; letter-spacing: -0.04em; font-variant-numeric: tabular-nums; }
+    .stat-meta { margin-top: 5px; color: var(--text-dim); font-size: 12px; }
+
+    .progress-shell {
+      height: 7px;
+      margin-top: 12px;
+      overflow: hidden;
+      background: #07090c;
+      border-radius: 999px;
+    }
+
+    .progress-value {
+      width: 0;
+      height: 100%;
+      background: linear-gradient(90deg, var(--brand), #fb923c);
+      border-radius: inherit;
+      transition: width 240ms ease;
+    }
+
+    .phase-strip {
+      display: grid;
+      grid-template-columns: repeat(8, minmax(120px, 1fr));
+      gap: 8px;
+      margin-bottom: 18px;
+      overflow-x: auto;
+      padding-bottom: 4px;
+    }
+
+    .phase-mini {
+      min-width: 120px;
+      padding: 13px;
+      color: var(--text-muted);
+      text-align: left;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      transition: 160ms ease;
+    }
+
+    .phase-mini:hover { color: var(--text); border-color: var(--border-strong); }
+    .phase-mini.active { color: var(--text); border-color: var(--brand); box-shadow: inset 0 0 0 1px var(--brand-ring); }
+    .phase-mini-head { display: flex; align-items: center; justify-content: space-between; }
+    .phase-mini-code { font-weight: 800; }
+    .phase-mini-progress { color: var(--text-dim); font-size: 11px; font-variant-numeric: tabular-nums; }
+
+    .mini-bar {
+      height: 4px;
+      margin-top: 10px;
+      overflow: hidden;
+      background: #080a0d;
+      border-radius: 999px;
+    }
+
+    .mini-bar > span { display: block; height: 100%; background: var(--done); }
+
+    .toolbar {
+      display: grid;
+      grid-template-columns: minmax(240px, 1fr) 190px 190px auto;
+      gap: 10px;
+      align-items: center;
+      margin-bottom: 18px;
+      padding: 12px;
+      background: rgba(17, 20, 26, 0.86);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      backdrop-filter: blur(10px);
+    }
+
+    .field {
+      position: relative;
+      display: flex;
+      align-items: center;
+    }
+
+    .field svg {
+      position: absolute;
+      left: 12px;
+      width: 16px;
+      height: 16px;
+      color: var(--text-dim);
+      pointer-events: none;
+    }
+
+    .field input,
+    .toolbar select {
+      width: 100%;
+      min-height: 44px;
+      color: var(--text);
+      background: #0b0e12;
+      border: 1px solid var(--border);
+      border-radius: 9px;
+    }
+
+    .field input { padding: 9px 12px 9px 38px; }
+    .toolbar select { padding: 9px 34px 9px 12px; }
+    .field input::placeholder { color: var(--text-dim); }
+
+    .result-count {
+      min-width: 110px;
+      color: var(--text-muted);
+      font-size: 12px;
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .phase-section {
+      margin: 0 0 18px;
+      overflow: hidden;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+    }
+
+    .phase-header {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: 14px;
+      align-items: center;
+      padding: 17px 18px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .phase-badge {
+      display: grid;
+      place-items: center;
+      min-width: 42px;
+      height: 42px;
+      padding: 0 8px;
+      color: #111827;
+      font-size: 12px;
+      font-weight: 800;
+      background: var(--brand);
+      border-radius: 10px;
+    }
+
+    .phase-title { margin: 0; font-size: 17px; letter-spacing: -0.015em; }
+    .phase-description { margin: 2px 0 0; color: var(--text-muted); font-size: 12px; }
+    .phase-summary { color: var(--text-muted); font-size: 12px; text-align: right; font-variant-numeric: tabular-nums; }
+
+    .issue-list { display: grid; }
+
+    .issue {
+      display: grid;
+      grid-template-columns: 94px minmax(220px, 1fr) 150px 38px;
+      gap: 14px;
+      align-items: center;
+      min-height: 62px;
+      padding: 10px 16px;
+      border-bottom: 1px solid rgba(43, 49, 60, 0.72);
+      transition: 140ms ease;
+    }
+
+    .issue:last-child { border-bottom: 0; }
+    .issue:hover { background: var(--surface-hover); }
+
+    .issue-id {
+      color: var(--text-muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .issue-title { min-width: 0; font-weight: 560; }
+    .issue.done .issue-title { color: var(--text-muted); text-decoration: line-through; text-decoration-color: var(--text-dim); }
+
+    .status-select {
+      width: 100%;
+      min-height: 44px;
+      padding: 7px 28px 7px 10px;
+      color: var(--text);
+      background: #0b0e12;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+    }
+
+    .status-select[data-status="ready"] { color: var(--ready); border-color: rgba(56, 189, 248, 0.35); background: var(--ready-soft); }
+    .status-select[data-status="blocked"] { color: var(--blocked); border-color: rgba(251, 113, 133, 0.35); background: var(--blocked-soft); }
+    .status-select[data-status="backlog"] { color: var(--backlog); background: var(--backlog-soft); }
+    .status-select[data-status="in_progress"] { color: var(--progress); border-color: rgba(251, 191, 36, 0.35); background: var(--progress-soft); }
+    .status-select[data-status="review"] { color: var(--review); border-color: rgba(167, 139, 250, 0.35); background: var(--review-soft); }
+    .status-select[data-status="done"] { color: var(--done); border-color: rgba(52, 211, 153, 0.35); background: var(--done-soft); }
+
+    .issue-link {
+      display: grid;
+      place-items: center;
+      width: 44px;
+      height: 44px;
+      color: var(--text-dim);
+      border-radius: 8px;
+    }
+
+    .issue-link:hover { color: var(--text); background: var(--surface-raised); }
+    .issue-link svg { width: 16px; height: 16px; }
+
+    .empty {
+      display: none;
+      padding: 54px 20px;
+      color: var(--text-muted);
+      text-align: center;
+      background: var(--surface);
+      border: 1px dashed var(--border-strong);
+      border-radius: var(--radius);
+    }
+
+    .toast {
+      position: fixed;
+      z-index: 100;
+      right: 20px;
+      bottom: 20px;
+      max-width: min(360px, calc(100vw - 40px));
+      padding: 12px 15px;
+      color: var(--text);
+      background: var(--surface-raised);
+      border: 1px solid var(--border-strong);
+      border-radius: 10px;
+      box-shadow: var(--shadow);
+      opacity: 0;
+      transform: translateY(12px);
+      pointer-events: none;
+      transition: 180ms ease;
+    }
+
+    .toast.show { opacity: 1; transform: translateY(0); }
+    .visually-hidden {
+      position: absolute !important;
+      width: 1px !important;
+      height: 1px !important;
+      padding: 0 !important;
+      margin: -1px !important;
+      overflow: hidden !important;
+      clip: rect(0, 0, 0, 0) !important;
+      white-space: nowrap !important;
+      border: 0 !important;
+    }
+
+    @media (max-width: 1050px) {
+      :root { --sidebar: 220px; }
+      .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .toolbar { grid-template-columns: 1fr 1fr; }
+      .result-count { text-align: left; }
+    }
+
+    @media (max-width: 760px) {
+      .app { display: block; }
+      .sidebar {
+        position: relative;
+        width: 100%;
+        height: auto;
+        padding: 16px;
+        border-right: 0;
+        border-bottom: 1px solid var(--border);
+      }
+      .brand { margin-bottom: 16px; }
+      .phase-nav {
+        display: flex;
+        overflow-x: auto;
+      }
+      .phase-nav button { display: flex; flex: 0 0 100px; min-width: 100px; }
+      .phase-nav-name, .phase-nav-count, .nav-label, .sidebar-note { display: none; }
+      .main { padding: 22px 14px 48px; }
+      .topbar { display: block; }
+      .actions { justify-content: flex-start; margin-top: 18px; }
+      .toolbar { grid-template-columns: 1fr; }
+      .stats { grid-template-columns: 1fr 1fr; }
+      .issue {
+        grid-template-columns: 72px minmax(0, 1fr) 44px;
+        gap: 8px;
+        padding: 13px;
+      }
+      .issue > label { grid-column: 2 / 4; grid-row: 2; }
+      .issue-link { grid-column: 3; grid-row: 1; }
+      .phase-header { grid-template-columns: auto minmax(0, 1fr); }
+      .phase-summary { grid-column: 2; text-align: left; }
+    }
+
+    @media (max-width: 430px) {
+      .stats { grid-template-columns: 1fr; }
+      .actions .button span { display: none; }
+      .actions .button { width: 44px; justify-content: center; padding: 0; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Bỏ qua điều hướng</a>
+  <div class="app">
+    <aside class="sidebar" aria-label="Điều hướng roadmap">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M4 19V5a2 2 0 0 1 2-2h9l5 5v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Z"/>
+            <path d="M14 3v6h6M8 13h8M8 17h5"/>
+          </svg>
+        </span>
+        <div>
+          <div class="brand-name">Markhand Web</div>
+          <div class="brand-subtitle">Delivery roadmap</div>
+        </div>
+      </div>
+      <p class="nav-label">Milestones</p>
+      <nav class="phase-nav" id="phaseNav"></nav>
+      <div class="sidebar-note">
+        <strong>Trạng thái được lưu cục bộ</strong>
+        Dùng Export JSON để chia sẻ hoặc lưu phiên bản theo dõi.
+      </div>
+    </aside>
+
+    <main class="main" id="main" tabindex="-1">
+      <header class="topbar">
+        <div>
+          <p class="eyebrow">Engineering delivery plan</p>
+          <h1>Roadmap triển khai Markhand Web</h1>
+          <p class="lead">Theo dõi 8 milestones, 113 issues và các gate từ engineering foundation đến production go-live.</p>
+        </div>
+        <div class="actions" aria-label="Thao tác dữ liệu">
+          <button class="button" id="exportButton" type="button" aria-label="Export trạng thái roadmap ra JSON">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/>
+            </svg>
+            <span>Export JSON</span>
+          </button>
+          <button class="button" id="importButton" type="button" aria-label="Import trạng thái roadmap từ JSON">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M12 21V9m0 0 4 4m-4-4-4 4M5 3h14"/>
+            </svg>
+            <span>Import</span>
+          </button>
+          <button class="button danger" id="resetButton" type="button" aria-label="Đặt lại toàn bộ trạng thái roadmap">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M3 12a9 9 0 1 0 3-6.7L3 8m0-5v5h5"/>
+            </svg>
+            <span>Đặt lại</span>
+          </button>
+          <input class="visually-hidden" id="importFile" type="file" accept="application/json">
+        </div>
+      </header>
+
+      <div class="dashboard">
+        <section class="stats" aria-label="Tổng quan tiến độ">
+          <article class="stat">
+            <div class="stat-label">Tổng issues</div>
+            <div class="stat-value" id="totalStat">113</div>
+            <div class="stat-meta">trên 8 milestones</div>
+          </article>
+          <article class="stat">
+            <div class="stat-label">Đã hoàn thành</div>
+            <div class="stat-value" id="doneStat">0</div>
+            <div class="progress-shell" aria-hidden="true"><div class="progress-value" id="overallProgress"></div></div>
+            <div class="stat-meta" id="doneMeta">0% tổng tiến độ</div>
+          </article>
+          <article class="stat">
+            <div class="stat-label">Đang thực hiện / review</div>
+            <div class="stat-value" id="activeStat">0</div>
+            <div class="stat-meta">issues đang có chuyển động</div>
+          </article>
+          <article class="stat">
+            <div class="stat-label">Blocked</div>
+            <div class="stat-value" id="blockedStat">55</div>
+            <div class="stat-meta">cần dependency hoặc gate</div>
+          </article>
+        </section>
+
+        <section class="phase-strip" id="phaseStrip" aria-label="Tiến độ theo phase"></section>
+
+        <section class="toolbar" aria-label="Bộ lọc roadmap">
+          <label class="field">
+            <span class="visually-hidden">Tìm issue</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/>
+            </svg>
+            <input id="searchInput" type="search" placeholder="Tìm theo ID hoặc tên issue…" autocomplete="off">
+          </label>
+          <label>
+            <span class="visually-hidden">Lọc theo trạng thái</span>
+            <select id="statusFilter">
+              <option value="all">Mọi trạng thái</option>
+              <option value="ready">Ready</option>
+              <option value="blocked">Blocked</option>
+              <option value="backlog">Backlog</option>
+              <option value="in_progress">In progress</option>
+              <option value="review">Review</option>
+              <option value="done">Done</option>
+            </select>
+          </label>
+          <label>
+            <span class="visually-hidden">Lọc theo phase</span>
+            <select id="phaseFilter"></select>
+          </label>
+          <div class="result-count" id="resultCount" aria-live="polite">113 issues</div>
+        </section>
+
+        <div id="roadmap"></div>
+        <div class="empty" id="emptyState">
+          <strong>Không tìm thấy issue phù hợp.</strong><br>
+          Thử đổi từ khóa hoặc bộ lọc.
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+  <script>
+    const STATUS = {
+      backlog: "Backlog",
+      ready: "Ready",
+      blocked: "Blocked",
+      in_progress: "In progress",
+      review: "Review",
+      done: "Done"
+    };
+
+    const phases = [
+      {
+        id: "phase-f", code: "F", name: "Engineering Foundation",
+        description: "Rules, skeleton, dev environment và CI foundation",
+        catalog: "backlog/phase-f/issues/README.md",
+        issues: [
+          ["F-01", "Architecture boundaries và dependency rules", "ready"],
+          ["F-02", "Workspace và folder skeleton", "blocked"],
+          ["F-03", "Rust coding và crate conventions", "blocked"],
+          ["F-04", "TypeScript/React conventions", "blocked"],
+          ["F-05", "SQL/data/migration conventions", "blocked"],
+          ["F-06", "REST/OpenAPI/SSE/error conventions", "blocked"],
+          ["F-07", "Configuration, secrets và environment profiles", "blocked"],
+          ["F-08", "Reproducible local development environment", "blocked"],
+          ["F-09", "Root task runner, quality tools và CI baseline", "blocked"],
+          ["F-10", "Test pyramid, fixtures và golden-data conventions", "blocked"],
+          ["F-11", "Observability/audit conventions", "blocked"],
+          ["F-12", "Contributor workflow, setup docs và foundation gate", "blocked"]
+        ]
+      },
+      {
+        id: "phase-0", code: "0", name: "Discovery & Gates",
+        description: "Benchmark, threat model, SLA và architecture decisions",
+        catalog: "backlog/phase-0/issues/README.md",
+        issues: [
+          ["P0-01", "Khóa workload, hardware và gate registry", "blocked"],
+          ["P0-02", "Golden corpus tiếng Việt và adversarial corpus", "blocked"],
+          ["P0-03", "Mở rộng desktop baseline trên corpus Phase 0", "blocked"],
+          ["P0-04", "Spike infrastructure tái lập", "blocked"],
+          ["P0-05", "Đánh giá embedding tiếng Việt", "blocked"],
+          ["P0-06", "Chunking, hybrid tuning và index signature", "blocked"],
+          ["P0-07", "PG/Qdrant target-scale topology", "blocked"],
+          ["P0-08", "Sizing converter và ingest backpressure", "blocked"],
+          ["P0-09", "Upload threat model, sandbox và license inventory", "blocked"],
+          ["P0-10", "ADR, SLO/RPO/RTO và Phase 0 gate", "blocked"]
+        ]
+      },
+      {
+        id: "phase-1a", code: "1A", name: "Knowledge Extraction",
+        description: "Tách fileconv-knowledge, giữ desktop parity",
+        catalog: "backlog/phase-1a/issues/README.md",
+        issues: [
+          ["P1A-01", "Freeze desktop RAG và IPC contracts", "blocked"],
+          ["P1A-02", "Populate knowledge skeleton và enforce dependency boundaries", "blocked"],
+          ["P1A-03", "Shared DTO và serde contract", "blocked"],
+          ["P1A-04", "Durable identities và index signatures", "blocked"],
+          ["P1A-05", "Query, local vectors và embedding plan", "blocked"],
+          ["P1A-06", "Rank, citation và grounded answer", "blocked"],
+          ["P1A-07", "SQLite desktop storage feature", "blocked"],
+          ["P1A-08", "Persistent HNSW desktop feature", "blocked"],
+          ["P1A-09", "Thin Tauri adapters", "blocked"],
+          ["P1A-10", "CI parity và extraction gate", "blocked"]
+        ]
+      },
+      {
+        id: "phase-1b", code: "1B", name: "Single-org POC",
+        description: "Upload → convert → index → Q&A citation",
+        catalog: "backlog/phase-1b/issues/README.md",
+        issues: [
+          ["P1B-F01", "Extend server skeleton với runtime POC", "blocked"],
+          ["P1B-F02", "POC deployment và isolation scaffold", "blocked"],
+          ["P1B-F03", "Multi-org-ready schema và immutable migrations", "blocked"],
+          ["P1B-F04", "OrgContext, repositories và state machine", "blocked"],
+          ["P1B-F05", "Password auth, rotating sessions và browser refresh transport", "blocked"],
+          ["P1B-F06", "Fail-closed PG/Qdrant/MinIO adapters", "blocked"],
+          ["P1B-I01", "Streaming quarantine upload validation", "blocked"],
+          ["P1B-I02", "Atomic quota admission", "blocked"],
+          ["P1B-I03", "Durable jobs, outbox và event log", "blocked"],
+          ["P1B-I04", "Isolated converter worker", "blocked"],
+          ["P1B-I05", "Idempotent conversion promotion saga", "blocked"],
+          ["P1B-I06", "Chunk/embedding/index worker", "blocked"],
+          ["P1B-I07", "Tombstone delete và reconcile", "blocked"],
+          ["P1B-R01", "Tenant-scoped hybrid retrieval", "blocked"],
+          ["P1B-R02", "Citation, preview và download authorization", "blocked"],
+          ["P1B-R03", "Grounded Q&A, stream và fallback", "blocked"],
+          ["P1B-R04", "Collection/document/job REST API", "blocked"],
+          ["P1B-R05", "Search/ask/resumable SSE API", "blocked"],
+          ["P1B-R06", "OpenAPI, rate limit và readiness", "blocked"],
+          ["P1B-O01", "End-to-end telemetry và safe audit", "blocked"],
+          ["P1B-O02", "Dashboards, alerts và runbooks", "blocked"],
+          ["P1B-O03", "Backup/restore và migration safety", "blocked"],
+          ["P1B-O04", "Vertical-slice/security release suite", "blocked"],
+          ["P1B-O05", "Mixed-load soak và POC qualification", "blocked"]
+        ]
+      },
+      {
+        id: "phase-1c", code: "1C", name: "Multi-org Security",
+        description: "RBAC, ACL, quota, fairness và denial suite",
+        catalog: "backlog/phase-1c/issues/README.md",
+        issues: [
+          ["1C-01", "Organization lifecycle và validated context", "backlog"],
+          ["1C-02", "Membership, invites và last-owner invariant", "backlog"],
+          ["1C-03", "Canonical RBAC seed", "backlog"],
+          ["1C-04", "Route/service guards và service identities", "backlog"],
+          ["1C-05", "Collection ACL resolver/cache", "backlog"],
+          ["1C-06", "PostgreSQL ACL enforcement", "backlog"],
+          ["1C-07", "Qdrant/storage/jobs fail-closed enforcement", "backlog"],
+          ["1C-08", "RLS và pool defense", "backlog"],
+          ["1C-09", "Atomic quota lifecycle", "backlog"],
+          ["1C-10", "Rate limit và per-org fairness", "backlog"],
+          ["1C-11", "Audit/admin APIs", "backlog"],
+          ["1C-12", "Multi-org denial suite", "backlog"],
+          ["1C-13", "Security/revoke/load gate", "backlog"]
+        ]
+      },
+      {
+        id: "phase-2", code: "2", name: "Web SPA MVP",
+        description: "Login, library, upload, Q&A và admin tối thiểu",
+        catalog: "backlog/phase-2/issues/README.md",
+        issues: [
+          ["P2-01", "React/Vite workspace và UI foundations", "backlog"],
+          ["P2-02", "OpenAPI contracts và mock server", "backlog"],
+          ["P2-03", "Typed HTTP client/session refresh", "backlog"],
+          ["P2-04", "Fetch-based SSE transport", "backlog"],
+          ["P2-05", "Login/session/application shell", "backlog"],
+          ["P2-06", "Org switch và scope-safe state", "backlog"],
+          ["P2-07", "Library/list/sanitized preview", "backlog"],
+          ["P2-08", "Upload progress và job lifecycle", "backlog"],
+          ["P2-09", "Download/delete/reindex/retry", "backlog"],
+          ["P2-10", "Streaming search/Q&A/citations", "backlog"],
+          ["P2-11", "Member/role admin", "backlog"],
+          ["P2-12", "Usage/quota/reservations", "backlog"],
+          ["P2-13", "Browser/SafeMarkdown hardening", "backlog"],
+          ["P2-14", "Accessibility/interaction quality", "backlog"],
+          ["P2-15", "Contract/integration/E2E suite", "backlog"],
+          ["P2-16", "Production build/static serving/final gate", "backlog"]
+        ]
+      },
+      {
+        id: "phase-3", code: "3", name: "Document Intelligence",
+        description: "BRD/PRD, quality, PII, tables, versions và export",
+        catalog: "backlog/phase-3/issues/README.md",
+        issues: [
+          ["P3-01", "Reusable intelligence service boundary", "backlog"],
+          ["P3-02", "Versioned derived-artifact schema", "backlog"],
+          ["P3-03", "Current-source ACL mỗi artifact access", "backlog"],
+          ["P3-04", "Deterministic BRD/PRD job", "backlog"],
+          ["P3-05", "Handoff edit/validate/ZIP export", "backlog"],
+          ["P3-06", "Quality và immutable reprocess", "backlog"],
+          ["P3-07", "Citation-backed summarization", "backlog"],
+          ["P3-08", "PII detection/reviewed redaction", "backlog"],
+          ["P3-09", "Schema/table edit và safe CSV", "backlog"],
+          ["P3-10", "Versions, diff và three-way merge", "backlog"],
+          ["P3-11", "Prompt/model/quota/cloud policy", "backlog"],
+          ["P3-12", "Intelligence web workspace", "backlog"],
+          ["P3-13", "Task-specific golden evaluation", "backlog"],
+          ["P3-14", "Intelligence denial/audit/reconcile/release gate", "backlog"]
+        ]
+      },
+      {
+        id: "phase-4", code: "4", name: "Production Hardening",
+        description: "OIDC, HA, DR, deployment và go-live",
+        catalog: "backlog/phase-4/issues/README.md",
+        issues: [
+          ["P4-01", "OIDC Authorization Code + PKCE", "backlog"],
+          ["P4-02", "JIT provisioning và account linking", "backlog"],
+          ["P4-03", "Group/role sync và bounded deprovision", "backlog"],
+          ["P4-04", "Session UI và break-glass", "backlog"],
+          ["P4-05", "Platform security/supply chain/secrets", "backlog"],
+          ["P4-06", "Threat review/external pentest/remediation", "backlog"],
+          ["P4-07", "HA/degraded modes/distributed limiting", "backlog"],
+          ["P4-08", "Reproducible production deployment", "backlog"],
+          ["P4-09", "Backup/PITR/restore tooling", "backlog"],
+          ["P4-10", "Clean DR/destructive failure drills", "backlog"],
+          ["P4-11", "Migration/canary/rollback discipline", "backlog"],
+          ["P4-12", "SRE dashboards/alerts/runbooks", "backlog"],
+          ["P4-13", "Onboarding/help/accessibility/operator docs", "backlog"],
+          ["P4-14", "Production go-live gate", "backlog"]
+        ]
+      }
+    ];
+
+    const STORAGE_KEY = "markhand-roadmap-status-v1";
+    let saved = loadSaved();
+    let phaseScope = "all";
+    let toastTimer;
+
+    const elements = {
+      phaseNav: document.querySelector("#phaseNav"),
+      phaseStrip: document.querySelector("#phaseStrip"),
+      phaseFilter: document.querySelector("#phaseFilter"),
+      statusFilter: document.querySelector("#statusFilter"),
+      searchInput: document.querySelector("#searchInput"),
+      roadmap: document.querySelector("#roadmap"),
+      emptyState: document.querySelector("#emptyState"),
+      resultCount: document.querySelector("#resultCount"),
+      totalStat: document.querySelector("#totalStat"),
+      doneStat: document.querySelector("#doneStat"),
+      doneMeta: document.querySelector("#doneMeta"),
+      activeStat: document.querySelector("#activeStat"),
+      blockedStat: document.querySelector("#blockedStat"),
+      overallProgress: document.querySelector("#overallProgress"),
+      toast: document.querySelector("#toast"),
+      importFile: document.querySelector("#importFile")
+    };
+
+    function loadSaved() {
+      try {
+        const value = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+        return value && typeof value === "object" ? value : {};
+      } catch {
+        return {};
+      }
+    }
+
+    function statusFor(issue) {
+      return STATUS[saved[issue[0]]] ? saved[issue[0]] : issue[2];
+    }
+
+    function allIssues() {
+      return phases.flatMap(phase => phase.issues.map(issue => ({ phase, issue, status: statusFor(issue) })));
+    }
+
+    function escapeHtml(value) {
+      return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;");
+    }
+
+    function slugText(value) {
+      return value.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+    }
+
+    function renderNavigation() {
+      const allButton = `
+        <button type="button" data-phase="all" class="${phaseScope === "all" ? "active" : ""}" aria-pressed="${phaseScope === "all"}">
+          <span class="phase-code">ALL</span><span class="phase-nav-name">Tất cả phases</span>
+          <span class="phase-nav-count">${allIssues().length}</span>
+        </button>`;
+      elements.phaseNav.innerHTML = allButton + phases.map(phase => {
+        const done = phase.issues.filter(issue => statusFor(issue) === "done").length;
+        return `
+          <button type="button" data-phase="${phase.id}" class="${phaseScope === phase.id ? "active" : ""}" aria-pressed="${phaseScope === phase.id}">
+            <span class="phase-code">${phase.code}</span><span class="phase-nav-name">${phase.name}</span>
+            <span class="phase-nav-count">${done}/${phase.issues.length}</span>
+          </button>`;
+      }).join("");
+
+      elements.phaseFilter.innerHTML = `<option value="all">Mọi phase</option>` +
+        phases.map(phase => `<option value="${phase.id}">Phase ${phase.code} — ${phase.name}</option>`).join("");
+      elements.phaseFilter.value = phaseScope;
+
+      elements.phaseStrip.innerHTML = phases.map(phase => {
+        const done = phase.issues.filter(issue => statusFor(issue) === "done").length;
+        const percent = Math.round(done / phase.issues.length * 100);
+        return `
+          <button type="button" class="phase-mini ${phaseScope === phase.id ? "active" : ""}" data-phase="${phase.id}" aria-pressed="${phaseScope === phase.id}">
+            <span class="phase-mini-head">
+              <span class="phase-mini-code">Phase ${phase.code}</span>
+              <span class="phase-mini-progress">${done}/${phase.issues.length}</span>
+            </span>
+            <span class="mini-bar"><span style="width:${percent}%"></span></span>
+          </button>`;
+      }).join("");
+    }
+
+    function renderStats() {
+      const issues = allIssues();
+      const done = issues.filter(item => item.status === "done").length;
+      const active = issues.filter(item => item.status === "in_progress" || item.status === "review").length;
+      const blocked = issues.filter(item => item.status === "blocked").length;
+      const percent = Math.round(done / issues.length * 100);
+      elements.totalStat.textContent = issues.length;
+      elements.doneStat.textContent = done;
+      elements.activeStat.textContent = active;
+      elements.blockedStat.textContent = blocked;
+      elements.doneMeta.textContent = `${percent}% tổng tiến độ`;
+      elements.overallProgress.style.width = `${percent}%`;
+    }
+
+    function matchesFilters(phase, issue) {
+      const text = slugText(`${issue[0]} ${issue[1]}`);
+      const query = slugText(elements.searchInput.value.trim());
+      const status = statusFor(issue);
+      const statusValue = elements.statusFilter.value;
+      return (!query || text.includes(query))
+        && (statusValue === "all" || status === statusValue)
+        && (phaseScope === "all" || phase.id === phaseScope);
+    }
+
+    function statusOptions(current) {
+      return Object.entries(STATUS)
+        .map(([value, label]) => `<option value="${value}" ${value === current ? "selected" : ""}>${label}</option>`)
+        .join("");
+    }
+
+    function renderRoadmap() {
+      let shown = 0;
+      const html = phases.map(phase => {
+        const visible = phase.issues.filter(issue => matchesFilters(phase, issue));
+        if (!visible.length) return "";
+        shown += visible.length;
+        const done = phase.issues.filter(issue => statusFor(issue) === "done").length;
+        const active = phase.issues.filter(issue => ["in_progress", "review"].includes(statusFor(issue))).length;
+        return `
+          <section class="phase-section" id="${phase.id}">
+            <header class="phase-header">
+              <span class="phase-badge">P${phase.code}</span>
+              <div>
+                <h2 class="phase-title">Phase ${phase.code} — ${phase.name}</h2>
+                <p class="phase-description">${phase.description}</p>
+              </div>
+              <div class="phase-summary">${done} done · ${active} active · ${phase.issues.length} total</div>
+            </header>
+            <div class="issue-list">
+              ${visible.map(issue => {
+                const current = statusFor(issue);
+                return `
+                  <article class="issue ${current === "done" ? "done" : ""}" data-issue="${issue[0]}">
+                    <span class="issue-id">${issue[0]}</span>
+                    <span class="issue-title">${escapeHtml(issue[1])}</span>
+                    <label>
+                      <span class="visually-hidden">Trạng thái ${issue[0]}</span>
+                      <select class="status-select" data-issue-status="${issue[0]}" data-status="${current}">
+                        ${statusOptions(current)}
+                      </select>
+                    </label>
+                    <a class="issue-link" href="${phase.catalog}" title="Mở catalog Phase ${phase.code}" aria-label="Mở catalog chứa ${issue[0]}">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path d="M14 3h7v7M10 14 21 3M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/>
+                      </svg>
+                    </a>
+                  </article>`;
+              }).join("")}
+            </div>
+          </section>`;
+      }).join("");
+
+      elements.roadmap.innerHTML = html;
+      elements.resultCount.textContent = `${shown} issue${shown === 1 ? "" : "s"}`;
+      elements.emptyState.style.display = shown ? "none" : "block";
+    }
+
+    function render() {
+      renderStats();
+      renderNavigation();
+      renderRoadmap();
+    }
+
+    function setPhase(value, focusTarget = "nav") {
+      phaseScope = value;
+      elements.phaseFilter.value = value;
+      render();
+      requestAnimationFrame(() => {
+        if (focusTarget === "filter") {
+          elements.phaseFilter.focus();
+          return;
+        }
+        const selector = focusTarget === "strip"
+          ? `.phase-mini[data-phase="${value}"]`
+          : `.phase-nav [data-phase="${value}"]`;
+        document.querySelector(selector)?.focus({ preventScroll: true });
+      });
+    }
+
+    function saveStatus(id, value) {
+      saved[id] = value;
+      persistSaved();
+      render();
+      requestAnimationFrame(() => document.querySelector(`[data-issue-status="${id}"]`)?.focus({ preventScroll: true }));
+      showToast(`${id} → ${STATUS[value]}`);
+    }
+
+    function persistSaved() {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
+        return true;
+      } catch {
+        showToast("Không thể lưu local; hãy Export JSON để giữ trạng thái");
+        return false;
+      }
+    }
+
+    function removeSaved() {
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+        return true;
+      } catch {
+        showToast("Không thể xóa local storage trong trình duyệt này");
+        return false;
+      }
+    }
+
+    function showToast(message) {
+      clearTimeout(toastTimer);
+      elements.toast.textContent = message;
+      elements.toast.classList.add("show");
+      toastTimer = setTimeout(() => elements.toast.classList.remove("show"), 2400);
+    }
+
+    function exportState() {
+      const payload = {
+        schemaVersion: 1,
+        project: "markhand-web",
+        exportedAt: new Date().toISOString(),
+        statuses: Object.fromEntries(allIssues().map(item => [item.issue[0], item.status]))
+      };
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `markhand-roadmap-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.append(link);
+      link.click();
+      link.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+      showToast("Đã export trạng thái roadmap");
+    }
+
+    async function importState(file) {
+      try {
+        if (file.size > 1024 * 1024) throw new Error("File import vượt quá 1 MB");
+        const payload = JSON.parse(await file.text());
+        const isPlainObject = payload.statuses
+          && typeof payload.statuses === "object"
+          && !Array.isArray(payload.statuses)
+          && Object.getPrototypeOf(payload.statuses) === Object.prototype;
+        if (payload.schemaVersion !== 1 || payload.project !== "markhand-web" || !isPlainObject) {
+          throw new Error("Định dạng không hợp lệ");
+        }
+        const ids = new Set(allIssues().map(item => item.issue[0]));
+        const incoming = Object.entries(payload.statuses);
+        if (incoming.length !== ids.size) throw new Error(`File phải có đủ ${ids.size} issues`);
+        const next = {};
+        for (const [id, status] of incoming) {
+          if (!ids.has(id)) throw new Error(`Issue không xác định: ${id}`);
+          if (!STATUS[status]) throw new Error(`Trạng thái không hợp lệ cho ${id}`);
+          next[id] = status;
+        }
+        if (!confirm("Import sẽ thay thế toàn bộ trạng thái hiện tại. Tiếp tục?")) return;
+        saved = next;
+        persistSaved();
+        render();
+        showToast(`Đã import ${Object.keys(next).length} trạng thái`);
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : "Không thể import file");
+      } finally {
+        elements.importFile.value = "";
+      }
+    }
+
+    document.addEventListener("change", event => {
+      const select = event.target.closest("[data-issue-status]");
+      if (select) saveStatus(select.dataset.issueStatus, select.value);
+    });
+
+    document.addEventListener("click", event => {
+      const phaseButton = event.target.closest("[data-phase]");
+      if (phaseButton) setPhase(phaseButton.dataset.phase, phaseButton.classList.contains("phase-mini") ? "strip" : "nav");
+    });
+
+    elements.searchInput.addEventListener("input", renderRoadmap);
+    elements.statusFilter.addEventListener("change", renderRoadmap);
+    elements.phaseFilter.addEventListener("change", event => setPhase(event.target.value, "filter"));
+    document.querySelector("#exportButton").addEventListener("click", exportState);
+    document.querySelector("#importButton").addEventListener("click", () => elements.importFile.click());
+    elements.importFile.addEventListener("change", event => {
+      if (event.target.files?.[0]) importState(event.target.files[0]);
+    });
+    document.querySelector("#resetButton").addEventListener("click", () => {
+      if (!confirm("Đặt lại toàn bộ trạng thái về mặc định trong plan?")) return;
+      saved = {};
+      removeSaved();
+      render();
+      showToast("Đã đặt lại roadmap");
+    });
+
+    render();
+  </script>
+</body>
+</html>

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -299,7 +299,7 @@
 
     .phase-strip {
       display: grid;
-      grid-template-columns: repeat(8, minmax(120px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
       gap: 8px;
       margin-bottom: 18px;
       overflow-x: auto;
@@ -415,6 +415,23 @@
 
     .phase-title { margin: 0; font-size: 17px; letter-spacing: -0.015em; }
     .phase-description { margin: 2px 0 0; color: var(--text-muted); font-size: 12px; }
+    .phase-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 7px;
+    }
+
+    .phase-links a {
+      display: inline-flex;
+      align-items: center;
+      min-height: 30px;
+      color: var(--brand);
+      font-size: 12px;
+      font-weight: 650;
+    }
+
+    .phase-links a:hover { text-decoration: underline; text-underline-offset: 3px; }
     .phase-summary { color: var(--text-muted); font-size: 12px; text-align: right; font-variant-numeric: tabular-nums; }
 
     .issue-list { display: grid; }
@@ -598,7 +615,9 @@
         <div>
           <p class="eyebrow">Engineering delivery plan</p>
           <h1>Roadmap triển khai Markhand Web</h1>
-          <p class="lead">Theo dõi 8 milestones, 113 issues và các gate từ engineering foundation đến production go-live.</p>
+          <p class="lead">Theo dõi <span id="phaseCountLead">—</span> milestones,
+            <span id="issueCountLead">—</span> issues và các gate từ engineering
+            foundation đến production go-live.</p>
         </div>
         <div class="actions" aria-label="Thao tác dữ liệu">
           <button class="button" id="exportButton" type="button" aria-label="Export trạng thái roadmap ra JSON">
@@ -627,8 +646,8 @@
         <section class="stats" aria-label="Tổng quan tiến độ">
           <article class="stat">
             <div class="stat-label">Tổng issues</div>
-            <div class="stat-value" id="totalStat">113</div>
-            <div class="stat-meta">trên 8 milestones</div>
+            <div class="stat-value" id="totalStat">—</div>
+            <div class="stat-meta" id="phaseCountMeta">đang tải milestones</div>
           </article>
           <article class="stat">
             <div class="stat-label">Đã hoàn thành</div>
@@ -643,7 +662,7 @@
           </article>
           <article class="stat">
             <div class="stat-label">Blocked</div>
-            <div class="stat-value" id="blockedStat">55</div>
+            <div class="stat-value" id="blockedStat">—</div>
             <div class="stat-meta">cần dependency hoặc gate</div>
           </article>
         </section>
@@ -674,7 +693,7 @@
             <span class="visually-hidden">Lọc theo phase</span>
             <select id="phaseFilter"></select>
           </label>
-          <div class="result-count" id="resultCount" tabindex="-1" aria-live="polite">113 issues</div>
+          <div class="result-count" id="resultCount" tabindex="-1" aria-live="polite">Đang tải issues</div>
         </section>
 
         <div id="roadmap"></div>
@@ -699,13 +718,14 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "79755c7d067b56b9";
+    const ROADMAP_SOURCE_HASH = "8d2be1c12e260cf0";
     const phases = [
       {
         "id": "phase-f",
         "code": "F",
-        "name": "Engineering Foundation",
-        "description": "Rules, skeleton, dev environment và CI foundation",
+        "name": "Engineering foundation và developer platform",
+        "description": "Engineering rules, skeleton, local dev environment và CI foundation",
+        "plan": "phase-f-engineering-foundation.md",
         "catalog": "backlog/phase-f/issues/README.md",
         "issues": [
           [
@@ -773,8 +793,9 @@
       {
         "id": "phase-0",
         "code": "0",
-        "name": "Discovery & Gates",
-        "description": "Benchmark, threat model, SLA và architecture decisions",
+        "name": "Discovery, benchmark và decision gates",
+        "description": "Chốt bằng số liệu: scale, retrieval, bảo mật upload, SLA/RPO/RTO",
+        "plan": "phase-0-discovery-and-gates.md",
         "catalog": "backlog/phase-0/issues/README.md",
         "issues": [
           [
@@ -832,8 +853,9 @@
       {
         "id": "phase-1a",
         "code": "1A",
-        "name": "Knowledge Extraction",
-        "description": "Tách fileconv-knowledge, giữ desktop parity",
+        "name": "Tách `crates/knowledge`",
+        "description": "Tách logic RAG dùng chung thành crates/knowledge, desktop không đổi hành vi",
+        "plan": "phase-1a-knowledge-extraction.md",
         "catalog": "backlog/phase-1a/issues/README.md",
         "issues": [
           [
@@ -891,8 +913,9 @@
       {
         "id": "phase-1b",
         "code": "1B",
-        "name": "Single-org POC",
-        "description": "Upload → convert → index → Q&A citation",
+        "name": "Secure single-org vertical slice",
+        "description": "POC single-org hoàn chỉnh: upload → convert → index → Q&A citation",
+        "plan": "phase-1b-single-org-poc.md",
         "catalog": "backlog/phase-1b/issues/README.md",
         "issues": [
           [
@@ -1020,8 +1043,9 @@
       {
         "id": "phase-1c",
         "code": "1C",
-        "name": "Multi-org Security",
-        "description": "RBAC, ACL, quota, fairness và denial suite",
+        "name": "Multi-org, RBAC/ACL và quota",
+        "description": "Multi-org, RBAC/ACL, quota atomic và denial test",
+        "plan": "phase-1c-multi-org-security.md",
         "catalog": "backlog/phase-1c/issues/README.md",
         "issues": [
           [
@@ -1095,7 +1119,8 @@
         "id": "phase-2",
         "code": "2",
         "name": "Web SPA MVP",
-        "description": "Login, library, upload, Q&A và admin tối thiểu",
+        "description": "Web SPA MVP: login, library, Q&A, admin tối thiểu",
+        "plan": "phase-2-web-spa.md",
         "catalog": "backlog/phase-2/issues/README.md",
         "issues": [
           [
@@ -1183,8 +1208,9 @@
       {
         "id": "phase-3",
         "code": "3",
-        "name": "Document Intelligence",
-        "description": "BRD/PRD, quality, PII, tables, versions và export",
+        "name": "Document Intelligence trên web",
+        "description": "Port intelligence: BRD/PRD, quality, PII, bảng, version, export",
+        "plan": "phase-3-intelligence.md",
         "catalog": "backlog/phase-3/issues/README.md",
         "issues": [
           [
@@ -1262,8 +1288,9 @@
       {
         "id": "phase-4",
         "code": "4",
-        "name": "Production Hardening",
-        "description": "OIDC, HA, DR, deployment và go-live",
+        "name": "SSO, production hardening và onboarding",
+        "description": "OIDC/SSO, hardening production, DR và onboarding/help",
+        "plan": "phase-4-production-hardening.md",
         "catalog": "backlog/phase-4/issues/README.md",
         "issues": [
           [
@@ -1356,6 +1383,9 @@
       emptyState: document.querySelector("#emptyState"),
       resultCount: document.querySelector("#resultCount"),
       totalStat: document.querySelector("#totalStat"),
+      phaseCountLead: document.querySelector("#phaseCountLead"),
+      issueCountLead: document.querySelector("#issueCountLead"),
+      phaseCountMeta: document.querySelector("#phaseCountMeta"),
       doneStat: document.querySelector("#doneStat"),
       doneMeta: document.querySelector("#doneMeta"),
       activeStat: document.querySelector("#activeStat"),
@@ -1402,24 +1432,29 @@
         </button>`;
       elements.phaseNav.innerHTML = allButton + phases.map(phase => {
         const done = phase.issues.filter(issue => statusFor(issue) === "done").length;
+        const id = escapeHtml(phase.id);
+        const code = escapeHtml(phase.code);
+        const name = escapeHtml(phase.name);
         return `
-          <button type="button" data-phase="${phase.id}" class="${phaseScope === phase.id ? "active" : ""}" aria-pressed="${phaseScope === phase.id}" aria-label="Lọc Phase ${phase.code} — ${phase.name}">
-            <span class="phase-code">${phase.code}</span><span class="phase-nav-name">${phase.name}</span>
+          <button type="button" data-phase="${id}" class="${phaseScope === phase.id ? "active" : ""}" aria-pressed="${phaseScope === phase.id}" aria-label="Lọc Phase ${code} — ${name}">
+            <span class="phase-code">${code}</span><span class="phase-nav-name">${name}</span>
             <span class="phase-nav-count">${done}/${phase.issues.length}</span>
           </button>`;
       }).join("");
 
       elements.phaseFilter.innerHTML = `<option value="all">Mọi phase</option>` +
-        phases.map(phase => `<option value="${phase.id}">Phase ${phase.code} — ${phase.name}</option>`).join("");
+        phases.map(phase => `<option value="${escapeHtml(phase.id)}">Phase ${escapeHtml(phase.code)} — ${escapeHtml(phase.name)}</option>`).join("");
       elements.phaseFilter.value = phaseScope;
 
       elements.phaseStrip.innerHTML = phases.map(phase => {
         const done = phase.issues.filter(issue => statusFor(issue) === "done").length;
         const percent = Math.round(done / phase.issues.length * 100);
+        const id = escapeHtml(phase.id);
+        const code = escapeHtml(phase.code);
         return `
-          <button type="button" class="phase-mini ${phaseScope === phase.id ? "active" : ""}" data-phase="${phase.id}" aria-pressed="${phaseScope === phase.id}">
+          <button type="button" class="phase-mini ${phaseScope === phase.id ? "active" : ""}" data-phase="${id}" aria-pressed="${phaseScope === phase.id}">
             <span class="phase-mini-head">
-              <span class="phase-mini-code">Phase ${phase.code}</span>
+              <span class="phase-mini-code">Phase ${code}</span>
               <span class="phase-mini-progress">${done}/${phase.issues.length}</span>
             </span>
             <span class="mini-bar"><span style="width:${percent}%"></span></span>
@@ -1434,6 +1469,9 @@
       const blocked = issues.filter(item => item.status === "blocked").length;
       const percent = Math.round(done / issues.length * 100);
       elements.totalStat.textContent = issues.length;
+      elements.phaseCountLead.textContent = phases.length;
+      elements.issueCountLead.textContent = issues.length;
+      elements.phaseCountMeta.textContent = `trên ${phases.length} milestones`;
       elements.doneStat.textContent = done;
       elements.activeStat.textContent = active;
       elements.blockedStat.textContent = blocked;
@@ -1465,30 +1503,41 @@
         shown += visible.length;
         const done = phase.issues.filter(issue => statusFor(issue) === "done").length;
         const active = phase.issues.filter(issue => ["in_progress", "review"].includes(statusFor(issue))).length;
+        const id = escapeHtml(phase.id);
+        const code = escapeHtml(phase.code);
+        const name = escapeHtml(phase.name);
+        const description = escapeHtml(phase.description);
+        const plan = escapeHtml(phase.plan);
+        const catalog = escapeHtml(phase.catalog);
         return `
-          <section class="phase-section" id="${phase.id}">
+          <section class="phase-section" id="${id}">
             <header class="phase-header">
-              <span class="phase-badge">P${phase.code}</span>
+              <span class="phase-badge">P${code}</span>
               <div>
-                <h2 class="phase-title">Phase ${phase.code} — ${phase.name}</h2>
-                <p class="phase-description">${phase.description}</p>
+                <h2 class="phase-title">Phase ${code} — ${name}</h2>
+                <p class="phase-description">${description}</p>
+                <div class="phase-links">
+                  <a href="${plan}">Mở phase plan</a>
+                  <a href="${catalog}">Mở ${phase.issues.length} issue specs</a>
+                </div>
               </div>
               <div class="phase-summary">${done} done · ${active} active · ${phase.issues.length} total</div>
             </header>
             <div class="issue-list">
               ${visible.map(issue => {
                 const current = statusFor(issue);
+                const issueId = escapeHtml(issue[0]);
                 return `
-                  <article class="issue ${current === "done" ? "done" : ""}" data-issue="${issue[0]}">
-                    <span class="issue-id">${issue[0]}</span>
+                  <article class="issue ${current === "done" ? "done" : ""}" data-issue="${issueId}">
+                    <span class="issue-id">${issueId}</span>
                     <span class="issue-title">${escapeHtml(issue[1])}</span>
                     <label>
-                      <span class="visually-hidden">Trạng thái ${issue[0]}</span>
-                      <select class="status-select" data-issue-status="${issue[0]}" data-status="${current}">
+                      <span class="visually-hidden">Trạng thái ${issueId}</span>
+                      <select class="status-select" data-issue-status="${issueId}" data-status="${current}">
                         ${statusOptions(current)}
                       </select>
                     </label>
-                    <a class="issue-link" href="${phase.catalog}" title="Mở catalog Phase ${phase.code}" aria-label="Mở catalog chứa ${issue[0]}">
+                    <a class="issue-link" href="${catalog}" title="Mở catalog Phase ${code}" aria-label="Mở catalog chứa ${issueId}">
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                         <path d="M14 3h7v7M10 14 21 3M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5"/>
                       </svg>

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -587,8 +587,9 @@
       <p class="nav-label">Milestones</p>
       <nav class="phase-nav" id="phaseNav"></nav>
       <div class="sidebar-note">
-        <strong>Trạng thái được lưu cục bộ</strong>
-        Dùng Export JSON để chia sẻ hoặc lưu phiên bản theo dõi.
+        <strong>Build từ Markdown</strong>
+        Trạng thái mặc định lấy từ issue catalogs. Thay đổi trên UI được lưu cục bộ
+        cho đúng phiên bản nguồn hiện tại.
       </div>
     </aside>
 
@@ -697,179 +698,650 @@
       done: "Done"
     };
 
+    /* ROADMAP_DATA_START */
+    const ROADMAP_SOURCE_HASH = "79755c7d067b56b9";
     const phases = [
       {
-        id: "phase-f", code: "F", name: "Engineering Foundation",
-        description: "Rules, skeleton, dev environment và CI foundation",
-        catalog: "backlog/phase-f/issues/README.md",
-        issues: [
-          ["F-01", "Architecture boundaries và dependency rules", "ready"],
-          ["F-02", "Workspace và folder skeleton", "blocked"],
-          ["F-03", "Rust coding và crate conventions", "blocked"],
-          ["F-04", "TypeScript/React conventions", "blocked"],
-          ["F-05", "SQL/data/migration conventions", "blocked"],
-          ["F-06", "REST/OpenAPI/SSE/error conventions", "blocked"],
-          ["F-07", "Configuration, secrets và environment profiles", "blocked"],
-          ["F-08", "Reproducible local development environment", "blocked"],
-          ["F-09", "Root task runner, quality tools và CI baseline", "blocked"],
-          ["F-10", "Test pyramid, fixtures và golden-data conventions", "blocked"],
-          ["F-11", "Observability/audit conventions", "blocked"],
-          ["F-12", "Contributor workflow, setup docs và foundation gate", "blocked"]
+        "id": "phase-f",
+        "code": "F",
+        "name": "Engineering Foundation",
+        "description": "Rules, skeleton, dev environment và CI foundation",
+        "catalog": "backlog/phase-f/issues/README.md",
+        "issues": [
+          [
+            "F-01",
+            "Architecture boundaries và dependency rules",
+            "ready"
+          ],
+          [
+            "F-02",
+            "Workspace và folder skeleton",
+            "blocked"
+          ],
+          [
+            "F-03",
+            "Rust coding và crate conventions",
+            "blocked"
+          ],
+          [
+            "F-04",
+            "TypeScript/React conventions",
+            "blocked"
+          ],
+          [
+            "F-05",
+            "SQL/data/migration conventions",
+            "blocked"
+          ],
+          [
+            "F-06",
+            "REST/OpenAPI/SSE/error conventions",
+            "blocked"
+          ],
+          [
+            "F-07",
+            "Configuration, secrets và environment profiles",
+            "blocked"
+          ],
+          [
+            "F-08",
+            "Reproducible local development environment",
+            "blocked"
+          ],
+          [
+            "F-09",
+            "Root task runner, quality tools và CI baseline",
+            "blocked"
+          ],
+          [
+            "F-10",
+            "Test pyramid, fixtures và golden-data conventions",
+            "blocked"
+          ],
+          [
+            "F-11",
+            "Observability/audit conventions",
+            "blocked"
+          ],
+          [
+            "F-12",
+            "Contributor workflow, setup docs và foundation gate",
+            "blocked"
+          ]
         ]
       },
       {
-        id: "phase-0", code: "0", name: "Discovery & Gates",
-        description: "Benchmark, threat model, SLA và architecture decisions",
-        catalog: "backlog/phase-0/issues/README.md",
-        issues: [
-          ["P0-01", "Khóa workload, hardware và gate registry", "blocked"],
-          ["P0-02", "Golden corpus tiếng Việt và adversarial corpus", "blocked"],
-          ["P0-03", "Mở rộng desktop baseline trên corpus Phase 0", "blocked"],
-          ["P0-04", "Spike infrastructure tái lập", "blocked"],
-          ["P0-05", "Đánh giá embedding tiếng Việt", "blocked"],
-          ["P0-06", "Chunking, hybrid tuning và index signature", "blocked"],
-          ["P0-07", "PG/Qdrant target-scale topology", "blocked"],
-          ["P0-08", "Sizing converter và ingest backpressure", "blocked"],
-          ["P0-09", "Upload threat model, sandbox và license inventory", "blocked"],
-          ["P0-10", "ADR, SLO/RPO/RTO và Phase 0 gate", "blocked"]
+        "id": "phase-0",
+        "code": "0",
+        "name": "Discovery & Gates",
+        "description": "Benchmark, threat model, SLA và architecture decisions",
+        "catalog": "backlog/phase-0/issues/README.md",
+        "issues": [
+          [
+            "P0-01",
+            "Khóa workload, hardware và gate registry",
+            "blocked"
+          ],
+          [
+            "P0-02",
+            "Golden corpus tiếng Việt và adversarial corpus",
+            "blocked"
+          ],
+          [
+            "P0-03",
+            "Mở rộng desktop baseline trên corpus Phase 0",
+            "blocked"
+          ],
+          [
+            "P0-04",
+            "Spike infrastructure tái lập",
+            "blocked"
+          ],
+          [
+            "P0-05",
+            "Đánh giá embedding tiếng Việt",
+            "blocked"
+          ],
+          [
+            "P0-06",
+            "Chunking, hybrid tuning và index signature",
+            "blocked"
+          ],
+          [
+            "P0-07",
+            "PG/Qdrant target-scale topology",
+            "blocked"
+          ],
+          [
+            "P0-08",
+            "Sizing converter và ingest backpressure",
+            "blocked"
+          ],
+          [
+            "P0-09",
+            "Upload threat model, sandbox và license inventory",
+            "blocked"
+          ],
+          [
+            "P0-10",
+            "ADR, SLO/RPO/RTO và Phase 0 gate",
+            "blocked"
+          ]
         ]
       },
       {
-        id: "phase-1a", code: "1A", name: "Knowledge Extraction",
-        description: "Tách fileconv-knowledge, giữ desktop parity",
-        catalog: "backlog/phase-1a/issues/README.md",
-        issues: [
-          ["P1A-01", "Freeze desktop RAG và IPC contracts", "blocked"],
-          ["P1A-02", "Populate knowledge skeleton và enforce dependency boundaries", "blocked"],
-          ["P1A-03", "Shared DTO và serde contract", "blocked"],
-          ["P1A-04", "Durable identities và index signatures", "blocked"],
-          ["P1A-05", "Query, local vectors và embedding plan", "blocked"],
-          ["P1A-06", "Rank, citation và grounded answer", "blocked"],
-          ["P1A-07", "SQLite desktop storage feature", "blocked"],
-          ["P1A-08", "Persistent HNSW desktop feature", "blocked"],
-          ["P1A-09", "Thin Tauri adapters", "blocked"],
-          ["P1A-10", "CI parity và extraction gate", "blocked"]
+        "id": "phase-1a",
+        "code": "1A",
+        "name": "Knowledge Extraction",
+        "description": "Tách fileconv-knowledge, giữ desktop parity",
+        "catalog": "backlog/phase-1a/issues/README.md",
+        "issues": [
+          [
+            "P1A-01",
+            "Freeze desktop RAG và IPC contracts",
+            "blocked"
+          ],
+          [
+            "P1A-02",
+            "Populate knowledge skeleton và enforce dependency boundaries",
+            "blocked"
+          ],
+          [
+            "P1A-03",
+            "Shared DTO và serde contract",
+            "blocked"
+          ],
+          [
+            "P1A-04",
+            "Durable identities và index signatures",
+            "blocked"
+          ],
+          [
+            "P1A-05",
+            "Query, local vectors và embedding plan",
+            "blocked"
+          ],
+          [
+            "P1A-06",
+            "Rank, citation và grounded answer",
+            "blocked"
+          ],
+          [
+            "P1A-07",
+            "SQLite desktop storage feature",
+            "blocked"
+          ],
+          [
+            "P1A-08",
+            "Persistent HNSW desktop feature",
+            "blocked"
+          ],
+          [
+            "P1A-09",
+            "Thin Tauri adapters",
+            "blocked"
+          ],
+          [
+            "P1A-10",
+            "CI parity và extraction gate",
+            "blocked"
+          ]
         ]
       },
       {
-        id: "phase-1b", code: "1B", name: "Single-org POC",
-        description: "Upload → convert → index → Q&A citation",
-        catalog: "backlog/phase-1b/issues/README.md",
-        issues: [
-          ["P1B-F01", "Extend server skeleton với runtime POC", "blocked"],
-          ["P1B-F02", "POC deployment và isolation scaffold", "blocked"],
-          ["P1B-F03", "Multi-org-ready schema và immutable migrations", "blocked"],
-          ["P1B-F04", "OrgContext, repositories và state machine", "blocked"],
-          ["P1B-F05", "Password auth, rotating sessions và browser refresh transport", "blocked"],
-          ["P1B-F06", "Fail-closed PG/Qdrant/MinIO adapters", "blocked"],
-          ["P1B-I01", "Streaming quarantine upload validation", "blocked"],
-          ["P1B-I02", "Atomic quota admission", "blocked"],
-          ["P1B-I03", "Durable jobs, outbox và event log", "blocked"],
-          ["P1B-I04", "Isolated converter worker", "blocked"],
-          ["P1B-I05", "Idempotent conversion promotion saga", "blocked"],
-          ["P1B-I06", "Chunk/embedding/index worker", "blocked"],
-          ["P1B-I07", "Tombstone delete và reconcile", "blocked"],
-          ["P1B-R01", "Tenant-scoped hybrid retrieval", "blocked"],
-          ["P1B-R02", "Citation, preview và download authorization", "blocked"],
-          ["P1B-R03", "Grounded Q&A, stream và fallback", "blocked"],
-          ["P1B-R04", "Collection/document/job REST API", "blocked"],
-          ["P1B-R05", "Search/ask/resumable SSE API", "blocked"],
-          ["P1B-R06", "OpenAPI, rate limit và readiness", "blocked"],
-          ["P1B-O01", "End-to-end telemetry và safe audit", "blocked"],
-          ["P1B-O02", "Dashboards, alerts và runbooks", "blocked"],
-          ["P1B-O03", "Backup/restore và migration safety", "blocked"],
-          ["P1B-O04", "Vertical-slice/security release suite", "blocked"],
-          ["P1B-O05", "Mixed-load soak và POC qualification", "blocked"]
+        "id": "phase-1b",
+        "code": "1B",
+        "name": "Single-org POC",
+        "description": "Upload → convert → index → Q&A citation",
+        "catalog": "backlog/phase-1b/issues/README.md",
+        "issues": [
+          [
+            "P1B-F01",
+            "Extend server skeleton với runtime POC",
+            "blocked"
+          ],
+          [
+            "P1B-F02",
+            "POC deployment và isolation scaffold",
+            "blocked"
+          ],
+          [
+            "P1B-F03",
+            "Multi-org-ready schema và immutable migrations",
+            "blocked"
+          ],
+          [
+            "P1B-F04",
+            "OrgContext, repositories và state machine",
+            "blocked"
+          ],
+          [
+            "P1B-F05",
+            "Password auth, rotating sessions và browser refresh transport",
+            "blocked"
+          ],
+          [
+            "P1B-F06",
+            "Fail-closed PG/Qdrant/MinIO adapters",
+            "blocked"
+          ],
+          [
+            "P1B-I01",
+            "Streaming quarantine upload validation",
+            "blocked"
+          ],
+          [
+            "P1B-I02",
+            "Atomic quota admission",
+            "blocked"
+          ],
+          [
+            "P1B-I03",
+            "Durable jobs, outbox và event log",
+            "blocked"
+          ],
+          [
+            "P1B-I04",
+            "Isolated converter worker",
+            "blocked"
+          ],
+          [
+            "P1B-I05",
+            "Idempotent conversion promotion saga",
+            "blocked"
+          ],
+          [
+            "P1B-I06",
+            "Chunk/embedding/index worker",
+            "blocked"
+          ],
+          [
+            "P1B-I07",
+            "Tombstone delete và reconcile",
+            "blocked"
+          ],
+          [
+            "P1B-R01",
+            "Tenant-scoped hybrid retrieval",
+            "blocked"
+          ],
+          [
+            "P1B-R02",
+            "Citation, preview và download authorization",
+            "blocked"
+          ],
+          [
+            "P1B-R03",
+            "Grounded Q&A, stream và fallback",
+            "blocked"
+          ],
+          [
+            "P1B-R04",
+            "Collection/document/job REST API",
+            "blocked"
+          ],
+          [
+            "P1B-R05",
+            "Search/ask/resumable SSE API",
+            "blocked"
+          ],
+          [
+            "P1B-R06",
+            "OpenAPI, rate limit và readiness",
+            "blocked"
+          ],
+          [
+            "P1B-O01",
+            "End-to-end telemetry và safe audit",
+            "blocked"
+          ],
+          [
+            "P1B-O02",
+            "Dashboards, alerts và runbooks",
+            "blocked"
+          ],
+          [
+            "P1B-O03",
+            "Backup/restore và migration safety",
+            "blocked"
+          ],
+          [
+            "P1B-O04",
+            "Vertical-slice/security release suite",
+            "blocked"
+          ],
+          [
+            "P1B-O05",
+            "Mixed-load soak và POC qualification",
+            "blocked"
+          ]
         ]
       },
       {
-        id: "phase-1c", code: "1C", name: "Multi-org Security",
-        description: "RBAC, ACL, quota, fairness và denial suite",
-        catalog: "backlog/phase-1c/issues/README.md",
-        issues: [
-          ["1C-01", "Organization lifecycle và validated context", "backlog"],
-          ["1C-02", "Membership, invites và last-owner invariant", "backlog"],
-          ["1C-03", "Canonical RBAC seed", "backlog"],
-          ["1C-04", "Route/service guards và service identities", "backlog"],
-          ["1C-05", "Collection ACL resolver/cache", "backlog"],
-          ["1C-06", "PostgreSQL ACL enforcement", "backlog"],
-          ["1C-07", "Qdrant/storage/jobs fail-closed enforcement", "backlog"],
-          ["1C-08", "RLS và pool defense", "backlog"],
-          ["1C-09", "Atomic quota lifecycle", "backlog"],
-          ["1C-10", "Rate limit và per-org fairness", "backlog"],
-          ["1C-11", "Audit/admin APIs", "backlog"],
-          ["1C-12", "Multi-org denial suite", "backlog"],
-          ["1C-13", "Security/revoke/load gate", "backlog"]
+        "id": "phase-1c",
+        "code": "1C",
+        "name": "Multi-org Security",
+        "description": "RBAC, ACL, quota, fairness và denial suite",
+        "catalog": "backlog/phase-1c/issues/README.md",
+        "issues": [
+          [
+            "1C-01",
+            "Organization lifecycle và validated context",
+            "backlog"
+          ],
+          [
+            "1C-02",
+            "Membership, invites và last-owner invariant",
+            "backlog"
+          ],
+          [
+            "1C-03",
+            "Canonical RBAC seed",
+            "backlog"
+          ],
+          [
+            "1C-04",
+            "Route/service guards và service identities",
+            "backlog"
+          ],
+          [
+            "1C-05",
+            "Collection ACL resolver/cache",
+            "backlog"
+          ],
+          [
+            "1C-06",
+            "PostgreSQL ACL enforcement",
+            "backlog"
+          ],
+          [
+            "1C-07",
+            "Qdrant/storage/jobs fail-closed enforcement",
+            "backlog"
+          ],
+          [
+            "1C-08",
+            "RLS và pool defense",
+            "backlog"
+          ],
+          [
+            "1C-09",
+            "Atomic quota lifecycle",
+            "backlog"
+          ],
+          [
+            "1C-10",
+            "Rate limit và per-org fairness",
+            "backlog"
+          ],
+          [
+            "1C-11",
+            "Audit/admin APIs",
+            "backlog"
+          ],
+          [
+            "1C-12",
+            "Multi-org denial suite",
+            "backlog"
+          ],
+          [
+            "1C-13",
+            "Security/revoke/load gate",
+            "backlog"
+          ]
         ]
       },
       {
-        id: "phase-2", code: "2", name: "Web SPA MVP",
-        description: "Login, library, upload, Q&A và admin tối thiểu",
-        catalog: "backlog/phase-2/issues/README.md",
-        issues: [
-          ["P2-01", "React/Vite workspace và UI foundations", "backlog"],
-          ["P2-02", "OpenAPI contracts và mock server", "backlog"],
-          ["P2-03", "Typed HTTP client/session refresh", "backlog"],
-          ["P2-04", "Fetch-based SSE transport", "backlog"],
-          ["P2-05", "Login/session/application shell", "backlog"],
-          ["P2-06", "Org switch và scope-safe state", "backlog"],
-          ["P2-07", "Library/list/sanitized preview", "backlog"],
-          ["P2-08", "Upload progress và job lifecycle", "backlog"],
-          ["P2-09", "Download/delete/reindex/retry", "backlog"],
-          ["P2-10", "Streaming search/Q&A/citations", "backlog"],
-          ["P2-11", "Member/role admin", "backlog"],
-          ["P2-12", "Usage/quota/reservations", "backlog"],
-          ["P2-13", "Browser/SafeMarkdown hardening", "backlog"],
-          ["P2-14", "Accessibility/interaction quality", "backlog"],
-          ["P2-15", "Contract/integration/E2E suite", "backlog"],
-          ["P2-16", "Production build/static serving/final gate", "backlog"]
+        "id": "phase-2",
+        "code": "2",
+        "name": "Web SPA MVP",
+        "description": "Login, library, upload, Q&A và admin tối thiểu",
+        "catalog": "backlog/phase-2/issues/README.md",
+        "issues": [
+          [
+            "P2-01",
+            "React/Vite workspace và UI foundations",
+            "backlog"
+          ],
+          [
+            "P2-02",
+            "OpenAPI contracts và mock server",
+            "backlog"
+          ],
+          [
+            "P2-03",
+            "Typed HTTP client/session refresh",
+            "backlog"
+          ],
+          [
+            "P2-04",
+            "Fetch-based SSE transport",
+            "backlog"
+          ],
+          [
+            "P2-05",
+            "Login/session/application shell",
+            "backlog"
+          ],
+          [
+            "P2-06",
+            "Org switch và scope-safe state",
+            "backlog"
+          ],
+          [
+            "P2-07",
+            "Library/list/sanitized preview",
+            "backlog"
+          ],
+          [
+            "P2-08",
+            "Upload progress và job lifecycle",
+            "backlog"
+          ],
+          [
+            "P2-09",
+            "Download/delete/reindex/retry",
+            "backlog"
+          ],
+          [
+            "P2-10",
+            "Streaming search/Q&A/citations",
+            "backlog"
+          ],
+          [
+            "P2-11",
+            "Member/role admin",
+            "backlog"
+          ],
+          [
+            "P2-12",
+            "Usage/quota/reservations",
+            "backlog"
+          ],
+          [
+            "P2-13",
+            "Browser/SafeMarkdown hardening",
+            "backlog"
+          ],
+          [
+            "P2-14",
+            "Accessibility/interaction quality",
+            "backlog"
+          ],
+          [
+            "P2-15",
+            "Contract/integration/E2E suite",
+            "backlog"
+          ],
+          [
+            "P2-16",
+            "Production build/static serving/final gate",
+            "backlog"
+          ]
         ]
       },
       {
-        id: "phase-3", code: "3", name: "Document Intelligence",
-        description: "BRD/PRD, quality, PII, tables, versions và export",
-        catalog: "backlog/phase-3/issues/README.md",
-        issues: [
-          ["P3-01", "Reusable intelligence service boundary", "backlog"],
-          ["P3-02", "Versioned derived-artifact schema", "backlog"],
-          ["P3-03", "Current-source ACL mỗi artifact access", "backlog"],
-          ["P3-04", "Deterministic BRD/PRD job", "backlog"],
-          ["P3-05", "Handoff edit/validate/ZIP export", "backlog"],
-          ["P3-06", "Quality và immutable reprocess", "backlog"],
-          ["P3-07", "Citation-backed summarization", "backlog"],
-          ["P3-08", "PII detection/reviewed redaction", "backlog"],
-          ["P3-09", "Schema/table edit và safe CSV", "backlog"],
-          ["P3-10", "Versions, diff và three-way merge", "backlog"],
-          ["P3-11", "Prompt/model/quota/cloud policy", "backlog"],
-          ["P3-12", "Intelligence web workspace", "backlog"],
-          ["P3-13", "Task-specific golden evaluation", "backlog"],
-          ["P3-14", "Intelligence denial/audit/reconcile/release gate", "backlog"]
+        "id": "phase-3",
+        "code": "3",
+        "name": "Document Intelligence",
+        "description": "BRD/PRD, quality, PII, tables, versions và export",
+        "catalog": "backlog/phase-3/issues/README.md",
+        "issues": [
+          [
+            "P3-01",
+            "Reusable intelligence service boundary",
+            "backlog"
+          ],
+          [
+            "P3-02",
+            "Versioned derived-artifact schema",
+            "backlog"
+          ],
+          [
+            "P3-03",
+            "Current-source ACL mỗi artifact access",
+            "backlog"
+          ],
+          [
+            "P3-04",
+            "Deterministic BRD/PRD job",
+            "backlog"
+          ],
+          [
+            "P3-05",
+            "Handoff edit/validate/ZIP export",
+            "backlog"
+          ],
+          [
+            "P3-06",
+            "Quality và immutable reprocess",
+            "backlog"
+          ],
+          [
+            "P3-07",
+            "Citation-backed summarization",
+            "backlog"
+          ],
+          [
+            "P3-08",
+            "PII detection/reviewed redaction",
+            "backlog"
+          ],
+          [
+            "P3-09",
+            "Schema/table edit và safe CSV",
+            "backlog"
+          ],
+          [
+            "P3-10",
+            "Versions, diff và three-way merge",
+            "backlog"
+          ],
+          [
+            "P3-11",
+            "Prompt/model/quota/cloud policy",
+            "backlog"
+          ],
+          [
+            "P3-12",
+            "Intelligence web workspace",
+            "backlog"
+          ],
+          [
+            "P3-13",
+            "Task-specific golden evaluation",
+            "backlog"
+          ],
+          [
+            "P3-14",
+            "Intelligence denial/audit/reconcile/release gate",
+            "backlog"
+          ]
         ]
       },
       {
-        id: "phase-4", code: "4", name: "Production Hardening",
-        description: "OIDC, HA, DR, deployment và go-live",
-        catalog: "backlog/phase-4/issues/README.md",
-        issues: [
-          ["P4-01", "OIDC Authorization Code + PKCE", "backlog"],
-          ["P4-02", "JIT provisioning và account linking", "backlog"],
-          ["P4-03", "Group/role sync và bounded deprovision", "backlog"],
-          ["P4-04", "Session UI và break-glass", "backlog"],
-          ["P4-05", "Platform security/supply chain/secrets", "backlog"],
-          ["P4-06", "Threat review/external pentest/remediation", "backlog"],
-          ["P4-07", "HA/degraded modes/distributed limiting", "backlog"],
-          ["P4-08", "Reproducible production deployment", "backlog"],
-          ["P4-09", "Backup/PITR/restore tooling", "backlog"],
-          ["P4-10", "Clean DR/destructive failure drills", "backlog"],
-          ["P4-11", "Migration/canary/rollback discipline", "backlog"],
-          ["P4-12", "SRE dashboards/alerts/runbooks", "backlog"],
-          ["P4-13", "Onboarding/help/accessibility/operator docs", "backlog"],
-          ["P4-14", "Production go-live gate", "backlog"]
+        "id": "phase-4",
+        "code": "4",
+        "name": "Production Hardening",
+        "description": "OIDC, HA, DR, deployment và go-live",
+        "catalog": "backlog/phase-4/issues/README.md",
+        "issues": [
+          [
+            "P4-01",
+            "OIDC Authorization Code + PKCE",
+            "backlog"
+          ],
+          [
+            "P4-02",
+            "JIT provisioning và account linking",
+            "backlog"
+          ],
+          [
+            "P4-03",
+            "Group/role sync và bounded deprovision",
+            "backlog"
+          ],
+          [
+            "P4-04",
+            "Session UI và break-glass",
+            "backlog"
+          ],
+          [
+            "P4-05",
+            "Platform security/supply chain/secrets",
+            "backlog"
+          ],
+          [
+            "P4-06",
+            "Threat review/external pentest/remediation",
+            "backlog"
+          ],
+          [
+            "P4-07",
+            "HA/degraded modes/distributed limiting",
+            "backlog"
+          ],
+          [
+            "P4-08",
+            "Reproducible production deployment",
+            "backlog"
+          ],
+          [
+            "P4-09",
+            "Backup/PITR/restore tooling",
+            "backlog"
+          ],
+          [
+            "P4-10",
+            "Clean DR/destructive failure drills",
+            "backlog"
+          ],
+          [
+            "P4-11",
+            "Migration/canary/rollback discipline",
+            "backlog"
+          ],
+          [
+            "P4-12",
+            "SRE dashboards/alerts/runbooks",
+            "backlog"
+          ],
+          [
+            "P4-13",
+            "Onboarding/help/accessibility/operator docs",
+            "backlog"
+          ],
+          [
+            "P4-14",
+            "Production go-live gate",
+            "backlog"
+          ]
         ]
       }
     ];
+    /* ROADMAP_DATA_END */
 
-    const STORAGE_KEY = "markhand-roadmap-status-v1";
+    const STORAGE_KEY = `markhand-roadmap-status-v1-${ROADMAP_SOURCE_HASH}`;
     let saved = loadSaved();
     let phaseScope = "all";
     let toastTimer;
@@ -1096,6 +1568,7 @@
       const payload = {
         schemaVersion: 1,
         project: "markhand-web",
+        sourceHash: ROADMAP_SOURCE_HASH,
         exportedAt: new Date().toISOString(),
         statuses: Object.fromEntries(allIssues().map(item => [item.issue[0], item.status]))
       };
@@ -1121,6 +1594,13 @@
           && Object.getPrototypeOf(payload.statuses) === Object.prototype;
         if (payload.schemaVersion !== 1 || payload.project !== "markhand-web" || !isPlainObject) {
           throw new Error("Định dạng không hợp lệ");
+        }
+        if (payload.sourceHash !== ROADMAP_SOURCE_HASH) {
+          const proceed = confirm(
+            "File được export từ phiên bản Markdown khác. "
+            + "Import có thể ghi đè trạng thái nguồn mới. Vẫn tiếp tục?"
+          );
+          if (!proceed) return;
         }
         const ids = new Set(allIssues().map(item => item.issue[0]));
         const incoming = Object.entries(payload.statuses);

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -538,6 +538,7 @@
       .phase-nav button { display: flex; flex: 0 0 100px; min-width: 100px; }
       .phase-nav-name, .phase-nav-count, .nav-label, .sidebar-note { display: none; }
       .main { padding: 22px 14px 48px; }
+      input, select { font-size: 16px; }
       .topbar { display: block; }
       .actions { justify-content: flex-start; margin-top: 18px; }
       .toolbar { grid-template-columns: 1fr; }
@@ -672,7 +673,7 @@
             <span class="visually-hidden">Lọc theo phase</span>
             <select id="phaseFilter"></select>
           </label>
-          <div class="result-count" id="resultCount" aria-live="polite">113 issues</div>
+          <div class="result-count" id="resultCount" tabindex="-1" aria-live="polite">113 issues</div>
         </section>
 
         <div id="roadmap"></div>
@@ -923,14 +924,14 @@
 
     function renderNavigation() {
       const allButton = `
-        <button type="button" data-phase="all" class="${phaseScope === "all" ? "active" : ""}" aria-pressed="${phaseScope === "all"}">
+        <button type="button" data-phase="all" class="${phaseScope === "all" ? "active" : ""}" aria-pressed="${phaseScope === "all"}" aria-label="Lọc tất cả phases">
           <span class="phase-code">ALL</span><span class="phase-nav-name">Tất cả phases</span>
           <span class="phase-nav-count">${allIssues().length}</span>
         </button>`;
       elements.phaseNav.innerHTML = allButton + phases.map(phase => {
         const done = phase.issues.filter(issue => statusFor(issue) === "done").length;
         return `
-          <button type="button" data-phase="${phase.id}" class="${phaseScope === phase.id ? "active" : ""}" aria-pressed="${phaseScope === phase.id}">
+          <button type="button" data-phase="${phase.id}" class="${phaseScope === phase.id ? "active" : ""}" aria-pressed="${phaseScope === phase.id}" aria-label="Lọc Phase ${phase.code} — ${phase.name}">
             <span class="phase-code">${phase.code}</span><span class="phase-nav-name">${phase.name}</span>
             <span class="phase-nav-count">${done}/${phase.issues.length}</span>
           </button>`;
@@ -1055,10 +1056,13 @@
 
     function saveStatus(id, value) {
       saved[id] = value;
-      persistSaved();
+      const persisted = persistSaved();
       render();
-      requestAnimationFrame(() => document.querySelector(`[data-issue-status="${id}"]`)?.focus({ preventScroll: true }));
-      showToast(`${id} → ${STATUS[value]}`);
+      requestAnimationFrame(() => {
+        const select = document.querySelector(`[data-issue-status="${id}"]`);
+        (select || elements.resultCount).focus({ preventScroll: true });
+      });
+      if (persisted) showToast(`${id} → ${STATUS[value]}`);
     }
 
     function persistSaved() {
@@ -1129,9 +1133,9 @@
         }
         if (!confirm("Import sẽ thay thế toàn bộ trạng thái hiện tại. Tiếp tục?")) return;
         saved = next;
-        persistSaved();
+        const persisted = persistSaved();
         render();
-        showToast(`Đã import ${Object.keys(next).length} trạng thái`);
+        if (persisted) showToast(`Đã import ${Object.keys(next).length} trạng thái`);
       } catch (error) {
         showToast(error instanceof Error ? error.message : "Không thể import file");
       } finally {
@@ -1160,9 +1164,9 @@
     document.querySelector("#resetButton").addEventListener("click", () => {
       if (!confirm("Đặt lại toàn bộ trạng thái về mặc định trong plan?")) return;
       saved = {};
-      removeSaved();
+      const removed = removeSaved();
       render();
-      showToast("Đã đặt lại roadmap");
+      if (removed) showToast("Đã đặt lại roadmap");
     });
 
     render();

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -256,9 +256,165 @@
     .button.danger:hover { color: #fecdd3; border-color: var(--blocked); }
     .button svg { width: 16px; height: 16px; }
 
+    [hidden] { display: none !important; }
+
+    .content-tabs {
+      display: flex;
+      gap: 6px;
+      max-width: 1460px;
+      margin: 0 auto 22px;
+      padding: 4px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      width: fit-content;
+      margin-left: max(0px, calc((100% - 1460px) / 2));
+    }
+
+    .content-tab {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+      padding: 0 18px;
+      border: 1px solid transparent;
+      border-radius: 9px;
+      background: transparent;
+      color: var(--text-muted);
+      font: inherit;
+      font-size: 13px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: color 180ms ease, background 180ms ease, border-color 180ms ease;
+    }
+
+    .content-tab svg { width: 17px; height: 17px; }
+    .content-tab:hover { color: var(--text); background: var(--surface-raised); }
+    .content-tab[aria-selected="true"] {
+      border-color: var(--brand-ring);
+      background: var(--brand-soft);
+      color: var(--brand);
+    }
+
     .dashboard {
       max-width: 1460px;
       margin: 0 auto;
+    }
+
+    .tech-stack-view {
+      max-width: 1460px;
+      margin: 0 auto;
+    }
+
+    .stack-intro {
+      display: grid;
+      grid-template-columns: minmax(0, 1.4fr) minmax(260px, .6fr);
+      gap: 16px;
+      margin-bottom: 18px;
+    }
+
+    .stack-hero, .stack-source {
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface);
+    }
+
+    .stack-hero { padding: clamp(22px, 4vw, 38px); }
+    .stack-kicker {
+      margin: 0 0 9px;
+      color: var(--brand);
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+    .stack-hero h2 { margin: 0; font-size: clamp(24px, 3vw, 38px); letter-spacing: -.04em; }
+    .stack-hero p {
+      max-width: 720px;
+      margin: 12px 0 0;
+      color: var(--text-muted);
+      line-height: 1.65;
+    }
+
+    .stack-source {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 22px;
+    }
+    .stack-source-label {
+      color: var(--text-dim);
+      font-size: 11px;
+      font-weight: 750;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    .stack-source strong { display: block; margin: 8px 0; font-size: 15px; }
+    .stack-source p { margin: 0; color: var(--text-muted); font-size: 12px; line-height: 1.55; }
+    .stack-source a {
+      display: inline-flex;
+      align-items: center;
+      min-height: 44px;
+      margin-top: 15px;
+      color: var(--brand);
+      font-size: 12px;
+      font-weight: 750;
+    }
+
+    .stack-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .stack-card {
+      position: relative;
+      min-height: 190px;
+      padding: 22px;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      background: var(--surface);
+    }
+    .stack-card::after {
+      position: absolute;
+      right: -34px;
+      bottom: -48px;
+      width: 120px;
+      height: 120px;
+      border: 1px solid var(--brand-ring);
+      border-radius: 50%;
+      content: "";
+      opacity: .36;
+    }
+    .stack-layer {
+      color: var(--brand);
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: .09em;
+      text-transform: uppercase;
+    }
+    .stack-card h3 { max-width: 88%; margin: 12px 0 9px; font-size: 18px; line-height: 1.3; }
+    .stack-card p {
+      position: relative;
+      z-index: 1;
+      margin: 0 0 18px;
+      color: var(--text-muted);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .stack-delivery {
+      display: inline-flex;
+      align-items: center;
+      min-height: 27px;
+      padding: 0 9px;
+      border: 1px solid var(--border-strong);
+      border-radius: 999px;
+      color: var(--text-dim);
+      background: var(--surface-raised);
+      font-size: 11px;
+      font-weight: 700;
     }
 
     .stats {
@@ -535,6 +691,7 @@
       .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .toolbar { grid-template-columns: 1fr 1fr; }
       .result-count { text-align: left; }
+      .stack-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     }
 
     @media (max-width: 760px) {
@@ -558,8 +715,11 @@
       input, select { font-size: 16px; }
       .topbar { display: block; }
       .actions { justify-content: flex-start; margin-top: 18px; }
+      .content-tabs { width: 100%; margin: 0 0 18px; }
+      .content-tab { flex: 1; }
       .toolbar { grid-template-columns: 1fr; }
       .stats { grid-template-columns: 1fr 1fr; }
+      .stack-intro, .stack-grid { grid-template-columns: 1fr; }
       .issue {
         grid-template-columns: 72px minmax(0, 1fr) 44px;
         gap: 8px;
@@ -619,7 +779,7 @@
             <span id="issueCountLead">—</span> issues và các gate từ engineering
             foundation đến production go-live.</p>
         </div>
-        <div class="actions" aria-label="Thao tác dữ liệu">
+        <div class="actions" id="roadmapActions" aria-label="Thao tác dữ liệu">
           <button class="button" id="exportButton" type="button" aria-label="Export trạng thái roadmap ra JSON">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
               <path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/>
@@ -642,7 +802,26 @@
         </div>
       </header>
 
-      <div class="dashboard">
+      <div class="content-tabs" role="tablist" aria-label="Nội dung kế hoạch">
+        <button class="content-tab" id="roadmapTab" type="button" role="tab"
+          aria-selected="true" aria-controls="roadmapView" data-content-tab="roadmap">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M4 19V5M4 7h6v5H4m6-3h5v8h-5m5-6h5v4h-5"/>
+          </svg>
+          Roadmap
+        </button>
+        <button class="content-tab" id="techStackTab" type="button" role="tab"
+          aria-selected="false" aria-controls="techStackView" data-content-tab="tech-stack"
+          tabindex="-1">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="m12 3 8 4-8 4-8-4 8-4Z"/>
+            <path d="m4 12 8 4 8-4M4 17l8 4 8-4"/>
+          </svg>
+          Tech stack
+        </button>
+      </div>
+
+      <section class="dashboard" id="roadmapView" role="tabpanel" aria-labelledby="roadmapTab">
         <section class="stats" aria-label="Tổng quan tiến độ">
           <article class="stat">
             <div class="stat-label">Tổng issues</div>
@@ -701,7 +880,29 @@
           <strong>Không tìm thấy issue phù hợp.</strong><br>
           Thử đổi từ khóa hoặc bộ lọc.
         </div>
-      </div>
+      </section>
+
+      <section class="tech-stack-view" id="techStackView" role="tabpanel"
+        aria-labelledby="techStackTab" tabindex="-1" hidden>
+        <div class="stack-intro">
+          <div class="stack-hero">
+            <p class="stack-kicker">Target architecture</p>
+            <h2>Tech stack theo từng lớp hệ thống</h2>
+            <p>Stack phục vụ document conversion, hybrid retrieval và grounded Q&amp;A
+              trong môi trường on-prem, với tenant isolation và khả năng vận hành production.</p>
+          </div>
+          <aside class="stack-source">
+            <div>
+              <span class="stack-source-label">Single source of truth</span>
+              <strong>Được tạo từ plan tổng</strong>
+              <p>Mỗi card bên dưới được generator đọc trực tiếp từ bảng Technology stack
+                trong Markdown, không duy trì bản sao thủ công trong HTML.</p>
+            </div>
+            <a href="README.md">Mở Markhand Web plan →</a>
+          </aside>
+        </div>
+        <div class="stack-grid" id="techStackGrid"></div>
+      </section>
     </main>
   </div>
 
@@ -1366,11 +1567,86 @@
         ]
       }
     ];
+    const techStack = [
+      {
+        "layer": "Web client",
+        "technology": "React + Vite + TypeScript",
+        "responsibility": "SPA cho library, upload, search, Q&A và admin",
+        "delivery": "Phase 2"
+      },
+      {
+        "layer": "API",
+        "technology": "Rust + axum + OpenAPI",
+        "responsibility": "REST API, SSE progress, auth middleware và OrgContext",
+        "delivery": "Phase 1B"
+      },
+      {
+        "layer": "Shared knowledge",
+        "technology": "Rust crate knowledge",
+        "responsibility": "Hybrid rank/merge, grounding, citation và index signature",
+        "delivery": "Phase 1A"
+      },
+      {
+        "layer": "Document engine",
+        "technology": "fileconv-core",
+        "responsibility": "Convert, OCR, chunk và deterministic intelligence",
+        "delivery": "Existing core"
+      },
+      {
+        "layer": "System of record",
+        "technology": "PostgreSQL + FTS",
+        "responsibility": "Metadata, ACL, auth, jobs, quota, audit và lexical search",
+        "delivery": "Phase 1B"
+      },
+      {
+        "layer": "Vector retrieval",
+        "technology": "Qdrant",
+        "responsibility": "Vector candidates; kết quả luôn được hydrate và kiểm ACL lại",
+        "delivery": "Phase 1B"
+      },
+      {
+        "layer": "Object storage",
+        "technology": "MinIO",
+        "responsibility": "File gốc, quarantine, Markdown và derived artifacts",
+        "delivery": "Phase 1B"
+      },
+      {
+        "layer": "Embeddings",
+        "technology": "vLLM GPU endpoint",
+        "responsibility": "Batch embedding với model/dimension/normalize được pin",
+        "delivery": "Phase 0 → 1B"
+      },
+      {
+        "layer": "Chat and extraction",
+        "technology": "GLM via LLM client",
+        "responsibility": "Grounded Q&A, summarize và structured extraction theo policy",
+        "delivery": "Phase 1B → 3"
+      },
+      {
+        "layer": "Identity",
+        "technology": "JWT + rotating refresh + OIDC",
+        "responsibility": "Session cho POC; SSO/OIDC và key rotation cho production",
+        "delivery": "Phase 1B → 4"
+      },
+      {
+        "layer": "Observability",
+        "technology": "OpenTelemetry + structured logs",
+        "responsibility": "Trace, metrics, audit correlation và redacted diagnostics",
+        "delivery": "Phase F → 4"
+      },
+      {
+        "layer": "Runtime",
+        "technology": "Docker Compose → production orchestrator",
+        "responsibility": "Local/POC reproducible; Kubernetes hoặc nền tảng on-prem tương đương được chốt ở Phase 4",
+        "delivery": "Phase F → 4"
+      }
+    ];
     /* ROADMAP_DATA_END */
 
     const STORAGE_KEY = `markhand-roadmap-status-v1-${ROADMAP_SOURCE_HASH}`;
     let saved = loadSaved();
     let phaseScope = "all";
+    let activeContent = location.hash === "#tech-stack" ? "tech-stack" : "roadmap";
     let toastTimer;
 
     const elements = {
@@ -1392,7 +1668,12 @@
       blockedStat: document.querySelector("#blockedStat"),
       overallProgress: document.querySelector("#overallProgress"),
       toast: document.querySelector("#toast"),
-      importFile: document.querySelector("#importFile")
+      importFile: document.querySelector("#importFile"),
+      roadmapActions: document.querySelector("#roadmapActions"),
+      roadmapView: document.querySelector("#roadmapView"),
+      techStackView: document.querySelector("#techStackView"),
+      techStackGrid: document.querySelector("#techStackGrid"),
+      contentTabs: [...document.querySelectorAll("[data-content-tab]")]
     };
 
     function loadSaved() {
@@ -1422,6 +1703,44 @@
 
     function slugText(value) {
       return value.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+    }
+
+    function renderTechStack() {
+      elements.techStackGrid.innerHTML = techStack.map(item => `
+        <article class="stack-card">
+          <div class="stack-layer">${escapeHtml(item.layer)}</div>
+          <h3>${escapeHtml(item.technology)}</h3>
+          <p>${escapeHtml(item.responsibility)}</p>
+          <span class="stack-delivery">${escapeHtml(item.delivery)}</span>
+        </article>
+      `).join("");
+    }
+
+    function activateContentTab(name, updateHash = true) {
+      const activeName = name === "tech-stack" ? "tech-stack" : "roadmap";
+      const showRoadmap = activeName === "roadmap";
+      const focusWouldHide = showRoadmap
+        ? elements.techStackView.contains(document.activeElement)
+        : elements.roadmapView.contains(document.activeElement)
+          || elements.roadmapActions.contains(document.activeElement);
+      const focusedTabChanges = elements.contentTabs.includes(document.activeElement)
+        && document.activeElement.dataset.contentTab !== activeName;
+      elements.roadmapView.hidden = !showRoadmap;
+      elements.techStackView.hidden = showRoadmap;
+      elements.roadmapActions.hidden = !showRoadmap;
+      elements.contentTabs.forEach(tab => {
+        const selected = tab.dataset.contentTab === activeName;
+        tab.setAttribute("aria-selected", String(selected));
+        tab.tabIndex = selected ? 0 : -1;
+      });
+      const changed = activeContent !== activeName;
+      activeContent = activeName;
+      if (updateHash && changed) history.pushState(null, "", `#${activeName}`);
+      if (focusWouldHide || focusedTabChanges) {
+        requestAnimationFrame(() => {
+          elements.contentTabs.find(tab => tab.dataset.contentTab === activeName)?.focus();
+        });
+      }
     }
 
     function renderNavigation() {
@@ -1679,7 +1998,30 @@
 
     document.addEventListener("click", event => {
       const phaseButton = event.target.closest("[data-phase]");
-      if (phaseButton) setPhase(phaseButton.dataset.phase, phaseButton.classList.contains("phase-mini") ? "strip" : "nav");
+      if (phaseButton) {
+        activateContentTab("roadmap");
+        setPhase(phaseButton.dataset.phase, phaseButton.classList.contains("phase-mini") ? "strip" : "nav");
+      }
+    });
+
+    elements.contentTabs.forEach(tab => {
+      tab.addEventListener("click", () => activateContentTab(tab.dataset.contentTab));
+      tab.addEventListener("keydown", event => {
+        if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+        event.preventDefault();
+        const current = elements.contentTabs.indexOf(event.currentTarget);
+        const next = event.key === "Home"
+          ? 0
+          : event.key === "End"
+            ? elements.contentTabs.length - 1
+            : (current + (event.key === "ArrowRight" ? 1 : -1) + elements.contentTabs.length)
+              % elements.contentTabs.length;
+        elements.contentTabs[next].focus();
+        activateContentTab(elements.contentTabs[next].dataset.contentTab);
+      });
+    });
+    window.addEventListener("hashchange", () => {
+      activateContentTab(location.hash === "#tech-stack" ? "tech-stack" : "roadmap", false);
     });
 
     elements.searchInput.addEventListener("input", renderRoadmap);
@@ -1699,6 +2041,8 @@
     });
 
     render();
+    renderTechStack();
+    activateContentTab(location.hash === "#tech-stack" ? "tech-stack" : "roadmap", false);
   </script>
 </body>
 </html>

--- a/plans/reports/brainstorm-260713-1656-markhand-web-rag-multi-org-report.md
+++ b/plans/reports/brainstorm-260713-1656-markhand-web-rag-multi-org-report.md
@@ -114,6 +114,7 @@ Embed query → Qdrant top-k (filter org + collection ACL) ∥ PG FTS (`unaccent
 
 | Phase | Deliverable | Gate |
 |---|---|---|
+| **F** | Engineering foundation: architecture rules, workspace skeleton, coding/API/SQL conventions, local dev environment, CI/test/observability baseline | Clean-checkout foundation gate |
 | **0** | Spike scale/security: benchmark Qdrant+PG FTS với phân bố org thật; eval embedding golden-set tiếng Việt (bge-m3 vs e5); upload threat model; chốt SLA số | Số liệu đạt ngưỡng mới đi tiếp |
 | **1A** | Tách `crates/knowledge` — desktop behavior giữ nguyên, test pass | `cargo test` + desktop chạy đúng |
 | **1B** | Server vertical slice **single-org (POC)**: auth JWT đơn giản, upload (hardening đầy đủ) → convert → index → Q&A citation, state machine + reconciliation | Demo POC 1 đơn vị, vài account test |
@@ -122,7 +123,7 @@ Embed query → Qdrant top-k (filter org + collection ACL) ∥ PG FTS (`unaccent
 | **3** | Port intelligence: tóm tắt, quality, PII/redaction, BA/PM handoff | |
 | **4** | Hardening sâu (audit review, pentest checklist), SSO/OIDC, trang hướng dẫn sử dụng + onboarding | |
 
-POC hiện tại = Phase 0 → 1B. Schema multi-org từ đầu (org_id mọi bảng) nên 1C không cần migration phá.
+POC hiện tại = Phase F → (Phase 0 ∥ 1A) → 1B. Schema multi-org từ đầu (org_id mọi bảng) nên 1C không cần migration phá.
 
 ## 7. Rủi ro
 
@@ -144,7 +145,7 @@ POC hiện tại = Phase 0 → 1B. Schema multi-org từ đầu (org_id mọi b�
 
 ## 9. Next steps
 
-1. `/ck:plan` cho POC (Phase 0 → 1B), input = report này.
+1. Thực hiện Phase F, sau đó chạy Phase 0 và 1A song song trước Phase 1B.
 2. Xác nhận hạ tầng: GPU server (VRAM → chọn model embed), provisioning PG/Qdrant/MinIO, GLM endpoint.
 3. Chuẩn bị golden-set câu hỏi-đáp tiếng Việt từ tài liệu mẫu cho Phase 0.
 

--- a/plans/reports/brainstorm-260713-1656-markhand-web-rag-multi-org-report.md
+++ b/plans/reports/brainstorm-260713-1656-markhand-web-rag-multi-org-report.md
@@ -3,6 +3,7 @@
 - Date: 2026-07-13
 - Status: Design APPROVED bởi user; đã qua **Codex review** (8 finding) và cập nhật thiết kế + phasing theo review. User đã trả lời 4 câu hỏi mở của review.
 - Modes: none (không --html/--wiki)
+- Implementation plans: [`../markhand-web/README.md`](../markhand-web/README.md)
 
 ## 1. Bài toán
 
@@ -12,7 +13,7 @@ Xây web app quản lý tài liệu trên nền `fileconv-core`: trích xuất (
 
 ## 2. Hiện trạng codebase (scout)
 
-- Pipeline RAG đã tồn tại trong desktop: `app/src-tauri/knowledge.rs` (1.672 dòng, SQLite FTS5 + vector hybrid + citation), `vector_index.rs` (HNSW persistent), `intelligence.rs` (1.168 dòng: quality, PII, BA/PM handoff). Tổng ~5.200 dòng gắn chặt Tauri **và** SQLite/filesystem root/sync-blocking flow (`knowledge.rs:178`, `:1027`) — refactor khó hơn mức "bỏ tauri::State".
+- Pipeline RAG đã tồn tại trong desktop: `app/src-tauri/src/knowledge.rs` (1.672 dòng, SQLite FTS5 + vector hybrid + citation), `app/src-tauri/src/vector_index.rs` (HNSW persistent), `app/src-tauri/src/intelligence.rs` (1.168 dòng: quality, PII, BA/PM handoff). Tổng ~5.200 dòng gắn chặt Tauri **và** SQLite/filesystem root/sync-blocking flow (`knowledge.rs:178`, `:1027`) — refactor khó hơn mức "bỏ tauri::State".
 - `crates/core`: `chunk.rs` (chunk heading-path), `llm.rs` (chat/vision/embedding đa provider OpenAI-compatible — GLM/vLLM dùng được ngay; lưu ý embed hiện blocking HTTP, batch 64, timeout 60s — `llm.rs:801`), `intelligence.rs` thuần.
 - Chưa có web server crate. MCP server (`crates/mcp`) là convert-tool, không phải document store.
 - Frontend React+Vite desktop có component tái dùng: `SafeMarkdown`, pattern `LibraryView`/`IntelligenceView`, `ui.tsx`.
@@ -61,7 +62,7 @@ Kết luận: ~80% logic RAG đã có. Bài toán thực = **tách lớp intelli
 
 ### Workspace
 - `crates/core` — giữ nguyên.
-- `crates/knowledge` (mới) — tách từ `app/src-tauri/{knowledge,vector_index,intelligence}.rs`: **extract tối thiểu theo use-case** — logic thuần chunk→embed→rank→citation trước; desktop giữ SQLite/HNSW và hành vi không đổi (test chốt trước khi tách).
+- `crates/knowledge` (mới) — tách từ `app/src-tauri/src/{knowledge,vector_index,intelligence}.rs`: **extract tối thiểu theo use-case** — logic thuần chunk→embed→rank→citation trước; desktop giữ SQLite/HNSW và hành vi không đổi (test chốt trước khi tách).
 - `crates/server` (mới) — axum: JWT auth (module tách riêng, pluggable OIDC sau), RBAC middleware, tower_governor + quota, REST + SSE, worker pool, adapter PG/Qdrant/MinIO.
 - `web/` (mới) — React+Vite SPA; thay `ipc.ts` bằng HTTP client; tái dùng SafeMarkdown/pattern view.
 

--- a/scripts/build-roadmap.py
+++ b/scripts/build-roadmap.py
@@ -17,22 +17,23 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 ROADMAP = ROOT / "plans/markhand-web/roadmap.html"
 DATA_PATTERN = re.compile(
-    r"(?P<indent>[ \t]*)/\* ROADMAP_DATA_START \*/"
+    r"^(?P<indent>[ \t]*)/\* ROADMAP_DATA_START \*/[ \t]*\r?\n"
     r".*?"
-    r"(?P=indent)/\* ROADMAP_DATA_END \*/",
-    re.DOTALL,
+    r"^(?P=indent)/\* ROADMAP_DATA_END \*/[ \t]*$",
+    re.DOTALL | re.MULTILINE,
 )
 DEFAULT_STATUS_PATTERN = re.compile(
     r"<!--\s*roadmap-default-status:\s*([a-z_ ]+)\s*-->",
     re.IGNORECASE,
 )
 ISSUE_PATTERN = re.compile(
-    r"^#{2,3}\s+"
+    r"^(?P<heading>#{2,3})\s+"
     r"(?P<id>(?:F|P0|P1A|P1B|1C|P2|P3|P4)-[A-Z0-9]+)"
     r"\s+—\s+"
     r"(?P<title>.+?)\s*$",
     re.MULTILINE,
 )
+HEADING_PATTERN = re.compile(r"^(?P<heading>#{1,6})\s+", re.MULTILINE)
 STATUS_FIELD_PATTERN = re.compile(
     r"^\s*-\s*\*\*Status:\*\*\s*(?P<value>[^\r\n]*)$",
     re.IGNORECASE | re.MULTILINE,
@@ -193,8 +194,13 @@ def parse_phase(config: PhaseConfig) -> dict[str, object]:
     matches = list(ISSUE_PATTERN.finditer(content))
     issues: list[list[str]] = []
 
-    for index, match in enumerate(matches):
-        section_end = matches[index + 1].start() if index + 1 < len(matches) else len(content)
+    for match in matches:
+        heading_level = len(match.group("heading"))
+        section_end = len(content)
+        for next_heading in HEADING_PATTERN.finditer(content, match.end()):
+            if len(next_heading.group("heading")) <= heading_level:
+                section_end = next_heading.start()
+                break
         section = content[match.end() : section_end]
         status_fields = list(STATUS_FIELD_PATTERN.finditer(section))
         if len(status_fields) > 1:
@@ -288,6 +294,7 @@ def render(current: str, phases: list[dict[str, object]]) -> str:
 
 def atomic_write(path: Path, content: str) -> None:
     temporary: Path | None = None
+    mode = path.stat().st_mode & 0o777
     try:
         with tempfile.NamedTemporaryFile(
             mode="w",
@@ -302,6 +309,7 @@ def atomic_write(path: Path, content: str) -> None:
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
+        os.chmod(temporary, mode)
         os.replace(temporary, path)
     finally:
         if temporary and temporary.exists():

--- a/scripts/build-roadmap.py
+++ b/scripts/build-roadmap.py
@@ -37,6 +37,12 @@ GROUPS_PATTERN = re.compile(
     r"<!--\s*roadmap-groups:\s*([A-Z](?:\s*,\s*[A-Z])*)\s*-->",
     re.IGNORECASE,
 )
+TECH_STACK_BLOCK_PATTERN = re.compile(
+    r"<!--\s*roadmap-tech-stack-start\s*-->\s*"
+    r"(?P<table>.*?)"
+    r"\s*<!--\s*roadmap-tech-stack-end\s*-->",
+    re.DOTALL | re.IGNORECASE,
+)
 DATA_PATTERN = re.compile(
     r"^(?P<indent>[ \t]*)/\* ROADMAP_DATA_START \*/[ \t]*\r?\n"
     r".*?"
@@ -150,7 +156,92 @@ def resolve_registry_path(raw: str, *, kind: str) -> Path:
 
 
 def clean_inline_markdown(value: str) -> str:
-    return re.sub(r"`([^`]+)`", r"\1", value).strip()
+    return re.sub(r"(`+)(.*?)\1", r"\2", value).strip()
+
+
+def split_markdown_table_row(line: str, *, line_number: int) -> list[str]:
+    content = line[1:-1]
+    cells: list[str] = []
+    current: list[str] = []
+    index = 0
+    while index < len(content):
+        char = content[index]
+        if (
+            char == "\\"
+            and index + 1 < len(content)
+            and content[index + 1] in {"|", "`"}
+        ):
+            current.append(content[index + 1])
+            index += 2
+            continue
+        if char == "`":
+            end = index + 1
+            while end < len(content) and content[end] == "`":
+                end += 1
+            marker = content[index:end]
+            closing = re.search(
+                rf"(?<!`){re.escape(marker)}(?!`)",
+                content[end:],
+            )
+            if closing is None:
+                current.append(marker)
+                index = end
+                continue
+            closing_end = end + closing.end()
+            current.append(content[index:closing_end])
+            index = closing_end
+            continue
+        if char == "|":
+            cells.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+        index += 1
+    cells.append("".join(current))
+    return cells
+
+
+def parse_tech_stack(markdown: str) -> list[dict[str, str]]:
+    blocks = TECH_STACK_BLOCK_PATTERN.findall(markdown)
+    if len(blocks) != 1:
+        raise ValueError(
+            f"{MASTER_PLAN}: cần đúng một roadmap tech-stack block, có {len(blocks)}"
+        )
+    lines = [line.strip() for line in blocks[0].splitlines() if line.strip()]
+    if len(lines) < 3:
+        raise ValueError(f"{MASTER_PLAN}: tech-stack table không có data rows")
+    if lines[0] != "| Lớp | Công nghệ | Trách nhiệm | Delivery |":
+        raise ValueError(f"{MASTER_PLAN}: tech-stack table header không hợp lệ")
+    if not re.fullmatch(r"\|\s*---\s*\|\s*---\s*\|\s*---\s*\|\s*---\s*\|", lines[1]):
+        raise ValueError(f"{MASTER_PLAN}: tech-stack table separator không hợp lệ")
+
+    stack: list[dict[str, str]] = []
+    for line_number, line in enumerate(lines[2:], start=3):
+        if not line.startswith("|") or not line.endswith("|"):
+            raise ValueError(
+                f"{MASTER_PLAN}: tech-stack row {line_number} không phải Markdown table row"
+            )
+        cells = [
+            clean_inline_markdown(cell)
+            for cell in split_markdown_table_row(line, line_number=line_number)
+        ]
+        if len(cells) != 4 or any(not cell for cell in cells):
+            raise ValueError(
+                f"{MASTER_PLAN}: tech-stack row {line_number} cần đúng 4 cells có nội dung"
+            )
+        stack.append(
+            {
+                "layer": cells[0],
+                "technology": cells[1],
+                "responsibility": cells[2],
+                "delivery": cells[3],
+            }
+        )
+
+    layers = [item["layer"] for item in stack]
+    if len(layers) != len(set(layers)):
+        raise ValueError(f"{MASTER_PLAN}: trùng tech-stack layers")
+    return stack
 
 
 def parse_registry() -> tuple[list[PhaseConfig], int]:
@@ -386,27 +477,41 @@ def source_hash(phases: list[dict[str, object]]) -> str:
     return hashlib.sha256(canonical).hexdigest()[:16]
 
 
-def data_block(phases: list[dict[str, object]], indent: str) -> str:
-    payload = json.dumps(phases, ensure_ascii=False, indent=2)
+def javascript_payload(value: object, indent: str) -> str:
+    payload = json.dumps(value, ensure_ascii=False, indent=2)
     # Keep the generated JavaScript safe even if a future Markdown title contains HTML.
     payload = payload.replace("<", r"\u003c")
-    payload = payload.replace("\n", "\n" + indent)
+    return payload.replace("\n", "\n" + indent)
+
+
+def data_block(
+    phases: list[dict[str, object]],
+    tech_stack: list[dict[str, str]],
+    indent: str,
+) -> str:
+    phase_payload = javascript_payload(phases, indent)
+    stack_payload = javascript_payload(tech_stack, indent)
     return (
         f"{indent}/* ROADMAP_DATA_START */\n"
         f'{indent}const ROADMAP_SOURCE_HASH = "{source_hash(phases)}";\n'
-        f"{indent}const phases = {payload};\n"
+        f"{indent}const phases = {phase_payload};\n"
+        f"{indent}const techStack = {stack_payload};\n"
         f"{indent}/* ROADMAP_DATA_END */"
     )
 
 
-def render(current: str, phases: list[dict[str, object]]) -> str:
+def render(
+    current: str,
+    phases: list[dict[str, object]],
+    tech_stack: list[dict[str, str]],
+) -> str:
     matches = list(DATA_PATTERN.finditer(current))
     if len(matches) != 1:
         raise ValueError(
             f"{ROADMAP}: cần đúng một roadmap data block, có {len(matches)}"
         )
     match = matches[0]
-    block = data_block(phases, match.group("indent"))
+    block = data_block(phases, tech_stack, match.group("indent"))
     return current[: match.start()] + block + current[match.end() :]
 
 
@@ -454,9 +559,11 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
+        master_markdown = MASTER_PLAN.read_text(encoding="utf-8")
         phases = load_phases()
+        tech_stack = parse_tech_stack(master_markdown)
         current = ROADMAP.read_text(encoding="utf-8")
-        generated = render(current, phases)
+        generated = render(current, phases, tech_stack)
     except (OSError, ValueError) as error:
         print(f"roadmap build error: {error}", file=sys.stderr)
         return 1

--- a/scripts/build-roadmap.py
+++ b/scripts/build-roadmap.py
@@ -15,7 +15,28 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+MASTER_PLAN = ROOT / "plans/markhand-web/README.md"
 ROADMAP = ROOT / "plans/markhand-web/roadmap.html"
+TOTAL_PATTERN = re.compile(r"Issue-level backlog \((\d+) issues\)")
+PHASE_ROW_PATTERN = re.compile(
+    r"^\|\s*(?P<code>F|[0-9]+[A-Z]?)\s*"
+    r"\|\s*(?P<description>.*?)\s*"
+    r"\|\s*\[[^\]]+\]\((?P<plan>[^)]+)\)\s*"
+    r"\|\s*\[(?P<count>\d+)\s+issues\]\((?P<catalog>[^)]+)\)\s*\|\s*$",
+    re.MULTILINE,
+)
+PLAN_TITLE_PATTERN = re.compile(
+    r"^#\s+Phase\s+(?P<code>[A-Z0-9]+)\s+—\s+(?P<title>.+?)\s*$",
+    re.MULTILINE,
+)
+PARENT_PLAN_PATTERN = re.compile(
+    r"^Parent plan:\s*\[[^\]]+\]\((?P<plan>[^)]+)\)\s*$",
+    re.MULTILINE,
+)
+GROUPS_PATTERN = re.compile(
+    r"<!--\s*roadmap-groups:\s*([A-Z](?:\s*,\s*[A-Z])*)\s*-->",
+    re.IGNORECASE,
+)
 DATA_PATTERN = re.compile(
     r"^(?P<indent>[ \t]*)/\* ROADMAP_DATA_START \*/[ \t]*\r?\n"
     r".*?"
@@ -28,7 +49,7 @@ DEFAULT_STATUS_PATTERN = re.compile(
 )
 ISSUE_PATTERN = re.compile(
     r"^(?P<heading>#{2,3})\s+"
-    r"(?P<id>(?:F|P0|P1A|P1B|1C|P2|P3|P4)-[A-Z0-9]+)"
+    r"(?P<id>[A-Z0-9]+(?:-[A-Z0-9]+)+)"
     r"\s+—\s+"
     r"(?P<title>.+?)\s*$",
     re.MULTILINE,
@@ -39,7 +60,8 @@ STATUS_FIELD_PATTERN = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 STATUS_VALUE_PATTERN = re.compile(
-    r"^(Ready|Blocked|Backlog|In progress|Review|Done)\b",
+    r"^(Ready|Blocked|Backlog|In progress|Review|Done)"
+    r"(?:\s*(?:[.;,:—-]\s*.*|bởi\b.*))?$",
     re.IGNORECASE,
 )
 VALID_STATUSES = {
@@ -54,89 +76,25 @@ VALID_STATUSES = {
 
 @dataclass(frozen=True)
 class PhaseConfig:
-    directory: str
     code: str
     name: str
     description: str
-    expected_ids: tuple[str, ...]
+    plan: Path
+    catalog: Path
+    expected_issues: int
+    expected_groups: tuple[str, ...] = ()
 
     @property
-    def catalog(self) -> Path:
-        return (
-            ROOT
-            / "plans/markhand-web/backlog"
-            / self.directory
-            / "issues/README.md"
-        )
+    def directory(self) -> str:
+        return self.catalog.parent.parent.name
 
     @property
     def html_catalog(self) -> str:
-        return f"backlog/{self.directory}/issues/README.md"
+        return self.catalog.relative_to(MASTER_PLAN.parent).as_posix()
 
-
-PHASES = (
-    PhaseConfig(
-        "phase-f",
-        "F",
-        "Engineering Foundation",
-        "Rules, skeleton, dev environment và CI foundation",
-        tuple(f"F-{number:02d}" for number in range(1, 13)),
-    ),
-    PhaseConfig(
-        "phase-0",
-        "0",
-        "Discovery & Gates",
-        "Benchmark, threat model, SLA và architecture decisions",
-        tuple(f"P0-{number:02d}" for number in range(1, 11)),
-    ),
-    PhaseConfig(
-        "phase-1a",
-        "1A",
-        "Knowledge Extraction",
-        "Tách fileconv-knowledge, giữ desktop parity",
-        tuple(f"P1A-{number:02d}" for number in range(1, 11)),
-    ),
-    PhaseConfig(
-        "phase-1b",
-        "1B",
-        "Single-org POC",
-        "Upload → convert → index → Q&A citation",
-        tuple(
-            [f"P1B-F{number:02d}" for number in range(1, 7)]
-            + [f"P1B-I{number:02d}" for number in range(1, 8)]
-            + [f"P1B-R{number:02d}" for number in range(1, 7)]
-            + [f"P1B-O{number:02d}" for number in range(1, 6)]
-        ),
-    ),
-    PhaseConfig(
-        "phase-1c",
-        "1C",
-        "Multi-org Security",
-        "RBAC, ACL, quota, fairness và denial suite",
-        tuple(f"1C-{number:02d}" for number in range(1, 14)),
-    ),
-    PhaseConfig(
-        "phase-2",
-        "2",
-        "Web SPA MVP",
-        "Login, library, upload, Q&A và admin tối thiểu",
-        tuple(f"P2-{number:02d}" for number in range(1, 17)),
-    ),
-    PhaseConfig(
-        "phase-3",
-        "3",
-        "Document Intelligence",
-        "BRD/PRD, quality, PII, tables, versions và export",
-        tuple(f"P3-{number:02d}" for number in range(1, 15)),
-    ),
-    PhaseConfig(
-        "phase-4",
-        "4",
-        "Production Hardening",
-        "OIDC, HA, DR, deployment và go-live",
-        tuple(f"P4-{number:02d}" for number in range(1, 15)),
-    ),
-)
+    @property
+    def html_plan(self) -> str:
+        return self.plan.relative_to(MASTER_PLAN.parent).as_posix()
 
 
 def normalize_status(raw: str, *, source: Path) -> str:
@@ -179,6 +137,162 @@ def mask_non_content(markdown: str) -> str:
     if fence is not None:
         raise ValueError("Markdown có code fence chưa đóng")
     return "".join(result)
+
+
+def resolve_registry_path(raw: str, *, kind: str) -> Path:
+    base = MASTER_PLAN.parent.resolve()
+    resolved = (MASTER_PLAN.parent / raw).resolve()
+    if not resolved.is_relative_to(base):
+        raise ValueError(f"{MASTER_PLAN}: {kind} vượt ngoài Markhand Web plan: {raw}")
+    if not resolved.is_file():
+        raise ValueError(f"{MASTER_PLAN}: không tìm thấy {kind}: {raw}")
+    return resolved
+
+
+def clean_inline_markdown(value: str) -> str:
+    return re.sub(r"`([^`]+)`", r"\1", value).strip()
+
+
+def parse_registry() -> tuple[list[PhaseConfig], int]:
+    markdown = MASTER_PLAN.read_text(encoding="utf-8")
+    total_matches = TOTAL_PATTERN.findall(markdown)
+    if len(total_matches) != 1:
+        raise ValueError(
+            f"{MASTER_PLAN}: cần đúng một Issue-level backlog total, "
+            f"có {len(total_matches)}"
+        )
+    expected_total = int(total_matches[0])
+    rows = list(PHASE_ROW_PATTERN.finditer(mask_non_content(markdown)))
+    if not rows:
+        raise ValueError(f"{MASTER_PLAN}: không tìm thấy phase registry rows")
+
+    configs: list[PhaseConfig] = []
+    for row in rows:
+        plan = resolve_registry_path(row.group("plan"), kind="phase plan")
+        catalog = resolve_registry_path(row.group("catalog"), kind="issue catalog")
+        plan_titles = list(
+            PLAN_TITLE_PATTERN.finditer(
+                mask_non_content(plan.read_text(encoding="utf-8"))
+            )
+        )
+        if len(plan_titles) != 1:
+            raise ValueError(
+                f"{plan}: cần đúng một '# Phase ... — ...' title, có {len(plan_titles)}"
+            )
+        plan_title = plan_titles[0]
+        if plan_title.group("code") != row.group("code"):
+            raise ValueError(
+                f"{plan}: title Phase {plan_title.group('code')} không khớp "
+                f"registry Phase {row.group('code')}"
+            )
+        expected_directory = f"phase-{row.group('code').lower()}"
+        if catalog.parent.name != "issues" or catalog.parent.parent.name != expected_directory:
+            raise ValueError(
+                f"{catalog}: catalog phải nằm tại "
+                f"backlog/{expected_directory}/issues/README.md"
+            )
+        catalog_markdown = catalog.read_text(encoding="utf-8")
+        parent_links = PARENT_PLAN_PATTERN.findall(
+            mask_non_content(catalog_markdown)
+        )
+        if len(parent_links) != 1:
+            raise ValueError(
+                f"{catalog}: cần đúng một Parent plan backlink, có {len(parent_links)}"
+            )
+        catalog_parent = (catalog.parent / parent_links[0]).resolve()
+        if catalog_parent != plan:
+            raise ValueError(
+                f"{catalog}: Parent plan {catalog_parent} không khớp registry {plan}"
+            )
+        group_matches = GROUPS_PATTERN.findall(catalog_markdown)
+        if row.group("code") == "1B":
+            if len(group_matches) != 1:
+                raise ValueError(
+                    f"{catalog}: Phase 1B cần đúng một roadmap-groups"
+                )
+            expected_groups = tuple(
+                part.strip().upper() for part in group_matches[0].split(",")
+            )
+        else:
+            if group_matches:
+                raise ValueError(
+                    f"{catalog}: roadmap-groups chỉ được dùng cho grouped issue IDs"
+                )
+            expected_groups = ()
+        configs.append(
+            PhaseConfig(
+                code=row.group("code"),
+                name=plan_title.group("title").strip(),
+                description=clean_inline_markdown(row.group("description")),
+                plan=plan,
+                catalog=catalog,
+                expected_issues=int(row.group("count")),
+                expected_groups=expected_groups,
+            )
+        )
+
+    codes = [config.code for config in configs]
+    plans = [config.plan for config in configs]
+    catalogs = [config.catalog for config in configs]
+    if len(codes) != len(set(codes)):
+        raise ValueError(f"{MASTER_PLAN}: trùng phase codes")
+    if len(catalogs) != len(set(catalogs)):
+        raise ValueError(f"{MASTER_PLAN}: trùng issue catalogs")
+    if len(plans) != len(set(plans)):
+        raise ValueError(f"{MASTER_PLAN}: trùng phase plans")
+    if sum(config.expected_issues for config in configs) != expected_total:
+        raise ValueError(
+            f"{MASTER_PLAN}: tổng phase issue counts không bằng {expected_total}"
+        )
+    return configs, expected_total
+
+
+def validate_phase_issue_ids(config: PhaseConfig, issue_ids: tuple[str, ...]) -> None:
+    if len(issue_ids) != config.expected_issues:
+        raise ValueError(
+            f"{config.catalog}: tìm thấy {len(issue_ids)} issues, "
+            f"registry cần {config.expected_issues}"
+        )
+
+    if config.code == "F":
+        pattern = re.compile(r"^F-(?P<number>\d{2})$")
+    elif config.code == "1C":
+        pattern = re.compile(r"^1C-(?P<number>\d{2})$")
+    elif config.code == "1B":
+        pattern = re.compile(r"^P1B-(?P<group>[A-Z])(?P<number>\d{2})$")
+    else:
+        pattern = re.compile(
+            rf"^P{re.escape(config.code)}-(?P<number>\d{{2}})$"
+        )
+
+    parsed: list[tuple[str, int]] = []
+    for issue_id in issue_ids:
+        match = pattern.fullmatch(issue_id)
+        if not match:
+            raise ValueError(
+                f"{config.catalog}: {issue_id} không thuộc Phase {config.code}"
+            )
+        parsed.append((match.groupdict().get("group") or "", int(match.group("number"))))
+
+    groups: list[str] = []
+    for group, _ in parsed:
+        if group not in groups:
+            groups.append(group)
+    if tuple(groups) != config.expected_groups and config.expected_groups:
+        raise ValueError(
+            f"{config.catalog}: groups {tuple(groups)} không khớp "
+            f"roadmap-groups {config.expected_groups}"
+        )
+    if [group for group, _ in parsed] != [
+        group for group in groups for _ in range(sum(1 for item in parsed if item[0] == group))
+    ]:
+        raise ValueError(f"{config.catalog}: issue groups không liên tục")
+    for group in groups:
+        numbers = [number for item_group, number in parsed if item_group == group]
+        if numbers != list(range(1, len(numbers) + 1)):
+            raise ValueError(
+                f"{config.catalog}: numbering group {group or 'default'} không liên tục"
+            )
 
 
 def parse_phase(config: PhaseConfig) -> dict[str, object]:
@@ -226,30 +340,27 @@ def parse_phase(config: PhaseConfig) -> dict[str, object]:
         )
 
     issue_ids = tuple(issue[0] for issue in issues)
-    if issue_ids != config.expected_ids:
-        raise ValueError(
-            f"{source}: issue IDs/order không đúng; "
-            f"found={issue_ids}, expected={config.expected_ids}"
-        )
+    validate_phase_issue_ids(config, issue_ids)
 
     return {
         "id": config.directory,
         "code": config.code,
         "name": config.name,
         "description": config.description,
+        "plan": config.html_plan,
         "catalog": config.html_catalog,
         "issues": issues,
     }
 
 
 def load_phases() -> list[dict[str, object]]:
-    phases = [parse_phase(config) for config in PHASES]
+    configs, expected = parse_registry()
+    phases = [parse_phase(config) for config in configs]
     ids = [
         issue[0]
         for phase in phases
         for issue in phase["issues"]  # type: ignore[index]
     ]
-    expected = sum(len(config.expected_ids) for config in PHASES)
     if len(ids) != expected:
         raise ValueError(f"Tổng issues {len(ids)}, cần {expected}")
     duplicate_ids = sorted({issue_id for issue_id in ids if ids.count(issue_id) > 1})

--- a/scripts/build-roadmap.py
+++ b/scripts/build-roadmap.py
@@ -186,7 +186,14 @@ def parse_registry() -> tuple[list[PhaseConfig], int]:
                 f"registry Phase {row.group('code')}"
             )
         expected_directory = f"phase-{row.group('code').lower()}"
-        if catalog.parent.name != "issues" or catalog.parent.parent.name != expected_directory:
+        expected_catalog = (
+            MASTER_PLAN.parent
+            / "backlog"
+            / expected_directory
+            / "issues"
+            / "README.md"
+        ).resolve()
+        if catalog != expected_catalog:
             raise ValueError(
                 f"{catalog}: catalog phải nằm tại "
                 f"backlog/{expected_directory}/issues/README.md"

--- a/scripts/build-roadmap.py
+++ b/scripts/build-roadmap.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Build the standalone Markhand roadmap from Markdown issue catalogs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ROADMAP = ROOT / "plans/markhand-web/roadmap.html"
+DATA_PATTERN = re.compile(
+    r"(?P<indent>[ \t]*)/\* ROADMAP_DATA_START \*/"
+    r".*?"
+    r"(?P=indent)/\* ROADMAP_DATA_END \*/",
+    re.DOTALL,
+)
+DEFAULT_STATUS_PATTERN = re.compile(
+    r"<!--\s*roadmap-default-status:\s*([a-z_ ]+)\s*-->",
+    re.IGNORECASE,
+)
+ISSUE_PATTERN = re.compile(
+    r"^#{2,3}\s+"
+    r"(?P<id>(?:F|P0|P1A|P1B|1C|P2|P3|P4)-[A-Z0-9]+)"
+    r"\s+—\s+"
+    r"(?P<title>.+?)\s*$",
+    re.MULTILINE,
+)
+STATUS_FIELD_PATTERN = re.compile(
+    r"^\s*-\s*\*\*Status:\*\*\s*(?P<value>[^\r\n]*)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+STATUS_VALUE_PATTERN = re.compile(
+    r"^(Ready|Blocked|Backlog|In progress|Review|Done)\b",
+    re.IGNORECASE,
+)
+VALID_STATUSES = {
+    "ready": "ready",
+    "blocked": "blocked",
+    "backlog": "backlog",
+    "in progress": "in_progress",
+    "review": "review",
+    "done": "done",
+}
+
+
+@dataclass(frozen=True)
+class PhaseConfig:
+    directory: str
+    code: str
+    name: str
+    description: str
+    expected_ids: tuple[str, ...]
+
+    @property
+    def catalog(self) -> Path:
+        return (
+            ROOT
+            / "plans/markhand-web/backlog"
+            / self.directory
+            / "issues/README.md"
+        )
+
+    @property
+    def html_catalog(self) -> str:
+        return f"backlog/{self.directory}/issues/README.md"
+
+
+PHASES = (
+    PhaseConfig(
+        "phase-f",
+        "F",
+        "Engineering Foundation",
+        "Rules, skeleton, dev environment và CI foundation",
+        tuple(f"F-{number:02d}" for number in range(1, 13)),
+    ),
+    PhaseConfig(
+        "phase-0",
+        "0",
+        "Discovery & Gates",
+        "Benchmark, threat model, SLA và architecture decisions",
+        tuple(f"P0-{number:02d}" for number in range(1, 11)),
+    ),
+    PhaseConfig(
+        "phase-1a",
+        "1A",
+        "Knowledge Extraction",
+        "Tách fileconv-knowledge, giữ desktop parity",
+        tuple(f"P1A-{number:02d}" for number in range(1, 11)),
+    ),
+    PhaseConfig(
+        "phase-1b",
+        "1B",
+        "Single-org POC",
+        "Upload → convert → index → Q&A citation",
+        tuple(
+            [f"P1B-F{number:02d}" for number in range(1, 7)]
+            + [f"P1B-I{number:02d}" for number in range(1, 8)]
+            + [f"P1B-R{number:02d}" for number in range(1, 7)]
+            + [f"P1B-O{number:02d}" for number in range(1, 6)]
+        ),
+    ),
+    PhaseConfig(
+        "phase-1c",
+        "1C",
+        "Multi-org Security",
+        "RBAC, ACL, quota, fairness và denial suite",
+        tuple(f"1C-{number:02d}" for number in range(1, 14)),
+    ),
+    PhaseConfig(
+        "phase-2",
+        "2",
+        "Web SPA MVP",
+        "Login, library, upload, Q&A và admin tối thiểu",
+        tuple(f"P2-{number:02d}" for number in range(1, 17)),
+    ),
+    PhaseConfig(
+        "phase-3",
+        "3",
+        "Document Intelligence",
+        "BRD/PRD, quality, PII, tables, versions và export",
+        tuple(f"P3-{number:02d}" for number in range(1, 15)),
+    ),
+    PhaseConfig(
+        "phase-4",
+        "4",
+        "Production Hardening",
+        "OIDC, HA, DR, deployment và go-live",
+        tuple(f"P4-{number:02d}" for number in range(1, 15)),
+    ),
+)
+
+
+def normalize_status(raw: str, *, source: Path) -> str:
+    normalized = re.sub(r"\s+", " ", raw.strip().lower())
+    try:
+        return VALID_STATUSES[normalized]
+    except KeyError as error:
+        valid = ", ".join(sorted(VALID_STATUSES))
+        raise ValueError(
+            f"{source}: trạng thái không hợp lệ {raw!r}; cần một trong {valid}"
+        ) from error
+
+
+def mask_non_content(markdown: str) -> str:
+    """Mask fenced code and HTML comments while preserving character offsets."""
+
+    def masked_text(value: str) -> str:
+        return "".join("\n" if char == "\n" else " " for char in value)
+
+    def mask(match: re.Match[str]) -> str:
+        return masked_text(match.group(0))
+
+    without_comments = re.sub(r"<!--.*?-->", mask, markdown, flags=re.DOTALL)
+    lines = without_comments.splitlines(keepends=True)
+    result: list[str] = []
+    fence: str | None = None
+    for line in lines:
+        fence_match = re.match(r"^\s*(```+|~~~+)", line)
+        if fence_match:
+            marker = fence_match.group(1)[0]
+            if fence is None:
+                fence = marker
+            elif fence == marker:
+                fence = None
+            result.append(masked_text(line))
+        elif fence is not None:
+            result.append(masked_text(line))
+        else:
+            result.append(line)
+    if fence is not None:
+        raise ValueError("Markdown có code fence chưa đóng")
+    return "".join(result)
+
+
+def parse_phase(config: PhaseConfig) -> dict[str, object]:
+    source = config.catalog
+    markdown = source.read_text(encoding="utf-8")
+    default_matches = DEFAULT_STATUS_PATTERN.findall(markdown)
+    if len(default_matches) != 1:
+        raise ValueError(
+            f"{source}: cần đúng một roadmap-default-status, có {len(default_matches)}"
+        )
+    default_status = normalize_status(default_matches[0], source=source)
+    content = mask_non_content(markdown)
+    matches = list(ISSUE_PATTERN.finditer(content))
+    issues: list[list[str]] = []
+
+    for index, match in enumerate(matches):
+        section_end = matches[index + 1].start() if index + 1 < len(matches) else len(content)
+        section = content[match.end() : section_end]
+        status_fields = list(STATUS_FIELD_PATTERN.finditer(section))
+        if len(status_fields) > 1:
+            raise ValueError(
+                f"{source}: {match.group('id')} có {len(status_fields)} Status fields"
+            )
+        status = default_status
+        if status_fields:
+            raw_status = status_fields[0].group("value").strip()
+            status_match = STATUS_VALUE_PATTERN.match(raw_status)
+            if not status_match:
+                raise ValueError(
+                    f"{source}: {match.group('id')} có Status không hợp lệ: "
+                    f"{raw_status!r}"
+                )
+            status = normalize_status(status_match.group(1), source=source)
+        issues.append(
+            [
+                match.group("id").strip(),
+                match.group("title").strip(),
+                status,
+            ]
+        )
+
+    issue_ids = tuple(issue[0] for issue in issues)
+    if issue_ids != config.expected_ids:
+        raise ValueError(
+            f"{source}: issue IDs/order không đúng; "
+            f"found={issue_ids}, expected={config.expected_ids}"
+        )
+
+    return {
+        "id": config.directory,
+        "code": config.code,
+        "name": config.name,
+        "description": config.description,
+        "catalog": config.html_catalog,
+        "issues": issues,
+    }
+
+
+def load_phases() -> list[dict[str, object]]:
+    phases = [parse_phase(config) for config in PHASES]
+    ids = [
+        issue[0]
+        for phase in phases
+        for issue in phase["issues"]  # type: ignore[index]
+    ]
+    expected = sum(len(config.expected_ids) for config in PHASES)
+    if len(ids) != expected:
+        raise ValueError(f"Tổng issues {len(ids)}, cần {expected}")
+    duplicate_ids = sorted({issue_id for issue_id in ids if ids.count(issue_id) > 1})
+    if duplicate_ids:
+        raise ValueError(f"Trùng issue IDs: {', '.join(duplicate_ids)}")
+    return phases
+
+
+def source_hash(phases: list[dict[str, object]]) -> str:
+    canonical = json.dumps(
+        phases,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()[:16]
+
+
+def data_block(phases: list[dict[str, object]], indent: str) -> str:
+    payload = json.dumps(phases, ensure_ascii=False, indent=2)
+    # Keep the generated JavaScript safe even if a future Markdown title contains HTML.
+    payload = payload.replace("<", r"\u003c")
+    payload = payload.replace("\n", "\n" + indent)
+    return (
+        f"{indent}/* ROADMAP_DATA_START */\n"
+        f'{indent}const ROADMAP_SOURCE_HASH = "{source_hash(phases)}";\n'
+        f"{indent}const phases = {payload};\n"
+        f"{indent}/* ROADMAP_DATA_END */"
+    )
+
+
+def render(current: str, phases: list[dict[str, object]]) -> str:
+    matches = list(DATA_PATTERN.finditer(current))
+    if len(matches) != 1:
+        raise ValueError(
+            f"{ROADMAP}: cần đúng một roadmap data block, có {len(matches)}"
+        )
+    match = matches[0]
+    block = data_block(phases, match.group("indent"))
+    return current[: match.start()] + block + current[match.end() :]
+
+
+def atomic_write(path: Path, content: str) -> None:
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary and temporary.exists():
+            temporary.unlink()
+
+
+def status_summary(phases: list[dict[str, object]]) -> dict[str, int]:
+    summary = {status: 0 for status in VALID_STATUSES.values()}
+    for phase in phases:
+        for _, _, status in phase["issues"]:  # type: ignore[misc]
+            summary[status] += 1
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build plans/markhand-web/roadmap.html from Markdown catalogs."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if roadmap.html is stale; do not write.",
+    )
+    args = parser.parse_args()
+
+    try:
+        phases = load_phases()
+        current = ROADMAP.read_text(encoding="utf-8")
+        generated = render(current, phases)
+    except (OSError, ValueError) as error:
+        print(f"roadmap build error: {error}", file=sys.stderr)
+        return 1
+
+    issue_count = sum(len(phase["issues"]) for phase in phases)  # type: ignore[arg-type]
+    summary = status_summary(phases)
+    if args.check:
+        if generated != current:
+            print(
+                "roadmap build error: roadmap.html đã cũ; "
+                "chạy python3 scripts/build-roadmap.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"roadmap up to date: {issue_count} issues, "
+            f"source={source_hash(phases)}, status={summary}"
+        )
+        return 0
+
+    if generated != current:
+        atomic_write(ROADMAP, generated)
+    print(
+        f"built {ROADMAP.relative_to(ROOT)}: {issue_count} issues, "
+        f"source={source_hash(phases)}, status={summary}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add Phase F and detailed Phase 0–4 plans with 113 issue specs
- add an interactive Roadmap dashboard generated through the master Web plan registry
- add a responsive, keyboard-accessible Tech stack tab generated from the master plan
- enforce generated dashboard freshness in CI

## Registry-driven build

`plans/markhand-web/README.md` is the single registry. It declares phase metadata and links, plus the target technology stack by architecture layer.

`python3 scripts/build-roadmap.py` follows phase links, reads each catalog, extracts issue headings/statuses, parses the technology table, validates the inventory and atomically updates `plans/markhand-web/roadmap.html`.

Validation includes:

- unique phase codes, phase plans and issue catalogs
- phase title/code and catalog `Parent plan` backlink consistency
- catalog ownership, issue namespace, ordering and contiguous numbering
- exactly one phase default status and valid optional explicit status per issue
- registry phase counts matching the declared 113-issue total
- 113 unique issues across all phases
- a single, well-formed technology-stack table with unique architecture layers
- escaped Markdown pipes/code spans handled in technology cells
- code fences and HTML comments ignored during issue parsing
- stale generated output rejected by `--check` and CI

The HTML links to every phase plan and issue catalog. Roadmap and Tech stack are deep-linkable tabs with keyboard navigation. The source hash namespaces local issue-status overrides; JSON export includes the hash and warns before importing a different Markdown version.

## Usage

```bash
python3 scripts/build-roadmap.py
python3 scripts/build-roadmap.py --check
```

Run from repository root after changing the master registry, technology stack, phase titles, issue headings or statuses.

## Current generated state

- Ready: 1
- Blocked: 55
- Backlog: 57
- Total: 113
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

