### PR TITLE
fix: trigger issue sync after sync script changes

### DIFF
--- a/.github/workflows/sync-markhand-issues.yml
+++ b/.github/workflows/sync-markhand-issues.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
     paths:
       - "plans/markhand-web/backlog/**"
+      - "scripts/sync-github-issues.py"
+      - ".github/workflows/sync-markhand-issues.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ensure the automatic GitHub issue/milestone sync runs when either its implementation script or workflow definition changes, not only when backlog Markdown changes. This triggers the already-merged `Done` status synchronization and closes F-01 through F-06 tracker issues.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

