### PR TITLE
feat: extract query and embedding preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,7 +1638,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "siphasher",
  "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]

--- a/app/src-tauri/src/knowledge.rs
+++ b/app/src-tauri/src/knowledge.rs
@@ -4,6 +4,12 @@ use std::path::{Path, PathBuf};
 
 use fileconv_core::intelligence::{self, CorpusDocument};
 use fileconv_core::llm::EmbeddingConfig;
+use fileconv_knowledge::embedding::{
+    local_vector as shared_local_vector, validate_embedding_batch,
+    EmbeddingPlan as SharedEmbeddingPlan, EmbeddingVector, LOCAL_EMBEDDING_MODE,
+    LOCAL_VECTOR_DIMENSIONS, PROVIDER_EMBEDDING_MODE,
+};
+use fileconv_knowledge::query::{fts5_prefix_query, normalized_tokens};
 pub use fileconv_knowledge::types::{
     GroundedAnswer, HybridAskRequest, HybridSearchHit, HybridSearchRequest, HybridSearchResponse,
     IndexBuildResult, IndexMetadata, IndexRequest, IndexStats, SourceAnchor,
@@ -13,10 +19,7 @@ use tauri::State;
 
 use super::{data_root, es, resolve_within, AppState};
 
-const LOCAL_VECTOR_DIMENSIONS: usize = 256;
 const MAX_VECTOR_CANDIDATES: usize = 100_000;
-const LOCAL_EMBEDDING_MODE: &str = "local_hash_v1";
-const PROVIDER_EMBEDDING_MODE: &str = "provider_v1";
 
 #[derive(Debug, Clone)]
 struct IndexedChunk {
@@ -38,6 +41,7 @@ struct IndexedChunk {
 struct EmbeddingPlan {
     config: Option<EmbeddingConfig>,
     metadata: IndexMetadata,
+    shared: Option<SharedEmbeddingPlan>,
 }
 
 fn stable_hash(value: &str) -> String {
@@ -141,54 +145,8 @@ fn open_index(root: &Path) -> Result<Connection, String> {
     Ok(connection)
 }
 
-fn normalized_tokens(text: &str) -> Vec<String> {
-    intelligence::normalize_search_text(text)
-        .split(|character: char| !character.is_alphanumeric())
-        .filter(|token| token.chars().count() >= 2)
-        .map(str::to_string)
-        .collect()
-}
-
-fn hash_index(value: &str) -> (usize, f32) {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    value.hash(&mut hasher);
-    let hash = hasher.finish();
-    let index = (hash as usize) % LOCAL_VECTOR_DIMENSIONS;
-    let sign = if hash & (1 << 63) == 0 { 1.0 } else { -1.0 };
-    (index, sign)
-}
-
-/// Fully local feature-hashing vector. It is always available and provides a
-/// deterministic vector fallback when no embedding provider is configured.
 fn local_vector(text: &str) -> Vec<f32> {
-    let folded = intelligence::normalize_search_text(text);
-    let mut vector = vec![0.0_f32; LOCAL_VECTOR_DIMENSIONS];
-    let words = normalized_tokens(&folded);
-    for token in &words {
-        let (index, sign) = hash_index(token);
-        vector[index] += sign;
-    }
-    for pair in words.windows(2) {
-        let bigram = format!("{}:{}", pair[0], pair[1]);
-        let (index, sign) = hash_index(&bigram);
-        vector[index] += sign * 0.65;
-    }
-    let compact: Vec<char> = folded
-        .chars()
-        .filter(|character| !character.is_whitespace())
-        .collect();
-    for trigram in compact.windows(3) {
-        let feature: String = trigram.iter().collect();
-        let (index, sign) = hash_index(&feature);
-        vector[index] += sign * 0.15;
-    }
-    let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
-    if norm > 0.0 {
-        for value in &mut vector {
-            *value /= norm;
-        }
-    }
-    vector
+    shared_local_vector(text).into_values()
 }
 
 fn vector_bytes(vector: &[f32]) -> Vec<u8> {
@@ -251,14 +209,14 @@ fn embedding_plan(config: Option<EmbeddingConfig>) -> EmbeddingPlan {
         Some(config) => {
             let provider = provider_name(config.provider);
             let model = config.model.clone();
-            let signature = stable_hash(&format!(
-                "{PROVIDER_EMBEDDING_MODE}|{provider}|{model}|{}|{}",
-                config.base_url.as_deref().unwrap_or_default(),
-                config
-                    .dimensions
-                    .map(|value| value.to_string())
-                    .unwrap_or_default()
-            ));
+            let shared = SharedEmbeddingPlan::provider(
+                provider.clone(),
+                model.clone(),
+                model.clone(),
+                config.dimensions,
+            )
+            .expect("validated desktop embedding configuration");
+            let signature = shared.provisional_signature();
             EmbeddingPlan {
                 metadata: IndexMetadata {
                     mode: PROVIDER_EMBEDDING_MODE.into(),
@@ -268,6 +226,7 @@ fn embedding_plan(config: Option<EmbeddingConfig>) -> EmbeddingPlan {
                     signature,
                 },
                 config: Some(config),
+                shared: Some(shared),
             }
         }
         None => EmbeddingPlan {
@@ -279,8 +238,20 @@ fn embedding_plan(config: Option<EmbeddingConfig>) -> EmbeddingPlan {
                 dimensions: LOCAL_VECTOR_DIMENSIONS,
                 signature: LOCAL_EMBEDDING_MODE.into(),
             },
+            // Existing desktop indexes retain their legacy signature. New server
+            // consumers use the durable signature exposed by the shared plan.
+            shared: None,
         },
     }
+}
+
+fn finalize_provider_signature(plan: &mut EmbeddingPlan) -> Result<(), String> {
+    if let Some(shared) = plan.shared.as_ref() {
+        plan.metadata.signature = shared
+            .signature(plan.metadata.dimensions)
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
 }
 
 fn read_metadata(connection: &Connection) -> Result<IndexMetadata, String> {
@@ -379,13 +350,17 @@ fn index_documents_with_plan(
         .query_row("SELECT COUNT(*) FROM documents", [], |row| row.get(0))
         .map_err(es)?;
     let current_metadata = read_metadata(&connection)?;
-    if indexed_documents > 0 && current_metadata.signature != plan.metadata.signature {
-        clear_index(root, &mut connection)?;
-    } else if indexed_documents > 0
-        && current_metadata.signature == plan.metadata.signature
+    if indexed_documents > 0
         && plan.metadata.dimensions == 0
+        && current_metadata.mode == plan.metadata.mode
+        && current_metadata.provider == plan.metadata.provider
+        && current_metadata.model == plan.metadata.model
     {
         plan.metadata.dimensions = current_metadata.dimensions;
+        finalize_provider_signature(&mut plan)?;
+    }
+    if indexed_documents > 0 && current_metadata.signature != plan.metadata.signature {
+        clear_index(root, &mut connection)?;
     }
     let mut indexed = 0usize;
     let mut skipped = 0usize;
@@ -431,22 +406,20 @@ fn index_documents_with_plan(
                 .map(|input| local_vector(input))
                 .collect()
         };
-        if vectors.len() != chunks.len() {
-            return Err("số vector không khớp số chunk".into());
-        }
-        if let Some(vector) = vectors.first() {
-            if vector.is_empty() || vectors.iter().any(|item| item.len() != vector.len()) {
-                return Err("embedding index có vector khác số chiều".into());
-            }
-            if plan.metadata.dimensions == 0 {
-                plan.metadata.dimensions = vector.len();
-            } else if plan.metadata.dimensions != vector.len() {
-                return Err(format!(
-                    "embedding trả {} chiều, index yêu cầu {}",
-                    vector.len(),
-                    plan.metadata.dimensions
-                ));
-            }
+        let checked_vectors = vectors
+            .iter()
+            .cloned()
+            .map(EmbeddingVector::new)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        let expected_dimensions =
+            (plan.metadata.dimensions > 0).then_some(plan.metadata.dimensions);
+        let dimensions =
+            validate_embedding_batch(&checked_vectors, chunks.len(), expected_dimensions)
+                .map_err(|error| error.to_string())?;
+        if dimensions > 0 && plan.metadata.dimensions == 0 {
+            plan.metadata.dimensions = dimensions;
+            finalize_provider_signature(&mut plan)?;
         }
         let transaction = connection.transaction().map_err(es)?;
         transaction
@@ -643,14 +616,6 @@ fn load_all_chunks(
     Ok(chunks)
 }
 
-fn fts_query(query: &str) -> String {
-    normalized_tokens(query)
-        .into_iter()
-        .map(|token| format!("\"{}\"*", token.replace('"', "")))
-        .collect::<Vec<_>>()
-        .join(" OR ")
-}
-
 fn snippet(body: &str, query_tokens: &[String]) -> String {
     let words: Vec<&str> = body.split_whitespace().collect();
     let folded_words: Vec<String> = words
@@ -688,7 +653,7 @@ fn hybrid_search_inner(
     let metadata = read_metadata(&connection)?;
     let scope: HashSet<String> = source_rels.iter().cloned().collect();
     let query_tokens = normalized_tokens(query);
-    let fts = fts_query(query);
+    let fts = fts5_prefix_query(query);
     let mut lexical_rank: HashMap<String, (usize, f32)> = HashMap::new();
     if !fts.is_empty() {
         let mut statement = connection

--- a/app/src-tauri/src/knowledge.rs
+++ b/app/src-tauri/src/knowledge.rs
@@ -6,8 +6,8 @@ use fileconv_core::intelligence::{self, CorpusDocument};
 use fileconv_core::llm::EmbeddingConfig;
 use fileconv_knowledge::embedding::{
     local_vector as shared_local_vector, validate_embedding_batch,
-    EmbeddingPlan as SharedEmbeddingPlan, EmbeddingVector, LOCAL_EMBEDDING_MODE,
-    LOCAL_VECTOR_DIMENSIONS, PROVIDER_EMBEDDING_MODE,
+    EmbeddingPlan as SharedEmbeddingPlan, EmbeddingVector, ProviderDeployment,
+    LOCAL_EMBEDDING_MODE, LOCAL_VECTOR_DIMENSIONS, PROVIDER_EMBEDDING_MODE,
 };
 use fileconv_knowledge::query::{fts5_prefix_query, normalized_tokens};
 pub use fileconv_knowledge::types::{
@@ -209,10 +209,14 @@ fn embedding_plan(config: Option<EmbeddingConfig>) -> EmbeddingPlan {
         Some(config) => {
             let provider = provider_name(config.provider);
             let model = config.model.clone();
+            let deployment = ProviderDeployment::from_base_url(config.base_url.as_deref())
+                .or_else(|_| ProviderDeployment::from_base_url(None))
+                .expect("default deployment identity is valid");
             let shared = SharedEmbeddingPlan::provider(
                 provider.clone(),
                 model.clone(),
                 model.clone(),
+                deployment,
                 config.dimensions,
             )
             .expect("validated desktop embedding configuration");
@@ -252,6 +256,15 @@ fn finalize_provider_signature(plan: &mut EmbeddingPlan) -> Result<(), String> {
             .map_err(|error| error.to_string())?;
     }
     Ok(())
+}
+
+fn provider_config_matches(config: &EmbeddingConfig, metadata: &IndexMetadata) -> bool {
+    let mut plan = embedding_plan(Some(config.clone()));
+    if plan.metadata.dimensions == 0 && metadata.dimensions > 0 {
+        plan.metadata.dimensions = metadata.dimensions;
+    }
+    (plan.metadata.dimensions == 0 || finalize_provider_signature(&mut plan).is_ok())
+        && plan.metadata.signature == metadata.signature
 }
 
 fn read_metadata(connection: &Connection) -> Result<IndexMetadata, String> {
@@ -357,7 +370,9 @@ fn index_documents_with_plan(
         && current_metadata.model == plan.metadata.model
     {
         plan.metadata.dimensions = current_metadata.dimensions;
-        finalize_provider_signature(&mut plan)?;
+        if plan.metadata.dimensions > 0 {
+            finalize_provider_signature(&mut plan)?;
+        }
     }
     if indexed_documents > 0 && current_metadata.signature != plan.metadata.signature {
         clear_index(root, &mut connection)?;
@@ -399,7 +414,7 @@ fn index_documents_with_plan(
             .collect();
         let vectors = if let Some(config) = plan.config.as_ref() {
             fileconv_core::llm::embed_batch(config, &embedding_inputs)
-                .map_err(|error| format!("embedding provider lỗi: {error}"))?
+                .map_err(|_| "embedding provider lỗi; không thể tạo vector".to_string())?
         } else {
             embedding_inputs
                 .iter()
@@ -687,10 +702,7 @@ fn hybrid_search_inner(
     let mut warnings = Vec::new();
     let query_vector = if metadata.mode == PROVIDER_EMBEDDING_MODE {
         match config {
-            Some(config)
-                if embedding_plan(Some(config.clone())).metadata.signature
-                    == metadata.signature =>
-            {
+            Some(config) if provider_config_matches(&config, &metadata) => {
                 match fileconv_core::llm::embed_query(&config, query) {
                     Ok(vector) if vector.len() == metadata.dimensions => Some(vector),
                     Ok(vector) => {
@@ -701,10 +713,8 @@ fn hybrid_search_inner(
                         ));
                         None
                     }
-                    Err(error) => {
-                        warnings.push(format!(
-                            "Embedding provider lỗi ({error}); chỉ dùng FTS lexical."
-                        ));
+                    Err(_) => {
+                        warnings.push("Embedding provider lỗi; chỉ dùng FTS lexical.".to_string());
                         None
                     }
                 }
@@ -1471,9 +1481,9 @@ mod tests {
         let sources = seed(&root);
         let config = EmbeddingConfig::new(
             fileconv_core::llm::Provider::OpenAiCompatible,
-            "",
+            "provider-secret",
             "missing-model",
-            Some("http://127.0.0.1:1".into()),
+            Some("http://user:password@127.0.0.1:1?token=hidden".into()),
             None,
         )
         .unwrap();
@@ -1482,6 +1492,9 @@ mod tests {
         assert_eq!(result.vector_dimensions, LOCAL_VECTOR_DIMENSIONS);
         assert_eq!(result.indexed, 2);
         assert!(result.warnings[0].contains("rebuild"));
+        assert!(!result.warnings[0].contains("password"));
+        assert!(!result.warnings[0].contains("hidden"));
+        assert!(!result.warnings[0].contains("provider-secret"));
         let metadata = read_metadata(&open_index(&root).unwrap()).unwrap();
         assert_eq!(metadata.signature, LOCAL_EMBEDDING_MODE);
         std::fs::remove_dir_all(root).ok();
@@ -1503,6 +1516,63 @@ mod tests {
             .unwrap();
         let error = hybrid_search_inner(&root, &sources, "giao dịch", 5, None, true).unwrap_err();
         assert!(error.contains("không nhất quán"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn provider_signature_excludes_transport_url_and_credentials() {
+        let first = EmbeddingConfig::new(
+            fileconv_core::llm::Provider::OpenAiCompatible,
+            "first-secret",
+            "mock-embedding",
+            Some("https://user:password@embedding.example/v1?token=hidden".into()),
+            Some(768),
+        )
+        .unwrap();
+        let same_deployment = EmbeddingConfig::new(
+            fileconv_core::llm::Provider::OpenAiCompatible,
+            "second-secret",
+            "mock-embedding",
+            Some("https://embedding.example/v1".into()),
+            Some(768),
+        )
+        .unwrap();
+        let other_deployment = EmbeddingConfig::new(
+            fileconv_core::llm::Provider::OpenAiCompatible,
+            "second-secret",
+            "mock-embedding",
+            Some("https://embedding-two.example/v1".into()),
+            Some(768),
+        )
+        .unwrap();
+        let first_signature = embedding_plan(Some(first)).metadata.signature;
+        let same_signature = embedding_plan(Some(same_deployment)).metadata.signature;
+        let other_signature = embedding_plan(Some(other_deployment)).metadata.signature;
+        assert_eq!(first_signature, same_signature);
+        assert_ne!(first_signature, other_signature);
+        assert!(!first_signature.contains("password"));
+        assert!(!first_signature.contains("hidden"));
+    }
+
+    #[test]
+    fn unknown_provider_dimensions_remain_recoverable_for_empty_documents() {
+        let root = temp_root();
+        std::fs::write(root.join("empty.txt"), b"").unwrap();
+        std::fs::write(root.join("empty.txt.md"), b"").unwrap();
+        let config = EmbeddingConfig::new(
+            fileconv_core::llm::Provider::OpenAiCompatible,
+            "",
+            "mock-embedding",
+            Some("http://127.0.0.1:1".into()),
+            None,
+        )
+        .unwrap();
+        let sources = vec!["empty.txt".to_string()];
+        let first = index_documents_inner(&root, &sources, Some(config.clone()), false).unwrap();
+        let second = index_documents_inner(&root, &sources, Some(config), false).unwrap();
+        assert_eq!(first.vector_dimensions, 0);
+        assert_eq!(first.chunks, 0);
+        assert_eq!(second.skipped, 1);
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/knowledge/Cargo.toml
+++ b/crates/knowledge/Cargo.toml
@@ -18,6 +18,8 @@ serde = { version = "1", features = ["derive"] }
 rusqlite = { version = "0.37.0", features = ["bundled"], default-features = false, optional = true }
 hnsw_rs = { version = "0.3.4", optional = true }
 sha2 = "0.11.0"
+url = "2.5.8"
+siphasher = "1.0.3"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/knowledge/src/embedding.rs
+++ b/crates/knowledge/src/embedding.rs
@@ -1,4 +1,14 @@
+use std::hash::{Hash, Hasher};
+
+use crate::identity::IndexSignature;
+use crate::query::PreparedQuery;
 use crate::{KnowledgeError, Result};
+
+pub const LOCAL_VECTOR_DIMENSIONS: usize = 256;
+pub const LOCAL_EMBEDDING_MODE: &str = "local_hash_v1";
+pub const PROVIDER_EMBEDDING_MODE: &str = "provider_v1";
+pub const DEFAULT_CHUNKING_VERSION: &str = "heading-chunks-2000-v1";
+pub const QUERY_NORMALIZATION_VERSION: &str = "accent-fold-v1";
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct EmbeddingVector {
@@ -25,6 +35,10 @@ impl EmbeddingVector {
     pub fn dimensions(&self) -> usize {
         self.values.len()
     }
+
+    pub fn into_values(self) -> Vec<f32> {
+        self.values
+    }
 }
 
 pub trait EmbeddingProvider {
@@ -32,9 +46,224 @@ pub trait EmbeddingProvider {
     fn embed(&self, inputs: &[String]) -> Result<Vec<EmbeddingVector>>;
 }
 
+/// Secret-free description of how vectors in an index are produced.
+///
+/// Transport URLs and credentials deliberately cannot be represented here.
+/// HTTP clients remain in `fileconv-core`; callers map their configuration to
+/// this plan before validating provider output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingPlan {
+    mode: &'static str,
+    provider: String,
+    model: String,
+    revision: String,
+    expected_dimensions: Option<usize>,
+    normalized: bool,
+}
+
+impl EmbeddingPlan {
+    pub fn local_hash_v1() -> Self {
+        Self {
+            mode: LOCAL_EMBEDDING_MODE,
+            provider: "local".into(),
+            model: LOCAL_EMBEDDING_MODE.into(),
+            revision: "1".into(),
+            expected_dimensions: Some(LOCAL_VECTOR_DIMENSIONS),
+            normalized: true,
+        }
+    }
+
+    pub fn provider(
+        provider: impl Into<String>,
+        model: impl Into<String>,
+        revision: impl Into<String>,
+        expected_dimensions: Option<usize>,
+    ) -> Result<Self> {
+        let provider = provider.into();
+        let model = model.into();
+        let revision = revision.into();
+        if provider.trim().is_empty() {
+            return Err(KnowledgeError::InvalidInput("embedding provider is empty"));
+        }
+        if model.trim().is_empty() {
+            return Err(KnowledgeError::InvalidInput("embedding model is empty"));
+        }
+        if revision.trim().is_empty() {
+            return Err(KnowledgeError::InvalidInput("embedding revision is empty"));
+        }
+        if expected_dimensions == Some(0) {
+            return Err(KnowledgeError::InvalidInput(
+                "embedding dimensions must be positive",
+            ));
+        }
+        Ok(Self {
+            mode: PROVIDER_EMBEDDING_MODE,
+            provider,
+            model,
+            revision,
+            expected_dimensions,
+            normalized: true,
+        })
+    }
+
+    pub fn mode(&self) -> &'static str {
+        self.mode
+    }
+
+    pub fn provider_name(&self) -> &str {
+        &self.provider
+    }
+
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub fn expected_dimensions(&self) -> Option<usize> {
+        self.expected_dimensions
+    }
+
+    pub fn signature(&self, actual_dimensions: usize) -> Result<String> {
+        if actual_dimensions == 0 {
+            return Err(KnowledgeError::InvalidInput(
+                "embedding dimensions must be positive",
+            ));
+        }
+        if let Some(expected) = self.expected_dimensions {
+            if expected != actual_dimensions {
+                return Err(KnowledgeError::EmbeddingDimensionMismatch {
+                    expected,
+                    actual: actual_dimensions,
+                });
+            }
+        }
+        Ok(self.signature_with_dimensions(actual_dimensions))
+    }
+
+    /// Planning-only signature used before a provider reports its dimensions.
+    ///
+    /// It must not be persisted as index metadata; once vectors arrive callers
+    /// replace it with [`Self::signature`].
+    pub fn provisional_signature(&self) -> String {
+        self.signature_with_dimensions(self.expected_dimensions.unwrap_or(0))
+    }
+
+    fn signature_with_dimensions(&self, dimensions: usize) -> String {
+        let family = format!("{}/{}", self.provider, self.model);
+        IndexSignature {
+            embedding_family: &family,
+            embedding_revision: &self.revision,
+            dimensions,
+            normalized: self.normalized,
+            chunking_version: DEFAULT_CHUNKING_VERSION,
+            text_version: QUERY_NORMALIZATION_VERSION,
+        }
+        .digest()
+    }
+}
+
+pub fn validate_embedding_batch(
+    vectors: &[EmbeddingVector],
+    expected_count: usize,
+    expected_dimensions: Option<usize>,
+) -> Result<usize> {
+    if vectors.len() != expected_count {
+        return Err(KnowledgeError::EmbeddingCountMismatch {
+            expected: expected_count,
+            actual: vectors.len(),
+        });
+    }
+    if vectors.is_empty() {
+        return Ok(expected_dimensions.unwrap_or(0));
+    }
+    let dimensions = vectors[0].dimensions();
+    for vector in vectors.iter().skip(1) {
+        if vector.dimensions() != dimensions {
+            return Err(KnowledgeError::EmbeddingDimensionMismatch {
+                expected: dimensions,
+                actual: vector.dimensions(),
+            });
+        }
+    }
+    if let Some(expected) = expected_dimensions {
+        if dimensions != expected {
+            return Err(KnowledgeError::EmbeddingDimensionMismatch {
+                expected,
+                actual: dimensions,
+            });
+        }
+    }
+    Ok(dimensions)
+}
+
+pub fn embed_checked(
+    provider: &impl EmbeddingProvider,
+    inputs: &[String],
+    plan: &EmbeddingPlan,
+) -> Result<Vec<EmbeddingVector>> {
+    let vectors = provider.embed(inputs)?;
+    validate_embedding_batch(&vectors, inputs.len(), plan.expected_dimensions())?;
+    Ok(vectors)
+}
+
+/// Desktop-compatible, deterministic local feature-hashing fallback.
+pub fn local_vector(text: &str) -> EmbeddingVector {
+    let query = PreparedQuery::new(text);
+    let mut vector = vec![0.0_f32; LOCAL_VECTOR_DIMENSIONS];
+    for token in &query.tokens {
+        add_feature(&mut vector, token, 1.0);
+    }
+    for pair in query.tokens.windows(2) {
+        add_feature(&mut vector, &format!("{}:{}", pair[0], pair[1]), 0.65);
+    }
+    let compact: Vec<char> = query
+        .normalized
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect();
+    for trigram in compact.windows(3) {
+        add_feature(&mut vector, &trigram.iter().collect::<String>(), 0.15);
+    }
+    let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for value in &mut vector {
+            *value /= norm;
+        }
+    }
+    // The fixed-size, finite local vector always satisfies this invariant.
+    EmbeddingVector::new(vector).expect("local embedding vector is valid")
+}
+
+fn add_feature(vector: &mut [f32], feature: &str, weight: f32) {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    feature.hash(&mut hasher);
+    let hash = hasher.finish();
+    let index = (hash as usize) % vector.len();
+    let sign = if hash & (1 << 63) == 0 { 1.0 } else { -1.0 };
+    vector[index] += sign * weight;
+}
+
 #[cfg(test)]
 mod tests {
-    use super::EmbeddingVector;
+    use super::{
+        embed_checked, local_vector, validate_embedding_batch, EmbeddingPlan, EmbeddingProvider,
+        EmbeddingVector, LOCAL_VECTOR_DIMENSIONS,
+    };
+    use crate::{KnowledgeError, Result};
+
+    struct MockProvider {
+        signature: String,
+        vectors: Vec<EmbeddingVector>,
+    }
+
+    impl EmbeddingProvider for MockProvider {
+        fn signature(&self) -> &str {
+            &self.signature
+        }
+
+        fn embed(&self, _inputs: &[String]) -> Result<Vec<EmbeddingVector>> {
+            Ok(self.vectors.clone())
+        }
+    }
 
     #[test]
     fn rejects_empty_and_non_finite_vectors() {
@@ -44,5 +273,74 @@ mod tests {
             EmbeddingVector::new(vec![1.0, 0.0]).unwrap().dimensions(),
             2
         );
+    }
+
+    #[test]
+    fn local_vectors_preserve_desktop_normalization_and_determinism() {
+        let first = local_vector("đối soát giao dịch");
+        let second = local_vector("ĐỐI SOÁT GIAO DỊCH");
+        assert_eq!(first, second);
+        assert_eq!(first.dimensions(), LOCAL_VECTOR_DIMENSIONS);
+        let norm = first
+            .values()
+            .iter()
+            .map(|value| value * value)
+            .sum::<f32>()
+            .sqrt();
+        assert!((norm - 1.0).abs() < 0.0001);
+
+        let empty = local_vector("...");
+        assert!(empty.values().iter().all(|value| *value == 0.0));
+    }
+
+    #[test]
+    fn validates_provider_mock_count_and_dimensions() {
+        let plan = EmbeddingPlan::provider("vllm", "vi-model", "r1", Some(3)).unwrap();
+        let provider = MockProvider {
+            signature: plan.signature(3).unwrap(),
+            vectors: vec![
+                EmbeddingVector::new(vec![1.0, 0.0, 0.0]).unwrap(),
+                EmbeddingVector::new(vec![0.0, 1.0, 0.0]).unwrap(),
+            ],
+        };
+        let inputs = vec!["một".into(), "hai".into()];
+        assert_eq!(embed_checked(&provider, &inputs, &plan).unwrap().len(), 2);
+
+        let error = validate_embedding_batch(&provider.vectors, 1, Some(3)).unwrap_err();
+        assert_eq!(
+            error,
+            KnowledgeError::EmbeddingCountMismatch {
+                expected: 1,
+                actual: 2
+            }
+        );
+        let error = validate_embedding_batch(&provider.vectors, 2, Some(4)).unwrap_err();
+        assert_eq!(
+            error,
+            KnowledgeError::EmbeddingDimensionMismatch {
+                expected: 4,
+                actual: 3
+            }
+        );
+    }
+
+    #[test]
+    fn provider_signature_is_secret_free_and_covers_compatibility_fields() {
+        let first = EmbeddingPlan::provider("vllm", "vi-model", "r1", Some(768)).unwrap();
+        let same = EmbeddingPlan::provider("vllm", "vi-model", "r1", Some(768)).unwrap();
+        let changed_model =
+            EmbeddingPlan::provider("vllm", "other-model", "r1", Some(768)).unwrap();
+        let changed_dimensions =
+            EmbeddingPlan::provider("vllm", "vi-model", "r1", Some(1024)).unwrap();
+        assert_eq!(first.signature(768).unwrap(), same.signature(768).unwrap());
+        assert_ne!(
+            first.signature(768).unwrap(),
+            changed_model.signature(768).unwrap()
+        );
+        assert_ne!(
+            first.signature(768).unwrap(),
+            changed_dimensions.signature(1024).unwrap()
+        );
+        assert!(!format!("{first:?}").contains("https://"));
     }
 }

--- a/crates/knowledge/src/embedding.rs
+++ b/crates/knowledge/src/embedding.rs
@@ -1,5 +1,8 @@
 use std::hash::{Hash, Hasher};
 
+use sha2::{Digest, Sha256};
+use siphasher::sip::SipHasher13;
+
 use crate::identity::IndexSignature;
 use crate::query::PreparedQuery;
 use crate::{KnowledgeError, Result};
@@ -42,8 +45,49 @@ impl EmbeddingVector {
 }
 
 pub trait EmbeddingProvider {
-    fn signature(&self) -> &str;
     fn embed(&self, inputs: &[String]) -> Result<Vec<EmbeddingVector>>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderDeployment {
+    digest: String,
+}
+
+impl ProviderDeployment {
+    pub fn from_base_url(base_url: Option<&str>) -> Result<Self> {
+        let canonical = match base_url {
+            Some(value) => {
+                let mut url = url::Url::parse(value)
+                    .map_err(|_| KnowledgeError::InvalidInput("embedding base URL is invalid"))?;
+                if !matches!(url.scheme(), "http" | "https") {
+                    return Err(KnowledgeError::InvalidInput(
+                        "embedding base URL scheme is unsupported",
+                    ));
+                }
+                url.set_username("").map_err(|_| {
+                    KnowledgeError::InvalidInput("embedding base URL credentials are invalid")
+                })?;
+                url.set_password(None).map_err(|_| {
+                    KnowledgeError::InvalidInput("embedding base URL credentials are invalid")
+                })?;
+                url.set_query(None);
+                url.set_fragment(None);
+                let normalized_path = url.path().trim_end_matches('/').to_string();
+                url.set_path(if normalized_path.is_empty() {
+                    "/"
+                } else {
+                    &normalized_path
+                });
+                url.to_string()
+            }
+            None => "provider-default".to_string(),
+        };
+        let digest = Sha256::digest(canonical.as_bytes())
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect();
+        Ok(Self { digest })
+    }
 }
 
 /// Secret-free description of how vectors in an index are produced.
@@ -57,6 +101,7 @@ pub struct EmbeddingPlan {
     provider: String,
     model: String,
     revision: String,
+    deployment: ProviderDeployment,
     expected_dimensions: Option<usize>,
     normalized: bool,
 }
@@ -68,6 +113,8 @@ impl EmbeddingPlan {
             provider: "local".into(),
             model: LOCAL_EMBEDDING_MODE.into(),
             revision: "1".into(),
+            deployment: ProviderDeployment::from_base_url(None)
+                .expect("default deployment identity is valid"),
             expected_dimensions: Some(LOCAL_VECTOR_DIMENSIONS),
             normalized: true,
         }
@@ -77,6 +124,7 @@ impl EmbeddingPlan {
         provider: impl Into<String>,
         model: impl Into<String>,
         revision: impl Into<String>,
+        deployment: ProviderDeployment,
         expected_dimensions: Option<usize>,
     ) -> Result<Self> {
         let provider = provider.into();
@@ -101,6 +149,7 @@ impl EmbeddingPlan {
             provider,
             model,
             revision,
+            deployment,
             expected_dimensions,
             normalized: true,
         })
@@ -148,7 +197,10 @@ impl EmbeddingPlan {
     }
 
     fn signature_with_dimensions(&self, dimensions: usize) -> String {
-        let family = format!("{}/{}", self.provider, self.model);
+        let family = format!(
+            "{}/{}/{}",
+            self.provider, self.model, self.deployment.digest
+        );
         IndexSignature {
             embedding_family: &family,
             embedding_revision: &self.revision,
@@ -202,6 +254,21 @@ pub fn embed_checked(
 ) -> Result<Vec<EmbeddingVector>> {
     let vectors = provider.embed(inputs)?;
     validate_embedding_batch(&vectors, inputs.len(), plan.expected_dimensions())?;
+    if plan.normalized
+        && vectors.iter().any(|vector| {
+            let norm = vector
+                .values()
+                .iter()
+                .map(|value| value * value)
+                .sum::<f32>()
+                .sqrt();
+            (norm - 1.0).abs() > 0.001
+        })
+    {
+        return Err(KnowledgeError::InvalidInput(
+            "embedding vector is not L2-normalized",
+        ));
+    }
     Ok(vectors)
 }
 
@@ -234,7 +301,9 @@ pub fn local_vector(text: &str) -> EmbeddingVector {
 }
 
 fn add_feature(vector: &mut [f32], feature: &str, weight: f32) {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    // `DefaultHasher::new()` used SipHash-1-3 with zero keys in the original
+    // desktop implementation. Naming the algorithm makes local_hash_v1 stable.
+    let mut hasher = SipHasher13::new();
     feature.hash(&mut hasher);
     let hash = hasher.finish();
     let index = (hash as usize) % vector.len();
@@ -251,15 +320,10 @@ mod tests {
     use crate::{KnowledgeError, Result};
 
     struct MockProvider {
-        signature: String,
         vectors: Vec<EmbeddingVector>,
     }
 
     impl EmbeddingProvider for MockProvider {
-        fn signature(&self) -> &str {
-            &self.signature
-        }
-
         fn embed(&self, _inputs: &[String]) -> Result<Vec<EmbeddingVector>> {
             Ok(self.vectors.clone())
         }
@@ -289,15 +353,61 @@ mod tests {
             .sqrt();
         assert!((norm - 1.0).abs() < 0.0001);
 
-        let empty = local_vector("...");
-        assert!(empty.values().iter().all(|value| *value == 0.0));
+        let punctuation = local_vector("...");
+        assert_eq!(punctuation, local_vector("..."));
+        assert!(punctuation.values().iter().all(|value| value.is_finite()));
+        let sparse_bits = first
+            .values()
+            .iter()
+            .enumerate()
+            .filter(|(_, value)| **value != 0.0)
+            .map(|(index, value)| (index, value.to_bits()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            sparse_bits,
+            [
+                (3, 1031655018),
+                (15, 1049197177),
+                (24, 1031655018),
+                (26, 3179138666),
+                (45, 3196680825),
+                (46, 3179138666),
+                (97, 1031655018),
+                (111, 1031655018),
+                (121, 1031655018),
+                (132, 3179138666),
+                (135, 3179138666),
+                (141, 1054048600),
+                (160, 3203611429),
+                (170, 1049197177),
+                (188, 1031655018),
+                (191, 1054048600),
+                (195, 3179138666),
+                (212, 1031655018),
+                (229, 1054048600),
+            ]
+        );
+    }
+
+    #[test]
+    fn local_hash_v1_matches_legacy_desktop_hasher() {
+        use std::hash::{Hash, Hasher};
+
+        for feature in ["doi", "soat", "giao:dich", "gia"] {
+            let mut legacy = std::collections::hash_map::DefaultHasher::new();
+            feature.hash(&mut legacy);
+            let mut stable = siphasher::sip::SipHasher13::new();
+            feature.hash(&mut stable);
+            assert_eq!(stable.finish(), legacy.finish());
+        }
     }
 
     #[test]
     fn validates_provider_mock_count_and_dimensions() {
-        let plan = EmbeddingPlan::provider("vllm", "vi-model", "r1", Some(3)).unwrap();
+        let deployment =
+            super::ProviderDeployment::from_base_url(Some("http://embedding.internal")).unwrap();
+        let plan = EmbeddingPlan::provider("vllm", "vi-model", "r1", deployment, Some(3)).unwrap();
         let provider = MockProvider {
-            signature: plan.signature(3).unwrap(),
             vectors: vec![
                 EmbeddingVector::new(vec![1.0, 0.0, 0.0]).unwrap(),
                 EmbeddingVector::new(vec![0.0, 1.0, 0.0]).unwrap(),
@@ -322,17 +432,53 @@ mod tests {
                 actual: 3
             }
         );
+        let unnormalized = MockProvider {
+            vectors: vec![EmbeddingVector::new(vec![2.0, 0.0, 0.0]).unwrap()],
+        };
+        assert_eq!(
+            embed_checked(&unnormalized, &["một".into()], &plan).unwrap_err(),
+            KnowledgeError::InvalidInput("embedding vector is not L2-normalized")
+        );
     }
 
     #[test]
     fn provider_signature_is_secret_free_and_covers_compatibility_fields() {
-        let first = EmbeddingPlan::provider("vllm", "vi-model", "r1", Some(768)).unwrap();
-        let same = EmbeddingPlan::provider("vllm", "vi-model", "r1", Some(768)).unwrap();
-        let changed_model =
-            EmbeddingPlan::provider("vllm", "other-model", "r1", Some(768)).unwrap();
-        let changed_dimensions =
-            EmbeddingPlan::provider("vllm", "vi-model", "r1", Some(1024)).unwrap();
+        let deployment = super::ProviderDeployment::from_base_url(Some(
+            "https://user:secret@embedding.internal/v1?token=hidden",
+        ))
+        .unwrap();
+        let same_deployment =
+            super::ProviderDeployment::from_base_url(Some("https://embedding.internal/v1"))
+                .unwrap();
+        let other_deployment =
+            super::ProviderDeployment::from_base_url(Some("https://embedding.other/v1")).unwrap();
+        let first =
+            EmbeddingPlan::provider("vllm", "vi-model", "r1", deployment, Some(768)).unwrap();
+        let same =
+            EmbeddingPlan::provider("vllm", "vi-model", "r1", same_deployment, Some(768)).unwrap();
+        let changed_endpoint =
+            EmbeddingPlan::provider("vllm", "vi-model", "r1", other_deployment, Some(768)).unwrap();
+        let changed_model = EmbeddingPlan::provider(
+            "vllm",
+            "other-model",
+            "r1",
+            super::ProviderDeployment::from_base_url(None).unwrap(),
+            Some(768),
+        )
+        .unwrap();
+        let changed_dimensions = EmbeddingPlan::provider(
+            "vllm",
+            "vi-model",
+            "r1",
+            super::ProviderDeployment::from_base_url(None).unwrap(),
+            Some(1024),
+        )
+        .unwrap();
         assert_eq!(first.signature(768).unwrap(), same.signature(768).unwrap());
+        assert_ne!(
+            first.signature(768).unwrap(),
+            changed_endpoint.signature(768).unwrap()
+        );
         assert_ne!(
             first.signature(768).unwrap(),
             changed_model.signature(768).unwrap()
@@ -341,6 +487,9 @@ mod tests {
             first.signature(768).unwrap(),
             changed_dimensions.signature(1024).unwrap()
         );
-        assert!(!format!("{first:?}").contains("https://"));
+        let debug = format!("{first:?}");
+        assert!(!debug.contains("https://"));
+        assert!(!debug.contains("secret"));
+        assert!(!debug.contains("hidden"));
     }
 }

--- a/crates/knowledge/src/error.rs
+++ b/crates/knowledge/src/error.rs
@@ -4,6 +4,10 @@ pub enum KnowledgeError {
     InvalidInput(&'static str),
     #[error("knowledge index is incompatible: {0}")]
     IncompatibleIndex(&'static str),
+    #[error("embedding count mismatch: expected {expected}, received {actual}")]
+    EmbeddingCountMismatch { expected: usize, actual: usize },
+    #[error("embedding dimension mismatch: expected {expected}, received {actual}")]
+    EmbeddingDimensionMismatch { expected: usize, actual: usize },
     #[error("knowledge adapter is unavailable: {0}")]
     AdapterUnavailable(&'static str),
 }

--- a/crates/knowledge/src/query.rs
+++ b/crates/knowledge/src/query.rs
@@ -1,5 +1,7 @@
 use crate::{KnowledgeError, Result};
 
+pub const MIN_QUERY_TOKEN_CHARS: usize = 2;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SearchQuery {
     pub text: String,
@@ -21,5 +23,86 @@ impl SearchQuery {
             source_scope,
             limit,
         })
+    }
+}
+
+/// Query representation shared by lexical and local-vector retrieval.
+///
+/// The normalized form intentionally delegates to the established core
+/// accent-folding implementation so extraction does not change desktop search.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedQuery {
+    pub normalized: String,
+    pub tokens: Vec<String>,
+    pub fts5: String,
+}
+
+impl PreparedQuery {
+    pub fn new(text: &str) -> Self {
+        let normalized = fileconv_core::intelligence::normalize_search_text(text);
+        let tokens = tokens_from_normalized(&normalized);
+        let fts5 = tokens
+            .iter()
+            .map(|token| format!("\"{token}\"*"))
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        Self {
+            normalized,
+            tokens,
+            fts5,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+}
+
+pub fn normalized_tokens(text: &str) -> Vec<String> {
+    PreparedQuery::new(text).tokens
+}
+
+pub fn fts5_prefix_query(text: &str) -> String {
+    PreparedQuery::new(text).fts5
+}
+
+fn tokens_from_normalized(normalized: &str) -> Vec<String> {
+    normalized
+        .split(|character: char| !character.is_alphanumeric())
+        .filter(|token| token.chars().count() >= MIN_QUERY_TOKEN_CHARS)
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{fts5_prefix_query, normalized_tokens, PreparedQuery, SearchQuery};
+
+    #[test]
+    fn prepares_vietnamese_query_with_desktop_parity() {
+        let query = PreparedQuery::new("Đối soát GIAO DỊCH");
+        assert_eq!(query.normalized, "doi soat giao dich");
+        assert_eq!(query.tokens, ["doi", "soat", "giao", "dich"]);
+        assert_eq!(query.fts5, r#""doi"* OR "soat"* OR "giao"* OR "dich"*"#,);
+    }
+
+    #[test]
+    fn punctuation_and_fts_operators_are_data_not_syntax() {
+        assert_eq!(
+            fts5_prefix_query(r#"API: "xác thực" OR (giao dịch) - NEAR"#),
+            r#""api"* OR "xac"* OR "thuc"* OR "or"* OR "giao"* OR "dich"* OR "near"*"#,
+        );
+    }
+
+    #[test]
+    fn empty_and_punctuation_only_queries_are_safe() {
+        for value in ["", " \n\t ", "\"'()[]{}:;!?.,-"] {
+            let query = PreparedQuery::new(value);
+            assert!(query.is_empty());
+            assert!(query.fts5.is_empty());
+            assert!(normalized_tokens(value).is_empty());
+        }
+        assert!(SearchQuery::new("...", vec![], 10).is_ok());
+        assert!(SearchQuery::new(" ", vec![], 10).is_err());
     }
 }

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -78,7 +78,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 
 ## P1A-05 — Query, local vectors và embedding plan
 
-- **Status:** Ready — shared DTO đã đạt; tích hợp signature vẫn phụ thuộc P1A-04.
+- **Status:** Review — triển khai và kiểm thử hoàn tất trong PR #190; chờ merge.
 - **Objective:** Tách pure query/embedding preparation.
 - **Plan:** Normalization, feature hash/vector norm, provider plan, dimension check,
   FTS escape; HTTP client vẫn ở core; giữ local fallback semantics.

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "96c372c41950f97f";
+    const ROADMAP_SOURCE_HASH = "69d3b591b6f23bd5";
     const phases = [
       {
         "id": "phase-f",
@@ -1082,7 +1082,7 @@
           [
             "P1A-05",
             "Query, local vectors và embedding plan",
-            "ready"
+            "review"
           ],
           [
             "P1A-06",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Completes P1A-05 pure query and embedding preparation extraction into `fileconv-knowledge` while preserving desktop local fallback and retrieval behavior.

## Scope

- Add Vietnamese-safe normalization, tokenization, and FTS5 prefix preparation.
- Add deterministic `local_hash_v1` vectors with explicit SipHash-1-3 and golden parity values.
- Add provider batch/dimension/normalization validation and durable index signatures.
- Derive endpoint deployment identity while stripping credentials, query strings, and fragments.
- Handle unknown dimensions and empty documents without poisoning provider metadata.
- Delegate desktop query/local-vector preparation to the shared crate; HTTP remains in `fileconv-core`.

## Evidence

- [x] Tests: `cargo test -p fileconv-knowledge --all-features` — 13 passed.
- [x] Tests: `cargo test -p fileconv-desktop knowledge::tests` — 17 passed.
- [x] Manual/benchmark/migration evidence: local legacy hasher parity and golden vector; provider endpoint/credential, fallback redaction, dimension mismatch, and empty-document recovery tests pass.

## Boundary and security review

- [x] Dependency boundary check passed.
- [x] Tenant/ACL impact reviewed: N/A.
- [x] Sensitive logging/secret/egress impact reviewed: credentials and raw URLs are absent from signatures/errors.
- [x] Security review trigger checked.

## Follow-up

- [x] Roadmap moved P1A-05 to Review; mark Done and activate P1A-06 after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

