### PR TITLE
Document Cursor Cloud development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent guidance
+
+## Cursor Cloud specific instructions
+
+- See `CONTRIBUTING.md` and `docs/runbooks/contributor-setup.md` for the standard toolchain and quality-gate commands. The working products are the shared Rust converter, `fileconv` CLI, `fileconv-mcp`, and Markhand Tauri desktop app; `fileconv-server` and `web/` are currently foundation scaffolds, so the Compose stack is not required for desktop/CLI development.
+- The Cloud VM uses GNU `cc`/`c++` and Cargo's GNU linker. Keep this configuration: `whisper-rs-sys` may compile with the image's default Clang but then fail to find `libstdc++` while linking.
+- For a headless desktop runtime check, run `xvfb-run -a pnpm --dir app tauri dev`; Tauri starts the Vite server on port 1420 automatically. A harmless DRI3/libEGL warning is expected under Xvfb.
+- The snapshot includes Tesseract `vie+eng`, PDFium under `pdfium/`, and higher-quality OCR data under `tessdata_best/`. Audio transcription still requires a model from `bench/download_models.sh`; LLM-backed features require the optional `FILECONV_LLM_*` configuration described in `crates/mcp/README.md`.
+- pnpm 10 reports that the `esbuild` install script is ignored. The repository's Vite builds and tests work with its platform package, so do not run the interactive `pnpm approve-builds` during automated setup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Document the verified Cursor Cloud development environment, service scope, headless Tauri startup, native runtime assets, and compiler caveat.

## Scope

- Add `AGENTS.md` with durable Cloud-agent guidance.
- No application code or dependency changes.

## Evidence

- [x] Tests: `make check-rust-tests`, `make check-web`, `make check-desktop`
- [x] Manual/benchmark/migration evidence: built the Rust workspace and release CLI/MCP; ran Markhand via Xvfb; created a project and converted HTML to Markdown through the desktop UI; validated `fileconv-server --check-config`.

## Boundary and security review

- [x] Dependency boundary check passed.
- [x] Tenant/ACL impact reviewed: N/A (documentation only).
- [x] Sensitive logging/secret/egress impact reviewed: N/A.
- [x] Security review trigger checked: not triggered.

## Follow-up

- [x] Cloud-specific run instructions documented.
- Existing `master` issues observed but not changed: one Markhand gate self-test failure, desktop Prettier drift, and desktop ESLint errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3679400-7e5b-439d-b0eb-cbb12fbb81e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3679400-7e5b-439d-b0eb-cbb12fbb81e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

