### PR TITLE
ci: run expensive checks only when relevant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,51 +8,38 @@ on:
 permissions:
   contents: read
 
+# Một ref chỉ cần run mới nhất. Commit mới trên cùng PR sẽ hủy run cũ.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  architecture-boundaries:
+  changes-and-static:
     runs-on: ubuntu-22.04
+    outputs:
+      rust: ${{ steps.changes.outputs.rust }}
+      knowledge: ${{ steps.changes.outputs.knowledge }}
+      frontend: ${{ steps.changes.outputs.frontend }}
+      web: ${{ steps.changes.outputs.web }}
+      dev_stack: ${{ steps.changes.outputs.dev_stack }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - run: make check-boundaries
-
-  migrations:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - run: make check-migrations
-
-  fixtures:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - run: make check-fixtures
-      - run: make check-markhand-gates
-
-  dependencies:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
-          toolchain: 1.88.0
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 10.33.3
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
-      - run: bash scripts/check-foundation-gate.sh
-
-  roadmap:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - run: make check-roadmap
+          fetch-depth: 0
+      - id: changes
+        name: Classify changed paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          python3 scripts/classify-ci-changes.py \
+            --base "$BASE_SHA" \
+            --head HEAD \
+            --github-output "$GITHUB_OUTPUT"
+      - run: bash scripts/check-foundation-gate.sh --static-only
 
   rust:
+    needs: changes-and-static
+    if: github.event_name == 'pull_request' && needs.changes-and-static.outputs.rust == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -68,16 +55,26 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: make check-rust
-      - run: make check-knowledge-extraction-rust
+      - name: Run affected Rust test gate
+        env:
+          KNOWLEDGE_CHANGED: ${{ needs.changes-and-static.outputs.knowledge }}
+        run: |
+          if [[ "$KNOWLEDGE_CHANGED" == "true" ]]; then
+            make check-knowledge-extraction-rust
+          else
+            make check-rust-tests
+          fi
 
   frontend:
+    needs: changes-and-static
+    if: github.event_name == 'pull_request' && needs.changes-and-static.outputs.frontend == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.33.3
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@49933ea5288ca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -86,13 +83,15 @@ jobs:
       - run: make check-desktop
 
   web:
+    needs: changes-and-static
+    if: github.event_name == 'pull_request' && needs.changes-and-static.outputs.web == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.33.3
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@49933ea5288ca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -101,6 +100,8 @@ jobs:
       - run: make check-web
 
   dev-stack:
+    needs: changes-and-static
+    if: github.event_name == 'pull_request' && needs.changes-and-static.outputs.dev_stack == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -110,28 +111,3 @@ jobs:
           make dev-up
           make dev-health
           make dev-down
-
-  linux-bundle:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Install native bundle dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential clang cmake pkg-config \
-            libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
-            librsvg2-dev patchelf file
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
-        with:
-          toolchain: 1.88.0
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 10.33.3
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
-      - run: make bundle-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,10 @@ permissions:
 
 # Một ref chỉ cần run mới nhất. Commit mới trên cùng PR sẽ hủy run cũ.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  # PR commit mới thay thế commit cũ. Master runs không được hủy nhau vì mỗi run
+  # phân loại delta riêng; hủy run trước có thể bỏ sót gate của delta đó.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes-and-static:
@@ -22,6 +24,8 @@ jobs:
       frontend: ${{ steps.changes.outputs.frontend }}
       web: ${{ steps.changes.outputs.web }}
       dev_stack: ${{ steps.changes.outputs.dev_stack }}
+      bundle: ${{ steps.changes.outputs.bundle }}
+      toolchain: ${{ steps.changes.outputs.toolchain }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -39,7 +43,7 @@ jobs:
 
   rust:
     needs: changes-and-static
-    if: github.event_name == 'pull_request' && needs.changes-and-static.outputs.rust == 'true'
+    if: needs.changes-and-static.outputs.rust == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -65,16 +69,33 @@ jobs:
             make check-rust-tests
           fi
 
+  toolchain:
+    needs: changes-and-static
+    if: needs.changes-and-static.outputs.toolchain == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.88.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.33.3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+      - run: make check-toolchain
+
   frontend:
     needs: changes-and-static
-    if: github.event_name == 'pull_request' && needs.changes-and-static.outputs.frontend == 'true'
+    if: needs.changes-and-static.outputs.frontend == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.33.3
-      - uses: actions/setup-node@49933ea5288ca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -84,14 +105,14 @@ jobs:
 
   web:
     needs: changes-and-static
-    if: github.event_name == 'pull_request' && needs.changes-and-static.outputs.web == 'true'
+    if: needs.changes-and-static.outputs.web == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.33.3
-      - uses: actions/setup-node@49933ea5288ca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: pnpm
@@ -101,7 +122,7 @@ jobs:
 
   dev-stack:
     needs: changes-and-static
-    if: github.event_name == 'pull_request' && needs.changes-and-static.outputs.dev_stack == 'true'
+    if: needs.changes-and-static.outputs.dev_stack == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -111,3 +132,31 @@ jobs:
           make dev-up
           make dev-health
           make dev-down
+
+  linux-bundle:
+    needs: changes-and-static
+    if: needs.changes-and-static.outputs.bundle == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install native bundle dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential clang cmake pkg-config \
+            libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+            librsvg2-dev patchelf file tesseract-ocr
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: 1.88.0
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.33.3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: python3 scripts/prepare-desktop-runtime.py --platform linux
+      - run: make bundle-linux

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -3,16 +3,14 @@ name: Build desktop installers
 on:
   workflow_dispatch:
   push:
-    branches:
-      - master
     tags:
       - "markhand-v*"
 
 permissions:
   contents: read
 
-# Mỗi push master build lại từ đầu; hủy run cũ đang chạy của cùng ref để khỏi
-# đốt runner macOS (giá 10×) cho commit đã bị vượt qua.
+# Installer chỉ build khi phát hành tag hoặc chạy manual. Hủy run cũ cùng ref để
+# không đốt runner macOS (giá cao hơn Linux) cho bản đã bị vượt qua.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sync-markhand-issues.yml
+++ b/.github/workflows/sync-markhand-issues.yml
@@ -13,6 +13,10 @@ permissions:
   issues: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -21,8 +25,8 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-      - name: Install GitHub CLI
-        run: sudo apt-get update && sudo apt-get install -y gh
+      - name: Verify preinstalled GitHub CLI
+        run: gh --version
       - name: Ensure phase milestones
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/sync-markhand-issues.yml
+++ b/.github/workflows/sync-markhand-issues.yml
@@ -14,11 +14,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master' && github.run_id || 'repository' }}
   cancel-in-progress: true
 
 jobs:
   sync:
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: install check-toolchain check-static check-boundaries check-migrations \
+.PHONY: install check-toolchain check-static check-ci check-boundaries check-migrations \
 	check-fixtures check-markhand-gates check-roadmap check-dependencies check-rust check-rust-tests \
 	check-knowledge-features check-knowledge-extraction check-knowledge-extraction-rust \
 	check-web check-desktop check-foundation bundle-linux dev-up dev-health dev-down dev-reset
@@ -13,6 +13,9 @@ check-toolchain:
 	rustc --version | grep -q '^rustc 1\.88\.'
 	cargo --version
 	python3 --version
+
+check-ci:
+	python3 scripts/classify-ci-changes.py --self-test
 
 check-boundaries:
 	python3 scripts/check-architecture-boundaries.py
@@ -39,7 +42,7 @@ check-dependencies:
 	python3 scripts/check-dependency-policy.py
 	python3 scripts/check-dependency-policy.py --self-test
 
-check-static: check-boundaries check-migrations check-fixtures check-markhand-gates check-roadmap check-dependencies
+check-static: check-ci check-boundaries check-migrations check-fixtures check-markhand-gates check-roadmap check-dependencies
 
 check-rust:
 	bash scripts/check-rust-quality.sh

--- a/docs/conventions/ci.md
+++ b/docs/conventions/ci.md
@@ -36,9 +36,15 @@ validation uses `make bundle-linux`.
 ## CI behavior
 
 - Every PR and `master` push runs the consolidated static/foundation gate.
-- Heavy Rust, desktop frontend, web and dev-stack jobs run on PRs only when their
-  owned paths change. A CI/Makefile change deliberately activates every group.
-- A new commit on the same PR cancels the older in-progress run.
+- Heavy Rust, desktop frontend, web and dev-stack jobs run only when their owned paths
+  change, on both PR and `master`. This keeps direct pushes safe without running
+  unrelated product gates.
+- Linux bundle smoke (including native-runtime preparation) runs only for
+  packaging/runtime configuration changes; the full Linux/Windows/macOS installer
+  matrix remains release-only.
+- A CI/Makefile/classifier/toolchain change deliberately activates every group.
+- A new commit on the same PR cancels the older in-progress run. `master` runs are not
+  grouped or canceled because each run classifies a different push delta.
 - Installer matrices run only for `markhand-v*` tags or manual dispatch, never for an
   ordinary `master` push.
 - The issue-sync workflow remains path-filtered to backlog/sync changes.

--- a/docs/conventions/ci.md
+++ b/docs/conventions/ci.md
@@ -35,8 +35,13 @@ validation uses `make bundle-linux`.
 
 ## CI behavior
 
-- Full required gates still run on every PR/master push. Changed-path optimization is
-  deferred until it cannot skip required cross-boundary checks.
+- Every PR and `master` push runs the consolidated static/foundation gate.
+- Heavy Rust, desktop frontend, web and dev-stack jobs run on PRs only when their
+  owned paths change. A CI/Makefile change deliberately activates every group.
+- A new commit on the same PR cancels the older in-progress run.
+- Installer matrices run only for `markhand-v*` tags or manual dispatch, never for an
+  ordinary `master` push.
+- The issue-sync workflow remains path-filtered to backlog/sync changes.
 - Caches may speed work but a clean cache miss must pass.
 - CI permissions remain read-only except dedicated issue-sync/release workflows.
 - Artifacts follow [`testing-fixtures.md`](testing-fixtures.md): no secret/PII/content

--- a/scripts/check-foundation-gate.sh
+++ b/scripts/check-foundation-gate.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+static_only=false
+if [[ "${1:-}" == "--static-only" ]]; then
+  static_only=true
+elif [[ $# -ne 0 ]]; then
+  echo "usage: $0 [--static-only]" >&2
+  exit 2
+fi
+
 required_files=(
   CONTRIBUTING.md
   Makefile
@@ -26,9 +34,12 @@ for path in "${required_files[@]}"; do
   }
 done
 
-make check-toolchain
 make check-static
 cargo metadata --locked --no-deps --format-version 1 >/dev/null
-pnpm list --recursive --depth -1 >/dev/null
+
+if [[ "$static_only" == false ]]; then
+  make check-toolchain
+  pnpm list --recursive --depth -1 >/dev/null
+fi
 
 echo "Phase F foundation files, toolchain and static gates are ready"

--- a/scripts/classify-ci-changes.py
+++ b/scripts/classify-ci-changes.py
@@ -14,6 +14,7 @@ SHARED = (
     ".github/workflows/ci.yml",
     "Makefile",
     "scripts/classify-ci-changes.py",
+    "scripts/check-foundation-gate.sh",
 )
 GROUPS = {
     "rust": SHARED
@@ -23,6 +24,7 @@ GROUPS = {
         "**/Cargo.toml",
         "crates/**",
         "app/src-tauri/**",
+        "rust-toolchain.toml",
         "rustfmt.toml",
         "clippy.toml",
         "scripts/check-rust*",
@@ -33,6 +35,7 @@ GROUPS = {
     + (
         "Cargo.lock",
         "Cargo.toml",
+        "crates/server/Cargo.toml",
         "crates/knowledge/**",
         "crates/server/tests/knowledge_consumer.rs",
         "app/src-tauri/src/knowledge.rs",
@@ -53,6 +56,7 @@ GROUPS = {
         "app/tsconfig.json",
         "app/vite.config.ts",
         "app/eslint.config.js",
+        "app/index.html",
         "app/src/**",
     ),
     "web": SHARED
@@ -68,6 +72,28 @@ GROUPS = {
         "deploy/dev/**",
         "deploy/scripts/**",
         "docs/runbooks/local-development.md",
+    ),
+    "bundle": SHARED
+    + (
+        ".github/workflows/release-desktop.yml",
+        "package.json",
+        "pnpm-lock.yaml",
+        "app/package.json",
+        "app/index.html",
+        "app/src-tauri/Cargo.toml",
+        "app/src-tauri/build.rs",
+        "app/assets/folyvo-logo-icon/**",
+        "app/src-tauri/icons/**",
+        "app/src-tauri/tauri*.json",
+        "app/src-tauri/native-runtime/**",
+        "scripts/prepare-desktop-runtime.py",
+        "scripts/validate-desktop-bundle.sh",
+    ),
+    "toolchain": SHARED
+    + (
+        "rust-toolchain.toml",
+        "scripts/check-web-toolchain.sh",
+        "docs/runbooks/contributor-setup.md",
     ),
 }
 
@@ -89,7 +115,7 @@ def changed_paths(base: str, head: str) -> list[str]:
             ["git", "rev-parse", f"{head}^"], text=True
         ).strip()
     return subprocess.check_output(
-        ["git", "diff", "--name-only", base, head], text=True
+        ["git", "diff", "--name-only", "--no-renames", base, head], text=True
     ).splitlines()
 
 
@@ -103,6 +129,8 @@ class ClassifierTests(unittest.TestCase):
         self.assertTrue(result["frontend"])
         self.assertFalse(result["web"])
         self.assertFalse(result["dev_stack"])
+        self.assertFalse(result["bundle"])
+        self.assertFalse(result["toolchain"])
 
     def test_deploy_change_activates_only_dev_stack(self) -> None:
         result = classify(["deploy/dev/compose.yml"])
@@ -119,6 +147,29 @@ class ClassifierTests(unittest.TestCase):
         result = classify(["pnpm-lock.yaml"])
         self.assertTrue(result["frontend"])
         self.assertTrue(result["web"])
+
+    def test_vite_entry_and_server_manifest_activate_required_gates(self) -> None:
+        self.assertTrue(classify(["app/index.html"])["frontend"])
+        server = classify(["crates/server/Cargo.toml"])
+        self.assertTrue(server["rust"])
+        self.assertTrue(server["knowledge"])
+
+    def test_packaging_files_activate_linux_bundle(self) -> None:
+        self.assertTrue(classify(["app/src-tauri/tauri.conf.json"])["bundle"])
+        self.assertTrue(
+            classify(["app/assets/folyvo-logo-icon/4a-cam/app-icon.icns"])[
+                "bundle"
+            ]
+        )
+        self.assertTrue(classify(["app/package.json"])["bundle"])
+
+    def test_toolchain_checker_activates_toolchain_job(self) -> None:
+        result = classify(["scripts/check-web-toolchain.sh"])
+        self.assertTrue(result["toolchain"])
+        self.assertFalse(result["bundle"])
+        rust_toolchain = classify(["rust-toolchain.toml"])
+        self.assertTrue(rust_toolchain["rust"])
+        self.assertTrue(rust_toolchain["toolchain"])
 
 
 def main() -> int:

--- a/scripts/classify-ci-changes.py
+++ b/scripts/classify-ci-changes.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Classify changed paths for path-aware GitHub CI jobs."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import subprocess
+import unittest
+from pathlib import Path
+
+
+SHARED = (
+    ".github/workflows/ci.yml",
+    "Makefile",
+    "scripts/classify-ci-changes.py",
+)
+GROUPS = {
+    "rust": SHARED
+    + (
+        "Cargo.lock",
+        "Cargo.toml",
+        "**/Cargo.toml",
+        "crates/**",
+        "app/src-tauri/**",
+        "rustfmt.toml",
+        "clippy.toml",
+        "scripts/check-rust*",
+        "scripts/check-knowledge*",
+        "scripts/check-architecture-boundaries.py",
+    ),
+    "knowledge": SHARED
+    + (
+        "Cargo.lock",
+        "Cargo.toml",
+        "crates/knowledge/**",
+        "crates/server/tests/knowledge_consumer.rs",
+        "app/src-tauri/src/knowledge.rs",
+        "app/src-tauri/src/knowledge_contract.rs",
+        "app/src-tauri/fixtures/knowledge/**",
+        "app/src/lib/ipc.ts",
+        "app/src/lib/types.ts",
+        "app/src/lib/knowledgeContract.test.ts",
+        "scripts/check-knowledge*",
+        "docs/runbooks/knowledge-index-compatibility.md",
+    ),
+    "frontend": SHARED
+    + (
+        "package.json",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "app/package.json",
+        "app/tsconfig.json",
+        "app/vite.config.ts",
+        "app/eslint.config.js",
+        "app/src/**",
+    ),
+    "web": SHARED
+    + (
+        "package.json",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "web/**",
+        "crates/server/openapi/**",
+    ),
+    "dev_stack": SHARED
+    + (
+        "deploy/dev/**",
+        "deploy/scripts/**",
+        "docs/runbooks/local-development.md",
+    ),
+}
+
+
+def classify(paths: list[str]) -> dict[str, bool]:
+    return {
+        name: any(
+            fnmatch.fnmatch(path, pattern)
+            for path in paths
+            for pattern in patterns
+        )
+        for name, patterns in GROUPS.items()
+    }
+
+
+def changed_paths(base: str, head: str) -> list[str]:
+    if not base or set(base) == {"0"}:
+        base = subprocess.check_output(
+            ["git", "rev-parse", f"{head}^"], text=True
+        ).strip()
+    return subprocess.check_output(
+        ["git", "diff", "--name-only", base, head], text=True
+    ).splitlines()
+
+
+class ClassifierTests(unittest.TestCase):
+    def test_docs_only_uses_static_job(self) -> None:
+        self.assertFalse(any(classify(["docs/notes.md"]).values()))
+
+    def test_knowledge_adapter_activates_rust_knowledge_and_frontend(self) -> None:
+        result = classify(["app/src/lib/knowledgeContract.test.ts"])
+        self.assertTrue(result["knowledge"])
+        self.assertTrue(result["frontend"])
+        self.assertFalse(result["web"])
+        self.assertFalse(result["dev_stack"])
+
+    def test_deploy_change_activates_only_dev_stack(self) -> None:
+        result = classify(["deploy/dev/compose.yml"])
+        self.assertTrue(result["dev_stack"])
+        self.assertFalse(result["rust"])
+        self.assertFalse(result["frontend"])
+
+    def test_ci_or_makefile_change_activates_every_group(self) -> None:
+        self.assertTrue(all(classify([".github/workflows/ci.yml"]).values()))
+        self.assertTrue(all(classify(["Makefile"]).values()))
+        self.assertTrue(all(classify(["scripts/classify-ci-changes.py"]).values()))
+
+    def test_root_lockfile_activates_both_frontends(self) -> None:
+        result = classify(["pnpm-lock.yaml"])
+        self.assertTrue(result["frontend"])
+        self.assertTrue(result["web"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(ClassifierTests)
+        return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
+    if not args.base:
+        parser.error("--base is required unless --self-test is used")
+
+    paths = changed_paths(args.base, args.head)
+    result = classify(paths)
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            for name, enabled in result.items():
+                print(f"{name}={str(enabled).lower()}", file=output)
+    for name, enabled in result.items():
+        print(f"{name}={str(enabled).lower()}")
+    if paths:
+        print("Changed files:", *(f"- {path}" for path in paths), sep="\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Substantially reduces GitHub Actions runner usage without allowing affected product gates to disappear.

## Scope

- Full Linux/Windows/macOS installer matrix runs only for release tags or manual dispatch.
- One consolidated static/foundation job replaces five independent runners.
- Tested path classifier activates only affected Rust, knowledge, toolchain, desktop, web, dev-stack, and Linux bundle jobs on PR and master.
- PR commits cancel superseded runs; master runs use unique groups so push deltas cannot replace each other.
- Linux bundle smoke includes native-runtime preparation and only runs for packaging/runtime changes.
- Global issue sync is serialized/cancelable; non-master manual dispatch cannot cancel master synchronization.
- Issue sync uses the preinstalled GitHub CLI instead of apt update/install.

## Evidence

- [x] CI classifier: 8 self-tests passed; current CI change activates all seven groups.
- [x] Consolidated static/foundation gate passed in static and full modes.
- [x] All workflow YAML parsed; trigger, job, release-tag, and concurrency assertions passed.
- [x] Action SHA/dependency policy passed.
- [x] Independent review found no remaining high/medium implementation blockers.

## Expected runner impact

- Ordinary docs/master push: one Linux static job instead of up to 13 jobs.
- Typical focused code change: static + only affected product jobs.
- macOS/Windows installer minutes: zero outside release tag/manual runs.

## Boundary and security review

- [x] Workflow permissions remain read-only except issue sync.
- [x] Actions remain SHA-pinned.
- [x] CI/Makefile/classifier/foundation changes deliberately activate all groups.
- [x] Direct master code pushes still run affected heavy gates.

## Follow-up

- [ ] When GitHub billing is restored, monitor the first run and configure required PR checks in repository settings if desired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

