### PR TITLE
feat: define observability and audit contracts

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod api;
 pub mod config;
+pub mod telemetry;
 
 /// Validates the minimum non-secret server configuration contract.
 pub fn validate_configuration() -> Result<(), String> {

--- a/crates/server/src/telemetry.rs
+++ b/crates/server/src/telemetry.rs
@@ -1,0 +1,165 @@
+//! In-memory observability and audit contracts; no exporter or durable storage.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+const SENSITIVE_FRAGMENTS: &[&str] = &[
+    "authorization",
+    "cookie",
+    "database_url",
+    "document_content",
+    "password",
+    "pii",
+    "prompt",
+    "secret",
+    "signed_url",
+    "token",
+];
+
+const FORBIDDEN_METRIC_LABELS: &[&str] = &[
+    "actor_id",
+    "document_id",
+    "filename",
+    "job_id",
+    "org_id",
+    "request_id",
+    "url",
+    "user_id",
+];
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CorrelationContext {
+    pub request_id: String,
+    pub trace_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actor_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub document_version_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_signature: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEvent {
+    pub version: u16,
+    pub occurred_at: String,
+    pub request_id: String,
+    pub org_id: String,
+    pub actor_id: String,
+    pub action: String,
+    pub target_type: String,
+    pub target_id: String,
+    pub outcome: String,
+    pub metadata: BTreeMap<String, String>,
+}
+
+pub fn redacted_fields(fields: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    fields
+        .iter()
+        .map(|(key, value)| {
+            let normalized = key.to_ascii_lowercase();
+            let value = if SENSITIVE_FRAGMENTS
+                .iter()
+                .any(|fragment| normalized.contains(fragment))
+            {
+                "[REDACTED]".to_string()
+            } else {
+                value.clone()
+            };
+            (key.clone(), value)
+        })
+        .collect()
+}
+
+pub fn validate_metric(name: &str, labels: &[&str]) -> Result<(), String> {
+    if !name.starts_with("markhand_")
+        || name.is_empty()
+        || name
+            .bytes()
+            .any(|byte| !(byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'))
+    {
+        return Err("metric name must be markhand_ prefixed snake_case".into());
+    }
+    if let Some(label) = labels
+        .iter()
+        .find(|label| FORBIDDEN_METRIC_LABELS.contains(label))
+    {
+        return Err(format!("metric label has unbounded cardinality: {label}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{redacted_fields, validate_metric, AuditEvent, CorrelationContext};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn propagates_request_to_job_without_sensitive_content() {
+        let request = CorrelationContext {
+            request_id: "req-1".into(),
+            trace_id: "trace-1".into(),
+            org_id: Some("org-1".into()),
+            actor_id: Some("user-1".into()),
+            ..CorrelationContext::default()
+        };
+        let job = CorrelationContext {
+            job_id: Some("job-1".into()),
+            document_version_id: Some("version-1".into()),
+            index_signature: Some("sig-1".into()),
+            ..request.clone()
+        };
+        assert_eq!(job.request_id, request.request_id);
+        assert_eq!(job.org_id, request.org_id);
+        let json = serde_json::to_string(&job).unwrap();
+        assert!(!json.contains("documentContent"));
+        assert!(!json.contains("prompt"));
+    }
+
+    #[test]
+    fn redacts_canaries_and_rejects_high_cardinality_labels() {
+        let fields = BTreeMap::from([
+            ("request_id".into(), "req-1".into()),
+            ("authorization".into(), "Bearer canary-token".into()),
+            ("document_content".into(), "private text".into()),
+            (
+                "database_url".into(),
+                "postgres://user:secret@host/db".into(),
+            ),
+        ]);
+        let redacted = redacted_fields(&fields);
+        assert_eq!(redacted["request_id"], "req-1");
+        assert!(redacted
+            .values()
+            .all(|value| !value.contains("canary-token") && !value.contains("private text")));
+        assert!(validate_metric("markhand_job_duration_seconds", &["job_type", "outcome"]).is_ok());
+        assert!(validate_metric("markhand_job_total", &["org_id"]).is_err());
+        assert!(validate_metric("Bad-Metric", &[]).is_err());
+    }
+
+    #[test]
+    fn audit_envelope_round_trips_as_version_one() {
+        let event = AuditEvent {
+            version: 1,
+            occurred_at: "2026-07-17T00:00:00Z".into(),
+            request_id: "req-1".into(),
+            org_id: "org-1".into(),
+            actor_id: "actor-1".into(),
+            action: "document.delete".into(),
+            target_type: "document".into(),
+            target_id: "doc-1".into(),
+            outcome: "allowed".into(),
+            metadata: BTreeMap::from([("reason".into(), "user_requested".into())]),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let decoded: AuditEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, event);
+    }
+}

--- a/docs/conventions/observability-audit.md
+++ b/docs/conventions/observability-audit.md
@@ -1,0 +1,61 @@
+# Observability and audit conventions
+
+Observability diagnoses system behavior; audit records security/business actions.
+Neither channel may contain document text, prompt, PII, token, API key, signed URL,
+database URL or object-storage credential.
+
+## Correlation fields
+
+Propagate through request → service → job/outbox → worker/artifact:
+
+- `request_id`: one inbound interaction;
+- `trace_id`: OpenTelemetry trace identifier;
+- `org_id`: authorized tenant identifier, never user input before validation;
+- `actor_id`: authenticated user/service identity when applicable;
+- `job_id`, `document_id`, `document_version_id`;
+- `index_signature`: model/chunk/dimension/normalize signature.
+
+Missing tenant/actor fields are omitted, never filled with `"unknown"` for authorization.
+
+## Structured logs
+
+Allowlist stable identifiers, operation, outcome, duration, bounded error code and
+correlation fields. Redact keys containing password, secret, token, authorization,
+cookie, database URL, signed URL, document content, prompt or PII. Do not log raw
+request/response bodies.
+
+## Metrics
+
+- Prefix `markhand_`; snake_case; unit suffix (`_seconds`, `_bytes`, `_total`) where
+  applicable.
+- Labels are bounded enums/service/profile/outcome. Never use org/user/document/job ID,
+  URL, filename, prompt/model response or error message as a label.
+- Histogram buckets and SLO thresholds belong to Phase 0 evidence, not ad-hoc code.
+
+## Audit envelope
+
+Audit events are append-only and versioned:
+
+```json
+{
+  "version": 1,
+  "occurredAt": "RFC3339 UTC",
+  "requestId": "uuid",
+  "orgId": "uuid",
+  "actorId": "uuid",
+  "action": "document.delete",
+  "targetType": "document",
+  "targetId": "uuid",
+  "outcome": "allowed",
+  "metadata": {}
+}
+```
+
+Metadata is an allowlist of non-sensitive scalar identifiers/reasons. Audit is not an
+authorization cache; source ACL snapshots are provenance only.
+
+## Validation
+
+`fileconv-server::telemetry` supplies field propagation, metric-name/label checks and
+redaction helpers. F-11 is in-memory contract only: durable audit, middleware, exporter,
+dashboard and SIEM integration arrive in later phases.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Phase F / F-11

Define observability/audit contracts before business routes and durable audit storage.

## Delivered

- correlation fields for request → service → job/worker/artifact
- structured-log allowlist and sensitive-key redaction
- metric naming and bounded-label validation
- versioned append-only audit envelope
- synthetic propagation, redaction canary, cardinality denial and serde round-trip tests
- documentation separating observability from authorization/audit

## Verification

```bash
cargo test -p fileconv-server
cargo clippy --no-deps -p fileconv-server --all-targets -- -D warnings
make check-static
```

All pass locally. No exporter, durable queue, middleware, dashboard or SIEM implementation is included.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

