### PR TITLE
P1B-F04 — OrgContext, tenant repositories and document state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom 0.2.17",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "debug_unsafe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1897,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "deadpool-postgres",
  "fileconv-core",
  "fileconv-knowledge",
  "http-body-util",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/bin/worker.rs"
 [dependencies]
 axum = { version = "0.8.9", features = ["json"] }
 chrono = { version = "0.4.45", features = ["serde", "clock"] }
+deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
 fileconv-core = { path = "../core" }
 fileconv-knowledge = { path = "../knowledge" }
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }

--- a/crates/server/src/auth/context.rs
+++ b/crates/server/src/auth/context.rs
@@ -1,0 +1,112 @@
+//! Fail-closed tenant scope for every business repository call (ADR 0007).
+
+use std::collections::BTreeSet;
+
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Explicit org/user scope required by every business repository method.
+///
+/// Construction is fail-closed: a missing or nil `org_id` / `user_id` never yields
+/// a usable context. `allowed_collection_ids` is a plain field here; full ACL
+/// resolution belongs to Phase 1C.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrgContext {
+    org_id: Uuid,
+    user_id: Uuid,
+    permissions: BTreeSet<String>,
+    allowed_collection_ids: BTreeSet<Uuid>,
+}
+
+/// Errors when constructing an [`OrgContext`].
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum OrgContextError {
+    #[error("org_id is required and must not be nil")]
+    MissingOrgId,
+    #[error("user_id is required and must not be nil")]
+    MissingUserId,
+}
+
+impl OrgContext {
+    /// Builds a tenant context or rejects empty/nil scope.
+    pub fn try_new(
+        org_id: Uuid,
+        user_id: Uuid,
+        permissions: impl IntoIterator<Item = impl Into<String>>,
+        allowed_collection_ids: impl IntoIterator<Item = Uuid>,
+    ) -> Result<Self, OrgContextError> {
+        if org_id.is_nil() {
+            return Err(OrgContextError::MissingOrgId);
+        }
+        if user_id.is_nil() {
+            return Err(OrgContextError::MissingUserId);
+        }
+        Ok(Self {
+            org_id,
+            user_id,
+            permissions: permissions.into_iter().map(Into::into).collect(),
+            allowed_collection_ids: allowed_collection_ids.into_iter().collect(),
+        })
+    }
+
+    /// Tenant organization id (never nil after construction).
+    pub fn org_id(&self) -> Uuid {
+        self.org_id
+    }
+
+    /// Acting user id (never nil after construction).
+    pub fn user_id(&self) -> Uuid {
+        self.user_id
+    }
+
+    /// Permission codes resolved for this membership (plain set until 1C).
+    pub fn permissions(&self) -> &BTreeSet<String> {
+        &self.permissions
+    }
+
+    /// Collection ids the actor may touch (plain set until full ACL in 1C).
+    pub fn allowed_collection_ids(&self) -> &BTreeSet<Uuid> {
+        &self.allowed_collection_ids
+    }
+
+    /// Whether the actor holds the named permission code.
+    pub fn has_permission(&self, code: &str) -> bool {
+        self.permissions.contains(code)
+    }
+
+    /// Whether the collection is in the allowed set (empty set means none allowed).
+    pub fn allows_collection(&self, collection_id: Uuid) -> bool {
+        self.allowed_collection_ids.contains(&collection_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_nil_org_and_user() {
+        let user = Uuid::new_v4();
+        let org = Uuid::new_v4();
+        assert_eq!(
+            OrgContext::try_new(Uuid::nil(), user, [] as [&str; 0], []),
+            Err(OrgContextError::MissingOrgId)
+        );
+        assert_eq!(
+            OrgContext::try_new(org, Uuid::nil(), [] as [&str; 0], []),
+            Err(OrgContextError::MissingUserId)
+        );
+    }
+
+    #[test]
+    fn accepts_non_nil_scope() {
+        let org = Uuid::new_v4();
+        let user = Uuid::new_v4();
+        let collection = Uuid::new_v4();
+        let ctx = OrgContext::try_new(org, user, ["doc.upload"], [collection]).unwrap();
+        assert_eq!(ctx.org_id(), org);
+        assert_eq!(ctx.user_id(), user);
+        assert!(ctx.has_permission("doc.upload"));
+        assert!(ctx.allows_collection(collection));
+    }
+}

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -1,0 +1,3 @@
+//! Authentication and tenant context (ADR 0007 / ADR 0010).
+
+pub mod context;

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -163,7 +163,7 @@ async fn connect(database_url: &str) -> Result<Client, String> {
 }
 
 async fn connect_with_tls(database_url: &str) -> Result<Client, String> {
-    let connector = MakeRustlsConnect::new(tls_config()?);
+    let connector = make_rustls_connect()?;
     let (client, connection) = tokio_postgres::connect(database_url, connector)
         .await
         .map_err(|error| format!("PostgreSQL connection failed: {error}"))?;
@@ -173,12 +173,18 @@ async fn connect_with_tls(database_url: &str) -> Result<Client, String> {
     Ok(client)
 }
 
-fn database_requires_tls(database_url: &str) -> Result<bool, String> {
+/// Whether the URL requests TLS (`sslmode` present and not `disable`).
+pub fn database_requires_tls(database_url: &str) -> Result<bool, String> {
     let parsed = reqwest::Url::parse(database_url)
         .map_err(|_| "MARKHAND_DATABASE_URL must be an absolute URL".to_string())?;
     Ok(parsed
         .query_pairs()
         .any(|(key, value)| key == "sslmode" && value != "disable"))
+}
+
+/// Builds a rustls connector for tokio-postgres / deadpool-postgres.
+pub fn make_rustls_connect() -> Result<MakeRustlsConnect, String> {
+    Ok(MakeRustlsConnect::new(tls_config()?))
 }
 
 fn tls_config() -> Result<ClientConfig, String> {

--- a/crates/server/src/db/chunks.rs
+++ b/crates/server/src/db/chunks.rs
@@ -1,0 +1,117 @@
+//! Tenant-scoped chunk repository (ADR 0007).
+
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::Chunk;
+
+/// Input for inserting a retrieval chunk under the tenant.
+#[derive(Debug, Clone)]
+pub struct NewChunk<'a> {
+    pub id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub ordinal: i32,
+    pub heading_path: &'a [String],
+    pub body: &'a str,
+    pub body_text_version: &'a str,
+    pub chunk_identity_sha256: &'a str,
+    pub index_metadata_id: Uuid,
+    pub index_signature: &'a str,
+}
+
+/// Inserts a chunk row; `org_id` always comes from `ctx`.
+pub async fn insert(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewChunk<'_>,
+) -> Result<Chunk, DbError> {
+    let heading_path: Vec<&str> = input.heading_path.iter().map(String::as_str).collect();
+    let row = txn
+        .query_one(
+            "INSERT INTO chunks (
+                id, org_id, document_id, version_id, ordinal, heading_path, body,
+                body_text_version, chunk_identity_sha256, index_metadata_id,
+                index_signature, tsv
+             ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                to_tsvector('simple', $7)
+             )
+             RETURNING id, org_id, document_id, version_id, ordinal, heading_path, body,
+                       body_text_version, chunk_identity_sha256, index_metadata_id,
+                       index_signature, page, slide, sheet, span_start, span_end,
+                       tsv::text AS tsv, created_at",
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &input.document_id,
+                &input.version_id,
+                &input.ordinal,
+                &heading_path,
+                &input.body,
+                &input.body_text_version,
+                &input.chunk_identity_sha256,
+                &input.index_metadata_id,
+                &input.index_signature,
+            ],
+        )
+        .await?;
+    map_chunk(&row)
+}
+
+/// Lists chunks for a document within the tenant.
+pub async fn list_by_document(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<Vec<Chunk>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT id, org_id, document_id, version_id, ordinal, heading_path, body,
+                    body_text_version, chunk_identity_sha256, index_metadata_id,
+                    index_signature, page, slide, sheet, span_start, span_end,
+                    tsv::text AS tsv, created_at
+             FROM chunks
+             WHERE org_id = $1 AND document_id = $2
+             ORDER BY ordinal",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?;
+    rows.iter().map(map_chunk).collect()
+}
+
+/// Counts chunks visible under the tenant (cross-org denial evidence).
+pub async fn count(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<i64, DbError> {
+    let row = txn
+        .query_one(
+            "SELECT count(*)::bigint FROM chunks WHERE org_id = $1",
+            &[&ctx.org_id()],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
+fn map_chunk(row: &Row) -> Result<Chunk, DbError> {
+    Ok(Chunk {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        document_id: row.get("document_id"),
+        version_id: row.get("version_id"),
+        ordinal: row.get("ordinal"),
+        heading_path: row.get("heading_path"),
+        body: row.get("body"),
+        body_text_version: row.get("body_text_version"),
+        chunk_identity_sha256: row.get("chunk_identity_sha256"),
+        index_metadata_id: row.get("index_metadata_id"),
+        index_signature: row.get("index_signature"),
+        page: row.get("page"),
+        slide: row.get("slide"),
+        sheet: row.get("sheet"),
+        span_start: row.get("span_start"),
+        span_end: row.get("span_end"),
+        tsv: row.get("tsv"),
+        created_at: row.get("created_at"),
+    })
+}

--- a/crates/server/src/db/collections.rs
+++ b/crates/server/src/db/collections.rs
@@ -1,0 +1,96 @@
+//! Tenant-scoped collection repository (ADR 0007).
+
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{Collection, CollectionVisibility};
+
+/// Input for creating a collection under the caller's org.
+#[derive(Debug, Clone)]
+pub struct NewCollection<'a> {
+    pub id: Uuid,
+    pub name: &'a str,
+    pub slug: &'a str,
+    pub description: Option<&'a str>,
+    pub visibility: CollectionVisibility,
+}
+
+/// Inserts a collection for `ctx.org_id` / `ctx.user_id` as owner.
+pub async fn insert(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewCollection<'_>,
+) -> Result<Collection, DbError> {
+    let visibility = input.visibility.as_str();
+    let row = txn
+        .query_one(
+            "INSERT INTO collections (
+                id, org_id, name, slug, description, owner_user_id, visibility
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+             RETURNING id, org_id, name, slug, description, owner_user_id,
+                       visibility, created_at, updated_at, deleted_at",
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &input.name,
+                &input.slug,
+                &input.description,
+                &ctx.user_id(),
+                &visibility,
+            ],
+        )
+        .await?;
+    map_collection(&row)
+}
+
+/// Fetches one collection by id within the tenant; cross-org rows are invisible.
+pub async fn get_by_id(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    collection_id: Uuid,
+) -> Result<Collection, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, name, slug, description, owner_user_id,
+                    visibility, created_at, updated_at, deleted_at
+             FROM collections
+             WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL",
+            &[&ctx.org_id(), &collection_id],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_collection(&row)
+}
+
+/// Lists non-deleted collections for the tenant.
+pub async fn list(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<Vec<Collection>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT id, org_id, name, slug, description, owner_user_id,
+                    visibility, created_at, updated_at, deleted_at
+             FROM collections
+             WHERE org_id = $1 AND deleted_at IS NULL
+             ORDER BY name",
+            &[&ctx.org_id()],
+        )
+        .await?;
+    rows.iter().map(map_collection).collect()
+}
+
+fn map_collection(row: &Row) -> Result<Collection, DbError> {
+    let visibility: String = row.get("visibility");
+    Ok(Collection {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        name: row.get("name"),
+        slug: row.get("slug"),
+        description: row.get("description"),
+        owner_user_id: row.get("owner_user_id"),
+        visibility: CollectionVisibility::parse(&visibility).map_err(DbError::Config)?,
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+        deleted_at: row.get("deleted_at"),
+    })
+}

--- a/crates/server/src/db/documents.rs
+++ b/crates/server/src/db/documents.rs
@@ -1,0 +1,154 @@
+//! Tenant-scoped document repository (ADR 0007).
+
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{Document, DocumentState};
+
+/// Input for creating a document in `uploaded` state.
+#[derive(Debug, Clone)]
+pub struct NewDocument<'a> {
+    pub id: Uuid,
+    pub collection_id: Uuid,
+    pub title: &'a str,
+}
+
+/// Inserts a document owned by the acting user under `ctx.org_id`.
+pub async fn insert(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewDocument<'_>,
+) -> Result<Document, DbError> {
+    let state = DocumentState::Uploaded.as_str();
+    let row = txn
+        .query_one(
+            "INSERT INTO documents (
+                id, org_id, collection_id, title, state, created_by_user_id
+             ) VALUES ($1, $2, $3, $4, $5, $6)
+             RETURNING id, org_id, collection_id, title, state, current_version_id,
+                       created_by_user_id, created_at, updated_at, deleted_at",
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &input.collection_id,
+                &input.title,
+                &state,
+                &ctx.user_id(),
+            ],
+        )
+        .await?;
+    map_document(&row)
+}
+
+/// Fetches a document by id within the tenant.
+pub async fn get_by_id(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<Document, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, collection_id, title, state, current_version_id,
+                    created_by_user_id, created_at, updated_at, deleted_at
+             FROM documents
+             WHERE org_id = $1 AND id = $2",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_document(&row)
+}
+
+/// Locks the document row for an atomic state transition (`SELECT … FOR UPDATE`).
+///
+/// Intended for the document state machine (and tests that exercise lock contention).
+/// There is no public API to write an arbitrary state — use
+/// [`crate::services::document_state`].
+pub async fn get_by_id_for_update(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<Document, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, collection_id, title, state, current_version_id,
+                    created_by_user_id, created_at, updated_at, deleted_at
+             FROM documents
+             WHERE org_id = $1 AND id = $2
+             FOR UPDATE",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_document(&row)
+}
+
+/// Compare-and-set state write used only by the checked state machine.
+///
+/// Updates only when `org_id`, `id`, and `expected_state` all match (CAS). Not
+/// `pub` — callers must go through [`crate::services::document_state`].
+async fn update_state_cas(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    expected_state: DocumentState,
+    new_state: DocumentState,
+) -> Result<Document, DbError> {
+    let expected = expected_state.as_str();
+    let state = new_state.as_str();
+    let row = txn
+        .query_opt(
+            "UPDATE documents
+             SET state = $4, updated_at = now()
+             WHERE org_id = $1 AND id = $2 AND state = $3
+             RETURNING id, org_id, collection_id, title, state, current_version_id,
+                       created_by_user_id, created_at, updated_at, deleted_at",
+            &[&ctx.org_id(), &document_id, &expected, &state],
+        )
+        .await?
+        .ok_or_else(|| DbError::StaleState {
+            expected: expected_state.to_string(),
+            observed: "missing_or_changed".to_string(),
+        })?;
+    map_document(&row)
+}
+
+/// Module-private entry used by the state machine (same crate).
+pub(crate) async fn cas_state(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    expected_state: DocumentState,
+    new_state: DocumentState,
+) -> Result<Document, DbError> {
+    update_state_cas(txn, ctx, document_id, expected_state, new_state).await
+}
+
+/// Counts documents for the tenant (used by cross-org denial tests).
+pub async fn count(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<i64, DbError> {
+    let row = txn
+        .query_one(
+            "SELECT count(*)::bigint FROM documents WHERE org_id = $1",
+            &[&ctx.org_id()],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
+pub(crate) fn map_document(row: &Row) -> Result<Document, DbError> {
+    let state: String = row.get("state");
+    Ok(Document {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        collection_id: row.get("collection_id"),
+        title: row.get("title"),
+        state: DocumentState::parse(&state).map_err(DbError::Config)?,
+        current_version_id: row.get("current_version_id"),
+        created_by_user_id: row.get("created_by_user_id"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+        deleted_at: row.get("deleted_at"),
+    })
+}

--- a/crates/server/src/db/error.rs
+++ b/crates/server/src/db/error.rs
@@ -1,0 +1,36 @@
+//! Shared repository / pool error types.
+
+use deadpool_postgres::PoolError;
+use thiserror::Error;
+use tokio_postgres::Error as PgError;
+
+/// Errors from pool checkout, transactions, and tenant-scoped queries.
+#[derive(Debug, Error)]
+pub enum DbError {
+    #[error("database pool error")]
+    Pool(#[from] PoolError),
+    #[error("database query error")]
+    Query(#[from] PgError),
+    #[error("database configuration error: {0}")]
+    Config(String),
+    #[error("row not found")]
+    NotFound,
+    #[error("illegal document state transition from {from} to {to}")]
+    IllegalTransition { from: String, to: String },
+    #[error("stale document state: expected {expected}, observed {observed}")]
+    StaleState { expected: String, observed: String },
+}
+
+impl DbError {
+    /// Stable machine-facing error code (never includes row content).
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::Pool(_) => "db_pool",
+            Self::Query(_) => "db_query",
+            Self::Config(_) => "db_config",
+            Self::NotFound => "db_not_found",
+            Self::IllegalTransition { .. } => "db_illegal_transition",
+            Self::StaleState { .. } => "db_stale_state",
+        }
+    }
+}

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -1,3 +1,9 @@
-//! Database models and future repository modules.
+//! Database models, pool, and tenant-scoped repositories.
 
+pub mod chunks;
+pub mod collections;
+pub mod documents;
+pub mod error;
 pub mod models;
+pub mod orgs;
+pub mod pool;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -151,6 +151,25 @@ pub enum CollectionVisibility {
     Groups,
 }
 
+impl CollectionVisibility {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Private => "private",
+            Self::Org => "org",
+            Self::Groups => "groups",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "private" => Ok(Self::Private),
+            "org" => Ok(Self::Org),
+            "groups" => Ok(Self::Groups),
+            other => Err(format!("unknown collection visibility: {other}")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Collection {
     pub id: Uuid,
@@ -214,6 +233,43 @@ pub enum DocumentState {
     Failed,
     Tombstoned,
     Purged,
+}
+
+impl DocumentState {
+    /// PostgreSQL `documents.state` text value.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Uploaded => "uploaded",
+            Self::Converting => "converting",
+            Self::Converted => "converted",
+            Self::Indexing => "indexing",
+            Self::Indexed => "indexed",
+            Self::Failed => "failed",
+            Self::Tombstoned => "tombstoned",
+            Self::Purged => "purged",
+        }
+    }
+
+    /// Parses a DB state string; unknown values are rejected.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "uploaded" => Ok(Self::Uploaded),
+            "converting" => Ok(Self::Converting),
+            "converted" => Ok(Self::Converted),
+            "indexing" => Ok(Self::Indexing),
+            "indexed" => Ok(Self::Indexed),
+            "failed" => Ok(Self::Failed),
+            "tombstoned" => Ok(Self::Tombstoned),
+            "purged" => Ok(Self::Purged),
+            other => Err(format!("unknown document state: {other}")),
+        }
+    }
+}
+
+impl std::fmt::Display for DocumentState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/server/src/db/orgs.rs
+++ b/crates/server/src/db/orgs.rs
@@ -1,0 +1,79 @@
+//! Org lookup scoped by [`OrgContext`] (global `orgs` table, still fail-closed).
+
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::Org;
+
+/// Returns the organization named by `ctx.org_id()` only.
+pub async fn get(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<Org, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, slug, name, created_at, updated_at
+             FROM orgs
+             WHERE id = $1",
+            &[&ctx.org_id()],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_org(&row)
+}
+
+/// Ensures an org row exists for `ctx` (used by tests / bootstrap under context).
+pub async fn ensure_exists(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    slug: &str,
+    name: &str,
+) -> Result<Org, DbError> {
+    txn.execute(
+        "INSERT INTO orgs (id, slug, name)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (id) DO NOTHING",
+        &[&ctx.org_id(), &slug, &name],
+    )
+    .await?;
+    get(txn, ctx).await
+}
+
+fn map_org(row: &Row) -> Result<Org, DbError> {
+    Ok(Org {
+        id: row.get("id"),
+        slug: row.get("slug"),
+        name: row.get("name"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+/// Inserts a user if missing (users are global; still requires OrgContext for call sites).
+pub async fn ensure_user(
+    txn: &Transaction<'_>,
+    _ctx: &OrgContext,
+    user_id: Uuid,
+    email: &str,
+    display_name: &str,
+) -> Result<(), DbError> {
+    txn.execute(
+        "INSERT INTO users (id, email, display_name)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (id) DO NOTHING",
+        &[&user_id, &email, &display_name],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Ensures membership for `ctx.user_id` in `ctx.org_id` (RLS-scoped insert).
+pub async fn ensure_membership(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<(), DbError> {
+    txn.execute(
+        "INSERT INTO org_memberships (org_id, user_id, role)
+         VALUES ($1, $2, 'owner')
+         ON CONFLICT (org_id, user_id) DO NOTHING",
+        &[&ctx.org_id(), &ctx.user_id()],
+    )
+    .await?;
+    Ok(())
+}

--- a/crates/server/src/db/pool.rs
+++ b/crates/server/src/db/pool.rs
@@ -1,0 +1,71 @@
+//! Connection pool and transaction-local RLS helpers (ADR 0007).
+
+use std::future::Future;
+use std::pin::Pin;
+
+use deadpool_postgres::{Config, Pool, PoolConfig, Runtime};
+use tokio_postgres::{NoTls, Transaction};
+
+use crate::auth::context::OrgContext;
+use crate::database::{database_requires_tls, make_rustls_connect};
+use crate::db::error::DbError;
+
+/// Future returned by [`with_org_txn`] closures (boxed to satisfy HRTB + borrow).
+pub type OrgTxnFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, DbError>> + Send + 'a>>;
+
+/// Creates a deadpool-postgres pool with the default max size.
+pub fn create_pool(database_url: &str) -> Result<Pool, DbError> {
+    create_pool_with_max_size(database_url, PoolConfig::default().max_size)
+}
+
+/// Creates a pool with an explicit max size (use `1` to force connection reuse in tests).
+pub fn create_pool_with_max_size(database_url: &str, max_size: usize) -> Result<Pool, DbError> {
+    let mut cfg = Config::new();
+    cfg.url = Some(database_url.to_string());
+    cfg.pool = Some(PoolConfig::new(max_size));
+    if database_requires_tls(database_url).map_err(DbError::Config)? {
+        let connector = make_rustls_connect().map_err(DbError::Config)?;
+        cfg.create_pool(Some(Runtime::Tokio1), connector)
+            .map_err(|error| DbError::Config(error.to_string()))
+    } else {
+        cfg.create_pool(Some(Runtime::Tokio1), NoTls)
+            .map_err(|error| DbError::Config(error.to_string()))
+    }
+}
+
+/// Runs `f` inside a transaction with transaction-local RLS claims set.
+///
+/// Sets only `SET LOCAL` / `set_config(..., is_local=true)` for `app.org_id` and
+/// `app.user_id` so pooled connections never retain tenant state after commit or
+/// rollback. The closure must not perform network, converter, or LLM I/O.
+///
+/// Call sites should return `Box::pin(async move { ... })`.
+pub async fn with_org_txn<T, F>(pool: &Pool, ctx: &OrgContext, f: F) -> Result<T, DbError>
+where
+    F: for<'c> FnOnce(&'c Transaction<'c>) -> OrgTxnFuture<'c, T>,
+{
+    let mut client = pool.get().await?;
+    let txn = client.transaction().await?;
+    apply_org_context(&txn, ctx).await?;
+    match f(&txn).await {
+        Ok(value) => {
+            txn.commit().await?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = txn.rollback().await;
+            Err(error)
+        }
+    }
+}
+
+/// Applies tenant claims as transaction-local GUCs (never session-level).
+pub async fn apply_org_context(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<(), DbError> {
+    let org = ctx.org_id().to_string();
+    let user = ctx.user_id().to_string();
+    txn.execute("SELECT set_config('app.org_id', $1, true)", &[&org])
+        .await?;
+    txn.execute("SELECT set_config('app.user_id', $1, true)", &[&user])
+        .await?;
+    Ok(())
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,11 +1,13 @@
 //! Markhand's Phase 1B server boundary.
 
 pub mod api;
+pub mod auth;
 pub mod config;
 pub mod database;
 pub mod db;
 pub mod error;
 pub mod http;
+pub mod services;
 pub mod state;
 pub mod telemetry;
 

--- a/crates/server/src/services/document_state.rs
+++ b/crates/server/src/services/document_state.rs
@@ -1,0 +1,158 @@
+//! Legal document lifecycle transitions over `documents.state`.
+//!
+//! # Transition table
+//!
+//! | From        | Allowed targets                         |
+//! |-------------|-----------------------------------------|
+//! | uploaded    | converting, failed                      |
+//! | converting  | converted, failed                       |
+//! | converted   | indexing, failed                        |
+//! | indexing    | indexed, failed                         |
+//! | indexed     | tombstoned, failed                      |
+//! | failed      | converting _(only)_                     |
+//! | tombstoned  | purged                                  |
+//! | purged      | _(terminal)_                            |
+//!
+//! Happy path: `uploaded → converting → converted → indexing → indexed`.
+//! Any active state may fail. Soft-delete is `indexed → tombstoned → purged`.
+//!
+//! ## Failed retry policy (no failure-stage column in F03 schema)
+//!
+//! `documents.state = 'failed'` does not record which stage failed, so a retry
+//! cannot safely jump to `indexing`. Retries are restricted to
+//! `failed → converting` (full pipeline restart). Restoring
+//! `failed → indexing` requires a future failure-stage / provenance field.
+//!
+//! Transitions are applied under `SELECT … FOR UPDATE` plus a compare-and-set
+//! `UPDATE … WHERE state = $expected` so concurrent attempts serialize: exactly
+//! one commits.
+
+use deadpool_postgres::Pool;
+use tokio_postgres::Transaction;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::documents;
+use crate::db::error::DbError;
+use crate::db::models::{Document, DocumentState};
+use crate::db::pool::with_org_txn;
+
+/// Returns whether `from → to` is a legal lifecycle edge.
+pub fn is_legal_transition(from: DocumentState, to: DocumentState) -> bool {
+    use DocumentState::*;
+    matches!(
+        (from, to),
+        (Uploaded, Converting)
+            | (Uploaded, Failed)
+            | (Converting, Converted)
+            | (Converting, Failed)
+            | (Converted, Indexing)
+            | (Converted, Failed)
+            | (Indexing, Indexed)
+            | (Indexing, Failed)
+            | (Indexed, Tombstoned)
+            | (Indexed, Failed)
+            // No failure-stage provenance in schema: only full convert retry.
+            | (Failed, Converting)
+            | (Tombstoned, Purged)
+    )
+}
+
+/// Applies `to` if the locked row's current state matches `expected_from`.
+///
+/// Acquires `SELECT … FOR UPDATE`, validates the legal transition table, then
+/// compare-and-sets the state. On illegal or stale transitions this returns
+/// [`DbError::IllegalTransition`] / [`DbError::StaleState`] without mutating.
+pub async fn apply_transition(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    expected_from: DocumentState,
+    to: DocumentState,
+) -> Result<Document, DbError> {
+    let current = documents::get_by_id_for_update(txn, ctx, document_id).await?;
+    if current.state != expected_from {
+        return Err(DbError::StaleState {
+            expected: expected_from.to_string(),
+            observed: current.state.to_string(),
+        });
+    }
+    if !is_legal_transition(current.state, to) {
+        return Err(DbError::IllegalTransition {
+            from: current.state.to_string(),
+            to: to.to_string(),
+        });
+    }
+    documents::cas_state(txn, ctx, document_id, expected_from, to).await
+}
+
+/// Convenience: open an org transaction, lock, and transition.
+///
+/// Keeps the transaction short — no network/converter/LLM work inside.
+pub async fn transition(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    expected_from: DocumentState,
+    to: DocumentState,
+) -> Result<Document, DbError> {
+    let owned = ctx.clone();
+    with_org_txn(pool, ctx, move |txn| {
+        Box::pin(async move { apply_transition(txn, &owned, document_id, expected_from, to).await })
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn happy_path_and_terminal_edges() {
+        assert!(is_legal_transition(
+            DocumentState::Uploaded,
+            DocumentState::Converting
+        ));
+        assert!(is_legal_transition(
+            DocumentState::Converting,
+            DocumentState::Converted
+        ));
+        assert!(is_legal_transition(
+            DocumentState::Converted,
+            DocumentState::Indexing
+        ));
+        assert!(is_legal_transition(
+            DocumentState::Indexing,
+            DocumentState::Indexed
+        ));
+        assert!(is_legal_transition(
+            DocumentState::Indexed,
+            DocumentState::Tombstoned
+        ));
+        assert!(is_legal_transition(
+            DocumentState::Tombstoned,
+            DocumentState::Purged
+        ));
+        assert!(!is_legal_transition(
+            DocumentState::Purged,
+            DocumentState::Uploaded
+        ));
+        assert!(!is_legal_transition(
+            DocumentState::Uploaded,
+            DocumentState::Indexed
+        ));
+        assert!(is_legal_transition(
+            DocumentState::Failed,
+            DocumentState::Converting
+        ));
+        // Without failure-stage provenance, indexing retry from failed is illegal.
+        assert!(!is_legal_transition(
+            DocumentState::Failed,
+            DocumentState::Indexing
+        ));
+        assert!(!is_legal_transition(
+            DocumentState::Uploaded,
+            DocumentState::Indexing
+        ));
+    }
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -1,0 +1,3 @@
+//! Application services (use cases over repositories).
+
+pub mod document_state;

--- a/crates/server/tests/repositories.rs
+++ b/crates/server/tests/repositories.rs
@@ -1,0 +1,681 @@
+//! Integration tests for OrgContext, repositories, RLS, and document state machine.
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` is unset (same pattern as
+//! `schema_migrations.rs`). Uses the non-superuser `markhand_app` role so FORCE
+//! RLS genuinely applies.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::{OrgContext, OrgContextError};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::collections::{self, NewCollection};
+use fileconv_server::db::documents::{self, NewDocument};
+use fileconv_server::db::error::DbError;
+use fileconv_server::db::models::{CollectionVisibility, DocumentState};
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{
+    apply_org_context, create_pool, create_pool_with_max_size, with_org_txn,
+};
+use fileconv_server::services::document_state;
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!(
+                "skipped: MARKHAND_TEST_DATABASE_URL unset — repository integration tests require PostgreSQL"
+            );
+            None
+        }
+    }
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+fn admin_database_url(base_url: &str) -> String {
+    rewrite_database_url(base_url, "postgres")
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("connect failed for {database_url}: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_it_{}", Uuid::new_v4().simple());
+        let admin_url = admin_database_url(base_url);
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+async fn boot_pool(base_url: &str) -> (EphemeralDb, Pool) {
+    let ephemeral = EphemeralDb::create(base_url).await;
+    apply_migrations(&ephemeral.url)
+        .await
+        .expect("apply migrations");
+    let pool = create_pool(&ephemeral.url).expect("create pool");
+    (ephemeral, pool)
+}
+
+fn make_ctx(org: Uuid, user: Uuid) -> OrgContext {
+    OrgContext::try_new(org, user, ["doc.upload"], []).expect("valid OrgContext")
+}
+
+async fn seed_org(pool: &Pool, org: Uuid, user: Uuid, slug: &str) -> OrgContext {
+    let context = make_ctx(org, user);
+    let slug_owned = slug.to_string();
+    with_org_txn(pool, &context, {
+        let owned = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &owned, &slug_owned, &slug_owned).await?;
+                orgs::ensure_user(
+                    txn,
+                    &owned,
+                    user,
+                    &format!("{slug_owned}@example.com"),
+                    &slug_owned,
+                )
+                .await?;
+                orgs::ensure_membership(txn, &owned).await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed org");
+    context
+}
+
+async fn seed_collection(pool: &Pool, context: &OrgContext, slug: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let slug = slug.to_string();
+    with_org_txn(pool, context, {
+        let owned = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                collections::insert(
+                    txn,
+                    &owned,
+                    NewCollection {
+                        id,
+                        name: &slug,
+                        slug: &slug,
+                        description: None,
+                        visibility: CollectionVisibility::Org,
+                    },
+                )
+                .await?;
+                Ok(id)
+            })
+        }
+    })
+    .await
+    .expect("seed collection")
+}
+
+#[test]
+fn org_context_fail_closed_on_empty_scope() {
+    // Typed API: every public repository method requires `&OrgContext`.
+    // Construction rejects nil org/user so no usable context exists without scope.
+    assert_eq!(
+        OrgContext::try_new(Uuid::nil(), Uuid::new_v4(), [] as [&str; 0], []),
+        Err(OrgContextError::MissingOrgId)
+    );
+    assert_eq!(
+        OrgContext::try_new(Uuid::new_v4(), Uuid::nil(), [] as [&str; 0], []),
+        Err(OrgContextError::MissingUserId)
+    );
+}
+
+#[tokio::test]
+async fn cross_org_deny_via_predicate_and_rls() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+
+    let org_a = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let org_b = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+
+    let ctx_a = seed_org(&pool, org_a, user_a, "orga").await;
+    let ctx_b = seed_org(&pool, org_b, user_b, "orgb").await;
+    let collection_a = seed_collection(&pool, &ctx_a, "lib-a").await;
+    let collection_b = seed_collection(&pool, &ctx_b, "lib-b").await;
+
+    let doc_a = Uuid::new_v4();
+    let doc_b = Uuid::new_v4();
+    with_org_txn(&pool, &ctx_a, {
+        let owned = ctx_a.clone();
+        move |txn| {
+            Box::pin(async move {
+                documents::insert(
+                    txn,
+                    &owned,
+                    NewDocument {
+                        id: doc_a,
+                        collection_id: collection_a,
+                        title: "Doc A",
+                    },
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+    with_org_txn(&pool, &ctx_b, {
+        let owned = ctx_b.clone();
+        move |txn| {
+            Box::pin(async move {
+                documents::insert(
+                    txn,
+                    &owned,
+                    NewDocument {
+                        id: doc_b,
+                        collection_id: collection_b,
+                        title: "Doc B",
+                    },
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+
+    // App predicate: A's repository methods never see B.
+    with_org_txn(&pool, &ctx_a, {
+        let owned = ctx_a.clone();
+        move |txn| {
+            Box::pin(async move {
+                assert!(matches!(
+                    documents::get_by_id(txn, &owned, doc_b).await,
+                    Err(DbError::NotFound)
+                ));
+                assert_eq!(documents::count(txn, &owned).await?, 1);
+                assert!(matches!(
+                    collections::get_by_id(txn, &owned, collection_b).await,
+                    Err(DbError::NotFound)
+                ));
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+
+    // RLS defense-in-depth: raw read for B's id under A's GUC returns zero rows.
+    with_org_txn(&pool, &ctx_a, move |txn| {
+        Box::pin(async move {
+            let leaked: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM documents WHERE id = $1",
+                    &[&doc_b],
+                )
+                .await?
+                .get(0);
+            assert_eq!(leaked, 0, "RLS must hide org B rows under org A context");
+            let foreign_org: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM documents WHERE org_id = $1",
+                    &[&org_b],
+                )
+                .await?
+                .get(0);
+            assert_eq!(foreign_org, 0);
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn pool_does_not_leak_tenant_gucs() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    // Max size 1 forces the same physical backend connection to be reused.
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url)
+        .await
+        .expect("apply migrations");
+    let pool = create_pool_with_max_size(&ephemeral.url, 1).expect("pool size 1");
+
+    let org_a = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let org_b = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let ctx_a = seed_org(&pool, org_a, user_a, "leak-a").await;
+    let ctx_b = seed_org(&pool, org_b, user_b, "leak-b").await;
+    let collection_a = seed_collection(&pool, &ctx_a, "leak-lib-a").await;
+
+    // --- Commit path: capture backend pid while GUCs are set, then prove reuse + clear ---
+    let commit_pid: i32 = with_org_txn(&pool, &ctx_a, {
+        let owned = ctx_a.clone();
+        move |txn| {
+            Box::pin(async move {
+                documents::insert(
+                    txn,
+                    &owned,
+                    NewDocument {
+                        id: Uuid::new_v4(),
+                        collection_id: collection_a,
+                        title: "A only",
+                    },
+                )
+                .await?;
+                let setting: String = txn
+                    .query_one("SELECT current_setting('app.org_id', true)", &[])
+                    .await?
+                    .get(0);
+                assert_eq!(setting, org_a.to_string());
+                let pid: i32 = txn.query_one("SELECT pg_backend_pid()", &[]).await?.get(0);
+                Ok(pid)
+            })
+        }
+    })
+    .await
+    .unwrap();
+
+    let client = pool.get().await.expect("checkout after commit");
+    let reuse_pid: i32 = client
+        .query_one("SELECT pg_backend_pid()", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(
+        reuse_pid, commit_pid,
+        "pool max_size=1 must reuse the same backend after commit"
+    );
+    let leaked: Option<String> = client
+        .query_one(
+            "SELECT NULLIF(current_setting('app.org_id', true), '')",
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert!(
+        leaked.is_none(),
+        "app.org_id must be empty after committed txn, got {leaked:?}"
+    );
+    drop(client);
+
+    // --- Rollback path: forced Err must also clear GUCs on the same backend ---
+    let rollback_pid = std::sync::Arc::new(std::sync::Mutex::new(None::<i32>));
+    let rollback_pid_slot = std::sync::Arc::clone(&rollback_pid);
+    let rolled_back: Result<(), DbError> = with_org_txn(&pool, &ctx_a, move |txn| {
+        Box::pin(async move {
+            let setting: String = txn
+                .query_one("SELECT current_setting('app.org_id', true)", &[])
+                .await?
+                .get(0);
+            assert_eq!(setting, org_a.to_string());
+            let pid: i32 = txn.query_one("SELECT pg_backend_pid()", &[]).await?.get(0);
+            *rollback_pid_slot.lock().expect("pid lock") = Some(pid);
+            Err(DbError::Config("forced rollback".into()))
+        })
+    })
+    .await;
+    assert!(
+        matches!(rolled_back, Err(DbError::Config(_))),
+        "closure Err must take the rollback path: {rolled_back:?}"
+    );
+    let rollback_pid = rollback_pid
+        .lock()
+        .expect("pid lock")
+        .expect("pid captured before forced Err");
+    assert_eq!(
+        rollback_pid, commit_pid,
+        "rollback must also run on the single pooled backend"
+    );
+
+    let client = pool.get().await.expect("checkout after rollback");
+    let reuse_pid: i32 = client
+        .query_one("SELECT pg_backend_pid()", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(
+        reuse_pid, rollback_pid,
+        "pool max_size=1 must reuse the same backend after rollback"
+    );
+    let leaked: Option<String> = client
+        .query_one(
+            "SELECT NULLIF(current_setting('app.org_id', true), '')",
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert!(
+        leaked.is_none(),
+        "app.org_id must be empty after rolled-back txn, got {leaked:?}"
+    );
+    drop(client);
+
+    // Query under B cannot see A's rows (no residual A context on reused backend).
+    with_org_txn(&pool, &ctx_b, {
+        let owned = ctx_b.clone();
+        move |txn| {
+            Box::pin(async move {
+                assert_eq!(documents::count(txn, &owned).await?, 0);
+                let raw: i64 = txn
+                    .query_one(
+                        "SELECT count(*)::bigint FROM documents WHERE org_id = $1",
+                        &[&org_a],
+                    )
+                    .await?
+                    .get(0);
+                assert_eq!(raw, 0);
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn document_state_machine_legal_illegal_and_concurrent() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let pool = Arc::new(pool);
+
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let context = seed_org(&pool, org, user, "state-org").await;
+    let collection = seed_collection(&pool, &context, "state-lib").await;
+    let document_id = Uuid::new_v4();
+
+    with_org_txn(&pool, &context, {
+        let owned = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                documents::insert(
+                    txn,
+                    &owned,
+                    NewDocument {
+                        id: document_id,
+                        collection_id: collection,
+                        title: "State Machine Doc",
+                    },
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+
+    // Legal transition persists.
+    let converted = document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Uploaded,
+        DocumentState::Converting,
+    )
+    .await
+    .expect("uploaded→converting");
+    assert_eq!(converted.state, DocumentState::Converting);
+
+    let converted = document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Converting,
+        DocumentState::Converted,
+    )
+    .await
+    .expect("converting→converted");
+    assert_eq!(converted.state, DocumentState::Converted);
+
+    // Illegal transition rejected.
+    let illegal = document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Converted,
+        DocumentState::Indexed,
+    )
+    .await;
+    assert!(
+        matches!(illegal, Err(DbError::IllegalTransition { .. })),
+        "{illegal:?}"
+    );
+    with_org_txn(&pool, &context, {
+        let owned = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                let doc = documents::get_by_id(txn, &owned, document_id).await?;
+                assert_eq!(doc.state, DocumentState::Converted);
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+
+    // failed→indexing is illegal (no failure-stage provenance).
+    document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Converted,
+        DocumentState::Failed,
+    )
+    .await
+    .unwrap();
+    let bad_retry = document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Failed,
+        DocumentState::Indexing,
+    )
+    .await;
+    assert!(matches!(bad_retry, Err(DbError::IllegalTransition { .. })));
+    document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Failed,
+        DocumentState::Converting,
+    )
+    .await
+    .expect("failed→converting retry");
+    document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Converting,
+        DocumentState::Converted,
+    )
+    .await
+    .unwrap();
+
+    // Advance to indexing for concurrency test.
+    document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Converted,
+        DocumentState::Indexing,
+    )
+    .await
+    .unwrap();
+
+    // True lock contention: holder acquires FOR UPDATE and HOLDS it while the
+    // challenger blocks inside its own transition. Without FOR UPDATE the
+    // challenger would finish before release and both could succeed.
+    let (locked_tx, locked_rx) = tokio::sync::oneshot::channel::<()>();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let pool_holder = Arc::clone(&pool);
+    let ctx_holder = context.clone();
+    let holder = tokio::spawn(async move {
+        let mut client = pool_holder.get().await.expect("holder checkout");
+        let txn = client.transaction().await.expect("holder txn");
+        apply_org_context(&txn, &ctx_holder)
+            .await
+            .expect("holder GUC");
+        documents::get_by_id_for_update(&txn, &ctx_holder, document_id)
+            .await
+            .expect("holder FOR UPDATE");
+        let _ = locked_tx.send(());
+        release_rx.await.expect("release signal");
+        let doc = document_state::apply_transition(
+            &txn,
+            &ctx_holder,
+            document_id,
+            DocumentState::Indexing,
+            DocumentState::Indexed,
+        )
+        .await
+        .expect("holder transition");
+        txn.commit().await.expect("holder commit");
+        doc
+    });
+
+    locked_rx.await.expect("lock acquired");
+
+    let pool_challenger = Arc::clone(&pool);
+    let ctx_challenger = context.clone();
+    let challenger = tokio::spawn(async move {
+        document_state::transition(
+            &pool_challenger,
+            &ctx_challenger,
+            document_id,
+            DocumentState::Indexing,
+            DocumentState::Indexed,
+        )
+        .await
+    });
+
+    // While the holder still holds FOR UPDATE, the challenger must be blocked.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(
+        !challenger.is_finished(),
+        "challenger must block on FOR UPDATE while holder retains the row lock; \
+         if this passes without FOR UPDATE the contention test is invalid"
+    );
+
+    release_tx.send(()).expect("release holder");
+    let holder_doc = holder.await.expect("holder join");
+    assert_eq!(holder_doc.state, DocumentState::Indexed);
+
+    let challenger_res = challenger.await.expect("challenger join");
+    assert!(
+        matches!(challenger_res, Err(DbError::StaleState { .. })),
+        "loser must observe updated state as stale: {challenger_res:?}"
+    );
+
+    with_org_txn(&pool, &context, {
+        let owned = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                let doc = documents::get_by_id(txn, &owned, document_id).await?;
+                assert_eq!(doc.state, DocumentState::Indexed);
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+
+    // Tombstone → purge path.
+    document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Indexed,
+        DocumentState::Tombstoned,
+    )
+    .await
+    .unwrap();
+    let purged = document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Tombstoned,
+        DocumentState::Purged,
+    )
+    .await
+    .unwrap();
+    assert_eq!(purged.state, DocumentState::Purged);
+    let terminal = document_state::transition(
+        &pool,
+        &context,
+        document_id,
+        DocumentState::Purged,
+        DocumentState::Uploaded,
+    )
+    .await;
+    assert!(matches!(terminal, Err(DbError::IllegalTransition { .. })));
+
+    ephemeral.drop().await;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue
Closes P1B-F04 (#81) — OrgContext, repositories và state machine (Phase 1B).

> **Stacked on #217 (P1B-F03).** Base is the F03 branch; review/merge F03 first. The net diff shown here is F04 only.

## What
The tenant-scoped repository boundary on top of the F03 schema — the layer that guarantees no business-data access without tenant context.

- `src/auth/context.rs` — fail-closed `OrgContext { org_id, user_id, permissions, allowed_collection_ids }` (private fields; nil/empty scope rejected at construction; ADR 0001/0007).
- `src/db/pool.rs` — `deadpool-postgres` pool + `with_org_txn` that sets **transaction-local** `app.org_id`/`app.user_id` (`SET LOCAL` only, never session) and returns the connection with no residual GUC on both commit and rollback.
- `src/db/{orgs,collections,documents,chunks}.rs` — every public business method takes `&OrgContext` and predicates `org_id = ctx.org_id()`; no context-free path. Arbitrary state writes are not public — state changes go through a compare-and-set guarded by the state machine.
- `src/services/document_state.rs` — legal-only document transitions (`uploaded→converting→converted→indexing→indexed`; active→`failed`; `failed→converting` retry; `indexed→tombstoned→purged` terminal), applied atomically via `SELECT ... FOR UPDATE` + CAS.

## Tests / evidence (real PostgreSQL 16, gated on `MARKHAND_TEST_DATABASE_URL`)
- OrgContext fail-closed on empty scope.
- Cross-org denial via **both** SQL predicate **and** RLS (raw-query evidence inside an org-A txn returns 0 org-B rows).
- Pool non-leak proven with a **size-1 pool** asserting identical `pg_backend_pid()` and empty `app.org_id` after **commit and rollback**.
- State machine: legal/illegal transitions + a genuine lock-contention concurrency test (fails if `FOR UPDATE` removed; exactly one winner, loser gets `StaleState`).

Local: 18 unit + 4 F04 integration + 8 F03 integration pass. fmt, clippy (`--no-deps` knowledge+server `--all-targets -D warnings`), architecture-boundary, and lint-baseline all pass.

## Review
Passed the mandatory review gate (GPT‑5.6 sol) after fixing 3 blocking findings (public arbitrary state write removed → CAS-only; concurrency test made to force real lock contention; pool-leak test hardened to prove same backend + rollback). Implementation by Grok.

## Out of scope
Full ACL semantics (1C), auth password/session (F05), Qdrant/MinIO adapters (F06).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

