### PR TITLE
test: freeze desktop RAG IPC contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ check-migrations:
 
 check-fixtures:
 	python3 scripts/check-fixtures.py
+	python3 scripts/check-fixtures.py --root app/src-tauri/fixtures/knowledge/v1
 	python3 scripts/check-fixtures.py --self-test
 
 check-markhand-gates:

--- a/app/src-tauri/fixtures/knowledge/v1/known-behaviors.md
+++ b/app/src-tauri/fixtures/knowledge/v1/known-behaviors.md
@@ -1,0 +1,22 @@
+# Frozen desktop RAG behavior (v1)
+
+P1A extraction preserves these behaviors first; later issues may change them with an
+explicit contract/version update.
+
+- Commands: `rebuild_knowledge_index`, `knowledge_index_stats`, `hybrid_search`,
+  `hybrid_ask`; request payload is wrapped in `req` except stats.
+- Defaults: search limit 20, ask topK 8, ask `useLlm=false`.
+- Modes: `offline_extractive`, `fallback_extractive`, `local_llm`, `cloud_llm`,
+  `subscription_cli`.
+- Local embedding mode is `local_hash_v1`, dimension 256; stats report ANN threshold
+  1000.
+- Search with non-empty scope may update the index before reading.
+- Small indexes do not persist HNSW; exact vector search is used.
+- Provider/signature mismatch warns and may fall back to lexical/local behavior.
+- Fallback answers currently report `grounded=true`; this semantic mismatch is frozen,
+  not endorsed.
+- Score fields are f32. Contract comparisons use epsilon `0.0001`; fixed fixture hit
+  order is exact.
+- Legacy chunk IDs use Rust hashing and are not promised cross-Rust-version stability.
+- Warning strings are user-facing Vietnamese and fixture scenarios lock their current
+  text where deterministic.

--- a/app/src-tauri/fixtures/knowledge/v1/manifest.json
+++ b/app/src-tauri/fixtures/knowledge/v1/manifest.json
@@ -1,0 +1,115 @@
+{
+  "version": 1,
+  "fixtures": [
+    {
+      "id": "desktop.rag.v1.known-behaviors",
+      "path": "known-behaviors.md",
+      "sha256": "5807339b1441934c58614d30091d44142211ceeecbe1985d22b6f56faa436948",
+      "kind": "documentation",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.request.ask",
+      "path": "requests/ask.json",
+      "sha256": "0687a6a13aa983e9b3a4da67328b4c2f2717ab5d0d44c94daab01e2ac72e08bc",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.request.rebuild",
+      "path": "requests/rebuild.json",
+      "sha256": "f452bc8ca57cc7b76db9ca3a080ce38e0679e4775feb50e621c4fe4b66b7933c",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.request.search",
+      "path": "requests/search.json",
+      "sha256": "ab79dd214bef32fa039bc563ddad4f0e11b995a77ef02f7d333b571aabb75c58",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.request.stats",
+      "path": "requests/stats.json",
+      "sha256": "5afd7c188b7db027b58825854048c12deb4c3f9bf72d775faac7aed744f4aa5a",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.response.ask-fallback",
+      "path": "responses/ask-fallback.json",
+      "sha256": "3db4636e3bd622284cd547eb636c0c51e293533fa359c2c85a508bb6fd51f673",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.response.ask",
+      "path": "responses/ask.json",
+      "sha256": "1425ead0a9c2f7c029fb0d83010164679193ce621ff4b7e7144b27a6c324f35f",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.response.rebuild-incremental",
+      "path": "responses/rebuild-incremental.json",
+      "sha256": "26c298706e603240a532b9f959d48cc2a603d44905aa15ebc029abb77750fc0f",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.response.rebuild",
+      "path": "responses/rebuild.json",
+      "sha256": "0b315d1cd57fc2bc01592c7b48dbcb16138b8075d82a7a47abc3ef6a85bc458a",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.response.search",
+      "path": "responses/search.json",
+      "sha256": "9e453a298bd8265b71fb8bb43cd7cc9558f2cdb42620dae24c8e587131bde6f8",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    },
+    {
+      "id": "desktop.rag.v1.response.stats",
+      "path": "responses/stats.json",
+      "sha256": "e4e2b2b2ba80e04367702f1e3426d8ab126a764d9a0d0a4b972e46e34fb4abea",
+      "kind": "json-contract",
+      "owner": "desktop-rag",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    }
+  ]
+}

--- a/app/src-tauri/fixtures/knowledge/v1/requests/ask.json
+++ b/app/src-tauri/fixtures/knowledge/v1/requests/ask.json
@@ -1,0 +1,11 @@
+{
+  "command": "hybrid_ask",
+  "args": {
+    "req": {
+      "sourceRels": ["payments.pdf"],
+      "question": "Quy trình đối soát gồm bước nào?",
+      "topK": 8,
+      "useLlm": false
+    }
+  }
+}

--- a/app/src-tauri/fixtures/knowledge/v1/requests/rebuild.json
+++ b/app/src-tauri/fixtures/knowledge/v1/requests/rebuild.json
@@ -1,0 +1,8 @@
+{
+  "command": "rebuild_knowledge_index",
+  "args": {
+    "req": {
+      "sourceRels": ["payments.pdf", "security.docx"]
+    }
+  }
+}

--- a/app/src-tauri/fixtures/knowledge/v1/requests/search.json
+++ b/app/src-tauri/fixtures/knowledge/v1/requests/search.json
@@ -1,0 +1,10 @@
+{
+  "command": "hybrid_search",
+  "args": {
+    "req": {
+      "sourceRels": ["payments.pdf", "security.docx"],
+      "query": "quy trình đối soát thanh toán",
+      "limit": 20
+    }
+  }
+}

--- a/app/src-tauri/fixtures/knowledge/v1/requests/stats.json
+++ b/app/src-tauri/fixtures/knowledge/v1/requests/stats.json
@@ -1,0 +1,4 @@
+{
+  "command": "knowledge_index_stats",
+  "args": {}
+}

--- a/app/src-tauri/fixtures/knowledge/v1/responses/ask-fallback.json
+++ b/app/src-tauri/fixtures/knowledge/v1/responses/ask-fallback.json
@@ -1,0 +1,25 @@
+{
+  "answer": "Đối soát giao dịch được thực hiện theo ngày. [CITE-0001]",
+  "citations": [
+    {
+      "chunkId": "fixture-chunk-payments-0001",
+      "sourceRel": "payments.pdf",
+      "mdRel": "payments.pdf.md",
+      "heading": "Đối soát",
+      "snippet": "Đối soát giao dịch được thực hiện theo ngày.",
+      "lexicalScore": 1.25,
+      "vectorScore": 0.75,
+      "rerankScore": 1.875,
+      "anchor": {
+        "page": 7,
+        "slide": null,
+        "sheet": null,
+        "start": 12,
+        "end": 68
+      }
+    }
+  ],
+  "mode": "fallback_extractive",
+  "grounded": true,
+  "warnings": ["Chưa cấu hình LLM; dùng câu trả lời trích xuất."]
+}

--- a/app/src-tauri/fixtures/knowledge/v1/responses/ask.json
+++ b/app/src-tauri/fixtures/knowledge/v1/responses/ask.json
@@ -1,0 +1,25 @@
+{
+  "answer": "Đối soát giao dịch được thực hiện theo ngày. [CITE-0001]",
+  "citations": [
+    {
+      "chunkId": "fixture-chunk-payments-0001",
+      "sourceRel": "payments.pdf",
+      "mdRel": "payments.pdf.md",
+      "heading": "Đối soát",
+      "snippet": "Đối soát giao dịch được thực hiện theo ngày.",
+      "lexicalScore": 1.25,
+      "vectorScore": 0.75,
+      "rerankScore": 1.875,
+      "anchor": {
+        "page": 7,
+        "slide": null,
+        "sheet": null,
+        "start": 12,
+        "end": 68
+      }
+    }
+  ],
+  "mode": "offline_extractive",
+  "grounded": true,
+  "warnings": []
+}

--- a/app/src-tauri/fixtures/knowledge/v1/responses/rebuild-incremental.json
+++ b/app/src-tauri/fixtures/knowledge/v1/responses/rebuild-incremental.json
@@ -1,0 +1,11 @@
+{
+  "documents": 2,
+  "chunks": 2,
+  "indexed": 0,
+  "skipped": 2,
+  "embeddingMode": "local_hash_v1",
+  "embeddingProvider": "local",
+  "embeddingModel": "local_hash_v1",
+  "vectorDimensions": 256,
+  "warnings": []
+}

--- a/app/src-tauri/fixtures/knowledge/v1/responses/rebuild.json
+++ b/app/src-tauri/fixtures/knowledge/v1/responses/rebuild.json
@@ -1,0 +1,11 @@
+{
+  "documents": 2,
+  "chunks": 2,
+  "indexed": 2,
+  "skipped": 0,
+  "embeddingMode": "local_hash_v1",
+  "embeddingProvider": "local",
+  "embeddingModel": "local_hash_v1",
+  "vectorDimensions": 256,
+  "warnings": []
+}

--- a/app/src-tauri/fixtures/knowledge/v1/responses/search.json
+++ b/app/src-tauri/fixtures/knowledge/v1/responses/search.json
@@ -1,0 +1,23 @@
+{
+  "hits": [
+    {
+      "chunkId": "fixture-chunk-payments-0001",
+      "sourceRel": "payments.pdf",
+      "mdRel": "payments.pdf.md",
+      "heading": "Đối soát",
+      "snippet": "Đối soát giao dịch được thực hiện theo ngày.",
+      "lexicalScore": 1.25,
+      "vectorScore": 0.75,
+      "rerankScore": 1.875,
+      "anchor": {
+        "page": 7,
+        "slide": null,
+        "sheet": null,
+        "start": 12,
+        "end": 68
+      }
+    }
+  ],
+  "warnings": [],
+  "embeddingMode": "local_hash_v1"
+}

--- a/app/src-tauri/fixtures/knowledge/v1/responses/stats.json
+++ b/app/src-tauri/fixtures/knowledge/v1/responses/stats.json
@@ -1,0 +1,11 @@
+{
+  "documents": 2,
+  "chunks": 2,
+  "databaseBytes": 4096,
+  "vectorDimensions": 256,
+  "embeddingMode": "local_hash_v1",
+  "embeddingProvider": "local",
+  "embeddingModel": "local_hash_v1",
+  "annAvailable": false,
+  "annThreshold": 1000
+}

--- a/app/src-tauri/src/knowledge.rs
+++ b/app/src-tauri/src/knowledge.rs
@@ -15,13 +15,13 @@ const MAX_VECTOR_CANDIDATES: usize = 100_000;
 const LOCAL_EMBEDDING_MODE: &str = "local_hash_v1";
 const PROVIDER_EMBEDDING_MODE: &str = "provider_v1";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexRequest {
     pub source_rels: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexBuildResult {
     pub documents: usize,
@@ -35,7 +35,7 @@ pub struct IndexBuildResult {
     pub warnings: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexStats {
     pub documents: usize,
@@ -49,7 +49,7 @@ pub struct IndexStats {
     pub ann_threshold: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HybridSearchRequest {
     pub source_rels: Vec<String>,
@@ -57,7 +57,7 @@ pub struct HybridSearchRequest {
     pub limit: Option<usize>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SourceAnchor {
     pub page: Option<u32>,
@@ -67,7 +67,7 @@ pub struct SourceAnchor {
     pub end: usize,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HybridSearchHit {
     pub chunk_id: String,
@@ -81,7 +81,7 @@ pub struct HybridSearchHit {
     pub anchor: SourceAnchor,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HybridSearchResponse {
     pub hits: Vec<HybridSearchHit>,
@@ -89,7 +89,7 @@ pub struct HybridSearchResponse {
     pub embedding_mode: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HybridAskRequest {
     pub source_rels: Vec<String>,
@@ -98,7 +98,7 @@ pub struct HybridAskRequest {
     pub use_llm: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroundedAnswer {
     pub answer: String,

--- a/app/src-tauri/src/knowledge_contract.rs
+++ b/app/src-tauri/src/knowledge_contract.rs
@@ -1,0 +1,84 @@
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::knowledge::{
+    GroundedAnswer, HybridAskRequest, HybridSearchRequest, HybridSearchResponse, IndexBuildResult,
+    IndexRequest, IndexStats,
+};
+
+fn value(source: &str) -> Value {
+    serde_json::from_str(source).unwrap()
+}
+
+fn assert_round_trip<T>(source: &str)
+where
+    T: DeserializeOwned + Serialize,
+{
+    let expected = value(source);
+    let decoded: T = serde_json::from_value(expected.clone()).unwrap();
+    assert_eq!(serde_json::to_value(decoded).unwrap(), expected);
+}
+
+fn assert_request<T>(source: &str, command: &str)
+where
+    T: DeserializeOwned + Serialize,
+{
+    let fixture = value(source);
+    assert_eq!(fixture["command"], command);
+    let expected = fixture["args"]["req"].clone();
+    let decoded: T = serde_json::from_value(expected.clone()).unwrap();
+    assert_eq!(serde_json::to_value(decoded).unwrap(), expected);
+}
+
+#[test]
+fn freezes_four_command_request_contracts() {
+    assert_request::<IndexRequest>(
+        include_str!("../fixtures/knowledge/v1/requests/rebuild.json"),
+        "rebuild_knowledge_index",
+    );
+    let stats = value(include_str!("../fixtures/knowledge/v1/requests/stats.json"));
+    assert_eq!(stats["command"], "knowledge_index_stats");
+    assert_eq!(stats["args"], serde_json::json!({}));
+    assert_request::<HybridSearchRequest>(
+        include_str!("../fixtures/knowledge/v1/requests/search.json"),
+        "hybrid_search",
+    );
+    assert_request::<HybridAskRequest>(
+        include_str!("../fixtures/knowledge/v1/requests/ask.json"),
+        "hybrid_ask",
+    );
+}
+
+#[test]
+fn freezes_response_casing_modes_anchors_warnings_and_stats() {
+    assert_round_trip::<IndexBuildResult>(include_str!(
+        "../fixtures/knowledge/v1/responses/rebuild.json"
+    ));
+    assert_round_trip::<IndexBuildResult>(include_str!(
+        "../fixtures/knowledge/v1/responses/rebuild-incremental.json"
+    ));
+    assert_round_trip::<IndexStats>(include_str!(
+        "../fixtures/knowledge/v1/responses/stats.json"
+    ));
+    assert_round_trip::<HybridSearchResponse>(include_str!(
+        "../fixtures/knowledge/v1/responses/search.json"
+    ));
+    assert_round_trip::<GroundedAnswer>(include_str!(
+        "../fixtures/knowledge/v1/responses/ask.json"
+    ));
+    assert_round_trip::<GroundedAnswer>(include_str!(
+        "../fixtures/knowledge/v1/responses/ask-fallback.json"
+    ));
+}
+
+#[test]
+fn score_contract_uses_epsilon_and_exact_hit_order() {
+    let response: HybridSearchResponse = serde_json::from_str(include_str!(
+        "../fixtures/knowledge/v1/responses/search.json"
+    ))
+    .unwrap();
+    assert_eq!(response.hits[0].source_rel, "payments.pdf");
+    assert!((response.hits[0].rerank_score - 1.875).abs() <= 0.0001);
+    assert_eq!(response.hits[0].anchor.page, Some(7));
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -21,6 +21,8 @@ use fileconv_core::{ConverterOptions, FormatKind};
 
 mod intelligence;
 mod knowledge;
+#[cfg(test)]
+mod knowledge_contract;
 mod projects;
 mod vector_index;
 mod watch;

--- a/app/src/lib/knowledgeContract.test.ts
+++ b/app/src/lib/knowledgeContract.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import askRequest from "../../src-tauri/fixtures/knowledge/v1/requests/ask.json";
+import rebuildRequest from "../../src-tauri/fixtures/knowledge/v1/requests/rebuild.json";
+import searchRequest from "../../src-tauri/fixtures/knowledge/v1/requests/search.json";
+import askResponse from "../../src-tauri/fixtures/knowledge/v1/responses/ask.json";
+import fallbackResponse from "../../src-tauri/fixtures/knowledge/v1/responses/ask-fallback.json";
+import rebuildResponse from "../../src-tauri/fixtures/knowledge/v1/responses/rebuild.json";
+import searchResponse from "../../src-tauri/fixtures/knowledge/v1/responses/search.json";
+import statsResponse from "../../src-tauri/fixtures/knowledge/v1/responses/stats.json";
+import type {
+  GroundedAnswer,
+  HybridAskRequest,
+  HybridSearchRequest,
+  HybridSearchResponse,
+  IndexBuildResult,
+  IndexRequest,
+  KnowledgeIndexStats,
+} from "./types";
+
+describe("desktop knowledge IPC v1", () => {
+  it("freezes request wrappers and camelCase keys", () => {
+    expect(rebuildRequest.command).toBe("rebuild_knowledge_index");
+    expectTypeOf(rebuildRequest.args.req).toMatchTypeOf<IndexRequest>();
+    expect(searchRequest.args.req).toEqual({
+      sourceRels: ["payments.pdf", "security.docx"],
+      query: "quy trình đối soát thanh toán",
+      limit: 20,
+    });
+    expectTypeOf(searchRequest.args.req).toMatchTypeOf<HybridSearchRequest>();
+    expectTypeOf(askRequest.args.req).toMatchTypeOf<HybridAskRequest>();
+    expect(askRequest.args.req).toHaveProperty("topK", 8);
+    expect(askRequest.args.req).not.toHaveProperty("top_k");
+  });
+
+  it("freezes response modes, warnings, anchors and index stats", () => {
+    expectTypeOf(rebuildResponse).toMatchTypeOf<IndexBuildResult>();
+    expectTypeOf(statsResponse).toMatchTypeOf<KnowledgeIndexStats>();
+    expectTypeOf(searchResponse).toMatchTypeOf<HybridSearchResponse>();
+    expectTypeOf(askResponse).toMatchTypeOf<Omit<GroundedAnswer, "mode"> & { mode: string }>();
+    expectTypeOf(fallbackResponse).toMatchTypeOf<
+      Omit<GroundedAnswer, "mode"> & { mode: string }
+    >();
+    expect(searchResponse.hits[0]?.anchor.page).toBe(7);
+    expect(searchResponse.hits[0]?.rerankScore).toBeCloseTo(1.875, 4);
+    expect(askResponse.mode).toBe("offline_extractive");
+    expect(fallbackResponse.mode).toBe("fallback_extractive");
+    const modes: GroundedAnswer["mode"][] = [
+      "offline_extractive",
+      "local_llm",
+      "cloud_llm",
+      "subscription_cli",
+      "fallback_extractive",
+    ];
+    expect(modes).toContain(askResponse.mode);
+    expect(modes).toContain(fallbackResponse.mode);
+    expect(fallbackResponse.grounded).toBe(true);
+    expect(fallbackResponse.warnings).toHaveLength(1);
+    expect(statsResponse.annThreshold).toBe(1000);
+  });
+});

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -155,6 +155,23 @@ export interface ImportFolderResult {
   convertRels: string[];
 }
 
+export interface IndexRequest {
+  sourceRels: string[];
+}
+
+export interface HybridSearchRequest {
+  sourceRels: string[];
+  query: string;
+  limit?: number;
+}
+
+export interface HybridAskRequest {
+  sourceRels: string[];
+  question: string;
+  topK?: number;
+  useLlm?: boolean;
+}
+
 export interface KnowledgeIndexStats {
   documents: number;
   chunks: number;

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -17,7 +17,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 
 ## P1A-01 — Freeze desktop RAG và IPC contracts
 
-- **Status:** Ready — Phase F exit gate đã đạt.
+- **Status:** In progress — canonical desktop RAG/IPC fixtures đang được khóa.
 - **Objective:** Baseline parity trước khi move code.
 - **Plan:** Inventory tests; fixtures top-k/score/snippet/anchor/answer/fallback/stats/
   incremental; canonical JSON cho 4 hybrid commands; offline + mock-provider flows.

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "38ddf5b78b215787";
+    const ROADMAP_SOURCE_HASH = "e3124e4a01e58809";
     const phases = [
       {
         "id": "phase-f",
@@ -1062,7 +1062,7 @@
           [
             "P1A-01",
             "Freeze desktop RAG và IPC contracts",
-            "ready"
+            "in_progress"
           ],
           [
             "P1A-02",

--- a/scripts/check-rust-lint-baseline.py
+++ b/scripts/check-rust-lint-baseline.py
@@ -7,33 +7,28 @@ import json
 import subprocess
 import sys
 import unittest
+from collections import Counter
 
 
-LEGACY_WARNINGS = {
-    ("clippy::while_let_loop", "crates/core/src/audio.rs", 228),
-    ("clippy::manual_range_contains", "crates/core/src/chunk.rs", 43),
-    ("clippy::needless_range_loop", "crates/core/src/conv/csv_conv.rs", 125),
-    ("clippy::field_reassign_with_default", "crates/core/src/conv/pdf.rs", 185),
-    ("clippy::uninlined_format_args", "crates/core/src/conv/xlsx.rs", 35),
-    ("clippy::io_other_error", "crates/core/src/image_ocr.rs", 98),
-    ("clippy::io_other_error", "crates/core/src/image_ocr.rs", 262),
-    ("clippy::io_other_error", "crates/core/src/image_ocr.rs", 378),
-    ("clippy::io_other_error", "crates/core/src/image_ocr.rs", 435),
-    ("clippy::manual_ignore_case_cmp", "crates/core/src/intelligence.rs", 1087),
-    ("clippy::too_many_arguments", "crates/core/src/intelligence.rs", 1109),
-    ("clippy::uninlined_format_args", "crates/core/src/intelligence.rs", 1317),
-    ("clippy::needless_lifetimes", "crates/core/src/intelligence.rs", 1339),
-    ("clippy::uninlined_format_args", "app/src-tauri/src/intelligence.rs", 237),
-    ("clippy::uninlined_format_args", "app/src-tauri/src/intelligence.rs", 446),
-    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1293),
-    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1302),
-    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1314),
-    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1327),
-    ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs", 1341),
-}
+LEGACY_WARNINGS = Counter(
+    {
+        ("clippy::while_let_loop", "crates/core/src/audio.rs"): 1,
+        ("clippy::manual_range_contains", "crates/core/src/chunk.rs"): 1,
+        ("clippy::needless_range_loop", "crates/core/src/conv/csv_conv.rs"): 1,
+        ("clippy::field_reassign_with_default", "crates/core/src/conv/pdf.rs"): 1,
+        ("clippy::uninlined_format_args", "crates/core/src/conv/xlsx.rs"): 1,
+        ("clippy::io_other_error", "crates/core/src/image_ocr.rs"): 4,
+        ("clippy::manual_ignore_case_cmp", "crates/core/src/intelligence.rs"): 1,
+        ("clippy::too_many_arguments", "crates/core/src/intelligence.rs"): 1,
+        ("clippy::uninlined_format_args", "crates/core/src/intelligence.rs"): 1,
+        ("clippy::needless_lifetimes", "crates/core/src/intelligence.rs"): 1,
+        ("clippy::uninlined_format_args", "app/src-tauri/src/intelligence.rs"): 2,
+        ("clippy::field_reassign_with_default", "app/src-tauri/src/lib.rs"): 5,
+    }
+)
 
 
-def warning_key(message: dict) -> tuple[str | None, str, int] | None:
+def warning_key(message: dict) -> tuple[str, str, int] | None:
     if message.get("level") != "warning":
         return None
     code = message.get("code") or {}
@@ -43,18 +38,21 @@ def warning_key(message: dict) -> tuple[str | None, str, int] | None:
     primary = next((span for span in spans if span.get("is_primary")), None)
     if primary is None:
         return None
-    return code.get("code"), primary["file_name"], primary["line_start"]
+    return code["code"], primary["file_name"], primary["line_start"]
 
 
-def clippy_warnings(lines: list[str]) -> set[tuple[str | None, str, int]]:
-    warnings = set()
+def clippy_warnings(lines: list[str]) -> Counter[tuple[str, str]]:
+    warnings: Counter[tuple[str, str]] = Counter()
+    seen: set[tuple[str, str, int]] = set()
     for line in lines:
         record = json.loads(line)
         if record.get("reason") != "compiler-message":
             continue
         key = warning_key(record["message"])
-        if key:
-            warnings.add(key)
+        if key and key not in seen:
+            seen.add(key)
+            code, file_name, _line = key
+            warnings[(code, file_name)] += 1
     return warnings
 
 
@@ -72,7 +70,12 @@ class BaselineTests(unittest.TestCase):
                 },
             }
         )
-        self.assertEqual(clippy_warnings([line]), {("clippy::example", "a.rs", 1)})
+        self.assertEqual(clippy_warnings([line]), Counter({("clippy::example", "a.rs"): 1}))
+
+    def test_count_baseline_rejects_additional_warning_but_allows_line_shift(self) -> None:
+        current = Counter({("clippy::example", "a.rs"): 2})
+        allowed = Counter({("clippy::example", "a.rs"): 1})
+        self.assertEqual(current - allowed, Counter({("clippy::example", "a.rs"): 1}))
 
 
 def main() -> int:
@@ -88,11 +91,11 @@ def main() -> int:
     sys.stderr.write(result.stderr)
     if result.returncode:
         return result.returncode
-    unexpected = sorted(clippy_warnings(result.stdout.splitlines()) - LEGACY_WARNINGS)
+    unexpected = clippy_warnings(result.stdout.splitlines()) - LEGACY_WARNINGS
     if unexpected:
         print("new Clippy warning(s) outside legacy baseline:", file=sys.stderr)
-        for code, file_name, line in unexpected:
-            print(f"- {file_name}:{line}: {code}", file=sys.stderr)
+        for (code, file_name), count in sorted(unexpected.items()):
+            print(f"- {file_name}: {code} (+{count})", file=sys.stderr)
         return 1
     print("Clippy legacy baseline has no new warnings")
     return 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Phase 1A / P1A-01

Freeze desktop RAG behavior before moving implementation into `fileconv-knowledge`.

## Delivered

- canonical JSON fixtures for the four hybrid commands: rebuild, stats, search, ask
- response fixtures for incremental rebuild, scores/snippet/page anchor, offline answer and missing-LLM fallback warning
- Rust serde round-trip/casing/mode/anchor/epsilon tests
- TypeScript request interfaces and cross-language fixture tests
- fixture manifest with SHA-256/license/provenance and shared validator integration
- documented defaults/constants and known undesirable behavior that extraction must preserve first
- Clippy legacy baseline made line-shift tolerant while still rejecting extra warning counts

## Verification

```bash
cargo test -p fileconv-desktop knowledge_contract
pnpm --filter markhand-desktop test
pnpm --filter markhand-desktop build
make check-rust
make check-static
```

All pass locally. Hosted CI runners remain blocked before execution by repository billing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

