### PR TITLE
fix: call GitHub API without unsupported repo flag

### DIFF
--- a/scripts/sync-github-issues.py
+++ b/scripts/sync-github-issues.py
@@ -96,7 +96,9 @@ class CatalogIssue:
 
 
 def gh_json(args: list[str]) -> object:
-    command = ["gh", *args, "--repo", REPO]
+    command = ["gh", *args]
+    if args[0] != "api":
+        command.extend(["--repo", REPO])
     result = subprocess.run(command, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip())
@@ -106,7 +108,9 @@ def gh_json(args: list[str]) -> object:
 
 
 def gh_run(args: list[str]) -> None:
-    command = ["gh", *args, "--repo", REPO]
+    command = ["gh", *args]
+    if args[0] != "api":
+        command.extend(["--repo", REPO])
     result = subprocess.run(command, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix the automatic milestone/issue status sync workflow.

`gh api` does not accept `--repo`; the sync helper now adds `--repo` only for `gh issue`/`gh label` commands. This unblocks milestone discovery, issue updates and automatic closure of Markdown `Done` items.

Dry-run identifies six Phase F completion closures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

