### PR TITLE
fix: harden cross-platform PDF OCR runtime packaging

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -140,15 +140,16 @@ jobs:
               --tessdata-dir app/src-tauri/native-runtime/ocr/tessdata \
               --list-langs | grep -E '^(eng|vie)$'
             test -f app/src-tauri/native-runtime/pdfium/bin/pdfium.dll
-          else
+          elif [ "${{ runner.os }}" = "Linux" ]; then
             app/src-tauri/native-runtime/ocr/bin/tesseract \
               --tessdata-dir app/src-tauri/native-runtime/ocr/tessdata \
               --list-langs | grep -E '^(eng|vie)$'
-            if [ "${{ runner.os }}" = "macOS" ]; then
-              test -f app/src-tauri/native-runtime/pdfium/lib/libpdfium.dylib
-            else
-              test -f app/src-tauri/native-runtime/pdfium/lib/libpdfium.so
-            fi
+            test -f app/src-tauri/native-runtime/pdfium/lib/libpdfium.so
+          else
+            test -f app/src-tauri/native-runtime/pdfium/lib/libpdfium.dylib
+            sidecar=$(find app/src-tauri/native-runtime/sidecars -type f -name 'tesseract-*' -print -quit)
+            test -n "$sidecar"
+            ! otool -L "$sidecar" | grep -E '/(opt/homebrew|usr/local)/'
           fi
 
       # Secret trống (chưa cấu hình TAURI_SIGNING_PRIVATE_KEY) vẫn được GitHub Actions
@@ -213,6 +214,17 @@ jobs:
           fi
           pnpm tauri build --bundles ${{ matrix.bundles }} --ci
         working-directory: app
+
+      - name: Verify packaged macOS OCR runtime
+        if: runner.os == 'macOS'
+        run: |
+          APP=$(find target/release/bundle/macos -maxdepth 1 -name '*.app' -print -quit)
+          test -n "$APP"
+          "$APP/Contents/MacOS/tesseract" \
+            --tessdata-dir "$APP/Contents/Resources/native-runtime/ocr/tessdata" \
+            --list-langs | grep -E '^(eng|vie)$'
+          test -f "$APP/Contents/Frameworks/libpdfium.dylib"
+          ! otool -L "$APP/Contents/MacOS/tesseract" | grep -E '/(opt/homebrew|usr/local)/'
 
       - name: Verify Windows Authenticode
         if: runner.os == 'Windows' && vars.WINDOWS_SIGNING_ENABLED == 'true'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -45,18 +45,22 @@ jobs:
           - os: ubuntu-22.04
             bundles: deb,appimage
             artifact: linux
+            tesseract_version: 4.1.1
           - os: windows-latest
             bundles: msi,nsis
             artifact: windows
+            tesseract_version: 5.5.0
           - os: macos-latest
             bundles: dmg
             artifact: macos
+            tesseract_version: 5.5.2
     runs-on: ${{ matrix.os }}
     env:
       # Ký updater artifact (minisign) khi có secret; thiếu thì `createUpdaterArtifacts`
       # tự bỏ qua bước ký (không fail build .deb/.msi/.dmg thường).
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      FILECONV_TESSERACT_VERSION: ${{ matrix.tesseract_version }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Linux bundle dependencies

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -962,9 +962,11 @@ fn set_settings(state: State<AppState>, settings: Settings) -> Result<(), String
         && settings
             .ocr_langs
             .split('+')
-            .all(|lang| lang.len() == 3 && lang.bytes().all(|byte| byte.is_ascii_alphabetic()));
+            .all(|lang| matches!(lang, "vie" | "eng"));
     if !valid_ocr {
-        return Err("ngôn ngữ OCR cần có dạng vie hoặc vie+eng".into());
+        return Err(
+            "bản desktop đi kèm model OCR vie và eng; hãy chọn vie, eng hoặc vie+eng".into(),
+        );
     }
     if !matches!(
         settings.ocr_engine.as_str(),
@@ -1004,7 +1006,10 @@ fn configure_bundled_document_runtime(resource_dir: &Path) {
         let pdfium = if cfg!(target_os = "windows") {
             runtime.join("pdfium/bin/pdfium.dll")
         } else if cfg!(target_os = "macos") {
-            runtime.join("pdfium/lib/libpdfium.dylib")
+            resource_dir
+                .parent()
+                .unwrap_or(resource_dir)
+                .join("Frameworks/libpdfium.dylib")
         } else {
             runtime.join("pdfium/lib/libpdfium.so")
         };
@@ -1016,6 +1021,11 @@ fn configure_bundled_document_runtime(resource_dir: &Path) {
     if std::env::var_os("FILECONV_TESSERACT").is_none() {
         let executable = if cfg!(target_os = "windows") {
             runtime.join("ocr/bin/tesseract.exe")
+        } else if cfg!(target_os = "macos") {
+            resource_dir
+                .parent()
+                .unwrap_or(resource_dir)
+                .join("MacOS/tesseract")
         } else {
             runtime.join("ocr/bin/tesseract")
         };

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -956,14 +956,13 @@ fn get_live_watch_status(state: State<AppState>) -> watch::WatchStatus {
     state.watch_service.status()
 }
 
+fn bundled_ocr_langs_are_valid(langs: &str) -> bool {
+    !langs.trim().is_empty() && langs.split('+').all(|lang| matches!(lang, "vie" | "eng"))
+}
+
 #[tauri::command]
 fn set_settings(state: State<AppState>, settings: Settings) -> Result<(), String> {
-    let valid_ocr = !settings.ocr_langs.trim().is_empty()
-        && settings
-            .ocr_langs
-            .split('+')
-            .all(|lang| matches!(lang, "vie" | "eng"));
-    if !valid_ocr {
+    if !bundled_ocr_langs_are_valid(&settings.ocr_langs) {
         return Err(
             "bản desktop đi kèm model OCR vie và eng; hãy chọn vie, eng hoặc vie+eng".into(),
         );
@@ -1070,10 +1069,21 @@ pub fn run() {
             };
             fs::create_dir_all(&root).ok();
 
-            let settings = fs::read_to_string(settings_file(&config_dir))
+            let mut settings = fs::read_to_string(settings_file(&config_dir))
                 .ok()
                 .and_then(|s| serde_json::from_str::<Settings>(&s).ok())
                 .unwrap_or_default();
+            if !bundled_ocr_langs_are_valid(&settings.ocr_langs) {
+                eprintln!(
+                    "Markhand: OCR language '{}' không có trong runtime đi kèm; \
+                     chuyển về vie+eng",
+                    settings.ocr_langs
+                );
+                settings.ocr_langs = "vie+eng".into();
+                if let Ok(serialized) = serde_json::to_string_pretty(&settings) {
+                    let _ = fs::write(settings_file(&config_dir), serialized);
+                }
+            }
 
             let watch_service = watch::WatchService::new(app.handle().clone());
             watch_service

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -43,9 +43,6 @@
     "shortDescription": "Local-first document conversion and intelligence workbench",
     "longDescription": "Markhand converts PDF, Office, image and audio files into reviewable Markdown, then provides cited search, BRD/PRD handoff generation and privacy tools with offline fallbacks.",
     "copyright": "Copyright © 2026 anhnth24",
-    "resources": {
-      "native-runtime/": "native-runtime/"
-    },
     "linux": {
       "appimage": {
         "bundleMediaFramework": true

--- a/app/src-tauri/tauri.linux.conf.json
+++ b/app/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,7 @@
+{
+  "bundle": {
+    "resources": {
+      "native-runtime/": "native-runtime/"
+    }
+  }
+}

--- a/app/src-tauri/tauri.macos.conf.json
+++ b/app/src-tauri/tauri.macos.conf.json
@@ -1,5 +1,10 @@
 {
   "bundle": {
+    "resources": {
+      "native-runtime/ocr/tessdata/": "native-runtime/ocr/tessdata/",
+      "native-runtime/licenses/": "native-runtime/licenses/",
+      "native-runtime/runtime-manifest.json": "native-runtime/runtime-manifest.json"
+    },
     "macOS": {
       "entitlements": "./Entitlements.plist",
       "minimumSystemVersion": "11.0",

--- a/app/src-tauri/tauri.windows.conf.json
+++ b/app/src-tauri/tauri.windows.conf.json
@@ -1,5 +1,8 @@
 {
   "bundle": {
+    "resources": {
+      "native-runtime/": "native-runtime/"
+    },
     "windows": {
       "digestAlgorithm": "sha256",
       "timestampUrl": "http://timestamp.digicert.com",

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -99,6 +99,9 @@ pub fn to_markdown(
     }
     // 3) Cuối cùng: pdf-extract (không hỗ trợ lọc trang).
     if pages.is_some() {
+        if let Some(error) = image_ocr::take_last_ocr_error() {
+            return Err(fail(format!("OCR trang PDF đã chọn thất bại: {error}")));
+        }
         return Err(fail(
             "không thể trích đúng các trang đã chọn (pdf-inspector/PDFium thất bại)",
         ));
@@ -540,7 +543,7 @@ fn ocr_page_at(doc: &PdfDocument, page_0idx: u32, langs: &str) -> Option<String>
         Ok(text) if !text.trim().is_empty() => Some(text),
         Ok(_) => None,
         Err(error) => {
-            image_ocr::record_ocr_error(error);
+            image_ocr::record_ocr_error(format!("trang {}: {error}", page_0idx + 1));
             None
         }
     }
@@ -907,6 +910,7 @@ fn via_pdfium(
         let pdfium = opt.as_ref()?;
         let doc = pdfium.load_pdf_from_file(path, None).ok()?;
         let mut out = String::new();
+        let mut unresolved_pages = Vec::new();
         for (i, page) in doc.pages().iter().enumerate() {
             // Lọc trang (1-indexed) nếu người dùng chỉ định.
             if let Some(ps) = pages {
@@ -932,15 +936,24 @@ fn via_pdfium(
                             out.push_str(&format!("<!-- Trang {} (OCR) -->\n\n", i + 1));
                             out.push_str(ocr);
                             out.push_str("\n\n");
+                        } else {
+                            unresolved_pages.push(i + 1);
+                            image_ocr::record_ocr_error(format!(
+                                "trang {}: Tesseract không trả nội dung",
+                                i + 1
+                            ));
                         }
                     }
                     Err(error) => {
-                        image_ocr::record_ocr_error(error);
+                        unresolved_pages.push(i + 1);
+                        image_ocr::record_ocr_error(format!("trang {}: {error}", i + 1));
                     }
                 }
+            } else {
+                unresolved_pages.push(i + 1);
             }
         }
-        if out.trim().is_empty() {
+        if !unresolved_pages.is_empty() || out.trim().is_empty() {
             None
         } else {
             Some(out)

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -55,6 +55,11 @@ const PARALLEL_MAX_PAGES: u32 = 200;
 const PARALLEL_MAX_PDF_BYTES: usize = 32 * 1024 * 1024;
 const PARALLEL_MIN_CPUS: usize = 5;
 
+enum PageOcr {
+    Text(String),
+    Blank,
+}
+
 pub fn to_markdown(
     path: &Path,
     ocr_langs: &str,
@@ -540,8 +545,8 @@ fn via_pdf_inspector(
 fn ocr_page_at(doc: &PdfDocument, page_0idx: u32, langs: &str) -> Option<String> {
     let page = doc.pages().get(page_0idx as i32).ok()?;
     match ocr_full_page(&page, langs) {
-        Ok(text) if !text.trim().is_empty() => Some(text),
-        Ok(_) => None,
+        Ok(PageOcr::Text(text)) => Some(text),
+        Ok(PageOcr::Blank) => Some(String::new()),
         Err(error) => {
             image_ocr::record_ocr_error(format!("trang {}: {error}", page_0idx + 1));
             None
@@ -930,20 +935,13 @@ fn via_pdfium(
                 }
             } else if ocr_enabled {
                 match ocr_full_page(&page, ocr_langs) {
-                    Ok(ocr) => {
+                    Ok(PageOcr::Text(ocr)) => {
                         let ocr = ocr.trim();
-                        if !ocr.is_empty() {
-                            out.push_str(&format!("<!-- Trang {} (OCR) -->\n\n", i + 1));
-                            out.push_str(ocr);
-                            out.push_str("\n\n");
-                        } else {
-                            unresolved_pages.push(i + 1);
-                            image_ocr::record_ocr_error(format!(
-                                "trang {}: Tesseract không trả nội dung",
-                                i + 1
-                            ));
-                        }
+                        out.push_str(&format!("<!-- Trang {} (OCR) -->\n\n", i + 1));
+                        out.push_str(ocr);
+                        out.push_str("\n\n");
                     }
+                    Ok(PageOcr::Blank) => {}
                     Err(error) => {
                         unresolved_pages.push(i + 1);
                         image_ocr::record_ocr_error(format!("trang {}: {error}", i + 1));
@@ -998,7 +996,13 @@ fn ocr_page_images(
 }
 
 /// Render cả trang ở OCR_DPI rồi OCR (qua image_ocr có tiền xử lý).
-fn ocr_full_page(page: &PdfPage, langs: &str) -> Result<String, ConvertError> {
+fn rendered_page_is_blank(image: &image::DynamicImage) -> bool {
+    let grayscale = image.to_luma8();
+    let dark_pixels = grayscale.pixels().filter(|pixel| pixel[0] < 200).count();
+    dark_pixels.saturating_mul(1000) < grayscale.len()
+}
+
+fn ocr_full_page(page: &PdfPage, langs: &str) -> Result<PageOcr, ConvertError> {
     let w = (((page.width().value / 72.0) * OCR_DPI).round() as i32).clamp(100, 5000);
     let h = (((page.height().value / 72.0) * OCR_DPI).round() as i32).clamp(100, 7000);
     let bitmap = page
@@ -1007,7 +1011,15 @@ fn ocr_full_page(page: &PdfPage, langs: &str) -> Result<String, ConvertError> {
     let img = bitmap
         .as_image()
         .map_err(|e| fail(format!("as_image: {e}")))?;
-    image_ocr::ocr_dynimage(&img, langs).map_err(fail)
+    if rendered_page_is_blank(&img) {
+        return Ok(PageOcr::Blank);
+    }
+    let text = image_ocr::ocr_dynimage(&img, langs).map_err(fail)?;
+    if text.trim().is_empty() {
+        Err(fail("Tesseract không trả nội dung cho trang có nét chữ"))
+    } else {
+        Ok(PageOcr::Text(text))
+    }
 }
 
 /// Bind libpdfium (nếu có).
@@ -1085,7 +1097,7 @@ mod tests {
     use super::{
         load_pdfium, markdown_has_malformed_table, native_text_covers_markdown,
         native_text_for_pages, native_text_is_high_confidence, native_text_is_trustworthy,
-        parse_marked_pages, strip_repeated_marginal_lines,
+        parse_marked_pages, rendered_page_is_blank, strip_repeated_marginal_lines,
     };
 
     /// PDF một trang tối giản, tự tính offset xref để PDFium load được thật.
@@ -1149,6 +1161,27 @@ mod tests {
         let printable_gid_noise = "bcdfg hjklm npqrs tvwxyz BCDFG HJKLM NPQRS TVWXYZ ".repeat(20);
         assert!(native_text_is_trustworthy(&printable_gid_noise));
         assert!(!native_text_is_high_confidence(&printable_gid_noise));
+    }
+
+    #[test]
+    fn distinguishes_blank_scan_noise_from_content() {
+        let mut blank = image::GrayImage::from_pixel(1000, 1000, image::Luma([255]));
+        for index in 0..500 {
+            blank.put_pixel(index % 1000, index / 1000, image::Luma([0]));
+        }
+        assert!(rendered_page_is_blank(&image::DynamicImage::ImageLuma8(
+            blank
+        )));
+
+        let mut content = image::GrayImage::from_pixel(1000, 1000, image::Luma([255]));
+        for y in 100..900 {
+            for x in (100..900).step_by(20) {
+                content.put_pixel(x, y, image::Luma([0]));
+            }
+        }
+        assert!(!rendered_page_is_blank(&image::DynamicImage::ImageLuma8(
+            content
+        )));
     }
 
     #[test]

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -62,6 +62,7 @@ pub fn to_markdown(
     ocr_images: bool,
     pages: Option<&[u32]>,
 ) -> Result<String, ConvertError> {
+    image_ocr::clear_last_ocr_error();
     let bytes = std::fs::read(path).map_err(fail)?;
 
     // Page-filtered requests are common in the desktop/MCP token-saving flow.
@@ -105,20 +106,31 @@ pub fn to_markdown(
     match extract_with_pdf_extract(&bytes) {
         Ok(text) if !text.trim().is_empty() => Ok(text),
         Err(error) => Err(error),
-        Ok(_) if !ocr_enabled => Err(fail(
-            "PDF không có text layer; hãy bật OCR trang scan trong Settings",
-        )),
-        Ok(_) if !pdfium_available() => Err(fail(
-            "PDF là bản scan nhưng không tìm thấy PDFium để render trang; \
-             hãy cài lại Markhand Desktop hoặc đặt FILECONV_PDFIUM_LIB",
-        )),
-        Ok(_) if !image_ocr::tesseract_available() => Err(fail(
-            "PDF là bản scan nhưng không tìm thấy Tesseract OCR; \
-             hãy cài lại Markhand Desktop hoặc đặt FILECONV_TESSERACT",
-        )),
-        Ok(_) => Err(fail(
-            "PDF không có text layer và OCR không nhận được nội dung",
-        )),
+        Ok(_) => {
+            if !ocr_enabled {
+                return Err(fail(
+                    "PDF không có text layer; hãy bật OCR trang scan trong Settings",
+                ));
+            }
+            if !pdfium_available() {
+                return Err(fail(
+                    "PDF là bản scan nhưng không tìm thấy PDFium để render trang; \
+                     hãy cài lại Markhand Desktop hoặc đặt FILECONV_PDFIUM_LIB",
+                ));
+            }
+            if !image_ocr::tesseract_available() {
+                return Err(fail(
+                    "PDF là bản scan nhưng không tìm thấy Tesseract OCR; \
+                     hãy cài lại Markhand Desktop hoặc đặt FILECONV_TESSERACT",
+                ));
+            }
+            if let Some(error) = image_ocr::take_last_ocr_error() {
+                return Err(fail(format!("OCR trang PDF thất bại: {error}")));
+            }
+            Err(fail(
+                "PDF không có text layer và OCR không nhận được nội dung",
+            ))
+        }
     }
 }
 
@@ -524,9 +536,14 @@ fn via_pdf_inspector(
 /// Render + OCR một trang theo chỉ số 0-based.
 fn ocr_page_at(doc: &PdfDocument, page_0idx: u32, langs: &str) -> Option<String> {
     let page = doc.pages().get(page_0idx as i32).ok()?;
-    ocr_full_page(&page, langs)
-        .ok()
-        .filter(|t| !t.trim().is_empty())
+    match ocr_full_page(&page, langs) {
+        Ok(text) if !text.trim().is_empty() => Some(text),
+        Ok(_) => None,
+        Err(error) => {
+            image_ocr::record_ocr_error(error);
+            None
+        }
+    }
 }
 
 /// Extract the page's native text layer through PDFium.
@@ -908,12 +925,17 @@ fn via_pdfium(
                     }
                 }
             } else if ocr_enabled {
-                if let Ok(ocr) = ocr_full_page(&page, ocr_langs) {
-                    let ocr = ocr.trim();
-                    if !ocr.is_empty() {
-                        out.push_str(&format!("<!-- Trang {} (OCR) -->\n\n", i + 1));
-                        out.push_str(ocr);
-                        out.push_str("\n\n");
+                match ocr_full_page(&page, ocr_langs) {
+                    Ok(ocr) => {
+                        let ocr = ocr.trim();
+                        if !ocr.is_empty() {
+                            out.push_str(&format!("<!-- Trang {} (OCR) -->\n\n", i + 1));
+                            out.push_str(ocr);
+                            out.push_str("\n\n");
+                        }
+                    }
+                    Err(error) => {
+                        image_ocr::record_ocr_error(error);
                     }
                 }
             }

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -1006,7 +1006,7 @@ fn rendered_page_is_blank(image: &image::DynamicImage) -> bool {
         max_row_dark = max_row_dark.max(row_dark);
     }
     dark_pixels.saturating_mul(1000) < grayscale.len()
-        && max_row_dark < (grayscale.width() as usize / 200).max(8)
+        && max_row_dark <= (grayscale.width() as usize / 200).max(8)
 }
 
 fn ocr_full_page(page: &PdfPage, langs: &str) -> Result<PageOcr, ConvertError> {

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -104,18 +104,21 @@ pub fn to_markdown(
     }
     match extract_with_pdf_extract(&bytes) {
         Ok(text) if !text.trim().is_empty() => Ok(text),
-        _result if ocr_enabled && !pdfium_available() => Err(fail(
+        Err(error) => Err(error),
+        Ok(_) if !ocr_enabled => Err(fail(
+            "PDF không có text layer; hãy bật OCR trang scan trong Settings",
+        )),
+        Ok(_) if !pdfium_available() => Err(fail(
             "PDF là bản scan nhưng không tìm thấy PDFium để render trang; \
              hãy cài lại Markhand Desktop hoặc đặt FILECONV_PDFIUM_LIB",
         )),
-        _result if ocr_enabled && !image_ocr::tesseract_available() => Err(fail(
+        Ok(_) if !image_ocr::tesseract_available() => Err(fail(
             "PDF là bản scan nhưng không tìm thấy Tesseract OCR; \
              hãy cài lại Markhand Desktop hoặc đặt FILECONV_TESSERACT",
         )),
         Ok(_) => Err(fail(
             "PDF không có text layer và OCR không nhận được nội dung",
         )),
-        Err(error) => Err(error),
     }
 }
 

--- a/crates/core/src/conv/pdf.rs
+++ b/crates/core/src/conv/pdf.rs
@@ -998,8 +998,15 @@ fn ocr_page_images(
 /// Render cả trang ở OCR_DPI rồi OCR (qua image_ocr có tiền xử lý).
 fn rendered_page_is_blank(image: &image::DynamicImage) -> bool {
     let grayscale = image.to_luma8();
-    let dark_pixels = grayscale.pixels().filter(|pixel| pixel[0] < 200).count();
+    let mut dark_pixels = 0usize;
+    let mut max_row_dark = 0usize;
+    for row in grayscale.rows() {
+        let row_dark = row.filter(|pixel| pixel[0] < 200).count();
+        dark_pixels += row_dark;
+        max_row_dark = max_row_dark.max(row_dark);
+    }
     dark_pixels.saturating_mul(1000) < grayscale.len()
+        && max_row_dark < (grayscale.width() as usize / 200).max(8)
 }
 
 fn ocr_full_page(page: &PdfPage, langs: &str) -> Result<PageOcr, ConvertError> {
@@ -1011,14 +1018,13 @@ fn ocr_full_page(page: &PdfPage, langs: &str) -> Result<PageOcr, ConvertError> {
     let img = bitmap
         .as_image()
         .map_err(|e| fail(format!("as_image: {e}")))?;
-    if rendered_page_is_blank(&img) {
-        return Ok(PageOcr::Blank);
-    }
     let text = image_ocr::ocr_dynimage(&img, langs).map_err(fail)?;
-    if text.trim().is_empty() {
-        Err(fail("Tesseract không trả nội dung cho trang có nét chữ"))
-    } else {
+    if !text.trim().is_empty() {
         Ok(PageOcr::Text(text))
+    } else if rendered_page_is_blank(&img) {
+        Ok(PageOcr::Blank)
+    } else {
+        Err(fail("Tesseract không trả nội dung cho trang có nét chữ"))
     }
 }
 
@@ -1167,7 +1173,7 @@ mod tests {
     fn distinguishes_blank_scan_noise_from_content() {
         let mut blank = image::GrayImage::from_pixel(1000, 1000, image::Luma([255]));
         for index in 0..500 {
-            blank.put_pixel(index % 1000, index / 1000, image::Luma([0]));
+            blank.put_pixel((index * 37) % 1000, (index * 53) % 1000, image::Luma([0]));
         }
         assert!(rendered_page_is_blank(&image::DynamicImage::ImageLuma8(
             blank
@@ -1181,6 +1187,14 @@ mod tests {
         }
         assert!(!rendered_page_is_blank(&image::DynamicImage::ImageLuma8(
             content
+        )));
+
+        let mut sparse_line = image::GrayImage::from_pixel(1000, 1000, image::Luma([255]));
+        for x in 450..550 {
+            sparse_line.put_pixel(x, 500, image::Luma([0]));
+        }
+        assert!(!rendered_page_is_blank(&image::DynamicImage::ImageLuma8(
+            sparse_line
         )));
     }
 

--- a/crates/core/src/image_ocr.rs
+++ b/crates/core/src/image_ocr.rs
@@ -11,7 +11,7 @@
 //!   - Ảnh quá lớn (cạnh dài > 2400px) → thu xuống (giữ tốc độ).
 //!   - Còn lại (trang giấy tờ đủ nét) → GIỮ NGUYÊN.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -42,6 +42,7 @@ impl OcrEngine {
 
 thread_local! {
     static OCR_ENGINE: Cell<OcrEngine> = const { Cell::new(OcrEngine::Tesseract) };
+    static LAST_OCR_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 pub fn with_ocr_engine<T>(engine: OcrEngine, operation: impl FnOnce() -> T) -> T {
@@ -56,6 +57,18 @@ pub fn with_ocr_engine<T>(engine: OcrEngine, operation: impl FnOnce() -> T) -> T
         let _reset = Reset(active, previous);
         operation()
     })
+}
+
+pub(crate) fn clear_last_ocr_error() {
+    LAST_OCR_ERROR.with(|error| *error.borrow_mut() = None);
+}
+
+pub(crate) fn record_ocr_error(error: impl std::fmt::Display) {
+    LAST_OCR_ERROR.with(|last| *last.borrow_mut() = Some(error.to_string()));
+}
+
+pub(crate) fn take_last_ocr_error() -> Option<String> {
+    LAST_OCR_ERROR.with(|error| error.borrow_mut().take())
 }
 
 fn active_engine() -> OcrEngine {
@@ -100,6 +113,9 @@ pub fn ocr_dynimage(img: &DynamicImage, langs: &str) -> io::Result<String> {
         }
     };
     let _ = std::fs::remove_file(&tmp);
+    if let Err(error) = &text {
+        record_ocr_error(error);
+    }
     text
 }
 

--- a/scripts/prepare-desktop-runtime.py
+++ b/scripts/prepare-desktop-runtime.py
@@ -46,6 +46,14 @@ def run(*args: str, capture: bool = False) -> str:
     return result.stdout.strip() if capture else ""
 
 
+def validate_tesseract_version(version: str, default_pattern: str) -> None:
+    expected = os.environ.get("FILECONV_TESSERACT_VERSION")
+    pattern = re.escape(expected) if expected else default_pattern
+    if not re.search(pattern, version):
+        requirement = expected or default_pattern
+        raise RuntimeError(f"expected Tesseract {requirement}, got {version}")
+
+
 def file_sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as source:
@@ -198,8 +206,7 @@ def prepare_linux_tesseract() -> str:
         json.dumps(sorted(packages), indent=2) + "\n"
     )
     version = run(str(bundled), "--version", capture=True).splitlines()[0]
-    if not re.search(r"\b5\.", version):
-        raise RuntimeError(f"expected Tesseract 5.x, got {version}")
+    validate_tesseract_version(version, r"\b[45]\.")
     return version
 
 
@@ -228,16 +235,16 @@ def prepare_windows_tesseract() -> str:
             )
     executable = DEST / "ocr/bin/tesseract.exe"
     version = run(str(executable), "--version", capture=True).splitlines()[0]
-    if "5.5.0" not in version:
-        raise RuntimeError(
-            f"expected Windows Tesseract {TESSERACT_WINDOWS_VERSION}, got {version}"
-        )
+    windows_semver = ".".join(TESSERACT_WINDOWS_VERSION.split(".")[:3])
+    validate_tesseract_version(version, rf"\b{re.escape(windows_semver)}\b")
     return version
 
 
 def prepare_macos_tesseract() -> str:
     prefix = Path(run("brew", "--prefix", "tesseract", capture=True))
     source = prefix / "bin/tesseract"
+    version = run(str(source), "--version", capture=True).splitlines()[0]
+    validate_tesseract_version(version, r"\b5\.")
     bundled = DEST / "ocr/bin/tesseract"
     shutil.copy2(source, bundled)
     run(
@@ -292,9 +299,6 @@ def prepare_macos_tesseract() -> str:
         for path in sorted(frameworks)
     ]
     config_path.write_text(json.dumps(config, indent=2) + "\n")
-    version = run(str(bundled), "--version", capture=True).splitlines()[0]
-    if not re.search(r"\b5\.", version):
-        raise RuntimeError(f"expected Tesseract 5.x, got {version}")
     return version
 
 

--- a/scripts/prepare-desktop-runtime.py
+++ b/scripts/prepare-desktop-runtime.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import platform
@@ -23,6 +24,16 @@ PDFIUM_VERSION = "152.0.7947.0"
 TESSDATA_COMMIT = "e12c65a915945e4c28e237a9b52bc4a8f39a0cec"
 TESSERACT_WINDOWS_VERSION = "5.5.0.20241111"
 MODELS = ("vie", "eng")
+DOWNLOAD_SHA256 = {
+    "pdfium-linux-x64.tgz": "f73d69d309fe1f33cc7269dcc99be31ec44e1cf608e31d7e2fcc6545fc2f9323",
+    "pdfium-win-x64.tgz": "75df6802fc090ad7c76ccc29ed80c3fcb1a375c775bbf8e522189174647b101f",
+    "pdfium-mac-arm64.tgz": "aa9739354fc7bc8f200f3f3c9532bd5233298203051e094820272ccd9c997a77",
+    "pdfium-mac-x64.tgz": "16d7a263b9e2f550d230ce81637697381b0ce898f2e3a22c7316594b15199d87",
+    "eng.traineddata": "8280aed0782fe27257a68ea10fe7ef324ca0f8d85bd2fd145d1c2b560bcb66ba",
+    "vie.traineddata": "b6b49293d95d0b6dbd8780174627e82c75be957b6f4ed9862155540d6b00bb45",
+    "tessdata-LICENSE": "a6cba85bc92e0cff7a450b1d873c0eaa2e9fc96bf472df0247a26bec77bf3ff9",
+    "tesseract-LICENSE": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+}
 
 
 def run(*args: str, capture: bool = False) -> str:
@@ -35,10 +46,25 @@ def run(*args: str, capture: bool = False) -> str:
     return result.stdout.strip() if capture else ""
 
 
-def download(url: str, target: Path) -> None:
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download(url: str, target: Path, lock_name: str) -> None:
     request = urllib.request.Request(url, headers={"User-Agent": "markhand-build"})
     with urllib.request.urlopen(request, timeout=180) as response, target.open("wb") as out:
         shutil.copyfileobj(response, out)
+    actual = file_sha256(target)
+    expected = DOWNLOAD_SHA256[lock_name]
+    if actual != expected:
+        target.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"checksum mismatch for {lock_name}: expected {expected}, got {actual}"
+        )
 
 
 def reset_destination() -> None:
@@ -72,7 +98,7 @@ def prepare_pdfium(system: str, architecture: str) -> None:
     )
     with tempfile.TemporaryDirectory() as temporary:
         archive = Path(temporary) / asset
-        download(url, archive)
+        download(url, archive, asset)
         with tarfile.open(archive, "r:gz") as package:
             package.extractall(DEST / "pdfium", filter="data")
     version_text = (DEST / "pdfium/VERSION").read_text().strip()
@@ -90,11 +116,24 @@ def prepare_pdfium(system: str, architecture: str) -> None:
 
 def prepare_models() -> None:
     for language in MODELS:
+        filename = f"{language}.traineddata"
         download(
             "https://raw.githubusercontent.com/tesseract-ocr/tessdata_best/"
-            f"{TESSDATA_COMMIT}/{language}.traineddata",
-            DEST / f"ocr/tessdata/{language}.traineddata",
+            f"{TESSDATA_COMMIT}/{filename}",
+            DEST / f"ocr/tessdata/{filename}",
+            filename,
         )
+    download(
+        "https://raw.githubusercontent.com/tesseract-ocr/tessdata_best/"
+        f"{TESSDATA_COMMIT}/LICENSE",
+        DEST / "licenses/tessdata-LICENSE",
+        "tessdata-LICENSE",
+    )
+    download(
+        "https://raw.githubusercontent.com/tesseract-ocr/tesseract/5.5.2/LICENSE",
+        DEST / "licenses/Tesseract-LICENSE",
+        "tesseract-LICENSE",
+    )
 
 
 def linux_library_dependencies(binary: Path) -> list[tuple[str, Path]]:
@@ -124,6 +163,7 @@ def prepare_linux_tesseract() -> str:
     }
     pending = [bundled]
     visited: set[str] = set()
+    packages: set[str] = {"tesseract-ocr"}
     while pending:
         current = pending.pop()
         for soname, source in linux_library_dependencies(current):
@@ -133,6 +173,14 @@ def prepare_linux_tesseract() -> str:
             target = DEST / "ocr/lib" / soname
             shutil.copy2(source.resolve(), target)
             pending.append(target)
+            owner = subprocess.run(
+                ("dpkg-query", "-S", str(source.resolve())),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if owner.returncode == 0:
+                packages.add(owner.stdout.split(":", 1)[0])
 
     run("patchelf", "--set-rpath", "$ORIGIN/../lib", str(bundled))
     for library in (DEST / "ocr/lib").iterdir():
@@ -141,7 +189,18 @@ def prepare_linux_tesseract() -> str:
     copyright = Path("/usr/share/doc/tesseract-ocr/copyright")
     if copyright.is_file():
         shutil.copy2(copyright, DEST / "licenses/Tesseract-COPYRIGHT")
-    return run(str(bundled), "--version", capture=True).splitlines()[0]
+    for package in sorted(packages):
+        notice = Path("/usr/share/doc") / package / "copyright"
+        if notice.is_file():
+            safe_name = package.replace(":", "_")
+            shutil.copy2(notice, DEST / "licenses" / f"linux-{safe_name}-copyright")
+    (DEST / "licenses/linux-packages.json").write_text(
+        json.dumps(sorted(packages), indent=2) + "\n"
+    )
+    version = run(str(bundled), "--version", capture=True).splitlines()[0]
+    if not re.search(r"\b5\.", version):
+        raise RuntimeError(f"expected Tesseract 5.x, got {version}")
+    return version
 
 
 def prepare_windows_tesseract() -> str:
@@ -168,7 +227,12 @@ def prepare_windows_tesseract() -> str:
                 license_path, DEST / "licenses" / f"Tesseract-{license_name}"
             )
     executable = DEST / "ocr/bin/tesseract.exe"
-    return run(str(executable), "--version", capture=True).splitlines()[0]
+    version = run(str(executable), "--version", capture=True).splitlines()[0]
+    if "5.5.0" not in version:
+        raise RuntimeError(
+            f"expected Windows Tesseract {TESSERACT_WINDOWS_VERSION}, got {version}"
+        )
+    return version
 
 
 def prepare_macos_tesseract() -> str:
@@ -185,7 +249,7 @@ def prepare_macos_tesseract() -> str:
         "-d",
         str(DEST / "ocr/lib"),
         "-p",
-        "@executable_path/../lib",
+        "@executable_path/../Frameworks",
     )
     for license_name in ("LICENSE", "COPYING"):
         license_path = prefix / license_name
@@ -193,7 +257,45 @@ def prepare_macos_tesseract() -> str:
             shutil.copy2(
                 license_path, DEST / "licenses" / f"Tesseract-{license_name}"
             )
-    return run(str(bundled), "--version", capture=True).splitlines()[0]
+    dependencies = run("brew", "deps", "--include-build", "tesseract", capture=True).split()
+    formulae = sorted(set(["tesseract", *dependencies]))
+    brew_inventory = run("brew", "info", "--json=v2", *formulae, capture=True)
+    (DEST / "licenses/macos-homebrew-formulae.json").write_text(
+        json.dumps(json.loads(brew_inventory), indent=2) + "\n"
+    )
+    architecture = platform.machine().lower()
+    triple = (
+        "aarch64-apple-darwin"
+        if architecture in {"arm64", "aarch64"}
+        else "x86_64-apple-darwin"
+    )
+    sidecar = DEST / "sidecars" / f"tesseract-{triple}"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(bundled, sidecar)
+
+    config_path = ROOT / "app/src-tauri/tauri.macos.conf.json"
+    config = json.loads(config_path.read_text())
+    bundle = config.setdefault("bundle", {})
+    bundle["externalBin"] = ["native-runtime/sidecars/tesseract"]
+    bundle["resources"] = {
+        "native-runtime/ocr/tessdata/": "native-runtime/ocr/tessdata/",
+        "native-runtime/licenses/": "native-runtime/licenses/",
+        "native-runtime/runtime-manifest.json": "native-runtime/runtime-manifest.json",
+    }
+    macos = bundle.setdefault("macOS", {})
+    frameworks = [DEST / "pdfium/lib/libpdfium.dylib"]
+    frameworks.extend(
+        path for path in (DEST / "ocr/lib").iterdir() if path.suffix == ".dylib"
+    )
+    macos["frameworks"] = [
+        path.relative_to(ROOT / "app/src-tauri").as_posix()
+        for path in sorted(frameworks)
+    ]
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    version = run(str(bundled), "--version", capture=True).splitlines()[0]
+    if not re.search(r"\b5\.", version):
+        raise RuntimeError(f"expected Tesseract 5.x, got {version}")
+    return version
 
 
 def main() -> int:
@@ -227,6 +329,11 @@ def main() -> int:
         "tesseract": tesseract_version,
         "tessdata_commit": TESSDATA_COMMIT,
         "languages": list(MODELS),
+    }
+    manifest["files"] = {
+        path.relative_to(DEST).as_posix(): file_sha256(path)
+        for path in sorted(DEST.rglob("*"))
+        if path.is_file() and path.name not in {"README.md", "runtime-manifest.json"}
     }
     (DEST / "runtime-manifest.json").write_text(
         json.dumps(manifest, ensure_ascii=False, indent=2) + "\n"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up hardening for the scanned-PDF runtime merged in #45:

- package macOS Tesseract as a Tauri sidecar and native dylibs/PDFium as signed frameworks
- verify the final packaged macOS sidecar and reject unresolved Homebrew load paths
- separate Linux, Windows and macOS resource layouts
- SHA-256 verify pinned PDFium archives and official `tessdata_best` models
- record hashes for every bundled runtime file and include platform license inventories
- preserve corrupt-PDF errors and surface page-numbered render/OCR subprocess failures
- reject partial Markdown when any requested scan page fails OCR
- validate and migrate desktop OCR language settings to bundled `vie`/`eng`
- enforce expected Tesseract versions per release platform

## Verification

- supplied 12-page HP scan converts with bundled Linux paths: ~35 KB / 5,937 words
- missing Tesseract produces an actionable runtime error
- runtime preparation validates checksums, PDFium and both OCR models
- core PDF tests pass
- desktop crate compiles locally
- release CI validates runtime contents before and after packaging
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

