### PR TITLE
fix: pass GitHub issue labels individually

### DIFF
--- a/scripts/sync-github-issues.py
+++ b/scripts/sync-github-issues.py
@@ -541,7 +541,10 @@ def update_issue(number: int, issue: CatalogIssue) -> None:
                 PHASE_LABELS[issue.phase_code][1],
             ]
         )
-        gh_run(["issue", "edit", str(number), "--add-label", *labels])
+        label_command = ["issue", "edit", str(number)]
+        for label in labels:
+            label_command.extend(["--add-label", label])
+        gh_run(label_command)
     finally:
         Path(body_path).unlink(missing_ok=True)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix automatic backlog synchronization after workflow logs showed `gh issue edit` rejected multiple labels passed after a single `--add-label`. The script now emits one `--add-label` argument per label, allowing it to update then close Markdown `Done` issues and advance milestones.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

