### PR TITLE
feat: move knowledge DTO contracts to shared crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ name = "fileconv-desktop"
 version = "0.1.0"
 dependencies = [
  "fileconv-core",
+ "fileconv-knowledge",
  "hnsw_rs",
  "notify",
  "rusqlite",
@@ -1599,6 +1600,8 @@ dependencies = [
  "fileconv-core",
  "hnsw_rs",
  "rusqlite",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ time = "=0.3.51"
 
 # Lõi convert dùng chung với CLI — KHÔNG viết lại.
 fileconv-core = { path = "../../crates/core", features = ["llm"] }
+fileconv-knowledge = { path = "../../crates/knowledge" }
 rusqlite = { version = "0.37.0", features = ["bundled"], default-features = false }
 notify = "8.2.0"
 hnsw_rs = "0.3.4"

--- a/app/src-tauri/src/knowledge.rs
+++ b/app/src-tauri/src/knowledge.rs
@@ -4,8 +4,11 @@ use std::path::{Path, PathBuf};
 
 use fileconv_core::intelligence::{self, CorpusDocument};
 use fileconv_core::llm::EmbeddingConfig;
+pub use fileconv_knowledge::types::{
+    GroundedAnswer, HybridAskRequest, HybridSearchHit, HybridSearchRequest, HybridSearchResponse,
+    IndexBuildResult, IndexMetadata, IndexRequest, IndexStats, SourceAnchor,
+};
 use rusqlite::{params, Connection, OptionalExtension};
-use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use super::{data_root, es, resolve_within, AppState};
@@ -14,99 +17,6 @@ const LOCAL_VECTOR_DIMENSIONS: usize = 256;
 const MAX_VECTOR_CANDIDATES: usize = 100_000;
 const LOCAL_EMBEDDING_MODE: &str = "local_hash_v1";
 const PROVIDER_EMBEDDING_MODE: &str = "provider_v1";
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct IndexRequest {
-    pub source_rels: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct IndexBuildResult {
-    pub documents: usize,
-    pub chunks: usize,
-    pub indexed: usize,
-    pub skipped: usize,
-    pub embedding_mode: String,
-    pub embedding_provider: String,
-    pub embedding_model: String,
-    pub vector_dimensions: usize,
-    pub warnings: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct IndexStats {
-    pub documents: usize,
-    pub chunks: usize,
-    pub database_bytes: u64,
-    pub vector_dimensions: usize,
-    pub embedding_mode: String,
-    pub embedding_provider: String,
-    pub embedding_model: String,
-    pub ann_available: bool,
-    pub ann_threshold: usize,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct HybridSearchRequest {
-    pub source_rels: Vec<String>,
-    pub query: String,
-    pub limit: Option<usize>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SourceAnchor {
-    pub page: Option<u32>,
-    pub slide: Option<u32>,
-    pub sheet: Option<String>,
-    pub start: usize,
-    pub end: usize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct HybridSearchHit {
-    pub chunk_id: String,
-    pub source_rel: String,
-    pub md_rel: String,
-    pub heading: String,
-    pub snippet: String,
-    pub lexical_score: f32,
-    pub vector_score: f32,
-    pub rerank_score: f32,
-    pub anchor: SourceAnchor,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct HybridSearchResponse {
-    pub hits: Vec<HybridSearchHit>,
-    pub warnings: Vec<String>,
-    pub embedding_mode: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct HybridAskRequest {
-    pub source_rels: Vec<String>,
-    pub question: String,
-    pub top_k: Option<usize>,
-    pub use_llm: Option<bool>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GroundedAnswer {
-    pub answer: String,
-    pub citations: Vec<HybridSearchHit>,
-    pub mode: String,
-    pub grounded: bool,
-    pub warnings: Vec<String>,
-}
 
 #[derive(Debug, Clone)]
 struct IndexedChunk {
@@ -122,15 +32,6 @@ struct IndexedChunk {
     sheet: Option<String>,
     vector: Vec<f32>,
     vector_dims: usize,
-}
-
-#[derive(Debug, Clone)]
-struct IndexMetadata {
-    mode: String,
-    provider: String,
-    model: String,
-    dimensions: usize,
-    signature: String,
 }
 
 #[derive(Debug, Clone)]

--- a/app/src-tauri/src/knowledge_contract.rs
+++ b/app/src-tauri/src/knowledge_contract.rs
@@ -2,7 +2,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::knowledge::{
+use fileconv_knowledge::types::{
     GroundedAnswer, HybridAskRequest, HybridSearchRequest, HybridSearchResponse, IndexBuildResult,
     IndexRequest, IndexStats,
 };

--- a/crates/knowledge/Cargo.toml
+++ b/crates/knowledge/Cargo.toml
@@ -14,5 +14,9 @@ desktop-hnsw = ["dep:hnsw_rs"]
 [dependencies]
 fileconv-core = { path = "../core" }
 thiserror.workspace = true
+serde = { version = "1", features = ["derive"] }
 rusqlite = { version = "0.37.0", features = ["bundled"], default-features = false, optional = true }
 hnsw_rs = { version = "0.3.4", optional = true }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/knowledge/src/types.rs
+++ b/crates/knowledge/src/types.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DocumentScope {
     source_rels: Vec<String>,
@@ -10,5 +12,141 @@ impl DocumentScope {
 
     pub fn source_rels(&self) -> &[String] {
         &self.source_rels
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexRequest {
+    pub source_rels: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexBuildResult {
+    pub documents: usize,
+    pub chunks: usize,
+    pub indexed: usize,
+    pub skipped: usize,
+    pub embedding_mode: String,
+    pub embedding_provider: String,
+    pub embedding_model: String,
+    pub vector_dimensions: usize,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexStats {
+    pub documents: usize,
+    pub chunks: usize,
+    pub database_bytes: u64,
+    pub vector_dimensions: usize,
+    pub embedding_mode: String,
+    pub embedding_provider: String,
+    pub embedding_model: String,
+    pub ann_available: bool,
+    pub ann_threshold: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HybridSearchRequest {
+    pub source_rels: Vec<String>,
+    pub query: String,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceAnchor {
+    pub page: Option<u32>,
+    pub slide: Option<u32>,
+    pub sheet: Option<String>,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HybridSearchHit {
+    pub chunk_id: String,
+    pub source_rel: String,
+    pub md_rel: String,
+    pub heading: String,
+    pub snippet: String,
+    pub lexical_score: f32,
+    pub vector_score: f32,
+    pub rerank_score: f32,
+    pub anchor: SourceAnchor,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HybridSearchResponse {
+    pub hits: Vec<HybridSearchHit>,
+    pub warnings: Vec<String>,
+    pub embedding_mode: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HybridAskRequest {
+    pub source_rels: Vec<String>,
+    pub question: String,
+    pub top_k: Option<usize>,
+    pub use_llm: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroundedAnswer {
+    pub answer: String,
+    pub citations: Vec<HybridSearchHit>,
+    pub mode: String,
+    pub grounded: bool,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexMetadata {
+    pub mode: String,
+    pub provider: String,
+    pub model: String,
+    pub dimensions: usize,
+    pub signature: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HybridAskRequest, IndexBuildResult};
+
+    #[test]
+    fn serializes_public_contract_as_camel_case() {
+        let request = HybridAskRequest {
+            source_rels: vec!["doc.pdf".into()],
+            question: "Nội dung?".into(),
+            top_k: Some(8),
+            use_llm: Some(false),
+        };
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["sourceRels"][0], "doc.pdf");
+        assert_eq!(value["topK"], 8);
+        assert!(value.get("top_k").is_none());
+
+        let result: IndexBuildResult = serde_json::from_value(serde_json::json!({
+            "documents": 1,
+            "chunks": 2,
+            "indexed": 1,
+            "skipped": 0,
+            "embeddingMode": "local_hash_v1",
+            "embeddingProvider": "local",
+            "embeddingModel": "local_hash_v1",
+            "vectorDimensions": 256,
+            "warnings": []
+        }))
+        .unwrap();
+        assert_eq!(result.vector_dimensions, 256);
     }
 }

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -48,7 +48,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 
 ## P1A-03 — Shared DTO và serde contract
 
-- **Status:** Ready — P1A-01/02 baseline và feature boundary đã đạt.
+- **Status:** In progress — shared DTO đã chuyển, đang xác nhận desktop parity.
 - **Objective:** Di chuyển index/search/ask types mà không đổi JSON.
 - **Plan:** Index request/result/stats, hit/anchor/grounded answer/metadata; serde
   fixtures; temporary desktop re-export.

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "3b88d9be8e93f9b8";
+    const ROADMAP_SOURCE_HASH = "b4acca0359dbcec2";
     const phases = [
       {
         "id": "phase-f",
@@ -1072,7 +1072,7 @@
           [
             "P1A-03",
             "Shared DTO và serde contract",
-            "ready"
+            "in_progress"
           ],
           [
             "P1A-04",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Phase 1A / P1A-03

Move index/search/ask public serde contracts into `fileconv-knowledge` without changing desktop IPC JSON.

## Delivered

- shared request/result/stats/hit/anchor/answer/index-metadata types
- camelCase serde contract in framework-free crate
- desktop depends on knowledge and temporarily re-exports shared DTOs
- existing canonical Rust and TypeScript fixtures remain unchanged
- shared crate serde casing test and complete desktop parity suite

## Verification

```bash
cargo test -p fileconv-knowledge
cargo test -p fileconv-desktop knowledge_contract
make check-knowledge-features
pnpm --filter markhand-desktop test
pnpm --filter markhand-desktop build
make check-rust
make check-static
```

All pass locally. Hosted runners remain unavailable due repository billing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

