### PR TITLE
test: add Phase 1A extraction gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: make check-rust
-      - run: make check-knowledge-extraction
-      - run: make check-rust-tests
+      - run: make check-knowledge-extraction-rust
 
   frontend:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: make check-rust
-      - run: make check-knowledge-features
+      - run: make check-knowledge-extraction
       - run: make check-rust-tests
 
   frontend:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ SHELL := /bin/bash
 
 .PHONY: install check-toolchain check-static check-boundaries check-migrations \
 	check-fixtures check-markhand-gates check-roadmap check-dependencies check-rust check-rust-tests \
-	check-knowledge-features check-knowledge-extraction check-web check-desktop check-foundation bundle-linux dev-up dev-health dev-down dev-reset
+	check-knowledge-features check-knowledge-extraction check-knowledge-extraction-rust \
+	check-web check-desktop check-foundation bundle-linux dev-up dev-health dev-down dev-reset
 
 install:
 	pnpm install --frozen-lockfile
@@ -49,6 +50,9 @@ check-knowledge-features:
 check-knowledge-extraction:
 	bash scripts/check-knowledge-extraction.sh
 
+check-knowledge-extraction-rust:
+	bash scripts/check-knowledge-extraction.sh --rust-only
+
 check-rust-tests:
 	cargo test -p fileconv-core
 	cargo test -p fileconv-core --features llm llm
@@ -67,7 +71,7 @@ check-desktop:
 	pnpm --filter markhand-desktop test
 	pnpm --filter markhand-desktop build
 
-check-foundation: check-toolchain check-static check-rust check-knowledge-extraction check-rust-tests check-web check-desktop
+check-foundation: check-toolchain check-static check-rust check-knowledge-extraction check-web
 
 bundle-linux:
 	pnpm --dir app tauri build --bundles deb --no-sign --ci

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 .PHONY: install check-toolchain check-static check-boundaries check-migrations \
 	check-fixtures check-markhand-gates check-roadmap check-dependencies check-rust check-rust-tests \
-	check-knowledge-features check-web check-desktop check-foundation bundle-linux dev-up dev-health dev-down dev-reset
+	check-knowledge-features check-knowledge-extraction check-web check-desktop check-foundation bundle-linux dev-up dev-health dev-down dev-reset
 
 install:
 	pnpm install --frozen-lockfile
@@ -46,6 +46,9 @@ check-rust:
 check-knowledge-features:
 	bash scripts/check-knowledge-features.sh
 
+check-knowledge-extraction:
+	bash scripts/check-knowledge-extraction.sh
+
 check-rust-tests:
 	cargo test -p fileconv-core
 	cargo test -p fileconv-core --features llm llm
@@ -64,7 +67,7 @@ check-desktop:
 	pnpm --filter markhand-desktop test
 	pnpm --filter markhand-desktop build
 
-check-foundation: check-toolchain check-static check-rust check-knowledge-features check-rust-tests check-web check-desktop
+check-foundation: check-toolchain check-static check-rust check-knowledge-extraction check-rust-tests check-web check-desktop
 
 bundle-linux:
 	pnpm --dir app tauri build --bundles deb --no-sign --ci

--- a/app/src-tauri/src/knowledge.rs
+++ b/app/src-tauri/src/knowledge.rs
@@ -19,6 +19,14 @@ use tauri::State;
 
 use super::{data_root, es, resolve_within, AppState};
 
+#[cfg(test)]
+pub(crate) const KNOWLEDGE_COMMAND_NAMES: [&str; 4] = [
+    "rebuild_knowledge_index",
+    "knowledge_index_stats",
+    "hybrid_search",
+    "hybrid_ask",
+];
+
 #[derive(Debug, Clone)]
 struct EmbeddingPlan {
     shared: DesktopEmbeddingPlan,

--- a/app/src-tauri/src/knowledge_contract.rs
+++ b/app/src-tauri/src/knowledge_contract.rs
@@ -82,3 +82,21 @@ fn score_contract_uses_epsilon_and_exact_hit_order() {
     assert!((response.hits[0].rerank_score - 1.875).abs() <= 0.0001);
     assert_eq!(response.hits[0].anchor.page, Some(7));
 }
+
+#[test]
+fn backend_handler_registers_every_frozen_knowledge_command() {
+    let handler_source = include_str!("lib.rs");
+    let expected = [
+        "rebuild_knowledge_index",
+        "knowledge_index_stats",
+        "hybrid_search",
+        "hybrid_ask",
+    ];
+    assert_eq!(crate::knowledge::KNOWLEDGE_COMMAND_NAMES, expected);
+    for command in expected {
+        assert!(
+            handler_source.contains(&format!("knowledge::{command}")),
+            "missing backend registration for {command}"
+        );
+    }
+}

--- a/app/src/lib/knowledgeContract.test.ts
+++ b/app/src/lib/knowledgeContract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import askRequest from "../../src-tauri/fixtures/knowledge/v1/requests/ask.json";
 import rebuildRequest from "../../src-tauri/fixtures/knowledge/v1/requests/rebuild.json";
 import searchRequest from "../../src-tauri/fixtures/knowledge/v1/requests/search.json";
@@ -7,6 +7,7 @@ import fallbackResponse from "../../src-tauri/fixtures/knowledge/v1/responses/as
 import rebuildResponse from "../../src-tauri/fixtures/knowledge/v1/responses/rebuild.json";
 import searchResponse from "../../src-tauri/fixtures/knowledge/v1/responses/search.json";
 import statsResponse from "../../src-tauri/fixtures/knowledge/v1/responses/stats.json";
+import { api } from "./ipc";
 import type {
   GroundedAnswer,
   HybridAskRequest,
@@ -17,7 +18,40 @@ import type {
   KnowledgeIndexStats,
 } from "./types";
 
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+
 describe("desktop knowledge IPC v1", () => {
+  beforeEach(() => invoke.mockReset());
+
+  it("invokes production wrappers with frozen command names and payloads", async () => {
+    invoke.mockResolvedValue(undefined);
+    await api.rebuildKnowledgeIndex(["payments.pdf", "security.docx"]);
+    await api.knowledgeIndexStats();
+    await api.hybridSearch(["payments.pdf"], "đối soát", 5);
+    await api.hybridAsk(["payments.pdf"], "Khi nào?", 3, true);
+
+    expect(invoke.mock.calls).toEqual([
+      [
+        "rebuild_knowledge_index",
+        { req: { sourceRels: ["payments.pdf", "security.docx"] } },
+      ],
+      ["knowledge_index_stats"],
+      ["hybrid_search", { req: { sourceRels: ["payments.pdf"], query: "đối soát", limit: 5 } }],
+      [
+        "hybrid_ask",
+        {
+          req: {
+            sourceRels: ["payments.pdf"],
+            question: "Khi nào?",
+            topK: 3,
+            useLlm: true,
+          },
+        },
+      ],
+    ]);
+  });
+
   it("freezes request wrappers and camelCase keys", () => {
     expect(rebuildRequest.command).toBe("rebuild_knowledge_index");
     expectTypeOf(rebuildRequest.args.req).toMatchTypeOf<IndexRequest>();

--- a/crates/knowledge/src/desktop/service.rs
+++ b/crates/knowledge/src/desktop/service.rs
@@ -508,3 +508,60 @@ fn answer(
         warnings,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_paths() -> KnowledgePaths {
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("markhand_service_{}_{}", std::process::id(), id));
+        KnowledgePaths::new(root.join(".markhand/knowledge.sqlite"), root)
+    }
+
+    fn document() -> CorpusDocument {
+        CorpusDocument {
+            source_rel: "payments.pdf".into(),
+            md_rel: "payments.pdf.md".into(),
+            format: "pdf".into(),
+            markdown: "# Đối soát\n\nGiao dịch được đối soát mỗi ngày.".into(),
+        }
+    }
+
+    #[test]
+    fn provider_signature_change_emits_explicit_rebuild_notice() {
+        let paths = temp_paths();
+        rebuild_index(
+            &paths,
+            &[document()],
+            &DesktopEmbeddingPlan::local(),
+            false,
+            |_| Err(KnowledgeError::EmbeddingProviderFailure),
+        )
+        .unwrap();
+        let provider = DesktopEmbeddingPlan::provider(
+            "openai-compatible",
+            "replacement-model",
+            Some("https://embedding.internal/v1"),
+            Some(LOCAL_VECTOR_DIMENSIONS),
+        )
+        .unwrap();
+        let result = rebuild_index(&paths, &[document()], &provider, false, |inputs| {
+            Ok(inputs
+                .iter()
+                .map(|input| local_vector(input).into_values())
+                .collect())
+        })
+        .unwrap();
+        assert!(result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("Embedding signature thay đổi")));
+        let _ = std::fs::remove_dir_all(paths.ann_root);
+    }
+}

--- a/crates/knowledge/src/desktop/service.rs
+++ b/crates/knowledge/src/desktop/service.rs
@@ -166,6 +166,10 @@ fn rebuild_once(
         || hnsw::clear(&paths.ann_root),
     )?;
     let mut warnings = Vec::new();
+    if stored.replaced_incompatible_index {
+        warnings
+            .push("Embedding signature thay đổi; đã rebuild knowledge index tương thích.".into());
+    }
     if stored.indexed > 0
         || !hnsw::is_available(
             &paths.ann_root,

--- a/crates/knowledge/src/desktop/sqlite.rs
+++ b/crates/knowledge/src/desktop/sqlite.rs
@@ -45,6 +45,7 @@ pub struct StoreIndexResult {
     pub indexed: usize,
     pub skipped: usize,
     pub metadata: IndexMetadata,
+    pub replaced_incompatible_index: bool,
 }
 
 pub struct SqliteKnowledgeStore {
@@ -378,6 +379,7 @@ impl SqliteKnowledgeStore {
             indexed,
             skipped,
             metadata,
+            replaced_incompatible_index: cleared,
         })
     }
 
@@ -878,6 +880,45 @@ mod tests {
         assert_eq!(store.document_count().unwrap(), 1);
         assert_eq!(store.chunk_count().unwrap(), 1);
         assert_eq!(store.metadata().unwrap().signature, LOCAL_EMBEDDING_MODE);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn incompatible_signature_reports_rebuild_after_atomic_commit() {
+        let path = temp_path("signature_rebuild");
+        let mut store = SqliteKnowledgeStore::open(&path).unwrap();
+        index(
+            &mut store,
+            &[document("# Đối soát\n\nGiao dịch được đối soát mỗi ngày.")],
+        );
+        let replacement = IndexMetadata {
+            mode: "provider_v1".into(),
+            provider: "mock".into(),
+            model: "mock-model".into(),
+            dimensions: LOCAL_VECTOR_DIMENSIONS,
+            signature: "replacement-signature".into(),
+        };
+        let mut cleared = false;
+        let result = store
+            .index_documents(
+                &[document("# Thay đổi\n\nNội dung mới.")],
+                replacement,
+                None,
+                |inputs| {
+                    Ok(inputs
+                        .iter()
+                        .map(|input| local_vector(input).into_values())
+                        .collect())
+                },
+                || {
+                    cleared = true;
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert!(result.replaced_incompatible_index);
+        assert!(cleared);
+        assert_eq!(store.metadata().unwrap().signature, "replacement-signature");
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/server/tests/knowledge_consumer.rs
+++ b/crates/server/tests/knowledge_consumer.rs
@@ -1,0 +1,50 @@
+use std::collections::HashSet;
+
+use fileconv_knowledge::ask::{extractive_answer, valid_citation_ids};
+use fileconv_knowledge::citation::{infer_source_anchor, validate_grounded_answer};
+use fileconv_knowledge::query::PreparedQuery;
+use fileconv_knowledge::rank::hybrid_rerank_score;
+use fileconv_knowledge::types::{HybridSearchHit, SourceAnchor};
+
+#[test]
+fn server_consumes_default_knowledge_api_without_desktop_features() {
+    let query = PreparedQuery::new("đối soát giao dịch");
+    let score = hybrid_rerank_score(
+        Some(0),
+        Some(0),
+        0.75,
+        &query.tokens,
+        "Đối soát",
+        "Đối soát giao theo ngày",
+    );
+    let anchor = infer_source_anchor("pdf", "Đối soát", Some(7), 12, 68);
+    let hits = vec![HybridSearchHit {
+        chunk_id: "server-chunk-1".into(),
+        source_rel: "payments.pdf".into(),
+        md_rel: "payments.pdf.md".into(),
+        heading: "Đối soát".into(),
+        snippet: "Đối soát giao theo ngày".into(),
+        lexical_score: 1.25,
+        vector_score: 0.75,
+        rerank_score: score,
+        anchor,
+    }];
+    let answer = extractive_answer("Đối soát khi nào?", &hits);
+
+    assert!((score - 1.875).abs() < 0.0001);
+    assert_eq!(
+        hits[0].anchor,
+        SourceAnchor {
+            page: Some(7),
+            slide: None,
+            sheet: None,
+            start: 12,
+            end: 68,
+        }
+    );
+    assert!(validate_grounded_answer(&answer, &valid_citation_ids(1)).is_ok());
+    assert_eq!(
+        valid_citation_ids(1),
+        HashSet::from(["CITE-0001".to_string()])
+    );
+}

--- a/docs/adr/0001-web-boundaries.md
+++ b/docs/adr/0001-web-boundaries.md
@@ -44,6 +44,8 @@ trở thành dependency/path dependency.
 ## Consequences
 
 - Tách `fileconv-knowledge` ở Phase 1A, không copy RAG desktop vào server.
+- SQLite/HNSW desktop adapters chỉ tồn tại sau opt-in features; default/server tree
+  không kéo các dependency này.
 - Server cần interface adapter cho PostgreSQL/Qdrant/MinIO; generic trait chỉ được tạo
   khi có ít nhất hai consumer thực tế.
 - Mọi business repository API ở web server bắt buộc truyền `OrgContext`; missing scope
@@ -65,4 +67,5 @@ trở thành dependency/path dependency.
 
 - `python3 scripts/check-architecture-boundaries.py`
 - `python3 scripts/check-architecture-boundaries.py --self-test`
+- `make check-knowledge-extraction`
 - Review theo `docs/conventions/dependencies.md` và CODEOWNERS.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -2,3 +2,7 @@
 
 Phase F-08 and later add local setup, backup/restore, incident and release runbooks.
 Each runbook must state prerequisites, commands, expected evidence and rollback.
+
+- [Local development](local-development.md)
+- [Contributor setup](contributor-setup.md)
+- [Knowledge index compatibility](knowledge-index-compatibility.md)

--- a/docs/runbooks/knowledge-index-compatibility.md
+++ b/docs/runbooks/knowledge-index-compatibility.md
@@ -1,0 +1,51 @@
+# Knowledge index compatibility
+
+## Stable desktop locations
+
+- SQLite authority: `<DATA>/.markhand/knowledge.sqlite`
+- HNSW cache: `<DATA>/.markhand/vector-index/<legacy-partition>`
+- Existing `local_hash_v1` indexes retain their legacy signature and partition hash.
+
+Tauri continues to path-jail `<DATA>/.markhand` before passing the database path and
+ANN root to `fileconv-knowledge`. Shared adapters never discover the data root.
+
+## Migration behavior
+
+- SQLite opens legacy databases additively. Missing `documents.embedding_signature`
+  and `chunks.vector_dims` columns are added without deleting rows.
+- Legacy local vectors remain readable without a forced rebuild.
+- Provider signatures now include model, dimensions, normalization, revision, and a
+  credential-free deployment identity. An incompatible provider signature triggers
+  one atomic SQLite rebuild and the response warning:
+  `Embedding signature thay đổi; đã rebuild knowledge index tương thích.`
+- HNSW is a disposable cache. Missing, corrupt, mismatched, oversized, or panicking
+  cache data falls back to exact cosine and is rebuilt from SQLite.
+- Interrupted HNSW directory replacement restores the last `.old` generation under
+  the cache lock.
+
+Committed synthetic fixtures cover the legacy SQLite database and the complete HNSW
+manifest/data/graph set. Fixture checksums are registered in
+`crates/knowledge/fixtures/manifest.json`.
+
+## Recovery
+
+1. Keep the original source files and Markdown sidecars.
+2. If SQLite reports incompatible vectors, use the desktop rebuild command.
+3. HNSW can be removed independently; the next index/search cycle rebuilds it.
+4. Never copy a provider index between deployments unless their signatures match.
+
+## Deferred concurrency/performance work
+
+SQLite is authoritative and detects concurrent commits while embeddings are prepared,
+returning a safe retry instead of partially writing. HNSW generation ordering across
+multiple independent desktop processes remains a cache-level optimization concern;
+search falls back to exact cosine when candidates are missing or incompatible. Tuning,
+cross-process generation epochs, and large-corpus performance belong to a dedicated
+post-extraction backlog and do not change Phase 1A contracts.
+
+## Verification
+
+```bash
+make check-knowledge-extraction
+make check-desktop
+```

--- a/docs/runbooks/knowledge-index-compatibility.md
+++ b/docs/runbooks/knowledge-index-compatibility.md
@@ -49,3 +49,8 @@ post-extraction backlog and do not change Phase 1A contracts.
 make check-knowledge-extraction
 make check-desktop
 ```
+
+For the Phase 1A closeout, these gates were run successfully on the Cloud Agent
+Linux environment. GitHub-hosted jobs were denied before their first step by the
+repository billing/spending limit; they did not report a code or test failure. Rerun
+the existing CI workflow when hosted runners are restored to attach remote evidence.

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -136,7 +136,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 
 ## P1A-09 — Thin Tauri adapters
 
-- **Status:** Review — thin adapters and backend/frontend parity gates passed.
+- **Status:** Done — merged to `master` with backend/frontend IPC parity.
 - **Objective:** Desktop commands delegate shared crate, IPC giữ nguyên.
 - **Plan:** Tauri giữ state/settings/path load/spawn_blocking/error mapping; delegate
   rebuild/stats/search/ask; retain legacy commands; remove duplicate only sau parity.
@@ -151,7 +151,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 
 ## P1A-10 — CI parity và extraction gate
 
-- **Status:** Blocked bởi P1A-09.
+- **Status:** In progress — wiring the final feature, consumer and compatibility gate.
 - **Objective:** Chứng minh desktop equivalence và server usability.
 - **Plan:** Full feature/contract/golden matrix; no-feature server consumer test;
   dependency deny-list; docs compatibility; file perf/concurrency defects riêng.

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -151,7 +151,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 
 ## P1A-10 — CI parity và extraction gate
 
-- **Status:** In progress — wiring the final feature, consumer and compatibility gate.
+- **Status:** Review — full local extraction gate passed; hosted CI awaits billing restore.
 - **Objective:** Chứng minh desktop equivalence và server usability.
 - **Plan:** Full feature/contract/golden matrix; no-feature server consumer test;
   dependency deny-list; docs compatibility; file perf/concurrency defects riêng.

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "adba924527f789e2";
+    const ROADMAP_SOURCE_HASH = "ff4d7f7adf022a18";
     const phases = [
       {
         "id": "phase-f",
@@ -1102,12 +1102,12 @@
           [
             "P1A-09",
             "Thin Tauri adapters",
-            "review"
+            "done"
           ],
           [
             "P1A-10",
             "CI parity và extraction gate",
-            "blocked"
+            "in_progress"
           ]
         ]
       },

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "ff4d7f7adf022a18";
+    const ROADMAP_SOURCE_HASH = "cfe99c50beb32039";
     const phases = [
       {
         "id": "phase-f",
@@ -1107,7 +1107,7 @@
           [
             "P1A-10",
             "CI parity và extraction gate",
-            "in_progress"
+            "review"
           ]
         ]
       },

--- a/scripts/check-architecture-boundaries.py
+++ b/scripts/check-architecture-boundaries.py
@@ -91,6 +91,43 @@ def validate(root: Path, *, cargo_dependencies=direct_dependencies) -> list[str]
                     f"crates/knowledge desktop dependency must be optional: {dependency}"
                 )
 
+    desktop_knowledge = root / "app/src-tauri/src/knowledge.rs"
+    if desktop_knowledge.is_file():
+        content = desktop_knowledge.read_text(encoding="utf-8")
+        for forbidden in (
+            "rusqlite::",
+            "hnsw_rs::",
+            "fn cosine(",
+            "fn hybrid_rerank_score(",
+            "fn extractive_answer(",
+            "fn answer_is_grounded(",
+            "CREATE TABLE",
+            "chunks_fts MATCH",
+        ):
+            if forbidden in content:
+                failures.append(
+                    f"desktop knowledge adapter contains extracted implementation: {forbidden}"
+                )
+        for required in (
+            "service::rebuild_index",
+            "service::hybrid_search",
+            "service::index_stats",
+            "service::grounded_answer",
+        ):
+            if required not in content:
+                failures.append(f"desktop knowledge adapter does not delegate {required}")
+        if (root / "app/src-tauri/src/vector_index.rs").exists():
+            failures.append("legacy desktop vector_index.rs must remain extracted")
+
+    knowledge_service = root / "crates/knowledge/src/desktop/service.rs"
+    if knowledge_service.is_file():
+        content = knowledge_service.read_text(encoding="utf-8")
+        for forbidden in ("tauri::", "AppState", "data_root", "resolve_within", "Settings"):
+            if forbidden in content:
+                failures.append(
+                    f"knowledge desktop service imports app boundary: {forbidden}"
+                )
+
     server_manifest = root / "crates/server/Cargo.toml"
     if server_manifest.is_file() and "fileconv-desktop" in cargo_dependencies(server_manifest):
         failures.append("crates/server không được depend ngược vào fileconv-desktop")
@@ -156,6 +193,17 @@ class BoundaryCheckTests(unittest.TestCase):
             )
             failures = validate(root, cargo_dependencies=lambda _: {"rusqlite"})
             self.assertTrue(any("must be optional" in failure for failure in failures))
+
+    def test_rejects_fat_desktop_knowledge_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "Cargo.toml").write_text("[workspace]\n")
+            adapter = root / "app/src-tauri/src/knowledge.rs"
+            adapter.parent.mkdir(parents=True)
+            adapter.write_text("fn cosine() {} // rusqlite::Connection\n")
+            failures = validate(root, cargo_dependencies=lambda _: set())
+            self.assertTrue(any("extracted implementation" in failure for failure in failures))
+            self.assertTrue(any("does not delegate" in failure for failure in failures))
 
 
 def main() -> int:

--- a/scripts/check-architecture-boundaries.py
+++ b/scripts/check-architecture-boundaries.py
@@ -56,6 +56,10 @@ def direct_dependencies(manifest: Path) -> set[str]:
 def rust_files(path: Path) -> list[Path]:
     return list(path.rglob("*.rs")) if path.is_dir() else []
 
+def rust_without_comments(content: str) -> str:
+    content = re.sub(r"/\*.*?\*/", "", content, flags=re.DOTALL)
+    return re.sub(r"//.*$", "", content, flags=re.MULTILINE)
+
 
 def validate(root: Path, *, cargo_dependencies=direct_dependencies) -> list[str]:
     failures: list[str] = []
@@ -94,17 +98,23 @@ def validate(root: Path, *, cargo_dependencies=direct_dependencies) -> list[str]
     desktop_knowledge = root / "app/src-tauri/src/knowledge.rs"
     if desktop_knowledge.is_file():
         content = desktop_knowledge.read_text(encoding="utf-8")
+        production = rust_without_comments(
+            re.split(r"#\[cfg\(test\)\]\s*mod tests", content, maxsplit=1)[0]
+        )
         for forbidden in (
             "rusqlite::",
             "hnsw_rs::",
-            "fn cosine(",
-            "fn hybrid_rerank_score(",
-            "fn extractive_answer(",
-            "fn answer_is_grounded(",
+            "HashMap",
+            "SqliteKnowledgeStore",
+            "StoredChunk",
+            "iter().zip(",
+            "lexical_ranks(",
+            ".load_chunks(",
+            "sort_by(",
             "CREATE TABLE",
             "chunks_fts MATCH",
         ):
-            if forbidden in content:
+            if forbidden in production:
                 failures.append(
                     f"desktop knowledge adapter contains extracted implementation: {forbidden}"
                 )
@@ -114,8 +124,10 @@ def validate(root: Path, *, cargo_dependencies=direct_dependencies) -> list[str]
             "service::index_stats",
             "service::grounded_answer",
         ):
-            if required not in content:
+            if not re.search(rf"\b{re.escape(required)}\s*\(", production):
                 failures.append(f"desktop knowledge adapter does not delegate {required}")
+        if production.count("\n") + 1 > 360:
+            failures.append("desktop knowledge adapter production section exceeds 360 lines")
         if (root / "app/src-tauri/src/vector_index.rs").exists():
             failures.append("legacy desktop vector_index.rs must remain extracted")
 
@@ -200,7 +212,15 @@ class BoundaryCheckTests(unittest.TestCase):
             (root / "Cargo.toml").write_text("[workspace]\n")
             adapter = root / "app/src-tauri/src/knowledge.rs"
             adapter.parent.mkdir(parents=True)
-            adapter.write_text("fn cosine() {} // rusqlite::Connection\n")
+            adapter.write_text(
+                "// service::rebuild_index()\n"
+                "// service::hybrid_search()\n"
+                "// service::index_stats()\n"
+                "// service::grounded_answer()\n"
+                "fn copied_similarity(a: &[f32], b: &[f32]) {\n"
+                "  a.iter().zip(b).map(|(x, y)| x * y).sum();\n"
+                "}\n"
+            )
             failures = validate(root, cargo_dependencies=lambda _: set())
             self.assertTrue(any("extracted implementation" in failure for failure in failures))
             self.assertTrue(any("does not delegate" in failure for failure in failures))

--- a/scripts/check-knowledge-extraction.sh
+++ b/scripts/check-knowledge-extraction.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bash scripts/check-knowledge-features.sh
+cargo test -p fileconv-server --test knowledge_consumer
+cargo test -p fileconv-desktop knowledge_contract
+cargo test -p fileconv-desktop knowledge::tests
+python3 scripts/check-architecture-boundaries.py
+python3 scripts/check-fixtures.py --root crates/knowledge/fixtures
+python3 scripts/build-roadmap.py --check
+
+echo "Phase 1A knowledge extraction gate passed"

--- a/scripts/check-knowledge-extraction.sh
+++ b/scripts/check-knowledge-extraction.sh
@@ -1,12 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+rust_only=false
+if [[ "${1:-}" == "--rust-only" ]]; then
+  rust_only=true
+elif [[ $# -ne 0 ]]; then
+  echo "usage: $0 [--rust-only]" >&2
+  exit 2
+fi
+
 bash scripts/check-knowledge-features.sh
-cargo test -p fileconv-server --test knowledge_consumer
-cargo test -p fileconv-desktop knowledge_contract
-cargo test -p fileconv-desktop knowledge::tests
+cargo test -p fileconv-core
+cargo test -p fileconv-core --features llm llm
+cargo test -p fileconv-cli metrics
+cargo test -p fileconv-server
+cargo test -p fileconv-desktop
 python3 scripts/check-architecture-boundaries.py
-python3 scripts/check-fixtures.py --root crates/knowledge/fixtures
+make check-fixtures
 python3 scripts/build-roadmap.py --check
+
+if [[ "$rust_only" == false ]]; then
+  pnpm --filter markhand-desktop test
+  pnpm --filter markhand-desktop build
+fi
 
 echo "Phase 1A knowledge extraction gate passed"

--- a/scripts/check-knowledge-features.sh
+++ b/scripts/check-knowledge-features.sh
@@ -3,18 +3,27 @@ set -euo pipefail
 
 cargo check -p fileconv-knowledge --no-default-features
 cargo test -p fileconv-knowledge --no-default-features
+cargo check -p fileconv-knowledge --no-default-features --features desktop-sqlite
+cargo check -p fileconv-knowledge --no-default-features --features desktop-hnsw
 cargo check -p fileconv-knowledge --all-features
 cargo test -p fileconv-knowledge --all-features
 
 default_tree="$(cargo tree -p fileconv-knowledge --no-default-features -e normal --prefix none)"
-if grep -Eq '^(rusqlite|hnsw_rs) ' <<<"$default_tree"; then
+if grep -Eq '^(fs2|rusqlite|hnsw_rs) ' <<<"$default_tree"; then
   echo "default fileconv-knowledge tree includes desktop adapter dependencies" >&2
   exit 1
 fi
 
 all_tree="$(cargo tree -p fileconv-knowledge --all-features -e normal --prefix none)"
+grep -Eq '^fs2 ' <<<"$all_tree"
 grep -Eq '^rusqlite ' <<<"$all_tree"
 grep -Eq '^hnsw_rs ' <<<"$all_tree"
+
+server_tree="$(cargo tree -p fileconv-server -e normal --prefix none)"
+if grep -Eq '^(fs2|hnsw_rs|rusqlite|tauri) ' <<<"$server_tree"; then
+  echo "fileconv-server default tree includes desktop dependencies" >&2
+  exit 1
+fi
 
 python3 scripts/check-architecture-boundaries.py
 echo "fileconv-knowledge feature matrix valid"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Completes the P1A-10 extraction gate proving desktop parity, optional adapter boundaries, legacy compatibility, production IPC wiring, and default server consumption.

## Scope

- Server default-feature consumer and dependency-tree deny-list.
- No-feature, individual SQLite/HNSW feature, and all-feature matrices.
- Full core, LLM, CLI metrics, server, desktop backend, desktop frontend test/build gate.
- Production `ipc.ts` invoke command/payload tests and backend handler registration test.
- Static thin-adapter/service boundary enforcement with regression tests.
- User-facing provider-signature rebuild warning with behavior test.
- Compatibility/recovery runbook and explicit hosted-CI billing caveat.

## Evidence

- [x] `make check-knowledge-extraction` passed end-to-end.
- [x] Knowledge: no-feature 23 + golden; all-feature 42 + golden.
- [x] Server complete tests including default knowledge consumer passed.
- [x] Desktop backend complete suite passed; production IPC wrappers tested.
- [x] Desktop frontend 40 tests and TypeScript/Vite build passed.
- [x] Core/core-LLM/CLI metrics, Rust quality, fixtures, dependencies, roadmap, and architecture checks passed.
- [x] Hosted GitHub jobs are denied before step 1 by billing/spending limits; documented for rerun and not a code/test failure.

## Boundary and security review

- [x] Default server/knowledge trees exclude fs2, HNSW, SQLite, and Tauri.
- [x] Optional feature combinations compile independently.
- [x] Synthetic fixture licenses/checksums/sensitivity pass.
- [x] Path jail, secret-safe errors, untrusted source framing, and recovery behavior covered.

## Follow-up

- [x] P1A-10 is in Review; after merge, closeout marks Phase 1A 10/10 Done.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

