### PR TITLE
feat: add durable knowledge identities and signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,7 +722,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -796,6 +805,12 @@ dependencies = [
  "log",
  "web-sys",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -959,6 +974,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1170,9 +1194,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1602,6 +1637,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
 ]
 
@@ -2229,7 +2265,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2316,6 +2352,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3028,7 +3073,7 @@ dependencies = [
  "rand 0.10.1",
  "rangemap",
  "rayon",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
  "thiserror 2.0.18",
  "time",
@@ -3108,7 +3153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3682,7 +3727,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -4890,7 +4935,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4901,7 +4946,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5498,7 +5554,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.118",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -7228,7 +7284,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ check-migrations:
 check-fixtures:
 	python3 scripts/check-fixtures.py
 	python3 scripts/check-fixtures.py --root app/src-tauri/fixtures/knowledge/v1
+	python3 scripts/check-fixtures.py --root crates/knowledge/fixtures
 	python3 scripts/check-fixtures.py --self-test
 
 check-markhand-gates:

--- a/crates/knowledge/Cargo.toml
+++ b/crates/knowledge/Cargo.toml
@@ -17,6 +17,7 @@ thiserror.workspace = true
 serde = { version = "1", features = ["derive"] }
 rusqlite = { version = "0.37.0", features = ["bundled"], default-features = false, optional = true }
 hnsw_rs = { version = "0.3.4", optional = true }
+sha2 = "0.11.0"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/knowledge/fixtures/identity-v1.json
+++ b/crates/knowledge/fixtures/identity-v1.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "document": {
+    "sourceRel": "pháp-luật/tài-liệu.pdf",
+    "contentSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "identity": "1c151dd7d6d8945f0316d6f772bea4893fd4126dea377434c96c7cf258344c10"
+  },
+  "chunk": {
+    "ordinal": 7,
+    "headingPath": "Chương I > Điều 2",
+    "body": "Nội dung tiếng Việt",
+    "textVersion": "nfc-v1",
+    "identity": "53461f68e90a7dba6f36a0ff523519739ff5beac01a7503a0d7ba9ac40cee88f"
+  },
+  "index": {
+    "embeddingFamily": "embedding-family",
+    "embeddingRevision": "revision-1",
+    "dimensions": 1024,
+    "normalized": true,
+    "chunkingVersion": "heading-v1",
+    "textVersion": "nfc-v1",
+    "signature": "54e805534b95787c376466a3d806665b9b3cacd852b39ddb38acf70b345e16e8"
+  }
+}

--- a/crates/knowledge/fixtures/manifest.json
+++ b/crates/knowledge/fixtures/manifest.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "fixtures": [
+    {
+      "id": "knowledge.identity.v1",
+      "path": "identity-v1.json",
+      "sha256": "219d822496ffdfebeeecafde9db22d0e8279a794d068ad1c7355a971048a0f09",
+      "kind": "identity-vector",
+      "owner": "knowledge",
+      "source": "synthetic",
+      "license": "CC0-1.0",
+      "sensitive": false
+    }
+  ]
+}

--- a/crates/knowledge/src/identity.rs
+++ b/crates/knowledge/src/identity.rs
@@ -1,0 +1,154 @@
+use sha2::{Digest, Sha256};
+use std::fmt::Write;
+
+pub const IDENTITY_VERSION: u16 = 1;
+
+fn update_field(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value);
+}
+
+fn digest(domain: &str, fields: &[&[u8]]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"markhand-knowledge-identity");
+    hasher.update(IDENTITY_VERSION.to_be_bytes());
+    update_field(&mut hasher, domain.as_bytes());
+    for field in fields {
+        update_field(&mut hasher, field);
+    }
+    let bytes = hasher.finalize();
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut encoded, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    encoded
+}
+
+pub fn document_identity(source_rel: &str, content_sha256: &str) -> String {
+    digest(
+        "document",
+        &[source_rel.as_bytes(), content_sha256.as_bytes()],
+    )
+}
+
+pub fn chunk_identity(
+    document_id: &str,
+    ordinal: u64,
+    heading_path: &str,
+    body: &str,
+    text_version: &str,
+) -> String {
+    digest(
+        "chunk",
+        &[
+            document_id.as_bytes(),
+            &ordinal.to_be_bytes(),
+            heading_path.as_bytes(),
+            body.as_bytes(),
+            text_version.as_bytes(),
+        ],
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexSignature<'a> {
+    pub embedding_family: &'a str,
+    pub embedding_revision: &'a str,
+    pub dimensions: usize,
+    pub normalized: bool,
+    pub chunking_version: &'a str,
+    pub text_version: &'a str,
+}
+
+impl IndexSignature<'_> {
+    pub fn digest(&self) -> String {
+        digest(
+            "index",
+            &[
+                self.embedding_family.as_bytes(),
+                self.embedding_revision.as_bytes(),
+                &(self.dimensions as u64).to_be_bytes(),
+                &[u8::from(self.normalized)],
+                self.chunking_version.as_bytes(),
+                self.text_version.as_bytes(),
+            ],
+        )
+    }
+}
+
+/// Compatibility only for existing desktop cache IDs; server code must use SHA-256 IDs.
+pub fn legacy_desktop_hash(value: &str) -> String {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    value.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{chunk_identity, digest, document_identity, IndexSignature};
+
+    #[test]
+    fn length_delimited_fields_are_not_ambiguous() {
+        assert_ne!(
+            digest("test", &[b"ab", b"c"]),
+            digest("test", &[b"a", b"bc"])
+        );
+    }
+
+    #[test]
+    fn unicode_order_and_version_are_stable() {
+        let fixture: serde_json::Value =
+            serde_json::from_str(include_str!("../fixtures/identity-v1.json")).unwrap();
+        let document = document_identity(
+            fixture["document"]["sourceRel"].as_str().unwrap(),
+            fixture["document"]["contentSha256"].as_str().unwrap(),
+        );
+        assert_eq!(document, fixture["document"]["identity"].as_str().unwrap());
+        let chunk = chunk_identity(
+            &document,
+            fixture["chunk"]["ordinal"].as_u64().unwrap(),
+            fixture["chunk"]["headingPath"].as_str().unwrap(),
+            fixture["chunk"]["body"].as_str().unwrap(),
+            fixture["chunk"]["textVersion"].as_str().unwrap(),
+        );
+        assert_eq!(chunk, fixture["chunk"]["identity"].as_str().unwrap());
+        assert_ne!(
+            chunk,
+            chunk_identity(
+                &document,
+                8,
+                "Chương I > Điều 2",
+                "Nội dung tiếng Việt",
+                "nfc-v1"
+            )
+        );
+    }
+
+    #[test]
+    fn index_signature_covers_every_compatibility_dimension() {
+        let fixture: serde_json::Value =
+            serde_json::from_str(include_str!("../fixtures/identity-v1.json")).unwrap();
+        let signature = IndexSignature {
+            embedding_family: fixture["index"]["embeddingFamily"].as_str().unwrap(),
+            embedding_revision: fixture["index"]["embeddingRevision"].as_str().unwrap(),
+            dimensions: fixture["index"]["dimensions"].as_u64().unwrap() as usize,
+            normalized: fixture["index"]["normalized"].as_bool().unwrap(),
+            chunking_version: fixture["index"]["chunkingVersion"].as_str().unwrap(),
+            text_version: fixture["index"]["textVersion"].as_str().unwrap(),
+        };
+        assert_eq!(
+            signature.digest(),
+            fixture["index"]["signature"].as_str().unwrap()
+        );
+        assert_ne!(
+            signature.digest(),
+            IndexSignature {
+                dimensions: 768,
+                ..signature.clone()
+            }
+            .digest()
+        );
+    }
+}

--- a/crates/knowledge/src/lib.rs
+++ b/crates/knowledge/src/lib.rs
@@ -7,6 +7,7 @@ pub mod ask;
 pub mod citation;
 pub mod embedding;
 pub mod error;
+pub mod identity;
 pub mod query;
 pub mod rank;
 pub mod types;

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -63,7 +63,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 
 ## P1A-04 — Durable identities và index signatures
 
-- **Status:** Ready — shared metadata contract đã chuyển sang knowledge crate.
+- **Status:** In progress — versioned SHA-256 identities/signatures đang được khóa.
 - **Objective:** Deterministic server identities, desktop compatibility.
 - **Plan:** Versioned length-delimited encoding; BLAKE3/SHA-256 document/chunk/index;
   signature model/revision/dim/normalize/chunk/text version; fixed vectors; legacy

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "9b75f3b0e585d6d7";
+    const ROADMAP_SOURCE_HASH = "8c6cbeaf742f7d6e";
     const phases = [
       {
         "id": "phase-f",
@@ -1077,7 +1077,7 @@
           [
             "P1A-04",
             "Durable identities và index signatures",
-            "ready"
+            "in_progress"
           ],
           [
             "P1A-05",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Phase 1A / P1A-04

Add cross-platform stable identities for future server documents/chunks/indexes while preserving legacy desktop hash compatibility.

## Delivered

- SHA-256 identity v1 with domain separation and u64 length-delimited fields
- document and chunk identities; no concatenation ambiguity
- index signature covers embedding family/revision, dimension, normalization, chunking and text versions
- fixed Unicode/order/version vectors in licensed checksum fixture
- explicit legacy `DefaultHasher` compatibility helper; server callers use durable identities
- no model selection or access-control semantics

## Verification

```bash
cargo test -p fileconv-knowledge identity
make check-knowledge-features
make check-fixtures
make check-static
```

All pass locally. Hosted CI is unavailable due repository billing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

