### PR TITLE
fix: complete P0 spike target evidence

### DIFF
--- a/bench/markhand_web/environments/on-prem-reference.yaml
+++ b/bench/markhand_web/environments/on-prem-reference.yaml
@@ -14,7 +14,7 @@
   "ramGb": 256,
   "disk": {
     "type": "nvme",
-    "capacityGb": 4096,
+    "capacityGb": 4000,
     "iopsNote": ">=100k random-read IOPS"
   },
   "gpu": {
@@ -39,5 +39,5 @@
     "fixtureManifestSha256",
     "hardware"
   ],
-  "notes": "Synthetic labels only; no customer name, credential or internal hostname."
+  "notes": "Capacity fields use decimal GB (10^9 bytes). Synthetic labels only; no customer name, credential or internal hostname."
 }

--- a/bench/markhand_web/reports/environment-report.schema.json
+++ b/bench/markhand_web/reports/environment-report.schema.json
@@ -73,7 +73,8 @@
                   "type": "object",
                   "required": [
                     "type", "capacityGb", "iopsNote", "iopsMeasured", "iopsVerified",
-                    "iopsEvidenceSha256", "storagePathSha256", "backingSource"
+                    "iopsEvidenceSha256", "iopsEvidence", "storagePathSha256",
+                    "storageIdentitySha256", "backingSource"
                   ],
                   "properties": {
                     "type": {"type": "string", "minLength": 1},
@@ -85,7 +86,9 @@
                       "type": ["string", "null"],
                       "pattern": "^[0-9a-f]{64}$"
                     },
+                    "iopsEvidence": {"type": ["object", "null"]},
                     "storagePathSha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                    "storageIdentitySha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
                     "backingSource": {"type": "string", "minLength": 1}
                   }
                 },

--- a/bench/markhand_web/reports/environment-report.schema.json
+++ b/bench/markhand_web/reports/environment-report.schema.json
@@ -86,7 +86,22 @@
                       "type": ["string", "null"],
                       "pattern": "^[0-9a-f]{64}$"
                     },
-                    "iopsEvidence": {"type": ["object", "null"]},
+                    "iopsEvidence": {
+                      "type": ["object", "null"],
+                      "required": [
+                        "storageIdentitySha256", "randomReadIops", "readOnly",
+                        "blockSizeBytes", "durationSeconds", "tool", "measuredAt"
+                      ],
+                      "properties": {
+                        "storageIdentitySha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                        "randomReadIops": {"type": "integer", "minimum": 0},
+                        "readOnly": {"type": "boolean"},
+                        "blockSizeBytes": {"type": "integer", "exclusiveMinimum": 0},
+                        "durationSeconds": {"type": "integer", "exclusiveMinimum": 0},
+                        "tool": {"type": "string", "minLength": 1},
+                        "measuredAt": {"type": "string", "minLength": 1}
+                      }
+                    },
                     "storagePathSha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
                     "storageIdentitySha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
                     "backingSource": {"type": "string", "minLength": 1}

--- a/bench/markhand_web/reports/spike-environment.json
+++ b/bench/markhand_web/reports/spike-environment.json
@@ -1,0 +1,100 @@
+{
+  "version": 1,
+  "reportId": "p0-04-spike-smoke",
+  "gateId": "P0-04-SPIKE",
+  "generatedAt": "2026-07-18T14:52:33.684360Z",
+  "git": {
+    "commit": "fd17e205caf4f4b6a1c69c916ccb61ffd59429fb",
+    "dirty": false
+  },
+  "command": "deploy/spike/up.sh",
+  "workloadProfileId": "on-prem-reference-v1",
+  "environment": {
+    "environmentId": "current-runner-spike-smoke",
+    "fingerprint": {
+      "gitCommit": "fd17e205caf4f4b6a1c69c916ccb61ffd59429fb",
+      "workloadProfileId": "on-prem-reference-v1",
+      "composeFileSha256": "7bda76c260ec7f9f86a61543f93b354dc47e1046288e196187f213faf2fa88d5",
+      "imageDigests": {
+        "postgres": "[\"postgres@sha256:1961f96e6029a02c3812d7cb329a3b03a3ac2bb067058dec17b0f5596aca9296\"]",
+        "qdrant": "[\"qdrant/qdrant@sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c\"]",
+        "minio": "[\"pgsty/minio@sha256:dacff8306a6e0a734518533992dbdcca26bc1ca47f77cf47cb9945725f92b29b\"]",
+        "otel": "[\"otel/opentelemetry-collector-contrib@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108\"]",
+        "mock-embedding": "[\"python@sha256:2d91681153dd4b8cdb52d4fd34a17b9edbafa4dd3086143cfd4b6c3a84c1acb0\"]",
+        "minio-init": "[\"minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727\"]"
+      },
+      "serviceVersions": {
+        "postgres": "postgres:18.4-bookworm@sha256:1961f96e6029a02c3812d7cb329a3b03a3ac2bb067058dec17b0f5596aca9296",
+        "qdrant": "qdrant/qdrant:v1.18.2@sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c",
+        "minio": "pgsty/minio:RELEASE.2026-06-18T00-00-00Z@sha256:dacff8306a6e0a734518533992dbdcca26bc1ca47f77cf47cb9945725f92b29b",
+        "otel": "otel/opentelemetry-collector-contrib:0.156.0@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108",
+        "mock-embedding": "python:3.12.12-alpine@sha256:2d91681153dd4b8cdb52d4fd34a17b9edbafa4dd3086143cfd4b6c3a84c1acb0",
+        "minio-init": "minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
+      },
+      "fixtureManifestSha256": "a1ccd95129815af085db95f4dfa9d8f6428050b4201a1418aba20c9e0f08f013",
+      "hardware": {
+        "cpu": {
+          "vendor": "GenuineIntel",
+          "model": "Intel(R) Xeon(R) Processor",
+          "cores": 8,
+          "threads": 8,
+          "physicalCoresMeasured": true
+        },
+        "ramGb": 50.54,
+        "disk": {
+          "type": "overlay",
+          "capacityGb": 270.44,
+          "iopsNote": "measured random-read IOPS: 0",
+          "iopsMeasured": 0,
+          "iopsVerified": false,
+          "iopsEvidenceSha256": null,
+          "iopsEvidence": null,
+          "storagePathSha256": "ef1d0360071ff3a5eab615dc0797ed7b8f7c2d03d495c97a01407acc1814d2d7",
+          "storageIdentitySha256": "8963825f6b32e70e6b9a80f433c02397aa8d00bcaa931024fca411231dcec392",
+          "backingSource": "docker-vfs]"
+        },
+        "gpu": {
+          "model": "none",
+          "vramGb": 0.0,
+          "count": 0
+        },
+        "network": {
+          "bandwidthGbps": 0.0,
+          "bandwidthMeasured": false,
+          "interface": "eth0",
+          "latencyMsAssumed": 1
+        },
+        "os": {
+          "distro": "ubuntu-24.04",
+          "arch": "x86_64"
+        }
+      }
+    }
+  },
+  "fixtures": {
+    "manifestSha256": "a1ccd95129815af085db95f4dfa9d8f6428050b4201a1418aba20c9e0f08f013"
+  },
+  "fixtureManifestPath": "tests/fixtures/manifest.json",
+  "implementationSha256": "f8c60d03dd131251e0583c0edb370063ad672e8fa9cb755e23d27cb3de2f9001",
+  "result": {
+    "metric": "healthy_spike_services",
+    "value": 5,
+    "pass": true
+  },
+  "profiles": [
+    "cpu-smoke",
+    "nested-network-workaround"
+  ],
+  "targetMatch": false,
+  "lifecycle": {
+    "restartPersistence": true,
+    "resetDeletion": true,
+    "stores": [
+      "postgres",
+      "qdrant",
+      "minio"
+    ],
+    "verifiedAt": "2026-07-18T14:52:34.254388Z"
+  },
+  "notes": "IOPS must be independently verified; target Profile B gates require targetMatch=true."
+}

--- a/bench/markhand_web/scripts/fingerprint_spike.py
+++ b/bench/markhand_web/scripts/fingerprint_spike.py
@@ -191,7 +191,11 @@ def hardware(storage_path: Path) -> dict:
             measured_iops = int(report.get("randomReadIops", 0))
             iops_evidence = report
             iops_evidence_sha256 = hashlib.sha256(
-                report_path.read_bytes()
+                json.dumps(
+                    report,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode()
             ).hexdigest()
     return {
         "cpu": {

--- a/bench/markhand_web/scripts/fingerprint_spike.py
+++ b/bench/markhand_web/scripts/fingerprint_spike.py
@@ -85,7 +85,13 @@ def hardware(storage_path: Path) -> dict:
         if devices:
             gpu_count = len(devices)
             gpu_name = devices[0].split(",", 1)[0].strip()
-            gpu_vram = round(float(devices[0].split(",", 1)[1]) / 1024, 2)
+            gpu_vram = round(
+                float(devices[0].split(",", 1)[1])
+                * 1024
+                * 1024
+                / 1_000_000_000,
+                2,
+            )
     default_route = subprocess.run(
         ["ip", "route", "show", "default"],
         capture_output=True,
@@ -117,13 +123,23 @@ def hardware(storage_path: Path) -> dict:
             if "=" in line:
                 key, value = line.split("=", 1)
                 os_release[key] = value.strip('"')
-    mount = subprocess.run(
-        ["findmnt", "-T", str(storage_path), "-n", "-o", "SOURCE,FSTYPE"],
+    mount_result = subprocess.run(
+        [
+            "findmnt",
+            "-J",
+            "-T",
+            str(storage_path),
+            "-o",
+            "SOURCE,FSTYPE,UUID,MAJ:MIN",
+        ],
         capture_output=True,
         text=True,
         check=False,
-    ).stdout.strip()
-    backing_source, _, filesystem = mount.partition(" ")
+    )
+    mount_payload = json.loads(mount_result.stdout or '{"filesystems":[]}')
+    mount = (mount_payload.get("filesystems") or [{}])[0]
+    backing_source = str(mount.get("source") or "unknown")
+    filesystem = str(mount.get("fstype") or "unknown")
     disk_type = filesystem or "unknown"
     if backing_source.startswith("/dev/"):
         topology = subprocess.run(
@@ -135,14 +151,45 @@ def hardware(storage_path: Path) -> dict:
         if "nvme" in topology:
             disk_type = "nvme"
     storage_hash = hashlib.sha256(str(storage_path.resolve()).encode()).hexdigest()
+    storage_identity = hashlib.sha256(
+        json.dumps(
+            {
+                "source": backing_source,
+                "filesystem": filesystem,
+                "uuid": mount.get("uuid"),
+                "majorMinor": mount.get("maj:min"),
+                "storagePathSha256": storage_hash,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
     measured_iops = 0
     iops_evidence_sha256 = None
+    iops_evidence = None
     iops_report_path = os.environ.get("MARKHAND_SPIKE_IOPS_REPORT")
     if iops_report_path and Path(iops_report_path).is_file():
         report_path = Path(iops_report_path)
         report = json.loads(report_path.read_text())
-        if report.get("storagePathSha256") == storage_hash:
+        measured_at = report.get("measuredAt")
+        try:
+            measured_time = dt.datetime.fromisoformat(
+                str(measured_at).replace("Z", "+00:00")
+            )
+        except ValueError:
+            measured_time = dt.datetime.min.replace(tzinfo=dt.timezone.utc)
+        age = dt.datetime.now(dt.timezone.utc) - measured_time
+        if (
+            report.get("storageIdentitySha256") == storage_identity
+            and report.get("readOnly") is True
+            and report.get("blockSizeBytes") == 4096
+            and int(report.get("durationSeconds", 0)) >= 30
+            and isinstance(report.get("tool"), str)
+            and report["tool"].strip()
+            and dt.timedelta(0) <= age <= dt.timedelta(hours=24)
+        ):
             measured_iops = int(report.get("randomReadIops", 0))
+            iops_evidence = report
             iops_evidence_sha256 = hashlib.sha256(
                 report_path.read_bytes()
             ).hexdigest()
@@ -154,15 +201,19 @@ def hardware(storage_path: Path) -> dict:
             "threads": os.cpu_count() or 1,
             "physicalCoresMeasured": bool(physical_cores),
         },
-        "ramGb": round(int(memory.group(1)) / 1024 / 1024, 2) if memory else 0.01,
+        "ramGb": round(int(memory.group(1)) * 1024 / 1_000_000_000, 2)
+        if memory
+        else 0.01,
         "disk": {
             "type": disk_type,
-            "capacityGb": round(disk.total / 1024**3, 2),
+            "capacityGb": round(disk.total / 1_000_000_000, 2),
             "iopsNote": f"measured random-read IOPS: {measured_iops}",
             "iopsMeasured": measured_iops,
             "iopsVerified": measured_iops >= 100_000,
             "iopsEvidenceSha256": iops_evidence_sha256,
+            "iopsEvidence": iops_evidence,
             "storagePathSha256": storage_hash,
+            "storageIdentitySha256": storage_identity,
             "backingSource": Path(backing_source).name or filesystem or "unknown",
         },
         "gpu": {"model": gpu_name, "vramGb": gpu_vram, "count": gpu_count},

--- a/plans/markhand-web/backlog/phase-0/issues/README.md
+++ b/plans/markhand-web/backlog/phase-0/issues/README.md
@@ -73,8 +73,8 @@ P1A-01 ──────────> P0-03
 
 ## P0-04 — Spike infrastructure tái lập
 
-- **Status:** Blocked bởi P0-01; chỉ ghi research note ngoài issue trước khi unblock,
-  không bắt đầu implementation.
+- **Status:** Review — isolated CPU smoke, three-store lifecycle and bound evidence
+  passed; Profile B GPU/IOPS target run remains external.
 - **Objective:** Stack disposable PG/Qdrant/MinIO/vLLM/telemetry cho benchmark.
 - **Plan:** Tái dùng compose/services/scripts base từ F-08; thêm benchmark-specific
   override với isolated volumes/data, vLLM/GPU profile, workload sizing, image digest

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "38a1df88bc6cf71a";
+    const ROADMAP_SOURCE_HASH = "d277e9ce3e979592";
     const phases = [
       {
         "id": "phase-f",
@@ -1017,7 +1017,7 @@
           [
             "P0-04",
             "Spike infrastructure tái lập",
-            "blocked"
+            "review"
           ],
           [
             "P0-05",

--- a/scripts/validate_spike.py
+++ b/scripts/validate_spike.py
@@ -173,6 +173,11 @@ def expected_target_match(hardware: dict, profiles: list[str]) -> bool:
             str(hardware.get("disk", {}).get("iopsEvidenceSha256", ""))
         )
         is not None
+        and isinstance(hardware.get("disk", {}).get("iopsEvidence"), dict)
+        and hardware["disk"]["iopsEvidence"].get("storageIdentitySha256")
+        == hardware["disk"]["storageIdentitySha256"]
+        and hardware["disk"]["iopsEvidence"].get("randomReadIops", 0)
+        == hardware["disk"]["iopsMeasured"]
         and hardware.get("gpu", {}).get("count", 0) >= target["gpu"]["count"]
         and hardware.get("gpu", {}).get("vramGb", 0) >= target["gpu"]["vramGb"]
         and hardware.get("network", {}).get("bandwidthGbps", 0)
@@ -437,6 +442,23 @@ def validate_report(
         or not isinstance(hardware.get("disk", {}).get("backingSource"), str)
     ):
         errors.append("spike report hardware is incomplete")
+    disk = hardware.get("disk", {})
+    if disk.get("iopsVerified"):
+        evidence = disk.get("iopsEvidence")
+        if (
+            not isinstance(evidence, dict)
+            or evidence.get("storageIdentitySha256")
+            != disk.get("storageIdentitySha256")
+            or evidence.get("randomReadIops") != disk.get("iopsMeasured")
+            or not SHA256.fullmatch(str(disk.get("iopsEvidenceSha256", "")))
+        ):
+            errors.append("spike report IOPS evidence is not storage-bound")
+    elif (
+        disk.get("iopsMeasured") != 0
+        or disk.get("iopsEvidence") is not None
+        or disk.get("iopsEvidenceSha256") is not None
+    ):
+        errors.append("spike report has unverified IOPS evidence")
     result = payload.get("result", {})
     if result.get("metric") != "healthy_spike_services" or result.get("value") != len(
         expected_runtime

--- a/scripts/validate_spike.py
+++ b/scripts/validate_spike.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import hashlib
 import json
 import math
@@ -445,11 +446,42 @@ def validate_report(
     disk = hardware.get("disk", {})
     if disk.get("iopsVerified"):
         evidence = disk.get("iopsEvidence")
+        try:
+            measured_at = dt.datetime.fromisoformat(
+                str(evidence.get("measuredAt", "")).replace("Z", "+00:00")
+            )
+            generated_at = dt.datetime.fromisoformat(
+                str(payload.get("generatedAt", "")).replace("Z", "+00:00")
+            )
+            evidence_age = generated_at - measured_at
+        except (AttributeError, ValueError):
+            evidence_age = dt.timedelta(days=999)
+        evidence_hash = (
+            hashlib.sha256(
+                json.dumps(
+                    evidence,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode()
+            ).hexdigest()
+            if isinstance(evidence, dict)
+            else None
+        )
         if (
             not isinstance(evidence, dict)
             or evidence.get("storageIdentitySha256")
             != disk.get("storageIdentitySha256")
             or evidence.get("randomReadIops") != disk.get("iopsMeasured")
+            or evidence.get("readOnly") is not True
+            or evidence.get("blockSizeBytes") != 4096
+            or not isinstance(evidence.get("durationSeconds"), int)
+            or evidence["durationSeconds"] < 30
+            or not isinstance(evidence.get("tool"), str)
+            or not evidence["tool"].strip()
+            or not dt.timedelta(0)
+            <= evidence_age
+            <= dt.timedelta(hours=24)
+            or evidence_hash != disk.get("iopsEvidenceSha256")
             or not SHA256.fullmatch(str(disk.get("iopsEvidenceSha256", "")))
         ):
             errors.append("spike report IOPS evidence is not storage-bound")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Completes the P0-04 evidence hardening added after the initial spike PR merged.

## Evidence

- Clean-volume and repeated-up CPU spike passed for PostgreSQL, Qdrant, MinIO, OTEL and deterministic embedding stub.
- Restart preserved PG/Qdrant/MinIO sentinels; reset deleted all three; seed is idempotent.
- Images use an immutable linux/amd64 digest lock; vLLM AMD64 GPU profile is opt-in.
- Report binds implementation/source/env/compose/fixture/image digests, Docker-root storage identity, physical CPU/default-route network provenance and lifecycle results.
- IOPS target accepts only fresh read-only 4K >=30s evidence bound to measured storage identity.
- Nested MinIO workaround is smoke-only and cannot targetMatch.
- Config/report/self-tests and independent technical review pass.

## Current limitation

`targetMatch=false`: this runner is below Profile B and has no GPU/IOPS evidence. Target evidence remains external and is not represented as passing.

## Follow-up

- [x] Roadmap moved P0-04 to Review.
- [ ] Repeat on approved Profile B hardware.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4c79-3dc3-7d5b-8de9-ba3d470751e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

