### PR TITLE
docs: add Rust quality conventions and lint baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --check
+      - name: Enforce strict Clippy for new server boundaries
+        run: cargo clippy --no-deps -p fileconv-knowledge -p fileconv-server --all-targets -- -D warnings
+      - name: Reject new Clippy warnings in legacy crates
+        run: python3 scripts/check-rust-lint-baseline.py
+      - name: Test Clippy baseline parser
+        run: python3 scripts/check-rust-lint-baseline.py --self-test
       - name: Test core
         run: cargo test -p fileconv-core
       - name: Test LLM protocols and bridges

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+msrv = "1.88.0"
+cognitive-complexity-threshold = 25

--- a/docs/conventions/rust.md
+++ b/docs/conventions/rust.md
@@ -1,0 +1,51 @@
+# Rust conventions
+
+Áp dụng cho `fileconv-core`, `fileconv-knowledge`, `fileconv-server` và worker.
+`rustfmt.toml`/`clippy.toml` là baseline máy thực thi; guard CI không cho warning mới
+vượt baseline trong code cũ.
+
+## Module và dependency
+
+- Tuân [`dependencies.md`](dependencies.md): core framework/storage-free; knowledge
+  pure mặc định; server route → service → repository/adapter.
+- `pub` là contract: public type/function phải có rustdoc ngắn nêu invariant, error
+  hoặc ownership khi không hiển nhiên.
+- Tên module/function `snake_case`, type/trait `PascalCase`, enum variant là danh từ,
+  error code là stable machine-facing string.
+- Không `mod` lộ implementation-only khi consumer chỉ cần facade.
+
+## Error, panic và logging
+
+- Request/worker/converter path không dùng `unwrap`, `expect`, `panic!` cho input,
+  filesystem, network, parse hoặc external process. Propagate typed error kèm context
+  không nhạy cảm.
+- `unwrap` chỉ trong test, invariant có chứng minh cục bộ hoặc bootstrap immutable;
+  comment lý do ngay tại chỗ nếu không hiển nhiên.
+- Không đưa document text, prompt, PII, token, API key, signed URL hoặc secret vào
+  `Display`, `Debug`, error context hay log.
+- `unsafe` bị cấm trừ khi ADR phê duyệt, safety invariant/test ghi cạnh block.
+
+## Async, blocking và cancellation
+
+- CPU-heavy conversion/OCR/parse và blocking external CLI chạy qua boundary blocking
+  rõ ràng; không block executor HTTP.
+- Mọi network/subprocess/job có timeout, cancellation propagation và cleanup
+  idempotent khi applicable.
+- Lock không được giữ qua await; pool/transaction scope ngắn và tenant context được
+  truyền explicit.
+
+## Quality policy
+
+```bash
+bash scripts/check-rust-quality.sh
+```
+
+Lệnh chạy format, Clippy warning-as-error cho crate mới (`knowledge`, `server`) và
+baseline delta cho code cũ. Baseline không phải miễn trừ vĩnh viễn: khi sửa một vị trí
+cũ, ưu tiên xử lý lint tại vị trí đó; thay đổi baseline cần giải thích trong PR.
+
+## Exception
+
+Exception lint/boundary cần: lý do kỹ thuật, phạm vi nhỏ nhất, owner, expiry hoặc
+follow-up issue, và regression test. Không dùng `#[allow(...)]` cấp module/crate để
+che warning hàng loạt.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+max_width = 100

--- a/scripts/check-rust-lint-baseline.py
+++ b/scripts/check-rust-lint-baseline.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Reject Clippy warnings that are not part of the approved legacy baseline."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+
+
+LEGACY_WARNINGS = {
+    ("clippy::while_let_loop", "crates/core/src/audio.rs", 228),
+    ("clippy::manual_range_contains", "crates/core/src/chunk.rs", 43),
+    ("clippy::needless_range_loop", "crates/core/src/conv/csv_conv.rs", 125),
+    ("clippy::field_reassign_with_default", "crates/core/src/conv/pdf.rs", 185),
+    ("clippy::uninlined_format_args", "crates/core/src/conv/xlsx.rs", 35),
+    ("clippy::io_other_error", "crates/core/src/image_ocr.rs", 98),
+    ("clippy::io_other_error", "crates/core/src/image_ocr.rs", 262),
+    ("clippy::io_other_error", "crates/core/src/image_ocr.rs", 378),
+    ("clippy::io_other_error", "crates/core/src/image_ocr.rs", 435),
+    ("clippy::manual_ignore_case_cmp", "crates/core/src/intelligence.rs", 1087),
+    ("clippy::too_many_arguments", "crates/core/src/intelligence.rs", 1109),
+    ("clippy::uninlined_format_args", "crates/core/src/intelligence.rs", 1317),
+    ("clippy::needless_lifetimes", "crates/core/src/intelligence.rs", 1339),
+    ("clippy::uninlined_format_args", "app/src-tauri/src/intelligence.rs", 237),
+    ("clippy::uninlined_format_args", "app/src-tauri/src/intelligence.rs", 446),
+    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1293),
+    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1302),
+    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1314),
+    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1327),
+    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1341),
+}
+
+
+def warning_key(message: dict) -> tuple[str | None, str, int] | None:
+    if message.get("level") != "warning":
+        return None
+    code = message.get("code") or {}
+    if not str(code.get("code", "")).startswith("clippy::"):
+        return None
+    spans = message.get("spans") or []
+    primary = next((span for span in spans if span.get("is_primary")), None)
+    if primary is None:
+        return None
+    return code.get("code"), primary["file_name"], primary["line_start"]
+
+
+def clippy_warnings(lines: list[str]) -> set[tuple[str | None, str, int]]:
+    warnings = set()
+    for line in lines:
+        record = json.loads(line)
+        if record.get("reason") != "compiler-message":
+            continue
+        key = warning_key(record["message"])
+        if key:
+            warnings.add(key)
+    return warnings
+
+
+class BaselineTests(unittest.TestCase):
+    def test_reads_primary_clippy_span(self) -> None:
+        line = json.dumps(
+            {
+                "reason": "compiler-message",
+                "message": {
+                    "level": "warning",
+                    "code": {"code": "clippy::example"},
+                    "spans": [
+                        {"file_name": "a.rs", "line_start": 1, "is_primary": True}
+                    ],
+                },
+            }
+        )
+        self.assertEqual(clippy_warnings([line]), {("clippy::example", "a.rs", 1)})
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return 0 if unittest.main(argv=[sys.argv[0]], exit=False).result.wasSuccessful() else 1
+
+    result = subprocess.run(
+        ["cargo", "clippy", "--workspace", "--all-targets", "--message-format=json"],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    sys.stderr.write(result.stderr)
+    if result.returncode:
+        return result.returncode
+    unexpected = sorted(clippy_warnings(result.stdout.splitlines()) - LEGACY_WARNINGS)
+    if unexpected:
+        print("new Clippy warning(s) outside legacy baseline:", file=sys.stderr)
+        for code, file_name, line in unexpected:
+            print(f"- {file_name}:{line}: {code}", file=sys.stderr)
+        return 1
+    print("Clippy legacy baseline has no new warnings")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-rust-quality.sh
+++ b/scripts/check-rust-quality.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo fmt --all -- --check
+cargo clippy --no-deps -p fileconv-knowledge -p fileconv-server --all-targets -- -D warnings
+python3 scripts/check-rust-lint-baseline.py


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Phase F / F-03

Dependent on #160 (which already contains merged F-02). Establish Rust conventions without forcing a broad cleanup of legacy warnings.

## Delivered

- `docs/conventions/rust.md`: module/dependency, error/panic, async/blocking, logging, unsafe and exception rules
- `rustfmt.toml` and `clippy.toml` baseline configuration
- strict Clippy `-D warnings` for new `fileconv-knowledge` and `fileconv-server` crates
- legacy Clippy baseline checker locks 20 existing warnings by lint/file/line and fails on new warnings
- CI runs strict new-crate lint, legacy delta check and parser fixture test
- root `scripts/check-rust-quality.sh`

## Verification

```bash
CC=gcc CXX=g++ LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu \
  bash scripts/check-rust-quality.sh
python3 scripts/check-rust-lint-baseline.py --self-test
```

Both pass locally. The policy intentionally does not turn all existing warnings into a blocking rewrite; each new warning now fails CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

