### PR TITLE
feat: add typed server configuration profiles

### DIFF
--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -6,3 +6,6 @@ route or job implementation.
 
 Later code follows `route → service → repository/adapter`; business operations require
 an explicit `OrgContext`.
+
+Run `cargo run -p fileconv-server -- --check-config` to validate typed configuration
+without starting a listener. See [`docs/conventions/config-secrets.md`](../../docs/conventions/config-secrets.md).

--- a/crates/server/src/bin/worker.rs
+++ b/crates/server/src/bin/worker.rs
@@ -1,11 +1,23 @@
 fn main() {
-    if std::env::args().any(|argument| argument == "--help" || argument == "-h") {
+    let args: Vec<String> = std::env::args().collect();
+    if args
+        .iter()
+        .any(|argument| argument == "--help" || argument == "-h")
+    {
         println!("fileconv-worker\n\nPhase F scaffold; no jobs are enabled yet.");
         return;
     }
-    if let Err(error) = fileconv_server::validate_configuration() {
-        eprintln!("invalid worker configuration: {error}");
-        std::process::exit(1);
+    match fileconv_server::config::ServerConfig::from_env() {
+        Ok(config) if args.iter().any(|argument| argument == "--check-config") => {
+            println!(
+                "configuration valid: profile={:?}, bind={}",
+                config.profile, config.bind_addr
+            );
+        }
+        Ok(_) => println!("fileconv-worker scaffold: no jobs are enabled yet"),
+        Err(error) => {
+            eprintln!("invalid worker configuration: {error}");
+            std::process::exit(1);
+        }
     }
-    println!("fileconv-worker scaffold: no jobs are enabled yet");
 }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,0 +1,181 @@
+//! Typed, fail-fast server configuration with redacted secrets.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::net::SocketAddr;
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// Deployment profile with explicitly different safety requirements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Profile {
+    Dev,
+    Test,
+    Prod,
+}
+
+impl Profile {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "dev" => Ok(Self::Dev),
+            "test" => Ok(Self::Test),
+            "prod" => Ok(Self::Prod),
+            _ => Err("MARKHAND_PROFILE must be dev, test, or prod".into()),
+        }
+    }
+}
+
+/// Secret configuration value that cannot leak through Debug output.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SecretString(String);
+
+impl SecretString {
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("[REDACTED]")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerConfig {
+    pub profile: Profile,
+    pub bind_addr: SocketAddr,
+    pub database_url: Option<SecretString>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigFile {
+    profile: Option<String>,
+    bind_addr: Option<String>,
+    database_url: Option<String>,
+}
+
+impl ServerConfig {
+    /// Precedence: safe defaults < optional JSON config file < environment.
+    pub fn from_env() -> Result<Self, String> {
+        let env: BTreeMap<String, String> = std::env::vars().collect();
+        let file = env
+            .get("MARKHAND_CONFIG_FILE")
+            .map(Path::new)
+            .map(load_file)
+            .transpose()?;
+        Self::from_sources(file.as_ref(), &env)
+    }
+
+    fn from_sources(
+        file: Option<&ConfigFile>,
+        env: &BTreeMap<String, String>,
+    ) -> Result<Self, String> {
+        let profile_raw = env
+            .get("MARKHAND_PROFILE")
+            .or_else(|| file.and_then(|value| value.profile.as_ref()))
+            .map_or("dev", String::as_str);
+        let profile = Profile::parse(profile_raw)?;
+
+        let bind_raw = env
+            .get("MARKHAND_BIND_ADDR")
+            .or_else(|| file.and_then(|value| value.bind_addr.as_ref()))
+            .map_or("127.0.0.1:8787", String::as_str);
+        let bind_addr = bind_raw
+            .parse::<SocketAddr>()
+            .map_err(|_| "MARKHAND_BIND_ADDR must be an IP address and port".to_string())?;
+
+        let database_url = env
+            .get("MARKHAND_DATABASE_URL")
+            .or_else(|| file.and_then(|value| value.database_url.as_ref()))
+            .filter(|value| !value.trim().is_empty())
+            .cloned()
+            .map(SecretString);
+
+        let config = Self {
+            profile,
+            bind_addr,
+            database_url,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.profile != Profile::Prod {
+            return Ok(());
+        }
+        if self.bind_addr.ip().is_loopback() || self.bind_addr.ip().is_unspecified() {
+            return Err("prod profile requires a non-loopback explicit bind address".into());
+        }
+        let Some(database_url) = self.database_url.as_ref() else {
+            return Err("prod profile requires MARKHAND_DATABASE_URL".into());
+        };
+        let value = database_url.expose().to_ascii_lowercase();
+        if value.contains("localhost") || value.contains("postgres:postgres") {
+            return Err("prod profile cannot use a development database URL".into());
+        }
+        Ok(())
+    }
+}
+
+fn load_file(path: &Path) -> Result<ConfigFile, String> {
+    let source = std::fs::read_to_string(path)
+        .map_err(|_| "cannot read MARKHAND_CONFIG_FILE".to_string())?;
+    serde_json::from_str(&source).map_err(|_| "MARKHAND_CONFIG_FILE contains invalid JSON".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConfigFile, Profile, ServerConfig};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn environment_overrides_file_and_defaults() {
+        let file = ConfigFile {
+            profile: Some("test".into()),
+            bind_addr: Some("127.0.0.1:9000".into()),
+            database_url: Some("postgres://file-secret".into()),
+        };
+        let env = BTreeMap::from([
+            ("MARKHAND_PROFILE".into(), "dev".into()),
+            ("MARKHAND_BIND_ADDR".into(), "127.0.0.1:9010".into()),
+        ]);
+        let config = ServerConfig::from_sources(Some(&file), &env).unwrap();
+        assert_eq!(config.profile, Profile::Dev);
+        assert_eq!(config.bind_addr.to_string(), "127.0.0.1:9010");
+        assert_eq!(
+            config.database_url.unwrap().expose(),
+            "postgres://file-secret"
+        );
+    }
+
+    #[test]
+    fn secret_is_redacted_and_prod_rejects_dev_values() {
+        let env = BTreeMap::from([
+            ("MARKHAND_PROFILE".into(), "prod".into()),
+            ("MARKHAND_BIND_ADDR".into(), "127.0.0.1:8787".into()),
+            (
+                "MARKHAND_DATABASE_URL".into(),
+                "postgres://postgres:postgres@localhost/db".into(),
+            ),
+        ]);
+        let error = ServerConfig::from_sources(None, &env).unwrap_err();
+        assert!(error.contains("bind address"));
+
+        let config = ServerConfig::from_sources(
+            None,
+            &BTreeMap::from([("MARKHAND_DATABASE_URL".into(), "top-secret".into())]),
+        )
+        .unwrap();
+        assert!(!format!("{config:?}").contains("top-secret"));
+    }
+
+    #[test]
+    fn invalid_bind_fails_fast() {
+        let env = BTreeMap::from([("MARKHAND_BIND_ADDR".into(), "not-an-address".into())]);
+        assert!(ServerConfig::from_sources(None, &env).is_err());
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,8 +4,9 @@
 //! database, storage or auth implementation yet.
 
 pub mod api;
+pub mod config;
 
 /// Validates the minimum non-secret server configuration contract.
-pub fn validate_configuration() -> Result<(), &'static str> {
-    Ok(())
+pub fn validate_configuration() -> Result<(), String> {
+    config::ServerConfig::from_env().map(|_| ())
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,11 +1,23 @@
 fn main() {
-    if std::env::args().any(|argument| argument == "--help" || argument == "-h") {
+    let args: Vec<String> = std::env::args().collect();
+    if args
+        .iter()
+        .any(|argument| argument == "--help" || argument == "-h")
+    {
         println!("fileconv-server\n\nPhase F scaffold; HTTP routes are not available yet.");
         return;
     }
-    if let Err(error) = fileconv_server::validate_configuration() {
-        eprintln!("invalid server configuration: {error}");
-        std::process::exit(1);
+    match fileconv_server::config::ServerConfig::from_env() {
+        Ok(config) if args.iter().any(|argument| argument == "--check-config") => {
+            println!(
+                "configuration valid: profile={:?}, bind={}",
+                config.profile, config.bind_addr
+            );
+        }
+        Ok(_) => println!("fileconv-server scaffold: no routes are enabled yet"),
+        Err(error) => {
+            eprintln!("invalid server configuration: {error}");
+            std::process::exit(1);
+        }
     }
-    println!("fileconv-server scaffold: no routes are enabled yet");
 }

--- a/deploy/dev/.env.example
+++ b/deploy/dev/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env only for local development. Never commit a filled file.
+MARKHAND_PROFILE=dev
+MARKHAND_BIND_ADDR=127.0.0.1:8787
+# MARKHAND_DATABASE_URL=postgres://markhand:change-me@127.0.0.1:5432/markhand
+# MARKHAND_CONFIG_FILE=/absolute/path/to/config.json

--- a/docs/conventions/config-secrets.md
+++ b/docs/conventions/config-secrets.md
@@ -1,0 +1,39 @@
+# Configuration and secrets
+
+`fileconv-server` uses typed configuration. Precedence is:
+
+```text
+safe defaults < MARKHAND_CONFIG_FILE JSON < MARKHAND_* environment
+```
+
+`MARKHAND_PROFILE` is `dev`, `test`, or `prod`. Dev/test default to loopback
+`127.0.0.1:8787`; production requires an explicit non-loopback bind address and
+non-development database URL. Invalid profile, address or production configuration
+fails before server/worker work begins.
+
+## Secrets
+
+- Never commit `.env`, API keys, database credentials, token signing keys, signed URLs
+  or customer hostnames. Use [`deploy/dev/.env.example`](../../deploy/dev/.env.example)
+  as the non-secret template.
+- Production uses orchestrator secret mounts or environment references. Do not put a
+  production secret in JSON config checked into source.
+- Secret values use redacted `Debug`; errors/logs state the invalid field without
+  echoing its value.
+- Rotate secret by deploying a new reference, verify health, then revoke old material.
+  Rotation implementation/secret manager selection is Phase 4.
+
+## Profiles
+
+| Profile | Bind default | Credential rule |
+|---|---|---|
+| `dev` | loopback | non-production local values only |
+| `test` | loopback | fixture/ephemeral values only |
+| `prod` | explicit required | no loopback/default database credential |
+
+Run a config-only check:
+
+```bash
+cargo run -p fileconv-server -- --check-config
+cargo run -p fileconv-server --bin fileconv-worker -- --check-config
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Phase F / F-07

Add typed, fail-fast, secret-safe server configuration before local-stack and business server work.

## Delivered

- profiles: `dev`, `test`, `prod`
- precedence: safe defaults < optional JSON config file < `MARKHAND_*` environment
- profile validation: prod requires non-loopback bind and non-development database URL
- `SecretString` redacts `Debug`
- `--check-config` server and worker startup mode
- non-secret `deploy/dev/.env.example` and config/secrets conventions
- precedence, redaction, invalid bind and production deny tests

## Verification

```bash
cargo test -p fileconv-server
cargo clippy --no-deps -p fileconv-server --all-targets -- -D warnings
cargo run -p fileconv-server -- --check-config
```

All pass locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

