### PR TITLE
P1B-F05 — Password auth, rotating sessions and bearer transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +521,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1129,6 +1156,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1253,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1349,6 +1415,7 @@ dependencies = [
  "const-oid 0.9.6",
  "der_derive",
  "flagset",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1424,6 +1491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1596,10 +1664,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embed-resource"
@@ -1801,6 +1928,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,12 +2038,17 @@ dependencies = [
 name = "fileconv-server"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "deadpool-postgres",
  "fileconv-core",
  "fileconv-knowledge",
+ "hex",
  "http-body-util",
+ "jsonwebtoken",
+ "rand 0.10.2",
  "reqwest 0.13.4",
  "rust_decimal",
  "rustls",
@@ -2242,6 +2390,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2390,6 +2539,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +2695,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "hmac"
@@ -3183,6 +3352,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac 0.12.1",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.7",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3218,6 +3411,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libappindicator"
@@ -3277,6 +3473,12 @@ dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -3363,7 +3565,7 @@ dependencies = [
  "log",
  "md-5 0.10.6",
  "nom 8.0.0",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rangemap",
  "rayon",
  "sha2 0.10.9",
@@ -3657,10 +3859,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3669,6 +3916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3980,6 +4228,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4031,6 +4303,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4106,6 +4389,25 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -4189,6 +4491,27 @@ name = "piston-float"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -4283,7 +4606,7 @@ dependencies = [
  "hmac 0.13.0",
  "md-5 0.11.0",
  "memchr",
- "rand 0.10.1",
+ "rand 0.10.2",
  "sha2 0.11.0",
  "stringprep",
 ]
@@ -4347,6 +4670,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -4590,9 +4922,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -4834,6 +5166,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4933,6 +5275,26 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5178,6 +5540,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -5468,6 +5844,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5488,6 +5874,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -5564,6 +5962,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -6501,7 +6905,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.10.1",
+ "rand 0.10.2",
  "socket2",
  "tokio",
  "tokio-util",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,11 +19,16 @@ name = "fileconv-worker"
 path = "src/bin/worker.rs"
 
 [dependencies]
+argon2 = "0.5.3"
 axum = { version = "0.8.9", features = ["json"] }
+base64 = "0.22.1"
 chrono = { version = "0.4.45", features = ["serde", "clock"] }
 deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
 fileconv-core = { path = "../core" }
 fileconv-knowledge = { path = "../knowledge" }
+hex = "0.4.3"
+jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+rand = "0.10.2"
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
 rust_decimal = { version = "1.42.1", features = ["serde", "db-tokio-postgres"] }
 rustls = "0.23.42"

--- a/crates/server/src/auth/jwt.rs
+++ b/crates/server/src/auth/jwt.rs
@@ -1,0 +1,438 @@
+//! Signed JWT access tokens with pinned algorithm, issuer, audience, and kid.
+
+use std::fmt;
+
+use base64::Engine;
+use chrono::{Duration, Utc};
+use jsonwebtoken::{
+    decode, decode_header, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::config::{AuthConfig, JwtAlgorithm, SecretString};
+
+/// Access-token claims. `org_id` / `sid` are hints only — authorization loads from PG.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccessClaims {
+    pub sub: String,
+    pub iss: String,
+    pub aud: String,
+    pub iat: i64,
+    pub nbf: i64,
+    pub exp: i64,
+    /// Org id hint (authorization must re-resolve from PostgreSQL).
+    pub org_id: String,
+    /// Session / refresh-token family id.
+    pub sid: String,
+}
+
+/// Errors from JWT signing or verification.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum JwtError {
+    #[error("authentication is not configured")]
+    NotConfigured,
+    #[error("token encoding failed")]
+    Encode,
+    #[error("token is invalid")]
+    Invalid,
+    #[error("token algorithm is not allowed")]
+    Algorithm,
+    #[error("token kid mismatch")]
+    Kid,
+    #[error("token claims are invalid")]
+    Claims,
+}
+
+/// HS256 signer/verifier bound to pinned AuthConfig values.
+#[derive(Clone)]
+pub struct JwtKeys {
+    encoding: EncodingKey,
+    decoding: DecodingKey,
+    issuer: String,
+    audience: String,
+    kid: String,
+    access_token_ttl_secs: u64,
+}
+
+impl fmt::Debug for JwtKeys {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JwtKeys")
+            .field("issuer", &self.issuer)
+            .field("audience", &self.audience)
+            .field("kid", &self.kid)
+            .field("access_token_ttl_secs", &self.access_token_ttl_secs)
+            .field("encoding", &"[REDACTED]")
+            .field("decoding", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl JwtKeys {
+    /// Builds keys from a fully configured [`AuthConfig`].
+    ///
+    /// Defense-in-depth: independently enforces HS256 key length ≥ 32 bytes and
+    /// access TTL in `(0, 900]` even if callers bypass [`ServerConfig`] validation.
+    pub fn from_auth(auth: &AuthConfig) -> Result<Self, JwtError> {
+        let issuer = auth.issuer.as_deref().ok_or(JwtError::NotConfigured)?;
+        let audience = auth.audience.as_deref().ok_or(JwtError::NotConfigured)?;
+        let signing_key = auth.signing_key.as_ref().ok_or(JwtError::NotConfigured)?;
+        let kid = auth.kid.as_deref().ok_or(JwtError::NotConfigured)?;
+        if auth.alg != JwtAlgorithm::Hs256 {
+            return Err(JwtError::Algorithm);
+        }
+        let secret = signing_key.expose().as_bytes();
+        if secret.len() < 32 {
+            return Err(JwtError::Claims);
+        }
+        if auth.access_token_ttl_secs == 0 || auth.access_token_ttl_secs > 900 {
+            return Err(JwtError::Claims);
+        }
+        if kid.trim().is_empty() || issuer.is_empty() || audience.is_empty() {
+            return Err(JwtError::NotConfigured);
+        }
+        Ok(Self {
+            encoding: EncodingKey::from_secret(secret),
+            decoding: DecodingKey::from_secret(secret),
+            issuer: issuer.to_string(),
+            audience: audience.to_string(),
+            kid: kid.to_string(),
+            access_token_ttl_secs: auth.access_token_ttl_secs,
+        })
+    }
+
+    pub fn kid(&self) -> &str {
+        &self.kid
+    }
+
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    pub fn audience(&self) -> &str {
+        &self.audience
+    }
+
+    /// Signs a short-lived access token for `user_id` / `org_id` / session family `sid`.
+    pub fn sign_access_token(
+        &self,
+        user_id: Uuid,
+        org_id: Uuid,
+        sid: Uuid,
+    ) -> Result<SecretString, JwtError> {
+        let now = Utc::now();
+        let ttl = Duration::seconds(self.access_token_ttl_secs as i64);
+        let claims = AccessClaims {
+            sub: user_id.to_string(),
+            iss: self.issuer.clone(),
+            aud: self.audience.clone(),
+            iat: now.timestamp(),
+            nbf: now.timestamp(),
+            exp: (now + ttl).timestamp(),
+            org_id: org_id.to_string(),
+            sid: sid.to_string(),
+        };
+        let mut header = Header::new(Algorithm::HS256);
+        header.kid = Some(self.kid.clone());
+        let token = encode(&header, &claims, &self.encoding).map_err(|_| JwtError::Encode)?;
+        Ok(SecretString::new(token))
+    }
+
+    /// Verifies signature and pinned alg/iss/aud/kid/exp/nbf. Rejects `none` and wrong alg.
+    pub fn verify_access_token(&self, token: &str) -> Result<AccessClaims, JwtError> {
+        // Reject `alg: none` even if the library cannot parse it into Algorithm.
+        let header_json = token
+            .split('.')
+            .next()
+            .ok_or(JwtError::Invalid)
+            .and_then(|part| {
+                Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, part)
+                    .or_else(|_| Engine::decode(&base64::engine::general_purpose::URL_SAFE, part))
+                    .map_err(|_| JwtError::Invalid)
+            })?;
+        let header_value: serde_json::Value =
+            serde_json::from_slice(&header_json).map_err(|_| JwtError::Invalid)?;
+        match header_value.get("alg").and_then(|value| value.as_str()) {
+            Some("HS256") => {}
+            Some("none") | Some("None") | Some("NONE") => return Err(JwtError::Algorithm),
+            Some(_) => return Err(JwtError::Algorithm),
+            None => return Err(JwtError::Algorithm),
+        }
+
+        let header = decode_header(token).map_err(|_| JwtError::Invalid)?;
+        if header.alg != Algorithm::HS256 {
+            return Err(JwtError::Algorithm);
+        }
+        if header.kid.as_deref() != Some(self.kid.as_str()) {
+            return Err(JwtError::Kid);
+        }
+
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.validate_nbf = true;
+        validation.set_issuer(&[self.issuer.as_str()]);
+        validation.set_audience(&[self.audience.as_str()]);
+        validation.set_required_spec_claims(&["exp", "iat", "nbf", "sub", "iss", "aud"]);
+
+        let data = decode::<AccessClaims>(token, &self.decoding, &validation)
+            .map_err(|_| JwtError::Invalid)?;
+        if data.header.alg != Algorithm::HS256 {
+            return Err(JwtError::Algorithm);
+        }
+        if data.header.kid.as_deref() != Some(self.kid.as_str()) {
+            return Err(JwtError::Kid);
+        }
+        let claims = data.claims;
+        if claims.sub.is_empty()
+            || Uuid::parse_str(&claims.sub).is_err()
+            || Uuid::parse_str(&claims.org_id).is_err()
+            || Uuid::parse_str(&claims.sid).is_err()
+        {
+            return Err(JwtError::Claims);
+        }
+        // jsonwebtoken 10.x does not enforce iat; do it explicitly with checked math.
+        self.validate_iat_lifetime(&claims)?;
+        Ok(claims)
+    }
+
+    fn validate_iat_lifetime(&self, claims: &AccessClaims) -> Result<(), JwtError> {
+        const LEEWAY_SECS: i64 = 60;
+        let now = Utc::now().timestamp();
+        // Reject future iat (beyond small clock skew leeway).
+        let max_iat = now.checked_add(LEEWAY_SECS).ok_or(JwtError::Claims)?;
+        if claims.iat > max_iat {
+            return Err(JwtError::Claims);
+        }
+        // exp must be strictly after iat.
+        if claims.exp <= claims.iat {
+            return Err(JwtError::Claims);
+        }
+        let lifetime = claims.exp.checked_sub(claims.iat).ok_or(JwtError::Claims)?;
+        let max_ttl = i64::try_from(self.access_token_ttl_secs).map_err(|_| JwtError::Claims)?;
+        if lifetime > max_ttl {
+            return Err(JwtError::Claims);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Argon2Config, AuthConfig, JwtAlgorithm, SecretString};
+    use base64::Engine;
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+
+    fn test_auth() -> AuthConfig {
+        AuthConfig {
+            issuer: Some("https://issuer.markhand.test".into()),
+            audience: Some("markhand-api".into()),
+            signing_key: Some(SecretString::new("unit-test-signing-key-at-least-32b!")),
+            alg: JwtAlgorithm::Hs256,
+            kid: Some("test-kid-1".into()),
+            access_token_ttl_secs: 900,
+            refresh_token_ttl_secs: 3600,
+            argon2: Argon2Config {
+                memory_kib: 8_192,
+                time_cost: 1,
+                parallelism: 1,
+            },
+        }
+    }
+
+    fn keys() -> JwtKeys {
+        JwtKeys::from_auth(&test_auth()).unwrap()
+    }
+
+    #[test]
+    fn sign_verify_round_trip_and_debug_redacts_secret() {
+        let keys = keys();
+        let user = Uuid::new_v4();
+        let org = Uuid::new_v4();
+        let sid = Uuid::new_v4();
+        let token = keys.sign_access_token(user, org, sid).unwrap();
+        let claims = keys.verify_access_token(token.expose()).unwrap();
+        assert_eq!(claims.sub, user.to_string());
+        assert_eq!(claims.org_id, org.to_string());
+        assert_eq!(claims.sid, sid.to_string());
+        assert!(!format!("{keys:?}").contains("unit-test-signing-key"));
+        assert!(!format!("{token:?}").contains(token.expose()));
+    }
+
+    #[test]
+    fn rejects_wrong_issuer_audience_kid_and_tamper() {
+        let keys = keys();
+        let token = keys
+            .sign_access_token(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4())
+            .unwrap();
+
+        let mut other = test_auth();
+        other.issuer = Some("https://other.example".into());
+        assert_eq!(
+            JwtKeys::from_auth(&other)
+                .unwrap()
+                .verify_access_token(token.expose()),
+            Err(JwtError::Invalid)
+        );
+
+        let mut other = test_auth();
+        other.audience = Some("other-aud".into());
+        assert_eq!(
+            JwtKeys::from_auth(&other)
+                .unwrap()
+                .verify_access_token(token.expose()),
+            Err(JwtError::Invalid)
+        );
+
+        let mut other = test_auth();
+        other.kid = Some("other-kid".into());
+        assert_eq!(
+            JwtKeys::from_auth(&other)
+                .unwrap()
+                .verify_access_token(token.expose()),
+            Err(JwtError::Kid)
+        );
+
+        let mut tampered = token.expose().to_string();
+        tampered.push('x');
+        assert_eq!(keys.verify_access_token(&tampered), Err(JwtError::Invalid));
+    }
+
+    #[test]
+    fn rejects_none_and_wrong_algorithm() {
+        let keys = keys();
+        let user = Uuid::new_v4();
+        let claims = AccessClaims {
+            sub: user.to_string(),
+            iss: keys.issuer.clone(),
+            aud: keys.audience.clone(),
+            iat: Utc::now().timestamp(),
+            nbf: Utc::now().timestamp(),
+            exp: (Utc::now() + Duration::minutes(5)).timestamp(),
+            org_id: Uuid::new_v4().to_string(),
+            sid: Uuid::new_v4().to_string(),
+        };
+
+        // Manually craft an unsigned "none" token.
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"none","typ":"JWT"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&claims).unwrap());
+        let none_token = format!("{header}.{payload}.");
+        assert_eq!(
+            keys.verify_access_token(&none_token),
+            Err(JwtError::Algorithm)
+        );
+
+        let mut header = Header::new(Algorithm::HS384);
+        header.kid = Some(keys.kid.clone());
+        let wrong_alg = encode(
+            &header,
+            &claims,
+            &EncodingKey::from_secret(b"unit-test-signing-key-at-least-32b!"),
+        )
+        .unwrap();
+        assert_eq!(
+            keys.verify_access_token(&wrong_alg),
+            Err(JwtError::Algorithm)
+        );
+    }
+
+    #[test]
+    fn rejects_expired_and_not_before() {
+        let keys = keys();
+        let now = Utc::now();
+        let claims = AccessClaims {
+            sub: Uuid::new_v4().to_string(),
+            iss: keys.issuer.clone(),
+            aud: keys.audience.clone(),
+            iat: (now - Duration::hours(2)).timestamp(),
+            nbf: (now - Duration::hours(2)).timestamp(),
+            exp: (now - Duration::hours(1)).timestamp(),
+            org_id: Uuid::new_v4().to_string(),
+            sid: Uuid::new_v4().to_string(),
+        };
+        let mut header = Header::new(Algorithm::HS256);
+        header.kid = Some(keys.kid.clone());
+        let expired = encode(&header, &claims, &keys.encoding).unwrap();
+        assert_eq!(keys.verify_access_token(&expired), Err(JwtError::Invalid));
+
+        let future = AccessClaims {
+            nbf: (now + Duration::hours(1)).timestamp(),
+            exp: (now + Duration::hours(2)).timestamp(),
+            iat: now.timestamp(),
+            ..claims
+        };
+        let not_before = encode(&header, &future, &keys.encoding).unwrap();
+        assert_eq!(
+            keys.verify_access_token(&not_before),
+            Err(JwtError::Invalid)
+        );
+    }
+
+    #[test]
+    fn rejects_overlong_lifetime_future_iat_and_exp_before_iat() {
+        let keys = keys();
+        let now = Utc::now();
+        let mut header = Header::new(Algorithm::HS256);
+        header.kid = Some(keys.kid.clone());
+        let base = AccessClaims {
+            sub: Uuid::new_v4().to_string(),
+            iss: keys.issuer.clone(),
+            aud: keys.audience.clone(),
+            iat: now.timestamp(),
+            nbf: now.timestamp(),
+            exp: (now + Duration::seconds(901)).timestamp(),
+            org_id: Uuid::new_v4().to_string(),
+            sid: Uuid::new_v4().to_string(),
+        };
+        let overlong = encode(&header, &base, &keys.encoding).unwrap();
+        assert_eq!(
+            keys.verify_access_token(&overlong),
+            Err(JwtError::Claims),
+            "lifetime > configured access TTL must be rejected"
+        );
+
+        let future_iat = AccessClaims {
+            iat: (now + Duration::hours(2)).timestamp(),
+            nbf: now.timestamp(),
+            exp: (now + Duration::hours(2) + Duration::minutes(5)).timestamp(),
+            ..base.clone()
+        };
+        let future = encode(&header, &future_iat, &keys.encoding).unwrap();
+        assert_eq!(
+            keys.verify_access_token(&future),
+            Err(JwtError::Claims),
+            "future iat must be rejected"
+        );
+
+        let inverted = AccessClaims {
+            iat: (now + Duration::seconds(30)).timestamp(),
+            nbf: now.timestamp(),
+            // Still in the future for the library clock check, but earlier than iat.
+            exp: (now + Duration::seconds(20)).timestamp(),
+            ..base
+        };
+        let bad_exp = encode(&header, &inverted, &keys.encoding).unwrap();
+        assert_eq!(
+            keys.verify_access_token(&bad_exp),
+            Err(JwtError::Claims),
+            "exp <= iat must be rejected"
+        );
+    }
+
+    #[test]
+    fn from_auth_rejects_short_key_and_overlong_ttl() {
+        let mut auth = test_auth();
+        auth.signing_key = Some(SecretString::new("too-short"));
+        assert!(matches!(JwtKeys::from_auth(&auth), Err(JwtError::Claims)));
+
+        let mut auth = test_auth();
+        auth.access_token_ttl_secs = 901;
+        assert!(matches!(JwtKeys::from_auth(&auth), Err(JwtError::Claims)));
+
+        let mut auth = test_auth();
+        auth.access_token_ttl_secs = 0;
+        assert!(matches!(JwtKeys::from_auth(&auth), Err(JwtError::Claims)));
+    }
+}

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -1,0 +1,249 @@
+//! Axum extractors that resolve OrgContext from current PostgreSQL state.
+
+use std::sync::Arc;
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use uuid::Uuid;
+
+use crate::api::ApiError;
+use crate::auth::context::OrgContext;
+use crate::auth::jwt::{AccessClaims, JwtKeys};
+use crate::auth::permissions::{resolve_org_context_in_txn, ResolveError};
+use crate::auth::session::SessionError;
+
+/// Authenticated request with OrgContext loaded from current PG membership.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedOrg {
+    pub context: OrgContext,
+    pub claims: AccessClaims,
+    pub request_id: String,
+}
+
+/// Rejection for auth middleware (stable API error body).
+pub struct AuthRejection {
+    status: StatusCode,
+    code: &'static str,
+    message: &'static str,
+    request_id: String,
+}
+
+impl AuthRejection {
+    fn new(
+        status: StatusCode,
+        code: &'static str,
+        message: &'static str,
+        request_id: String,
+    ) -> Self {
+        Self {
+            status,
+            code,
+            message,
+            request_id,
+        }
+    }
+}
+
+impl IntoResponse for AuthRejection {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            Json(ApiError {
+                code: self.code.into(),
+                message: self.message.into(),
+                request_id: self.request_id,
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}
+
+fn request_id_from(_parts: &Parts) -> String {
+    // Server-minted only — never persist caller-controlled correlation headers.
+    Uuid::new_v4().to_string()
+}
+
+fn bearer_token(parts: &Parts) -> Result<&str, ()> {
+    let header = parts
+        .headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or(())?;
+    let token = header
+        .strip_prefix("Bearer ")
+        .or_else(|| header.strip_prefix("bearer "))
+        .ok_or(())?;
+    if token.is_empty() || token.len() > 4096 {
+        return Err(());
+    }
+    Ok(token)
+}
+
+impl FromRequestParts<Arc<crate::http::AppState>> for AuthenticatedOrg {
+    type Rejection = AuthRejection;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &Arc<crate::http::AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        let request_id = request_id_from(parts);
+        let provider = state.auth_provider().ok_or_else(|| {
+            AuthRejection::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "auth_unavailable",
+                "Authentication is not configured",
+                request_id.clone(),
+            )
+        })?;
+
+        let token = bearer_token(parts).map_err(|_| {
+            AuthRejection::new(
+                StatusCode::UNAUTHORIZED,
+                "unauthorized",
+                "Missing or invalid bearer token",
+                request_id.clone(),
+            )
+        })?;
+
+        // Do not log the token.
+        let claims = provider.keys().verify_access_token(token).map_err(|_| {
+            AuthRejection::new(
+                StatusCode::UNAUTHORIZED,
+                "unauthorized",
+                "Access token is invalid or expired",
+                request_id.clone(),
+            )
+        })?;
+
+        let user_id = Uuid::parse_str(&claims.sub).map_err(|_| {
+            AuthRejection::new(
+                StatusCode::UNAUTHORIZED,
+                "unauthorized",
+                "Access token subject is invalid",
+                request_id.clone(),
+            )
+        })?;
+        let org_id = Uuid::parse_str(&claims.org_id).map_err(|_| {
+            AuthRejection::new(
+                StatusCode::UNAUTHORIZED,
+                "unauthorized",
+                "Access token org claim is invalid",
+                request_id.clone(),
+            )
+        })?;
+
+        // Authorization is current PG state — JWT org/user are hints only.
+        let context = resolve_org_context_in_txn(provider.pool(), org_id, user_id)
+            .await
+            .map_err(|error| map_resolve_error(error, &request_id))?;
+
+        Ok(Self {
+            context,
+            claims,
+            request_id,
+        })
+    }
+}
+
+fn map_resolve_error(error: ResolveError, request_id: &str) -> AuthRejection {
+    match error {
+        ResolveError::UserDisabled => AuthRejection::new(
+            StatusCode::FORBIDDEN,
+            "user_disabled",
+            "User account is disabled",
+            request_id.to_string(),
+        ),
+        ResolveError::MembershipMissing => AuthRejection::new(
+            StatusCode::FORBIDDEN,
+            "membership_missing",
+            "Org membership is missing",
+            request_id.to_string(),
+        ),
+        ResolveError::PermissionDenied => AuthRejection::new(
+            StatusCode::FORBIDDEN,
+            "permission_denied",
+            "Permission denied",
+            request_id.to_string(),
+        ),
+        ResolveError::CollectionDenied => AuthRejection::new(
+            StatusCode::FORBIDDEN,
+            "collection_denied",
+            "Collection access denied",
+            request_id.to_string(),
+        ),
+        ResolveError::InvalidContext | ResolveError::Database => AuthRejection::new(
+            StatusCode::UNAUTHORIZED,
+            "unauthorized",
+            "Unable to resolve organization context",
+            request_id.to_string(),
+        ),
+    }
+}
+
+/// Maps session errors to HTTP responses without embedding secrets.
+pub fn session_error_response(error: SessionError, request_id: &str) -> Response {
+    let (status, code, message) = match error {
+        SessionError::InvalidCredentials => (
+            StatusCode::UNAUTHORIZED,
+            "invalid_credentials",
+            "Email or password is incorrect",
+        ),
+        SessionError::UserDisabled => (
+            StatusCode::FORBIDDEN,
+            "user_disabled",
+            "User account is disabled",
+        ),
+        SessionError::MembershipMissing => (
+            StatusCode::FORBIDDEN,
+            "membership_missing",
+            "Org membership is missing",
+        ),
+        SessionError::InvalidRefresh => (
+            StatusCode::UNAUTHORIZED,
+            "invalid_refresh",
+            "Refresh token is invalid or expired",
+        ),
+        SessionError::RefreshReuse => (
+            StatusCode::UNAUTHORIZED,
+            "refresh_reuse",
+            "Refresh token reuse detected; session family revoked",
+        ),
+        SessionError::NotConfigured => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "auth_unavailable",
+            "Authentication is not configured",
+        ),
+        SessionError::Database | SessionError::Token | SessionError::Password => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_error",
+            "Authentication failed",
+        ),
+    };
+    (
+        status,
+        Json(ApiError {
+            code: code.into(),
+            message: message.into(),
+            request_id: request_id.to_string(),
+            details: None,
+        }),
+    )
+        .into_response()
+}
+
+/// Verify-only helper for tests that do not go through axum extractors.
+pub fn verify_bearer_claims(
+    keys: &JwtKeys,
+    authorization: &str,
+) -> Result<AccessClaims, SessionError> {
+    let token = authorization
+        .strip_prefix("Bearer ")
+        .or_else(|| authorization.strip_prefix("bearer "))
+        .ok_or(SessionError::InvalidCredentials)?;
+    keys.verify_access_token(token)
+        .map_err(|_| SessionError::Token)
+}

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -1,3 +1,9 @@
 //! Authentication and tenant context (ADR 0007 / ADR 0010).
 
 pub mod context;
+pub mod jwt;
+pub mod middleware;
+pub mod password;
+pub mod permissions;
+pub mod provider;
+pub mod session;

--- a/crates/server/src/auth/password.rs
+++ b/crates/server/src/auth/password.rs
@@ -1,0 +1,103 @@
+//! Argon2id password hashing with configurable parameters and rehash-on-login.
+
+use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
+use argon2::{Algorithm, Argon2, Params, Version};
+use thiserror::Error;
+
+use crate::config::{Argon2Config, SecretString};
+
+/// Errors from password hashing or verification.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PasswordError {
+    #[error("password hashing failed")]
+    Hash,
+    #[error("password verification failed")]
+    Verify,
+    #[error("stored password hash is invalid")]
+    InvalidHash,
+}
+
+/// Hashes a password with Argon2id using the configured parameters.
+pub fn hash_password(password: &str, params: &Argon2Config) -> Result<SecretString, PasswordError> {
+    let salt = SaltString::generate(&mut argon2::password_hash::rand_core::OsRng);
+    let argon = build_argon2(params)?;
+    let encoded = argon
+        .hash_password(password.as_bytes(), &salt)
+        .map_err(|_| PasswordError::Hash)?
+        .to_string();
+    Ok(SecretString::new(encoded))
+}
+
+/// Verifies `password` against a stored PHC hash string.
+pub fn verify_password(password: &str, password_hash: &str) -> Result<(), PasswordError> {
+    let parsed = PasswordHash::new(password_hash).map_err(|_| PasswordError::InvalidHash)?;
+    Argon2::default()
+        .verify_password(password.as_bytes(), &parsed)
+        .map_err(|_| PasswordError::Verify)
+}
+
+/// Returns true when the stored hash does not match the configured Argon2id parameters.
+pub fn needs_rehash(password_hash: &str, params: &Argon2Config) -> Result<bool, PasswordError> {
+    let parsed = PasswordHash::new(password_hash).map_err(|_| PasswordError::InvalidHash)?;
+    let stored = Params::try_from(&parsed).map_err(|_| PasswordError::InvalidHash)?;
+    let algorithm =
+        Algorithm::try_from(parsed.algorithm).map_err(|_| PasswordError::InvalidHash)?;
+    Ok(algorithm != Algorithm::Argon2id
+        || stored.m_cost() != params.memory_kib
+        || stored.t_cost() != params.time_cost
+        || stored.p_cost() != params.parallelism)
+}
+
+fn build_argon2(params: &Argon2Config) -> Result<Argon2<'static>, PasswordError> {
+    let argon_params = Params::new(
+        params.memory_kib,
+        params.time_cost,
+        params.parallelism,
+        None,
+    )
+    .map_err(|_| PasswordError::Hash)?;
+    Ok(Argon2::new(
+        Algorithm::Argon2id,
+        Version::V0x13,
+        argon_params,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Argon2Config;
+
+    fn fast_params() -> Argon2Config {
+        Argon2Config {
+            memory_kib: 8_192,
+            time_cost: 1,
+            parallelism: 1,
+        }
+    }
+
+    #[test]
+    fn hash_verifies_and_wrong_password_fails() {
+        let params = fast_params();
+        let hash = hash_password("correct horse battery", &params).unwrap();
+        assert!(verify_password("correct horse battery", hash.expose()).is_ok());
+        assert_eq!(
+            verify_password("wrong-password", hash.expose()),
+            Err(PasswordError::Verify)
+        );
+        assert!(!format!("{hash:?}").contains("correct"));
+    }
+
+    #[test]
+    fn rehash_triggered_when_params_change() {
+        let weak = fast_params();
+        let hash = hash_password("secret-value", &weak).unwrap();
+        assert!(!needs_rehash(hash.expose(), &weak).unwrap());
+        let stronger = Argon2Config {
+            memory_kib: 16_384,
+            time_cost: 2,
+            parallelism: 1,
+        };
+        assert!(needs_rehash(hash.expose(), &stronger).unwrap());
+    }
+}

--- a/crates/server/src/auth/permissions.rs
+++ b/crates/server/src/auth/permissions.rs
@@ -1,0 +1,235 @@
+//! Resolve current-state OrgContext from PostgreSQL (JWT claims are hints only).
+
+use deadpool_postgres::Client;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+
+/// Failures when resolving authorization from current PG membership state.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ResolveError {
+    #[error("user is disabled")]
+    UserDisabled,
+    #[error("org membership not found")]
+    MembershipMissing,
+    #[error("permission denied")]
+    PermissionDenied,
+    #[error("collection access denied")]
+    CollectionDenied,
+    #[error("org context construction failed")]
+    InvalidContext,
+    #[error("database error")]
+    Database,
+}
+
+impl From<DbError> for ResolveError {
+    fn from(_: DbError) -> Self {
+        Self::Database
+    }
+}
+
+/// Loads permissions and allowed collections from current PG state.
+///
+/// Requires `app.org_id` (and preferably `app.user_id`) already set on `client`
+/// when querying RLS-protected tables. Callers typically use [`crate::db::pool::with_org_txn`]
+/// with a provisional context, or set GUCs before calling.
+pub async fn resolve_org_context(
+    client: &Client,
+    org_id: Uuid,
+    user_id: Uuid,
+) -> Result<OrgContext, ResolveError> {
+    let user_row = client
+        .query_opt("SELECT disabled_at FROM users WHERE id = $1", &[&user_id])
+        .await
+        .map_err(|_| ResolveError::Database)?;
+    let Some(user_row) = user_row else {
+        return Err(ResolveError::MembershipMissing);
+    };
+    let disabled_at: Option<chrono::DateTime<chrono::Utc>> = user_row.get(0);
+    if disabled_at.is_some() {
+        return Err(ResolveError::UserDisabled);
+    }
+
+    let membership = client
+        .query_opt(
+            "SELECT role FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+            &[&org_id, &user_id],
+        )
+        .await
+        .map_err(|_| ResolveError::Database)?;
+    if membership.is_none() {
+        return Err(ResolveError::MembershipMissing);
+    }
+
+    let permission_rows = client
+        .query(
+            "SELECT p.code
+             FROM org_memberships m
+             JOIN roles r
+               ON r.org_id = m.org_id AND r.code = m.role
+             JOIN role_permissions rp
+               ON rp.org_id = r.org_id AND rp.role_id = r.id
+             JOIN permissions p
+               ON p.id = rp.permission_id
+             WHERE m.org_id = $1 AND m.user_id = $2
+             ORDER BY p.code",
+            &[&org_id, &user_id],
+        )
+        .await
+        .map_err(|_| ResolveError::Database)?;
+    let permissions: Vec<String> = permission_rows.iter().map(|row| row.get(0)).collect();
+
+    // POC collection allow-list (full ACL is Phase 1C): org-visible, owned, or direct user grant.
+    let collection_rows = client
+        .query(
+            "SELECT c.id
+             FROM collections c
+             WHERE c.org_id = $1
+               AND c.deleted_at IS NULL
+               AND (
+                 c.visibility = 'org'
+                 OR c.owner_user_id = $2
+                 OR EXISTS (
+                   SELECT 1 FROM collection_user_access cua
+                   WHERE cua.org_id = c.org_id
+                     AND cua.collection_id = c.id
+                     AND cua.user_id = $2
+                 )
+               )",
+            &[&org_id, &user_id],
+        )
+        .await
+        .map_err(|_| ResolveError::Database)?;
+    let collections: Vec<Uuid> = collection_rows.iter().map(|row| row.get(0)).collect();
+
+    OrgContext::try_new(org_id, user_id, permissions, collections)
+        .map_err(|_| ResolveError::InvalidContext)
+}
+
+/// Returns true when `ctx` holds the named permission code.
+pub fn check_permission(ctx: &OrgContext, code: &str) -> bool {
+    ctx.has_permission(code)
+}
+
+/// Fail-closed permission gate for business routes.
+pub fn require_permission(ctx: &OrgContext, code: &str) -> Result<(), ResolveError> {
+    if check_permission(ctx, code) {
+        Ok(())
+    } else {
+        Err(ResolveError::PermissionDenied)
+    }
+}
+
+/// Fail-closed collection allow-list gate for business routes.
+pub fn require_collection(ctx: &OrgContext, collection_id: Uuid) -> Result<(), ResolveError> {
+    if ctx.allows_collection(collection_id) {
+        Ok(())
+    } else {
+        Err(ResolveError::CollectionDenied)
+    }
+}
+
+/// Convenience: resolve inside a transaction-local org GUC scope.
+pub async fn resolve_org_context_in_txn(
+    pool: &deadpool_postgres::Pool,
+    org_id: Uuid,
+    user_id: Uuid,
+) -> Result<OrgContext, ResolveError> {
+    // Provisional context only to set RLS GUCs; real permissions come from the query below.
+    let provisional = OrgContext::try_new(org_id, user_id, [] as [&str; 0], [])
+        .map_err(|_| ResolveError::InvalidContext)?;
+    crate::db::pool::with_org_txn(pool, &provisional, move |txn| {
+        Box::pin(async move {
+            // Re-run resolution using the transaction connection via raw queries.
+            let user_row = txn
+                .query_opt("SELECT disabled_at FROM users WHERE id = $1", &[&user_id])
+                .await?;
+            let Some(user_row) = user_row else {
+                return Err(DbError::NotFound);
+            };
+            let disabled_at: Option<chrono::DateTime<chrono::Utc>> = user_row.get(0);
+            if disabled_at.is_some() {
+                return Err(DbError::Config("user_disabled".into()));
+            }
+            let membership = txn
+                .query_opt(
+                    "SELECT role FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+                    &[&org_id, &user_id],
+                )
+                .await?;
+            if membership.is_none() {
+                return Err(DbError::NotFound);
+            }
+            let permission_rows = txn
+                .query(
+                    "SELECT p.code
+                     FROM org_memberships m
+                     JOIN roles r
+                       ON r.org_id = m.org_id AND r.code = m.role
+                     JOIN role_permissions rp
+                       ON rp.org_id = r.org_id AND rp.role_id = r.id
+                     JOIN permissions p
+                       ON p.id = rp.permission_id
+                     WHERE m.org_id = $1 AND m.user_id = $2
+                     ORDER BY p.code",
+                    &[&org_id, &user_id],
+                )
+                .await?;
+            let permissions: Vec<String> = permission_rows.iter().map(|row| row.get(0)).collect();
+            let collection_rows = txn
+                .query(
+                    "SELECT c.id
+                     FROM collections c
+                     WHERE c.org_id = $1
+                       AND c.deleted_at IS NULL
+                       AND (
+                         c.visibility = 'org'
+                         OR c.owner_user_id = $2
+                         OR EXISTS (
+                           SELECT 1 FROM collection_user_access cua
+                           WHERE cua.org_id = c.org_id
+                             AND cua.collection_id = c.id
+                             AND cua.user_id = $2
+                         )
+                       )",
+                    &[&org_id, &user_id],
+                )
+                .await?;
+            let collections: Vec<Uuid> = collection_rows.iter().map(|row| row.get(0)).collect();
+            OrgContext::try_new(org_id, user_id, permissions, collections)
+                .map_err(|_| DbError::Config("invalid_org_context".into()))
+        })
+    })
+    .await
+    .map_err(|error| match error {
+        DbError::NotFound => ResolveError::MembershipMissing,
+        DbError::Config(ref msg) if msg == "user_disabled" => ResolveError::UserDisabled,
+        _ => ResolveError::Database,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permission_helpers_fail_closed() {
+        let org = Uuid::new_v4();
+        let user = Uuid::new_v4();
+        let collection = Uuid::new_v4();
+        let ctx = OrgContext::try_new(org, user, ["doc.upload"], [collection]).unwrap();
+        assert!(check_permission(&ctx, "doc.upload"));
+        assert!(require_permission(&ctx, "doc.upload").is_ok());
+        assert_eq!(
+            require_permission(&ctx, "doc.delete"),
+            Err(ResolveError::PermissionDenied)
+        );
+        assert!(require_collection(&ctx, collection).is_ok());
+        assert_eq!(
+            require_collection(&ctx, Uuid::new_v4()),
+            Err(ResolveError::CollectionDenied)
+        );
+    }
+}

--- a/crates/server/src/auth/provider.rs
+++ b/crates/server/src/auth/provider.rs
@@ -1,0 +1,147 @@
+//! Auth provider interface so OIDC can later mint the same session shape.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use deadpool_postgres::Pool;
+use uuid::Uuid;
+
+use crate::auth::jwt::JwtKeys;
+use crate::auth::session::{
+    self, logout_session, refresh_session, revoke_all_user_families, SessionError, TokenPair,
+};
+use crate::config::AuthConfig;
+
+/// Request metadata attached to auth operations (never includes secrets).
+#[derive(Debug, Clone)]
+pub struct AuthRequestMeta {
+    pub request_id: String,
+}
+
+/// Shared session shape minted by every auth provider (password today, OIDC later).
+#[derive(Debug, Clone)]
+pub struct InternalSession {
+    pub tokens: TokenPair,
+}
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Provider contract: password or OIDC may authenticate, but must mint sessions
+/// through the same rotation / OrgContext / audit path — never bypass it.
+pub trait AuthProvider: Send + Sync {
+    /// Exchange first-party credentials for an internal session.
+    fn login_password<'a>(
+        &'a self,
+        email: &'a str,
+        password: &'a str,
+        meta: &'a AuthRequestMeta,
+    ) -> BoxFuture<'a, Result<InternalSession, SessionError>>;
+
+    /// Rotate a refresh token (reuse revokes the family).
+    fn refresh<'a>(
+        &'a self,
+        refresh_token: &'a str,
+        meta: &'a AuthRequestMeta,
+    ) -> BoxFuture<'a, Result<InternalSession, SessionError>>;
+
+    /// Revoke the refresh token family.
+    fn logout<'a>(
+        &'a self,
+        refresh_token: &'a str,
+        meta: &'a AuthRequestMeta,
+    ) -> BoxFuture<'a, Result<(), SessionError>>;
+
+    /// Revoke every family for a user (disable / password-reset).
+    fn revoke_user_sessions<'a>(
+        &'a self,
+        org_id: Uuid,
+        user_id: Uuid,
+        meta: &'a AuthRequestMeta,
+        reason: &'a str,
+    ) -> BoxFuture<'a, Result<(), SessionError>>;
+}
+
+/// Phase 1B password auth provider.
+pub struct PasswordAuthProvider {
+    pool: Pool,
+    auth: AuthConfig,
+    keys: JwtKeys,
+}
+
+impl PasswordAuthProvider {
+    pub fn new(pool: Pool, auth: AuthConfig, keys: JwtKeys) -> Self {
+        Self { pool, auth, keys }
+    }
+
+    pub fn keys(&self) -> &JwtKeys {
+        &self.keys
+    }
+
+    pub fn auth_config(&self) -> &AuthConfig {
+        &self.auth
+    }
+
+    pub fn pool(&self) -> &Pool {
+        &self.pool
+    }
+}
+
+impl AuthProvider for PasswordAuthProvider {
+    fn login_password<'a>(
+        &'a self,
+        email: &'a str,
+        password: &'a str,
+        meta: &'a AuthRequestMeta,
+    ) -> BoxFuture<'a, Result<InternalSession, SessionError>> {
+        Box::pin(async move {
+            let tokens = session::login_with_password(
+                &self.pool,
+                &self.auth,
+                &self.keys,
+                email,
+                password,
+                &meta.request_id,
+            )
+            .await?;
+            Ok(InternalSession { tokens })
+        })
+    }
+
+    fn refresh<'a>(
+        &'a self,
+        refresh_token: &'a str,
+        meta: &'a AuthRequestMeta,
+    ) -> BoxFuture<'a, Result<InternalSession, SessionError>> {
+        Box::pin(async move {
+            let tokens = refresh_session(
+                &self.pool,
+                &self.auth,
+                &self.keys,
+                refresh_token,
+                &meta.request_id,
+            )
+            .await?;
+            Ok(InternalSession { tokens })
+        })
+    }
+
+    fn logout<'a>(
+        &'a self,
+        refresh_token: &'a str,
+        meta: &'a AuthRequestMeta,
+    ) -> BoxFuture<'a, Result<(), SessionError>> {
+        Box::pin(async move { logout_session(&self.pool, refresh_token, &meta.request_id).await })
+    }
+
+    fn revoke_user_sessions<'a>(
+        &'a self,
+        org_id: Uuid,
+        user_id: Uuid,
+        meta: &'a AuthRequestMeta,
+        reason: &'a str,
+    ) -> BoxFuture<'a, Result<(), SessionError>> {
+        Box::pin(async move {
+            revoke_all_user_families(&self.pool, org_id, user_id, &meta.request_id, reason).await
+        })
+    }
+}

--- a/crates/server/src/auth/session.rs
+++ b/crates/server/src/auth/session.rs
@@ -1,0 +1,1072 @@
+//! Opaque rotating refresh tokens with family-wide revoke-on-reuse.
+
+use chrono::{Duration, Utc};
+use deadpool_postgres::Object;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio_postgres::Transaction;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::auth::jwt::{JwtError, JwtKeys};
+use crate::auth::password::{self, PasswordError};
+use crate::auth::permissions::{resolve_org_context_in_txn, ResolveError};
+use crate::config::{Argon2Config, AuthConfig, SecretString};
+use crate::db::error::DbError;
+use crate::db::pool::{apply_org_context, with_org_txn};
+
+const REFRESH_PREFIX: &str = "mh1";
+const REFRESH_SECRET_BYTES: usize = 32;
+
+/// Issued access + refresh pair (secrets never appear in Debug).
+#[derive(Clone, PartialEq, Eq)]
+pub struct TokenPair {
+    pub access_token: SecretString,
+    pub refresh_token: SecretString,
+    pub expires_in: u64,
+    pub family_id: Uuid,
+    pub org_id: Uuid,
+    pub user_id: Uuid,
+}
+
+impl std::fmt::Debug for TokenPair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenPair")
+            .field("access_token", &"[REDACTED]")
+            .field("refresh_token", &"[REDACTED]")
+            .field("expires_in", &self.expires_in)
+            .field("family_id", &self.family_id)
+            .field("org_id", &self.org_id)
+            .field("user_id", &self.user_id)
+            .finish()
+    }
+}
+
+/// Auth/session errors (safe for clients; no secrets).
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum SessionError {
+    #[error("invalid credentials")]
+    InvalidCredentials,
+    #[error("user is disabled")]
+    UserDisabled,
+    #[error("org membership missing")]
+    MembershipMissing,
+    #[error("refresh token is invalid")]
+    InvalidRefresh,
+    #[error("refresh token reuse detected; family revoked")]
+    RefreshReuse,
+    #[error("authentication is not configured")]
+    NotConfigured,
+    #[error("database error")]
+    Database,
+    #[error("token error")]
+    Token,
+    #[error("password hashing failed")]
+    Password,
+}
+
+impl From<DbError> for SessionError {
+    fn from(_: DbError) -> Self {
+        Self::Database
+    }
+}
+
+impl From<JwtError> for SessionError {
+    fn from(value: JwtError) -> Self {
+        match value {
+            JwtError::NotConfigured => Self::NotConfigured,
+            _ => Self::Token,
+        }
+    }
+}
+
+impl From<PasswordError> for SessionError {
+    fn from(_: PasswordError) -> Self {
+        Self::Password
+    }
+}
+
+impl From<ResolveError> for SessionError {
+    fn from(value: ResolveError) -> Self {
+        match value {
+            ResolveError::UserDisabled => Self::UserDisabled,
+            ResolveError::MembershipMissing => Self::MembershipMissing,
+            ResolveError::PermissionDenied
+            | ResolveError::CollectionDenied
+            | ResolveError::InvalidContext
+            | ResolveError::Database => Self::Database,
+        }
+    }
+}
+
+/// Hashes an opaque refresh token for storage (SHA-256 hex).
+pub fn hash_refresh_token(token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    hex::encode(digest)
+}
+
+/// Parses `mh1.<org_id>.<secret>` without logging the secret.
+pub fn parse_refresh_token(token: &str) -> Result<(Uuid, &str), SessionError> {
+    let mut parts = token.splitn(3, '.');
+    let prefix = parts.next().ok_or(SessionError::InvalidRefresh)?;
+    let org_raw = parts.next().ok_or(SessionError::InvalidRefresh)?;
+    let secret = parts.next().ok_or(SessionError::InvalidRefresh)?;
+    if prefix != REFRESH_PREFIX || secret.is_empty() || secret.len() < 16 {
+        return Err(SessionError::InvalidRefresh);
+    }
+    let org_id = Uuid::parse_str(org_raw).map_err(|_| SessionError::InvalidRefresh)?;
+    Ok((org_id, secret))
+}
+
+fn mint_refresh_token(org_id: Uuid) -> SecretString {
+    let mut bytes = [0u8; REFRESH_SECRET_BYTES];
+    rand::fill(&mut bytes[..]);
+    let secret = base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, bytes);
+    SecretString::new(format!("{REFRESH_PREFIX}.{org_id}.{secret}"))
+}
+
+/// Append-only audit fields (metadata must never contain secrets).
+pub struct AuditEvent<'a> {
+    pub org_id: Uuid,
+    pub actor_user_id: Option<Uuid>,
+    pub action: &'a str,
+    pub resource_type: &'a str,
+    pub resource_id: Option<&'a str>,
+    pub outcome: &'a str,
+    pub request_id: &'a str,
+    pub metadata: serde_json::Value,
+}
+
+/// Append-only audit row (metadata must never contain secrets).
+pub async fn write_audit(txn: &Transaction<'_>, event: AuditEvent<'_>) -> Result<(), DbError> {
+    // Defense-in-depth: refuse metadata / request ids that embed raw secrets.
+    let rendered = event.metadata.to_string();
+    for fragment in [
+        "\"password\":",
+        "\"refreshToken\":",
+        "\"refresh_token\":",
+        "\"accessToken\":",
+        "\"access_token\":",
+        "Bearer ",
+        "mh1.",
+    ] {
+        if rendered.contains(fragment) {
+            return Err(DbError::Config("audit_metadata_contains_secret".into()));
+        }
+    }
+    if event.request_id.contains("mh1.")
+        || event.request_id.contains("Bearer ")
+        || event.request_id.starts_with("eyJ")
+        || event.request_id.len() > 64
+    {
+        return Err(DbError::Config("audit_request_id_contains_secret".into()));
+    }
+    txn.execute(
+        "INSERT INTO audit_log (
+            org_id, actor_user_id, action, resource_type, resource_id, outcome, metadata, request_id
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+        &[
+            &event.org_id,
+            &event.actor_user_id,
+            &event.action,
+            &event.resource_type,
+            &event.resource_id,
+            &event.outcome,
+            &event.metadata,
+            &event.request_id,
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Password login: verify Argon2id, mint access+refresh, rehash if params changed.
+pub async fn login_with_password(
+    pool: &deadpool_postgres::Pool,
+    auth: &AuthConfig,
+    keys: &JwtKeys,
+    email: &str,
+    password: &str,
+    request_id: &str,
+) -> Result<TokenPair, SessionError> {
+    let email = email.trim().to_ascii_lowercase();
+    if email.is_empty() || password.is_empty() || password.len() > 1024 || email.len() > 320 {
+        return Err(SessionError::InvalidCredentials);
+    }
+
+    let mut client = pool.get().await.map_err(|_| SessionError::Database)?;
+    let user_row = client
+        .query_opt(
+            "SELECT id, password_hash, disabled_at FROM users WHERE email = $1",
+            &[&email],
+        )
+        .await
+        .map_err(|_| SessionError::Database)?;
+
+    let Some(user_row) = user_row else {
+        // Constant-ish work so unknown emails are not a free timing oracle.
+        burn_password_verify_time(password, &auth.argon2);
+        // Unknown user: if a single org exists, audit against it without secrets.
+        let count: i64 = client
+            .query_one("SELECT count(*)::bigint FROM orgs", &[])
+            .await
+            .map(|row| row.get(0))
+            .unwrap_or(0);
+        if count == 1 {
+            if let Ok(row) = client
+                .query_one("SELECT id FROM orgs ORDER BY created_at LIMIT 1", &[])
+                .await
+            {
+                let org_id: Uuid = row.get(0);
+                let _ = audit_on_client(
+                    &mut client,
+                    AuditEvent {
+                        org_id,
+                        actor_user_id: None,
+                        action: "auth.login",
+                        resource_type: "session",
+                        resource_id: None,
+                        outcome: "deny",
+                        request_id,
+                        metadata: serde_json::json!({ "reason": "unknown_user" }),
+                    },
+                )
+                .await;
+            }
+        }
+        return Err(SessionError::InvalidCredentials);
+    };
+
+    let user_id: Uuid = user_row.get(0);
+    let password_hash: Option<String> = user_row.get(1);
+    let disabled_at: Option<chrono::DateTime<Utc>> = user_row.get(2);
+
+    // Disabled accounts: still burn verify time, audit distinctly, return generic error.
+    if disabled_at.is_some() {
+        if let Some(ref hash) = password_hash {
+            let _ = password::verify_password(password, hash);
+        } else {
+            burn_password_verify_time(password, &auth.argon2);
+        }
+        if let Some(org_id) = find_user_org(&mut client, user_id).await? {
+            let _ = audit_on_client(
+                &mut client,
+                AuditEvent {
+                    org_id,
+                    actor_user_id: Some(user_id),
+                    action: "auth.login",
+                    resource_type: "session",
+                    resource_id: None,
+                    outcome: "deny",
+                    request_id,
+                    metadata: serde_json::json!({ "reason": "user_disabled" }),
+                },
+            )
+            .await;
+        }
+        return Err(SessionError::InvalidCredentials);
+    }
+
+    let Some(password_hash) = password_hash else {
+        burn_password_verify_time(password, &auth.argon2);
+        return Err(SessionError::InvalidCredentials);
+    };
+    if password::verify_password(password, &password_hash).is_err() {
+        if let Some(org_id) = find_user_org(&mut client, user_id).await? {
+            let _ = audit_on_client(
+                &mut client,
+                AuditEvent {
+                    org_id,
+                    actor_user_id: Some(user_id),
+                    action: "auth.login",
+                    resource_type: "session",
+                    resource_id: None,
+                    outcome: "deny",
+                    request_id,
+                    metadata: serde_json::json!({ "reason": "bad_password" }),
+                },
+            )
+            .await;
+        }
+        return Err(SessionError::InvalidCredentials);
+    }
+
+    let Some(org_id) = find_user_org(&mut client, user_id).await? else {
+        // Membership missing: audit against any org the caller might have used is
+        // impossible without an org id; fail closed without writing tenant audit.
+        return Err(SessionError::MembershipMissing);
+    };
+
+    // Rehash-on-login when Argon2 params changed.
+    if password::needs_rehash(&password_hash, &auth.argon2)? {
+        let new_hash = password::hash_password(password, &auth.argon2)?;
+        client
+            .execute(
+                "UPDATE users SET password_hash = $1, updated_at = now() WHERE id = $2",
+                &[&new_hash.expose(), &user_id],
+            )
+            .await
+            .map_err(|_| SessionError::Database)?;
+    }
+
+    // Current-state authorization before minting tokens.
+    let _ctx = resolve_org_context_in_txn(pool, org_id, user_id).await?;
+
+    let family_id = Uuid::new_v4();
+    let pair = issue_new_family(
+        pool,
+        keys,
+        auth,
+        NewFamilyParams {
+            org_id,
+            user_id,
+            family_id,
+            request_id,
+            action: "auth.login",
+        },
+    )
+    .await?;
+    Ok(pair)
+}
+
+/// Dummy Argon2id verify using the configured parameters so timing matches real checks.
+fn burn_password_verify_time(password: &str, params: &Argon2Config) {
+    use std::sync::Mutex;
+    static CACHE: Mutex<Option<(u32, u32, u32, String)>> = Mutex::new(None);
+    let hash = {
+        let mut guard = CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let key = (params.memory_kib, params.time_cost, params.parallelism);
+        match guard.as_ref() {
+            Some((m, t, p, hash)) if (*m, *t, *p) == key => hash.clone(),
+            _ => {
+                let hash = password::hash_password("markhand-timing-oracle-pad", params)
+                    .expect("dummy argon2 hash")
+                    .expose()
+                    .to_string();
+                *guard = Some((key.0, key.1, key.2, hash.clone()));
+                hash
+            }
+        }
+    };
+    let _ = password::verify_password(password, &hash);
+}
+
+async fn find_user_org(client: &mut Object, user_id: Uuid) -> Result<Option<Uuid>, SessionError> {
+    let orgs = client
+        .query("SELECT id FROM orgs ORDER BY created_at", &[])
+        .await
+        .map_err(|_| SessionError::Database)?;
+    for row in orgs {
+        let org_id: Uuid = row.get(0);
+        // SET LOCAL only survives inside an explicit transaction.
+        let txn = client
+            .transaction()
+            .await
+            .map_err(|_| SessionError::Database)?;
+        set_org_guc_txn(&txn, org_id).await?;
+        let membership = txn
+            .query_opt(
+                "SELECT 1 FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+                &[&org_id, &user_id],
+            )
+            .await
+            .map_err(|_| SessionError::Database)?;
+        let found = membership.is_some();
+        txn.commit().await.map_err(|_| SessionError::Database)?;
+        if found {
+            return Ok(Some(org_id));
+        }
+    }
+    Ok(None)
+}
+
+async fn audit_on_client(client: &mut Object, event: AuditEvent<'_>) -> Result<(), SessionError> {
+    let org_id = event.org_id;
+    let txn = client
+        .transaction()
+        .await
+        .map_err(|_| SessionError::Database)?;
+    set_org_guc_txn(&txn, org_id).await?;
+    write_audit(&txn, event).await?;
+    txn.commit().await.map_err(|_| SessionError::Database)?;
+    Ok(())
+}
+
+async fn set_org_guc_txn(txn: &Transaction<'_>, org_id: Uuid) -> Result<(), DbError> {
+    let org = org_id.to_string();
+    txn.execute("SELECT set_config('app.org_id', $1, true)", &[&org])
+        .await?;
+    Ok(())
+}
+
+struct NewFamilyParams<'a> {
+    org_id: Uuid,
+    user_id: Uuid,
+    family_id: Uuid,
+    request_id: &'a str,
+    action: &'a str,
+}
+
+async fn issue_new_family(
+    pool: &deadpool_postgres::Pool,
+    keys: &JwtKeys,
+    auth: &AuthConfig,
+    params: NewFamilyParams<'_>,
+) -> Result<TokenPair, SessionError> {
+    let NewFamilyParams {
+        org_id,
+        user_id,
+        family_id,
+        request_id,
+        action,
+    } = params;
+    let refresh = mint_refresh_token(org_id);
+    let token_hash = hash_refresh_token(refresh.expose());
+    let refresh_id = Uuid::new_v4();
+    let expires_at = Utc::now() + Duration::seconds(auth.refresh_token_ttl_secs as i64);
+    let access = keys.sign_access_token(user_id, org_id, family_id)?;
+    let provisional = OrgContext::try_new(org_id, user_id, [] as [&str; 0], [])
+        .map_err(|_| SessionError::Database)?;
+
+    with_org_txn(pool, &provisional, {
+        let request_id = request_id.to_string();
+        let action = action.to_string();
+        move |txn| {
+            Box::pin(async move {
+                // Serialize with revoke_all: user lock first, then the new family lock.
+                lock_user_sessions(txn, user_id)
+                    .await
+                    .map_err(|_| DbError::Config("user_lock_failed".into()))?;
+                lock_refresh_family(txn, family_id)
+                    .await
+                    .map_err(|_| DbError::Config("family_lock_failed".into()))?;
+                txn.execute(
+                    "INSERT INTO refresh_tokens (
+                        id, org_id, user_id, family_id, token_hash, expires_at
+                     ) VALUES ($1, $2, $3, $4, $5, $6)",
+                    &[
+                        &refresh_id,
+                        &org_id,
+                        &user_id,
+                        &family_id,
+                        &token_hash,
+                        &expires_at,
+                    ],
+                )
+                .await?;
+                write_audit(
+                    txn,
+                    AuditEvent {
+                        org_id,
+                        actor_user_id: Some(user_id),
+                        action: &action,
+                        resource_type: "session",
+                        resource_id: Some(&family_id.to_string()),
+                        outcome: "success",
+                        request_id: &request_id,
+                        metadata: serde_json::json!({
+                            "familyId": family_id.to_string(),
+                            "refreshTokenId": refresh_id.to_string()
+                        }),
+                    },
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await?;
+
+    Ok(TokenPair {
+        access_token: access,
+        refresh_token: refresh,
+        expires_in: auth.access_token_ttl_secs,
+        family_id,
+        org_id,
+        user_id,
+    })
+}
+
+/// Rotates a refresh token. Reuse of an already-rotated token revokes the whole family.
+pub async fn refresh_session(
+    pool: &deadpool_postgres::Pool,
+    auth: &AuthConfig,
+    keys: &JwtKeys,
+    refresh_token: &str,
+    request_id: &str,
+) -> Result<TokenPair, SessionError> {
+    if refresh_token.len() > 512 {
+        return Err(SessionError::InvalidRefresh);
+    }
+    let (org_id, _) = parse_refresh_token(refresh_token)?;
+    let presented_hash = hash_refresh_token(refresh_token);
+
+    let mut client = pool.get().await.map_err(|_| SessionError::Database)?;
+    let txn = client
+        .transaction()
+        .await
+        .map_err(|_| SessionError::Database)?;
+    set_org_guc_txn(&txn, org_id).await?;
+
+    // Unlocked lookup only to discover family_id (and reject unknown tokens).
+    let row = txn
+        .query_opt(
+            "SELECT id, user_id, family_id
+             FROM refresh_tokens
+             WHERE token_hash = $1",
+            &[&presented_hash],
+        )
+        .await
+        .map_err(|_| SessionError::Database)?;
+
+    let Some(row) = row else {
+        write_audit(
+            &txn,
+            AuditEvent {
+                org_id,
+                actor_user_id: None,
+                action: "auth.refresh",
+                resource_type: "session",
+                resource_id: None,
+                outcome: "deny",
+                request_id,
+                metadata: serde_json::json!({ "reason": "unknown_token" }),
+            },
+        )
+        .await?;
+        txn.commit().await.map_err(|_| SessionError::Database)?;
+        return Err(SessionError::InvalidRefresh);
+    };
+
+    let token_id: Uuid = row.get(0);
+    let user_id: Uuid = row.get(1);
+    let family_id: Uuid = row.get(2);
+
+    // FAMILY-FIRST: serialize every refresh/reuse on the family before touching rows.
+    // Prevents deadlock (different token-row lock order) and partial-commit races where
+    // reuse revocation is aborted while a successor rotation commits.
+    lock_refresh_family(&txn, family_id).await?;
+
+    // Authoritative read under the family lock.
+    let row = txn
+        .query_one(
+            "SELECT expires_at, revoked_at, replaced_by_id
+             FROM refresh_tokens
+             WHERE id = $1 AND org_id = $2
+             FOR UPDATE",
+            &[&token_id, &org_id],
+        )
+        .await
+        .map_err(|_| SessionError::Database)?;
+    let expires_at: chrono::DateTime<Utc> = row.get(0);
+    let revoked_at: Option<chrono::DateTime<Utc>> = row.get(1);
+    let replaced_by_id: Option<Uuid> = row.get(2);
+
+    // Reuse detection: already rotated or revoked → revoke whole family.
+    if revoked_at.is_some() || replaced_by_id.is_some() {
+        revoke_family_in_txn(&txn, org_id, family_id).await?;
+        write_audit(
+            &txn,
+            AuditEvent {
+                org_id,
+                actor_user_id: Some(user_id),
+                action: "auth.refresh.reuse",
+                resource_type: "session",
+                resource_id: Some(&family_id.to_string()),
+                outcome: "deny",
+                request_id,
+                metadata: serde_json::json!({
+                    "reason": "refresh_reuse",
+                    "familyId": family_id.to_string(),
+                    "tokenId": token_id.to_string()
+                }),
+            },
+        )
+        .await?;
+        txn.commit().await.map_err(|_| SessionError::Database)?;
+        return Err(SessionError::RefreshReuse);
+    }
+
+    if expires_at <= Utc::now() {
+        txn.execute(
+            "UPDATE refresh_tokens SET revoked_at = now() WHERE id = $1 AND org_id = $2",
+            &[&token_id, &org_id],
+        )
+        .await
+        .map_err(|_| SessionError::Database)?;
+        write_audit(
+            &txn,
+            AuditEvent {
+                org_id,
+                actor_user_id: Some(user_id),
+                action: "auth.refresh",
+                resource_type: "session",
+                resource_id: Some(&family_id.to_string()),
+                outcome: "deny",
+                request_id,
+                metadata: serde_json::json!({ "reason": "expired" }),
+            },
+        )
+        .await?;
+        txn.commit().await.map_err(|_| SessionError::Database)?;
+        return Err(SessionError::InvalidRefresh);
+    }
+
+    // Current-state checks (disabled / membership).
+    let user_row = txn
+        .query_opt("SELECT disabled_at FROM users WHERE id = $1", &[&user_id])
+        .await
+        .map_err(|_| SessionError::Database)?;
+    let disabled_at: Option<chrono::DateTime<Utc>> =
+        user_row.ok_or(SessionError::InvalidRefresh)?.get(0);
+    if disabled_at.is_some() {
+        revoke_family_in_txn(&txn, org_id, family_id).await?;
+        write_audit(
+            &txn,
+            AuditEvent {
+                org_id,
+                actor_user_id: Some(user_id),
+                action: "auth.refresh",
+                resource_type: "session",
+                resource_id: Some(&family_id.to_string()),
+                outcome: "deny",
+                request_id,
+                metadata: serde_json::json!({ "reason": "user_disabled" }),
+            },
+        )
+        .await?;
+        txn.commit().await.map_err(|_| SessionError::Database)?;
+        return Err(SessionError::UserDisabled);
+    }
+    let membership = txn
+        .query_opt(
+            "SELECT 1 FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+            &[&org_id, &user_id],
+        )
+        .await
+        .map_err(|_| SessionError::Database)?;
+    if membership.is_none() {
+        revoke_family_in_txn(&txn, org_id, family_id).await?;
+        write_audit(
+            &txn,
+            AuditEvent {
+                org_id,
+                actor_user_id: Some(user_id),
+                action: "auth.refresh",
+                resource_type: "session",
+                resource_id: Some(&family_id.to_string()),
+                outcome: "deny",
+                request_id,
+                metadata: serde_json::json!({ "reason": "membership_missing" }),
+            },
+        )
+        .await?;
+        txn.commit().await.map_err(|_| SessionError::Database)?;
+        return Err(SessionError::MembershipMissing);
+    }
+
+    let new_refresh = mint_refresh_token(org_id);
+    let new_hash = hash_refresh_token(new_refresh.expose());
+    let new_id = Uuid::new_v4();
+    let new_expires = Utc::now() + Duration::seconds(auth.refresh_token_ttl_secs as i64);
+
+    txn.execute(
+        "INSERT INTO refresh_tokens (
+            id, org_id, user_id, family_id, token_hash, expires_at
+         ) VALUES ($1, $2, $3, $4, $5, $6)",
+        &[
+            &new_id,
+            &org_id,
+            &user_id,
+            &family_id,
+            &new_hash,
+            &new_expires,
+        ],
+    )
+    .await
+    .map_err(|_| SessionError::Database)?;
+
+    let updated = txn
+        .execute(
+            "UPDATE refresh_tokens
+             SET revoked_at = now(), replaced_by_id = $1
+             WHERE id = $2
+               AND org_id = $3
+               AND revoked_at IS NULL
+               AND replaced_by_id IS NULL",
+            &[&new_id, &token_id, &org_id],
+        )
+        .await
+        .map_err(|_| SessionError::Database)?;
+
+    if updated != 1 {
+        // Lost a race after family lock should be rare; treat as reuse.
+        revoke_family_in_txn(&txn, org_id, family_id).await?;
+        write_audit(
+            &txn,
+            AuditEvent {
+                org_id,
+                actor_user_id: Some(user_id),
+                action: "auth.refresh.reuse",
+                resource_type: "session",
+                resource_id: Some(&family_id.to_string()),
+                outcome: "deny",
+                request_id,
+                metadata: serde_json::json!({ "reason": "refresh_race" }),
+            },
+        )
+        .await?;
+        txn.commit().await.map_err(|_| SessionError::Database)?;
+        return Err(SessionError::RefreshReuse);
+    }
+
+    write_audit(
+        &txn,
+        AuditEvent {
+            org_id,
+            actor_user_id: Some(user_id),
+            action: "auth.refresh",
+            resource_type: "session",
+            resource_id: Some(&family_id.to_string()),
+            outcome: "success",
+            request_id,
+            metadata: serde_json::json!({
+                "familyId": family_id.to_string(),
+                "refreshTokenId": new_id.to_string(),
+                "replacedTokenId": token_id.to_string()
+            }),
+        },
+    )
+    .await?;
+    txn.commit().await.map_err(|_| SessionError::Database)?;
+
+    let access = keys.sign_access_token(user_id, org_id, family_id)?;
+    Ok(TokenPair {
+        access_token: access,
+        refresh_token: new_refresh,
+        expires_in: auth.access_token_ttl_secs,
+        family_id,
+        org_id,
+        user_id,
+    })
+}
+
+/// Transaction-scoped advisory lock that serializes all refresh activity for a family.
+///
+/// MUST be acquired before any `FOR UPDATE` on individual refresh_tokens rows.
+pub async fn lock_refresh_family(
+    txn: &Transaction<'_>,
+    family_id: Uuid,
+) -> Result<(), SessionError> {
+    let family = family_id.to_string();
+    txn.execute(
+        "SELECT pg_advisory_xact_lock(hashtext($1::text))",
+        &[&family],
+    )
+    .await
+    .map_err(|_| SessionError::Database)?;
+    Ok(())
+}
+
+/// User-level advisory lock shared by new-family issuance and revoke-all.
+///
+/// Lock order (global): user lock first, then per-family locks sorted by family_id.
+/// `refresh_session` only takes its single family lock (compatible — it does not create families).
+pub async fn lock_user_sessions(txn: &Transaction<'_>, user_id: Uuid) -> Result<(), SessionError> {
+    let key = format!("user:{user_id}");
+    txn.execute("SELECT pg_advisory_xact_lock(hashtext($1::text))", &[&key])
+        .await
+        .map_err(|_| SessionError::Database)?;
+    Ok(())
+}
+
+/// Holds a family advisory lock in a background transaction until [`Self::release`].
+///
+/// Used by integration tests to force real contention: refresh paths that take the
+/// same family-first lock will block until this guard is released.
+pub struct FamilyLockHold {
+    release_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    done_rx: Option<tokio::sync::oneshot::Receiver<Result<(), SessionError>>>,
+}
+
+impl FamilyLockHold {
+    /// Commits the holding transaction, releasing the advisory lock.
+    pub async fn release(mut self) -> Result<(), SessionError> {
+        if let Some(tx) = self.release_tx.take() {
+            let _ = tx.send(());
+        }
+        match self.done_rx.take() {
+            Some(rx) => rx.await.map_err(|_| SessionError::Database)?,
+            None => Ok(()),
+        }
+    }
+}
+
+/// Acquires the family advisory lock and keeps it until [`FamilyLockHold::release`].
+pub async fn acquire_family_lock_for_test(
+    pool: &deadpool_postgres::Pool,
+    org_id: Uuid,
+    family_id: Uuid,
+) -> Result<FamilyLockHold, SessionError> {
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<Result<(), SessionError>>();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<Result<(), SessionError>>();
+    let pool = pool.clone();
+
+    tokio::spawn(async move {
+        let fail = |ready: tokio::sync::oneshot::Sender<Result<(), SessionError>>,
+                    done: tokio::sync::oneshot::Sender<Result<(), SessionError>>,
+                    error: SessionError| {
+            let _ = ready.send(Err(error));
+            let _ = done.send(Err(error));
+        };
+
+        let mut client = match pool.get().await {
+            Ok(client) => client,
+            Err(_) => {
+                fail(ready_tx, done_tx, SessionError::Database);
+                return;
+            }
+        };
+        let txn = match client.transaction().await {
+            Ok(txn) => txn,
+            Err(_) => {
+                fail(ready_tx, done_tx, SessionError::Database);
+                return;
+            }
+        };
+        if set_org_guc_txn(&txn, org_id).await.is_err() {
+            fail(ready_tx, done_tx, SessionError::Database);
+            return;
+        }
+        if lock_refresh_family(&txn, family_id).await.is_err() {
+            fail(ready_tx, done_tx, SessionError::Database);
+            return;
+        }
+        let _ = ready_tx.send(Ok(()));
+        let _ = release_rx.await;
+        let outcome = txn
+            .commit()
+            .await
+            .map(|_| ())
+            .map_err(|_| SessionError::Database);
+        let _ = done_tx.send(outcome);
+    });
+
+    ready_rx.await.map_err(|_| SessionError::Database)??;
+    Ok(FamilyLockHold {
+        release_tx: Some(release_tx),
+        done_rx: Some(done_rx),
+    })
+}
+
+async fn revoke_family_in_txn(
+    txn: &Transaction<'_>,
+    org_id: Uuid,
+    family_id: Uuid,
+) -> Result<(), DbError> {
+    txn.execute(
+        "UPDATE refresh_tokens
+         SET revoked_at = COALESCE(revoked_at, now())
+         WHERE org_id = $1 AND family_id = $2 AND revoked_at IS NULL",
+        &[&org_id, &family_id],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Logout: revoke the presented refresh token's family.
+pub async fn logout_session(
+    pool: &deadpool_postgres::Pool,
+    refresh_token: &str,
+    request_id: &str,
+) -> Result<(), SessionError> {
+    let (org_id, _) = parse_refresh_token(refresh_token)?;
+    let presented_hash = hash_refresh_token(refresh_token);
+    let mut client = pool.get().await.map_err(|_| SessionError::Database)?;
+    let txn = client
+        .transaction()
+        .await
+        .map_err(|_| SessionError::Database)?;
+    set_org_guc_txn(&txn, org_id).await?;
+
+    // Unlocked lookup to discover family, then family-first advisory lock.
+    let row = txn
+        .query_opt(
+            "SELECT id, user_id, family_id FROM refresh_tokens WHERE token_hash = $1",
+            &[&presented_hash],
+        )
+        .await
+        .map_err(|_| SessionError::Database)?;
+
+    if let Some(row) = row {
+        let user_id: Uuid = row.get(1);
+        let family_id: Uuid = row.get(2);
+        lock_refresh_family(&txn, family_id).await?;
+        revoke_family_in_txn(&txn, org_id, family_id).await?;
+        write_audit(
+            &txn,
+            AuditEvent {
+                org_id,
+                actor_user_id: Some(user_id),
+                action: "auth.logout",
+                resource_type: "session",
+                resource_id: Some(&family_id.to_string()),
+                outcome: "success",
+                request_id,
+                metadata: serde_json::json!({ "familyId": family_id.to_string() }),
+            },
+        )
+        .await?;
+    } else {
+        write_audit(
+            &txn,
+            AuditEvent {
+                org_id,
+                actor_user_id: None,
+                action: "auth.logout",
+                resource_type: "session",
+                resource_id: None,
+                outcome: "deny",
+                request_id,
+                metadata: serde_json::json!({ "reason": "unknown_token" }),
+            },
+        )
+        .await?;
+    }
+    txn.commit().await.map_err(|_| SessionError::Database)?;
+    Ok(())
+}
+
+/// Revokes every refresh-token family for a user (disable / password-reset).
+///
+/// Takes the user-level advisory lock (shared with login/new-family issuance), then
+/// per-family locks in sorted order, then revokes — so a concurrent refresh cannot
+/// leave a successor active after revocation.
+pub async fn revoke_all_user_families(
+    pool: &deadpool_postgres::Pool,
+    org_id: Uuid,
+    user_id: Uuid,
+    request_id: &str,
+    reason: &str,
+) -> Result<(), SessionError> {
+    let provisional = OrgContext::try_new(org_id, user_id, [] as [&str; 0], [])
+        .map_err(|_| SessionError::Database)?;
+    let reason = reason.to_string();
+    let request_id = request_id.to_string();
+    with_org_txn(pool, &provisional, move |txn| {
+        Box::pin(async move {
+            // 1) User lock first — blocks concurrent login/new-family for this user.
+            lock_user_sessions(txn, user_id)
+                .await
+                .map_err(|_| DbError::Config("user_lock_failed".into()))?;
+
+            // 2) Discover families, lock each in deterministic order, then revoke.
+            let family_rows = txn
+                .query(
+                    "SELECT DISTINCT family_id
+                     FROM refresh_tokens
+                     WHERE org_id = $1 AND user_id = $2
+                     ORDER BY family_id",
+                    &[&org_id, &user_id],
+                )
+                .await?;
+            let mut family_ids: Vec<Uuid> = family_rows.iter().map(|row| row.get(0)).collect();
+            family_ids.sort_unstable();
+            family_ids.dedup();
+            for family_id in &family_ids {
+                lock_refresh_family(txn, *family_id)
+                    .await
+                    .map_err(|_| DbError::Config("family_lock_failed".into()))?;
+            }
+
+            txn.execute(
+                "UPDATE refresh_tokens
+                 SET revoked_at = COALESCE(revoked_at, now())
+                 WHERE org_id = $1 AND user_id = $2 AND revoked_at IS NULL",
+                &[&org_id, &user_id],
+            )
+            .await?;
+
+            // Re-scan under locks for any family that appeared after the first SELECT
+            // (should be empty once user-lock serializes login; defense in depth).
+            let late_rows = txn
+                .query(
+                    "SELECT DISTINCT family_id
+                     FROM refresh_tokens
+                     WHERE org_id = $1 AND user_id = $2 AND revoked_at IS NULL
+                     ORDER BY family_id",
+                    &[&org_id, &user_id],
+                )
+                .await?;
+            for row in late_rows {
+                let family_id: Uuid = row.get(0);
+                lock_refresh_family(txn, family_id)
+                    .await
+                    .map_err(|_| DbError::Config("family_lock_failed".into()))?;
+                revoke_family_in_txn(txn, org_id, family_id).await?;
+            }
+
+            write_audit(
+                txn,
+                AuditEvent {
+                    org_id,
+                    actor_user_id: Some(user_id),
+                    action: "auth.revoke_all",
+                    resource_type: "session",
+                    resource_id: Some(&user_id.to_string()),
+                    outcome: "success",
+                    request_id: &request_id,
+                    metadata: serde_json::json!({ "reason": reason }),
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    })
+    .await?;
+    Ok(())
+}
+
+/// Loads display profile fields for `/me` (users table has no RLS).
+pub async fn load_user_profile(
+    pool: &deadpool_postgres::Pool,
+    user_id: Uuid,
+) -> Result<(String, String), SessionError> {
+    let client = pool.get().await.map_err(|_| SessionError::Database)?;
+    let row = client
+        .query_opt(
+            "SELECT email, display_name FROM users WHERE id = $1",
+            &[&user_id],
+        )
+        .await
+        .map_err(|_| SessionError::Database)?
+        .ok_or(SessionError::InvalidCredentials)?;
+    Ok((row.get(0), row.get(1)))
+}
+
+/// Sets a user's password hash (test/bootstrap helper).
+pub async fn set_password_hash(
+    pool: &deadpool_postgres::Pool,
+    user_id: Uuid,
+    password: &str,
+    params: &Argon2Config,
+) -> Result<(), SessionError> {
+    let hash = password::hash_password(password, params)?;
+    let client = pool.get().await.map_err(|_| SessionError::Database)?;
+    client
+        .execute(
+            "UPDATE users SET password_hash = $1, updated_at = now() WHERE id = $2",
+            &[&hash.expose(), &user_id],
+        )
+        .await
+        .map_err(|_| SessionError::Database)?;
+    Ok(())
+}
+
+/// Applies org context GUCs on an existing transaction (re-export helper).
+pub async fn bind_org_context(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<(), DbError> {
+    apply_org_context(txn, ctx).await
+}

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -9,6 +9,14 @@ use serde::Deserialize;
 
 const DEFAULT_MAX_UPLOAD_BYTES: u64 = 200 * 1024 * 1024;
 const DEFAULT_JOB_LEASE_SECONDS: u64 = 60;
+const DEFAULT_ACCESS_TOKEN_TTL_SECS: u64 = 900;
+const DEFAULT_REFRESH_TOKEN_TTL_SECS: u64 = 60 * 60 * 24 * 7;
+const DEFAULT_ARGON2_MEMORY_KIB: u32 = 19_456;
+const DEFAULT_ARGON2_TIME_COST: u32 = 2;
+const DEFAULT_ARGON2_PARALLELISM: u32 = 1;
+const PROD_MIN_ARGON2_MEMORY_KIB: u32 = 19_456;
+const PROD_MIN_ARGON2_TIME_COST: u32 = 2;
+const PROD_MAX_ACCESS_TOKEN_TTL_SECS: u64 = 900;
 
 /// Deployment profile with explicitly different safety requirements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,11 +77,55 @@ pub struct ServerConfig {
     index_signature: Option<String>,
 }
 
+/// Pinned JWT signing algorithm. Only HS256 is supported for Phase 1B.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JwtAlgorithm {
+    Hs256,
+}
+
+impl JwtAlgorithm {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value.trim().to_ascii_uppercase().as_str() {
+            "HS256" => Ok(Self::Hs256),
+            _ => Err("MARKHAND_AUTH_ALG must be HS256".into()),
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Hs256 => "HS256",
+        }
+    }
+}
+
+/// Argon2id cost parameters (pinned in config; rehash-on-login when raised).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Argon2Config {
+    pub memory_kib: u32,
+    pub time_cost: u32,
+    pub parallelism: u32,
+}
+
+impl Argon2Config {
+    pub const fn defaults() -> Self {
+        Self {
+            memory_kib: DEFAULT_ARGON2_MEMORY_KIB,
+            time_cost: DEFAULT_ARGON2_TIME_COST,
+            parallelism: DEFAULT_ARGON2_PARALLELISM,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuthConfig {
     pub issuer: Option<String>,
     pub audience: Option<String>,
     pub signing_key: Option<SecretString>,
+    pub alg: JwtAlgorithm,
+    pub kid: Option<String>,
+    pub access_token_ttl_secs: u64,
+    pub refresh_token_ttl_secs: u64,
+    pub argon2: Argon2Config,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -93,6 +145,13 @@ struct ConfigFile {
     auth_issuer: Option<String>,
     auth_audience: Option<String>,
     auth_signing_key: Option<String>,
+    auth_alg: Option<String>,
+    auth_kid: Option<String>,
+    auth_access_token_ttl_secs: Option<u64>,
+    auth_refresh_token_ttl_secs: Option<u64>,
+    auth_argon2_memory_kib: Option<u64>,
+    auth_argon2_time_cost: Option<u64>,
+    auth_argon2_parallelism: Option<u64>,
     max_upload_bytes: Option<u64>,
     job_lease_seconds: Option<u64>,
     index_signature: Option<String>,
@@ -165,22 +224,78 @@ impl ServerConfig {
             value.minio_url.as_ref()
         });
         let auth = match role {
-            RuntimeRole::Api => AuthConfig {
-                issuer: optional_value(file, env, "MARKHAND_AUTH_ISSUER", |value| {
-                    value.auth_issuer.as_ref()
-                }),
-                audience: optional_value(file, env, "MARKHAND_AUTH_AUDIENCE", |value| {
-                    value.auth_audience.as_ref()
-                }),
-                signing_key: optional_value(file, env, "MARKHAND_AUTH_SIGNING_KEY", |value| {
-                    value.auth_signing_key.as_ref()
+            RuntimeRole::Api => {
+                let alg = optional_value(file, env, "MARKHAND_AUTH_ALG", |value| {
+                    value.auth_alg.as_ref()
                 })
-                .map(SecretString::new),
-            },
+                .as_deref()
+                .map(JwtAlgorithm::parse)
+                .transpose()?
+                .unwrap_or(JwtAlgorithm::Hs256);
+                let argon2 = Argon2Config {
+                    memory_kib: u32_value(
+                        file,
+                        env,
+                        "MARKHAND_AUTH_ARGON2_MEMORY_KIB",
+                        |value| value.auth_argon2_memory_kib,
+                        DEFAULT_ARGON2_MEMORY_KIB,
+                    )?,
+                    time_cost: u32_value(
+                        file,
+                        env,
+                        "MARKHAND_AUTH_ARGON2_TIME_COST",
+                        |value| value.auth_argon2_time_cost,
+                        DEFAULT_ARGON2_TIME_COST,
+                    )?,
+                    parallelism: u32_value(
+                        file,
+                        env,
+                        "MARKHAND_AUTH_ARGON2_PARALLELISM",
+                        |value| value.auth_argon2_parallelism,
+                        DEFAULT_ARGON2_PARALLELISM,
+                    )?,
+                };
+                AuthConfig {
+                    issuer: optional_value(file, env, "MARKHAND_AUTH_ISSUER", |value| {
+                        value.auth_issuer.as_ref()
+                    }),
+                    audience: optional_value(file, env, "MARKHAND_AUTH_AUDIENCE", |value| {
+                        value.auth_audience.as_ref()
+                    }),
+                    signing_key: optional_value(file, env, "MARKHAND_AUTH_SIGNING_KEY", |value| {
+                        value.auth_signing_key.as_ref()
+                    })
+                    .map(SecretString::new),
+                    alg,
+                    kid: optional_value(file, env, "MARKHAND_AUTH_KID", |value| {
+                        value.auth_kid.as_ref()
+                    }),
+                    access_token_ttl_secs: numeric_value(
+                        file,
+                        env,
+                        "MARKHAND_AUTH_ACCESS_TOKEN_TTL_SECS",
+                        |value| value.auth_access_token_ttl_secs,
+                        DEFAULT_ACCESS_TOKEN_TTL_SECS,
+                    )?,
+                    refresh_token_ttl_secs: numeric_value(
+                        file,
+                        env,
+                        "MARKHAND_AUTH_REFRESH_TOKEN_TTL_SECS",
+                        |value| value.auth_refresh_token_ttl_secs,
+                        DEFAULT_REFRESH_TOKEN_TTL_SECS,
+                    )?,
+                    argon2,
+                }
+            }
             RuntimeRole::Worker => AuthConfig {
                 issuer: None,
                 audience: None,
                 signing_key: None,
+                alg: JwtAlgorithm::Hs256,
+                kid: None,
+                access_token_ttl_secs: DEFAULT_ACCESS_TOKEN_TTL_SECS,
+                refresh_token_ttl_secs: DEFAULT_REFRESH_TOKEN_TTL_SECS,
+                argon2: Argon2Config::defaults(),
             },
         };
         let limits = RuntimeLimits {
@@ -226,21 +341,25 @@ impl ServerConfig {
         self.bind_addr
     }
 
+    /// Authentication configuration (API role). Worker configs leave credentials unset.
+    pub const fn auth(&self) -> &AuthConfig {
+        &self.auth
+    }
+
     pub(crate) fn is_api_role(&self) -> bool {
         self.role == RuntimeRole::Api
     }
 
-    #[cfg(test)]
-    pub(crate) fn test_with_endpoints(endpoints: RuntimeEndpoints) -> Self {
+    /// Test helper for integration crates (`tests/*.rs`) and in-crate HTTP tests.
+    pub fn test_with_endpoints(endpoints: RuntimeEndpoints) -> Self {
         Self::test_with_endpoints_for_role(endpoints, RuntimeRole::Api)
     }
 
-    #[cfg(test)]
-    pub(crate) fn test_worker_with_endpoints(endpoints: RuntimeEndpoints) -> Self {
+    /// Test helper for worker-role runtime state.
+    pub fn test_worker_with_endpoints(endpoints: RuntimeEndpoints) -> Self {
         Self::test_with_endpoints_for_role(endpoints, RuntimeRole::Worker)
     }
 
-    #[cfg(test)]
     fn test_with_endpoints_for_role(endpoints: RuntimeEndpoints, role: RuntimeRole) -> Self {
         Self {
             role,
@@ -253,6 +372,11 @@ impl ServerConfig {
                 issuer: None,
                 audience: None,
                 signing_key: None,
+                alg: JwtAlgorithm::Hs256,
+                kid: None,
+                access_token_ttl_secs: DEFAULT_ACCESS_TOKEN_TTL_SECS,
+                refresh_token_ttl_secs: DEFAULT_REFRESH_TOKEN_TTL_SECS,
+                argon2: Argon2Config::defaults(),
             },
             limits: RuntimeLimits {
                 max_upload_bytes: DEFAULT_MAX_UPLOAD_BYTES,
@@ -293,7 +417,10 @@ impl ServerConfig {
 
     fn validate_auth(&self) -> Result<(), String> {
         let Some(issuer) = self.auth.issuer.as_deref() else {
-            if self.auth.audience.is_some() || self.auth.signing_key.is_some() {
+            if self.auth.audience.is_some()
+                || self.auth.signing_key.is_some()
+                || self.auth.kid.is_some()
+            {
                 return Err(
                     "MARKHAND_AUTH_ISSUER is required when authentication is configured".into(),
                 );
@@ -314,6 +441,51 @@ impl ServerConfig {
         };
         if signing_key.expose().len() < 32 {
             return Err("MARKHAND_AUTH_SIGNING_KEY must contain at least 32 bytes".into());
+        }
+        if self.auth.alg != JwtAlgorithm::Hs256 {
+            return Err("MARKHAND_AUTH_ALG must be HS256".into());
+        }
+        let Some(kid) = self.auth.kid.as_deref() else {
+            return Err("MARKHAND_AUTH_KID is required when issuer is set".into());
+        };
+        if kid.trim().is_empty() {
+            return Err("MARKHAND_AUTH_KID must not be empty when issuer is set".into());
+        }
+        if self.auth.access_token_ttl_secs == 0
+            || self.auth.access_token_ttl_secs > DEFAULT_ACCESS_TOKEN_TTL_SECS
+        {
+            return Err(format!(
+                "MARKHAND_AUTH_ACCESS_TOKEN_TTL_SECS must be between 1 and {DEFAULT_ACCESS_TOKEN_TTL_SECS}"
+            ));
+        }
+        if self.auth.refresh_token_ttl_secs == 0 {
+            return Err("MARKHAND_AUTH_REFRESH_TOKEN_TTL_SECS must be at least 1".into());
+        }
+        if self.auth.argon2.memory_kib == 0
+            || self.auth.argon2.time_cost == 0
+            || self.auth.argon2.parallelism == 0
+        {
+            return Err("Argon2 parameters must be positive".into());
+        }
+        if self.profile == Profile::Prod {
+            if kid.eq_ignore_ascii_case("dev")
+                || kid.to_ascii_lowercase().starts_with("dev-")
+                || kid.to_ascii_lowercase().starts_with("test-")
+            {
+                return Err("prod profile rejects development MARKHAND_AUTH_KID values".into());
+            }
+            if self.auth.access_token_ttl_secs > PROD_MAX_ACCESS_TOKEN_TTL_SECS {
+                return Err(format!(
+                    "prod MARKHAND_AUTH_ACCESS_TOKEN_TTL_SECS must be <= {PROD_MAX_ACCESS_TOKEN_TTL_SECS}"
+                ));
+            }
+            if self.auth.argon2.memory_kib < PROD_MIN_ARGON2_MEMORY_KIB
+                || self.auth.argon2.time_cost < PROD_MIN_ARGON2_TIME_COST
+            {
+                return Err(format!(
+                    "prod Argon2id requires memory_kib>={PROD_MIN_ARGON2_MEMORY_KIB} and time_cost>={PROD_MIN_ARGON2_TIME_COST}"
+                ));
+            }
         }
         Ok(())
     }
@@ -391,6 +563,17 @@ fn numeric_value(
     }
 }
 
+fn u32_value(
+    file: Option<&ConfigFile>,
+    env: &BTreeMap<String, String>,
+    env_name: &str,
+    from_file: impl FnOnce(&ConfigFile) -> Option<u64>,
+    default: u32,
+) -> Result<u32, String> {
+    let value = numeric_value(file, env, env_name, from_file, u64::from(default))?;
+    u32::try_from(value).map_err(|_| format!("{env_name} is out of range for u32"))
+}
+
 fn required_url(value: Option<&str>, name: &str) -> Result<String, String> {
     let value = value.ok_or_else(|| format!("server requires {name}"))?;
     let parsed =
@@ -448,9 +631,15 @@ fn load_file(path: &Path, role: RuntimeRole) -> Result<ConfigFile, String> {
         let object = value
             .as_object_mut()
             .ok_or_else(|| "MARKHAND_CONFIG_FILE contains invalid JSON".to_string())?;
-        if ["authIssuer", "authAudience", "authSigningKey"]
-            .iter()
-            .any(|key| object.contains_key(*key))
+        if [
+            "authIssuer",
+            "authAudience",
+            "authSigningKey",
+            "authKid",
+            "authAlg",
+        ]
+        .iter()
+        .any(|key| object.contains_key(*key))
         {
             return Err("worker configuration must not contain API authentication settings".into());
         }
@@ -462,7 +651,16 @@ fn reject_worker_auth_environment(env: &BTreeMap<String, String>) -> Result<(), 
     if env.keys().any(|key| {
         matches!(
             key.as_str(),
-            "MARKHAND_AUTH_ISSUER" | "MARKHAND_AUTH_AUDIENCE" | "MARKHAND_AUTH_SIGNING_KEY"
+            "MARKHAND_AUTH_ISSUER"
+                | "MARKHAND_AUTH_AUDIENCE"
+                | "MARKHAND_AUTH_SIGNING_KEY"
+                | "MARKHAND_AUTH_ALG"
+                | "MARKHAND_AUTH_KID"
+                | "MARKHAND_AUTH_ACCESS_TOKEN_TTL_SECS"
+                | "MARKHAND_AUTH_REFRESH_TOKEN_TTL_SECS"
+                | "MARKHAND_AUTH_ARGON2_MEMORY_KIB"
+                | "MARKHAND_AUTH_ARGON2_TIME_COST"
+                | "MARKHAND_AUTH_ARGON2_PARALLELISM"
         )
     }) {
         Err("worker environment must not contain API authentication settings".into())
@@ -487,6 +685,13 @@ mod tests {
             auth_issuer: None,
             auth_audience: None,
             auth_signing_key: None,
+            auth_alg: None,
+            auth_kid: None,
+            auth_access_token_ttl_secs: None,
+            auth_refresh_token_ttl_secs: None,
+            auth_argon2_memory_kib: None,
+            auth_argon2_time_cost: None,
+            auth_argon2_parallelism: None,
             max_upload_bytes: None,
             job_lease_seconds: None,
             index_signature: None,
@@ -519,9 +724,19 @@ mod tests {
                 "MARKHAND_AUTH_SIGNING_KEY".into(),
                 "this-test-signing-key-is-at-least-32-bytes".into(),
             ),
+            ("MARKHAND_AUTH_KID".into(), "prod-key-1".into()),
             (
                 "MARKHAND_DATABASE_URL".into(),
                 "postgres://postgres:postgres@localhost/db".into(),
+            ),
+            (
+                "MARKHAND_QDRANT_URL".into(),
+                "https://qdrant.example".into(),
+            ),
+            ("MARKHAND_MINIO_URL".into(), "https://minio.example".into()),
+            (
+                "MARKHAND_INDEX_SIGNATURE".into(),
+                "d54db7b6de20b51a416670927eeab346256c9b891732965e51586fac333c1835".into(),
             ),
         ]);
         let error = ServerConfig::from_sources(None, &env).unwrap_err();
@@ -580,6 +795,7 @@ mod tests {
                 "MARKHAND_AUTH_SIGNING_KEY".into(),
                 "0123456789abcdef0123456789abcdef".into(),
             ),
+            ("MARKHAND_AUTH_KID".into(), "prod-key-1".into()),
             (
                 "MARKHAND_INDEX_SIGNATURE".into(),
                 "d54db7b6de20b51a416670927eeab346256c9b891732965e51586fac333c1835".into(),
@@ -589,6 +805,49 @@ mod tests {
             ServerConfig::from_sources(None, &env).unwrap_err(),
             "prod MARKHAND_MINIO_URL must use https"
         );
+    }
+
+    #[test]
+    fn auth_requires_kid_and_rejects_dev_kid_in_prod() {
+        let mut env = BTreeMap::from([
+            ("MARKHAND_PROFILE".into(), "dev".into()),
+            (
+                "MARKHAND_AUTH_ISSUER".into(),
+                "https://issuer.example.test".into(),
+            ),
+            ("MARKHAND_AUTH_AUDIENCE".into(), "markhand-api".into()),
+            (
+                "MARKHAND_AUTH_SIGNING_KEY".into(),
+                "this-test-signing-key-is-at-least-32-bytes".into(),
+            ),
+        ]);
+        assert_eq!(
+            ServerConfig::from_sources(None, &env).unwrap_err(),
+            "MARKHAND_AUTH_KID is required when issuer is set"
+        );
+        env.insert("MARKHAND_AUTH_KID".into(), "dev-local".into());
+        let config = ServerConfig::from_sources(None, &env).unwrap();
+        assert_eq!(config.auth.kid.as_deref(), Some("dev-local"));
+        assert!(!format!("{config:?}").contains("this-test-signing-key"));
+
+        env.insert("MARKHAND_PROFILE".into(), "prod".into());
+        env.insert("MARKHAND_BIND_ADDR".into(), "10.0.0.10:8787".into());
+        env.insert(
+            "MARKHAND_DATABASE_URL".into(),
+            "postgres://app:secret@postgres.internal/markhand?sslmode=require".into(),
+        );
+        env.insert(
+            "MARKHAND_QDRANT_URL".into(),
+            "https://qdrant.internal".into(),
+        );
+        env.insert("MARKHAND_MINIO_URL".into(), "https://minio.internal".into());
+        env.insert(
+            "MARKHAND_INDEX_SIGNATURE".into(),
+            "d54db7b6de20b51a416670927eeab346256c9b891732965e51586fac333c1835".into(),
+        );
+        assert!(ServerConfig::from_sources(None, &env)
+            .unwrap_err()
+            .contains("development MARKHAND_AUTH_KID"));
     }
 
     #[test]

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -1,4 +1,4 @@
-//! HTTP liveness and readiness routes backed by real POC dependencies.
+//! HTTP liveness, readiness, and API routes backed by real POC dependencies.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -8,12 +8,17 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
+use deadpool_postgres::Pool;
 use serde::Serialize;
 use tokio::time::timeout;
 use uuid::Uuid;
 
 use crate::api::ApiError;
+use crate::auth::jwt::JwtKeys;
+use crate::auth::provider::PasswordAuthProvider;
 use crate::database;
+use crate::db::pool::create_pool;
+use crate::routes;
 use crate::state::RuntimeState;
 
 const DEPENDENCY_TIMEOUT: Duration = Duration::from_secs(3);
@@ -23,6 +28,8 @@ pub struct AppState {
     runtime: RuntimeState,
     http_client: reqwest::Client,
     readiness: tokio::sync::Mutex<Option<CachedReadiness>>,
+    pool: Pool,
+    auth_provider: Option<PasswordAuthProvider>,
 }
 
 struct CachedReadiness {
@@ -39,11 +46,58 @@ impl AppState {
             .timeout(DEPENDENCY_TIMEOUT)
             .build()
             .map_err(|error| format!("cannot configure HTTP client: {error}"))?;
+        let pool = create_pool(runtime.endpoints().database_url.expose())
+            .map_err(|error| format!("cannot create database pool: {error}"))?;
+        let auth_provider = match JwtKeys::from_auth(runtime.config().auth()) {
+            Ok(keys) => Some(PasswordAuthProvider::new(
+                pool.clone(),
+                runtime.config().auth().clone(),
+                keys,
+            )),
+            Err(crate::auth::jwt::JwtError::NotConfigured) => None,
+            Err(error) => return Err(format!("cannot configure authentication: {error}")),
+        };
         Ok(Self {
             runtime,
             http_client,
             readiness: tokio::sync::Mutex::new(None),
+            pool,
+            auth_provider,
         })
+    }
+
+    /// Builds state for tests with an explicit pool and optional auth provider.
+    pub fn from_parts(
+        runtime: RuntimeState,
+        pool: Pool,
+        auth_provider: Option<PasswordAuthProvider>,
+    ) -> Result<Self, String> {
+        if !runtime.is_api_role() {
+            return Err("HTTP application requires API runtime configuration".into());
+        }
+        let http_client = reqwest::Client::builder()
+            .timeout(DEPENDENCY_TIMEOUT)
+            .build()
+            .map_err(|error| format!("cannot configure HTTP client: {error}"))?;
+        Ok(Self {
+            runtime,
+            http_client,
+            readiness: tokio::sync::Mutex::new(None),
+            pool,
+            auth_provider,
+        })
+    }
+
+    pub fn auth_provider(&self) -> Option<&PasswordAuthProvider> {
+        self.auth_provider.as_ref()
+    }
+
+    pub fn pool(&self) -> &Pool {
+        &self.pool
+    }
+
+    pub fn runtime(&self) -> &RuntimeState {
+        &self.runtime
     }
 }
 
@@ -58,6 +112,7 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/api/v1/health/live", get(liveness))
         .route("/api/v1/health/ready", get(readiness))
+        .merge(routes::auth::router())
         .with_state(Arc::new(state))
 }
 
@@ -157,21 +212,22 @@ mod tests {
 
     use super::{router, AppState};
     use crate::config::{RuntimeEndpoints, SecretString, ServerConfig};
+    use crate::db::pool::create_pool;
     use crate::state::RuntimeState;
 
     #[tokio::test]
     async fn liveness_has_a_contract_compliant_body() {
-        let app = router(
-            AppState::new(
-                RuntimeState::from_config(ServerConfig::test_with_endpoints(RuntimeEndpoints {
-                    database_url: SecretString::new("postgres://unused"),
-                    qdrant_url: "http://127.0.0.1:1".into(),
-                    minio_url: "http://127.0.0.1:1".into(),
-                }))
-                .unwrap(),
-            )
-            .unwrap(),
-        );
+        let runtime =
+            RuntimeState::from_config(ServerConfig::test_with_endpoints(RuntimeEndpoints {
+                database_url: SecretString::new("postgres://unused"),
+                qdrant_url: "http://127.0.0.1:1".into(),
+                minio_url: "http://127.0.0.1:1".into(),
+            }))
+            .unwrap();
+        // Pool construction is lazy; a dummy URL is enough for the liveness route.
+        let pool = create_pool("postgres://markhand_app:markhand_app@127.0.0.1:5432/markhand_test")
+            .expect("pool");
+        let app = router(AppState::from_parts(runtime, pool, None).unwrap());
         let response = app
             .oneshot(
                 axum::http::Request::builder()
@@ -197,8 +253,10 @@ mod tests {
                 minio_url: "http://127.0.0.1:1".into(),
             }))
             .unwrap();
+        let pool = create_pool("postgres://markhand_app:markhand_app@127.0.0.1:5432/markhand_test")
+            .expect("pool");
         assert_eq!(
-            AppState::new(state).err().as_deref(),
+            AppState::from_parts(state, pool, None).err().as_deref(),
             Some("HTTP application requires API runtime configuration")
         );
     }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,6 +7,7 @@ pub mod database;
 pub mod db;
 pub mod error;
 pub mod http;
+pub mod routes;
 pub mod services;
 pub mod state;
 pub mod telemetry;

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -1,0 +1,243 @@
+//! Authentication HTTP routes (bearer JWT access + opaque rotating refresh).
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api::ApiError;
+use crate::auth::middleware::{session_error_response, AuthenticatedOrg};
+use crate::auth::provider::{AuthProvider, AuthRequestMeta};
+use crate::http::AppState;
+
+const MAX_EMAIL_LEN: usize = 320;
+const MAX_PASSWORD_LEN: usize = 1024;
+const MAX_REFRESH_LEN: usize = 512;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoginRequest {
+    pub email: String,
+    pub password: String,
+}
+
+impl std::fmt::Debug for LoginRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoginRequest")
+            .field("email", &self.email)
+            .field("password", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshRequest {
+    pub refresh_token: String,
+}
+
+impl std::fmt::Debug for RefreshRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RefreshRequest")
+            .field("refresh_token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogoutRequest {
+    pub refresh_token: String,
+}
+
+impl std::fmt::Debug for LogoutRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LogoutRequest")
+            .field("refresh_token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: String,
+    token_type: &'static str,
+    expires_in: u64,
+    org_id: String,
+    user_id: String,
+}
+
+impl std::fmt::Debug for TokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenResponse")
+            .field("access_token", &"[REDACTED]")
+            .field("refresh_token", &"[REDACTED]")
+            .field("token_type", &self.token_type)
+            .field("expires_in", &self.expires_in)
+            .field("org_id", &self.org_id)
+            .field("user_id", &self.user_id)
+            .finish()
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MeResponse {
+    user_id: String,
+    org_id: String,
+    email: String,
+    display_name: String,
+    permissions: Vec<String>,
+    allowed_collection_ids: Vec<String>,
+    session_id: String,
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/v1/auth/login", post(login))
+        .route("/api/v1/auth/refresh", post(refresh))
+        .route("/api/v1/auth/logout", post(logout))
+        .route("/api/v1/auth/me", get(me))
+}
+
+/// Server-minted request id for API responses and audit rows.
+///
+/// Never persists caller-controlled `x-request-id` (could contain a refresh token).
+fn server_request_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+fn validation_error(request_id: &str, message: &str) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ApiError {
+            code: "validation_failed".into(),
+            message: message.into(),
+            request_id: request_id.to_string(),
+            details: None,
+        }),
+    )
+        .into_response()
+}
+
+async fn login(State(state): State<Arc<AppState>>, Json(body): Json<LoginRequest>) -> Response {
+    let request_id = server_request_id();
+    if body.email.len() > MAX_EMAIL_LEN || body.password.len() > MAX_PASSWORD_LEN {
+        return validation_error(&request_id, "Email or password exceeds allowed length");
+    }
+    if body.email.trim().is_empty() || body.password.is_empty() {
+        return validation_error(&request_id, "Email and password are required");
+    }
+    let Some(provider) = state.auth_provider() else {
+        return session_error_response(
+            crate::auth::session::SessionError::NotConfigured,
+            &request_id,
+        );
+    };
+    let meta = AuthRequestMeta {
+        request_id: request_id.clone(),
+    };
+    match provider
+        .login_password(&body.email, &body.password, &meta)
+        .await
+    {
+        Ok(session) => {
+            let tokens = session.tokens;
+            Json(TokenResponse {
+                access_token: tokens.access_token.expose().to_string(),
+                refresh_token: tokens.refresh_token.expose().to_string(),
+                token_type: "Bearer",
+                expires_in: tokens.expires_in,
+                org_id: tokens.org_id.to_string(),
+                user_id: tokens.user_id.to_string(),
+            })
+            .into_response()
+        }
+        Err(error) => session_error_response(error, &request_id),
+    }
+}
+
+async fn refresh(State(state): State<Arc<AppState>>, Json(body): Json<RefreshRequest>) -> Response {
+    let request_id = server_request_id();
+    if body.refresh_token.is_empty() || body.refresh_token.len() > MAX_REFRESH_LEN {
+        return validation_error(&request_id, "refreshToken is required");
+    }
+    let Some(provider) = state.auth_provider() else {
+        return session_error_response(
+            crate::auth::session::SessionError::NotConfigured,
+            &request_id,
+        );
+    };
+    let meta = AuthRequestMeta {
+        request_id: request_id.clone(),
+    };
+    match provider.refresh(&body.refresh_token, &meta).await {
+        Ok(session) => {
+            let tokens = session.tokens;
+            Json(TokenResponse {
+                access_token: tokens.access_token.expose().to_string(),
+                refresh_token: tokens.refresh_token.expose().to_string(),
+                token_type: "Bearer",
+                expires_in: tokens.expires_in,
+                org_id: tokens.org_id.to_string(),
+                user_id: tokens.user_id.to_string(),
+            })
+            .into_response()
+        }
+        Err(error) => session_error_response(error, &request_id),
+    }
+}
+
+async fn logout(State(state): State<Arc<AppState>>, Json(body): Json<LogoutRequest>) -> Response {
+    let request_id = server_request_id();
+    if body.refresh_token.is_empty() || body.refresh_token.len() > MAX_REFRESH_LEN {
+        return validation_error(&request_id, "refreshToken is required");
+    }
+    let Some(provider) = state.auth_provider() else {
+        return session_error_response(
+            crate::auth::session::SessionError::NotConfigured,
+            &request_id,
+        );
+    };
+    let meta = AuthRequestMeta {
+        request_id: request_id.clone(),
+    };
+    match provider.logout(&body.refresh_token, &meta).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => session_error_response(error, &request_id),
+    }
+}
+
+async fn me(State(state): State<Arc<AppState>>, auth: AuthenticatedOrg) -> Response {
+    let Some(provider) = state.auth_provider() else {
+        return session_error_response(
+            crate::auth::session::SessionError::NotConfigured,
+            &auth.request_id,
+        );
+    };
+    match crate::auth::session::load_user_profile(provider.pool(), auth.context.user_id()).await {
+        Ok((email, display_name)) => Json(MeResponse {
+            user_id: auth.context.user_id().to_string(),
+            org_id: auth.context.org_id().to_string(),
+            email,
+            display_name,
+            permissions: auth.context.permissions().iter().cloned().collect(),
+            allowed_collection_ids: auth
+                .context
+                .allowed_collection_ids()
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+            session_id: auth.claims.sid,
+        })
+        .into_response(),
+        Err(error) => session_error_response(error, &auth.request_id),
+    }
+}

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,0 +1,3 @@
+//! HTTP route modules.
+
+pub mod auth;

--- a/crates/server/tests/auth.rs
+++ b/crates/server/tests/auth.rs
@@ -1,0 +1,936 @@
+//! Integration tests for password auth, rotating refresh sessions, and OrgContext.
+//!
+//! Gated on `MARKHAND_TEST_DATABASE_URL` (same ephemeral-DB pattern as
+//! `repositories.rs` / `schema_migrations.rs`).
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::auth::jwt::JwtKeys;
+use fileconv_server::auth::permissions::resolve_org_context_in_txn;
+use fileconv_server::auth::provider::{AuthProvider, AuthRequestMeta, PasswordAuthProvider};
+use fileconv_server::auth::session::{self, SessionError};
+use fileconv_server::config::{
+    Argon2Config, AuthConfig, JwtAlgorithm, RuntimeEndpoints, SecretString, ServerConfig,
+};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::http::{router, AppState};
+use fileconv_server::state::RuntimeState;
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!(
+                "skipped: MARKHAND_TEST_DATABASE_URL unset — auth integration tests require PostgreSQL"
+            );
+            None
+        }
+    }
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+fn admin_database_url(base_url: &str) -> String {
+    rewrite_database_url(base_url, "postgres")
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, tokio_postgres::NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("connect failed for {database_url}: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_auth_{}", Uuid::new_v4().simple());
+        let admin_url = admin_database_url(base_url);
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+fn test_auth_config() -> AuthConfig {
+    AuthConfig {
+        issuer: Some("https://issuer.markhand.test".into()),
+        audience: Some("markhand-api".into()),
+        signing_key: Some(SecretString::new("integration-test-signing-key-32b!")),
+        alg: JwtAlgorithm::Hs256,
+        kid: Some("test-kid-1".into()),
+        access_token_ttl_secs: 900,
+        refresh_token_ttl_secs: 3_600,
+        argon2: Argon2Config {
+            memory_kib: 8_192,
+            time_cost: 1,
+            parallelism: 1,
+        },
+    }
+}
+
+fn test_runtime(database_url: &str) -> RuntimeState {
+    RuntimeState::from_config(ServerConfig::test_with_endpoints(RuntimeEndpoints {
+        database_url: SecretString::new(database_url),
+        qdrant_url: "http://127.0.0.1:1".into(),
+        minio_url: "http://127.0.0.1:1".into(),
+    }))
+    .expect("runtime")
+}
+
+async fn boot(base_url: &str) -> (EphemeralDb, Pool, PasswordAuthProvider, Arc<AppState>) {
+    let ephemeral = EphemeralDb::create(base_url).await;
+    apply_migrations(&ephemeral.url)
+        .await
+        .expect("apply migrations");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let auth = test_auth_config();
+    let keys = JwtKeys::from_auth(&auth).expect("jwt keys");
+    let provider = PasswordAuthProvider::new(pool.clone(), auth, keys);
+    let runtime = test_runtime(&ephemeral.url);
+    let state = AppState::from_parts(
+        runtime,
+        pool.clone(),
+        Some(PasswordAuthProvider::new(
+            pool.clone(),
+            test_auth_config(),
+            JwtKeys::from_auth(&test_auth_config()).unwrap(),
+        )),
+    )
+    .expect("app state");
+    (ephemeral, pool, provider, Arc::new(state))
+}
+
+async fn seed_user(pool: &Pool, org: Uuid, user: Uuid, email: &str, password: &str) {
+    let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
+    let email = email.to_string();
+    with_org_txn(pool, &ctx, {
+        let owned = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &owned, "authorg", "Auth Org").await?;
+                orgs::ensure_user(txn, &owned, user, &email, "Auth User").await?;
+                orgs::ensure_membership(txn, &owned).await?;
+                // Seed matching system role + permission so /me has permissions.
+                txn.execute(
+                    "INSERT INTO permissions (id, code, description)
+                     VALUES ($1, 'doc.upload', 'Upload')
+                     ON CONFLICT (code) DO NOTHING",
+                    &[&Uuid::new_v4()],
+                )
+                .await?;
+                let role_id = Uuid::new_v4();
+                txn.execute(
+                    "INSERT INTO roles (id, org_id, code, name, is_system)
+                     VALUES ($1, $2, 'owner', 'Owner', true)
+                     ON CONFLICT (org_id, code) DO NOTHING",
+                    &[&role_id, &org],
+                )
+                .await?;
+                let role_id: Uuid = txn
+                    .query_one(
+                        "SELECT id FROM roles WHERE org_id = $1 AND code = 'owner'",
+                        &[&org],
+                    )
+                    .await?
+                    .get(0);
+                let perm_id: Uuid = txn
+                    .query_one("SELECT id FROM permissions WHERE code = 'doc.upload'", &[])
+                    .await?
+                    .get(0);
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     VALUES ($1, $2, $3)
+                     ON CONFLICT DO NOTHING",
+                    &[&org, &role_id, &perm_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed user");
+    session::set_password_hash(pool, user, password, &test_auth_config().argon2)
+        .await
+        .expect("set password");
+}
+
+async fn json_request(
+    app: axum::Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+    bearer: Option<&str>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(token) = bearer {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    builder = builder.header("x-request-id", "req-auth-test-1");
+    let request = builder
+        .body(match body {
+            Some(value) => Body::from(serde_json::to_vec(&value).unwrap()),
+            None => Body::empty(),
+        })
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes)
+            .unwrap_or(Value::String(String::from_utf8_lossy(&bytes).into_owned()))
+    };
+    (status, value)
+}
+
+fn assert_no_secrets(value: &Value, password: &str, refresh: Option<&str>, access: Option<&str>) {
+    let rendered = value.to_string();
+    assert!(!rendered.contains(password));
+    if let Some(token) = refresh {
+        assert!(!rendered.contains(token) || rendered.contains("refreshToken"));
+        // Response bodies intentionally include tokens; audit metadata must not.
+    }
+    let _ = access;
+}
+
+#[tokio::test]
+async fn login_me_refresh_logout_and_audit() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool, provider, state) = boot(&base_url).await;
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let email = format!("user-{}@example.com", user.simple());
+    let password = "correct-horse-battery";
+    seed_user(&pool, org, user, &email, password).await;
+
+    let app = router(
+        AppState::from_parts(
+            state.runtime().clone(),
+            pool.clone(),
+            Some(PasswordAuthProvider::new(
+                pool.clone(),
+                test_auth_config(),
+                JwtKeys::from_auth(&test_auth_config()).unwrap(),
+            )),
+        )
+        .unwrap(),
+    );
+
+    let (status, body) = json_request(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/login",
+        Some(serde_json::json!({ "email": email, "password": password })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let access = body["accessToken"].as_str().unwrap().to_string();
+    let refresh = body["refreshToken"].as_str().unwrap().to_string();
+    assert!(refresh.starts_with("mh1."));
+    assert!(!format!("{body:?}").contains(password));
+
+    let (status, me) =
+        json_request(app.clone(), "GET", "/api/v1/auth/me", None, Some(&access)).await;
+    assert_eq!(status, StatusCode::OK, "{me}");
+    assert_eq!(me["email"], email);
+    assert_eq!(me["orgId"], org.to_string());
+    assert!(me["permissions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|p| p == "doc.upload"));
+
+    // Wrong password rejected + audited.
+    let (status, err) = json_request(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/login",
+        Some(serde_json::json!({ "email": email, "password": "wrong-password" })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(err["code"], "invalid_credentials");
+    assert!(!err.to_string().contains(password));
+    assert!(!err.to_string().contains("wrong-password"));
+
+    // Unknown user rejected.
+    let (status, _) = json_request(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/login",
+        Some(serde_json::json!({
+            "email": "nobody@example.com",
+            "password": password
+        })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // Refresh rotates.
+    let (status, rotated) = json_request(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/refresh",
+        Some(serde_json::json!({ "refreshToken": refresh })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{rotated}");
+    let refresh2 = rotated["refreshToken"].as_str().unwrap().to_string();
+    assert_ne!(refresh, refresh2);
+
+    let (status, _) = json_request(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/refresh",
+        Some(serde_json::json!({ "refreshToken": refresh })),
+        None,
+    )
+    .await;
+    // Old refresh was rotated → reuse → family revoke.
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // New refresh from before reuse should also be dead after family revoke.
+    let (status, _) = json_request(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/refresh",
+        Some(serde_json::json!({ "refreshToken": refresh2 })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // Fresh login for logout path.
+    let meta = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let session = provider
+        .login_password(&email, password, &meta)
+        .await
+        .unwrap();
+    let refresh3 = session.tokens.refresh_token.expose().to_string();
+    let (status, _) = json_request(
+        app.clone(),
+        "POST",
+        "/api/v1/auth/logout",
+        Some(serde_json::json!({ "refreshToken": refresh3 })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    let (status, _) = json_request(
+        app,
+        "POST",
+        "/api/v1/auth/refresh",
+        Some(serde_json::json!({ "refreshToken": refresh3 })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    // Audit rows exist without secret material.
+    let ctx = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    let audits = with_org_txn(&pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let rows = txn
+                .query(
+                    "SELECT action, outcome, metadata::text, request_id
+                     FROM audit_log WHERE org_id = $1 ORDER BY seq",
+                    &[&org],
+                )
+                .await?;
+            Ok(rows
+                .into_iter()
+                .map(|row| {
+                    (
+                        row.get::<_, String>(0),
+                        row.get::<_, String>(1),
+                        row.get::<_, String>(2),
+                        row.get::<_, Option<String>>(3),
+                    )
+                })
+                .collect::<Vec<_>>())
+        })
+    })
+    .await
+    .unwrap();
+    assert!(audits
+        .iter()
+        .any(|(action, outcome, _, _)| { action == "auth.login" && outcome == "success" }));
+    assert!(audits
+        .iter()
+        .any(|(action, outcome, _, _)| { action == "auth.login" && outcome == "deny" }));
+    assert!(audits
+        .iter()
+        .any(|(action, _, _, _)| action == "auth.refresh.reuse"));
+    for (_, _, metadata, request_id) in &audits {
+        assert!(!metadata.contains(password));
+        assert!(!metadata.contains(&refresh));
+        assert!(!metadata.contains("mh1."));
+        let rid = request_id.as_deref().expect("audit request_id required");
+        assert!(
+            Uuid::parse_str(rid).is_ok(),
+            "audit request_id must be a server-minted uuid, got {rid}"
+        );
+        assert_ne!(rid, "req-auth-test-1");
+        assert_no_secrets(&Value::String(metadata.clone()), password, None, None);
+    }
+
+    // Client-controlled x-request-id that looks like a refresh token must never be audited.
+    let malicious_rid = format!("mh1.{org}.{}", "a".repeat(40));
+    let (status, _) = {
+        let builder = Request::builder()
+            .method("POST")
+            .uri("/api/v1/auth/login")
+            .header("content-type", "application/json")
+            .header("x-request-id", &malicious_rid);
+        let request = builder
+            .body(Body::from(
+                serde_json::to_vec(&serde_json::json!({
+                    "email": email,
+                    "password": "wrong-password-again"
+                }))
+                .unwrap(),
+            ))
+            .unwrap();
+        let app = router(
+            AppState::from_parts(
+                state.runtime().clone(),
+                pool.clone(),
+                Some(PasswordAuthProvider::new(
+                    pool.clone(),
+                    test_auth_config(),
+                    JwtKeys::from_auth(&test_auth_config()).unwrap(),
+                )),
+            )
+            .unwrap(),
+        );
+        let response = app.oneshot(request).await.unwrap();
+        (response.status(), ())
+    };
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let audits_after = with_org_txn(&pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let rows = txn
+                .query(
+                    "SELECT request_id FROM audit_log WHERE org_id = $1",
+                    &[&org],
+                )
+                .await?;
+            Ok(rows
+                .into_iter()
+                .map(|row| row.get::<_, Option<String>>(0))
+                .collect::<Vec<_>>())
+        })
+    })
+    .await
+    .unwrap();
+    for rid in audits_after.into_iter().flatten() {
+        assert_ne!(rid, malicious_rid);
+        assert!(!rid.contains("mh1."));
+        assert!(
+            Uuid::parse_str(&rid).is_ok(),
+            "expected uuid request_id, got {rid}"
+        );
+    }
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn refresh_reuse_revokes_family_under_concurrency() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool, provider, _) = boot(&base_url).await;
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let email = format!("race-{}@example.com", user.simple());
+    let password = "race-password-value";
+    seed_user(&pool, org, user, &email, password).await;
+
+    let meta = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let session = provider
+        .login_password(&email, password, &meta)
+        .await
+        .unwrap();
+    let refresh = session.tokens.refresh_token.expose().to_string();
+    let family_id = session.tokens.family_id;
+
+    // Force real contention: hold the family-first advisory lock so refreshes block.
+    let hold = session::acquire_family_lock_for_test(&pool, org, family_id)
+        .await
+        .expect("hold family lock");
+    let meta_a = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let meta_b = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let refresh_a = refresh.clone();
+    let refresh_b = refresh.clone();
+    let provider_a = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+    let provider_b = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+    let handle_a = tokio::spawn(async move { provider_a.refresh(&refresh_a, &meta_a).await });
+    let handle_b = tokio::spawn(async move { provider_b.refresh(&refresh_b, &meta_b).await });
+
+    // While the family lock is held, neither refresh may complete.
+    // If family-first locking were removed, these would finish immediately.
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    assert!(
+        !handle_a.is_finished(),
+        "refresh A must block on family-first advisory lock"
+    );
+    assert!(
+        !handle_b.is_finished(),
+        "refresh B must block on family-first advisory lock"
+    );
+
+    hold.release().await.expect("release family lock");
+    let a = handle_a.await.expect("join A");
+    let b = handle_b.await.expect("join B");
+    let results = [a, b];
+    let successes = results.iter().filter(|r| r.is_ok()).count();
+    let reuses = results
+        .iter()
+        .filter(|r| matches!(r, Err(SessionError::RefreshReuse)))
+        .count();
+    assert_eq!(
+        successes, 1,
+        "exactly one refresh must succeed: {results:?}"
+    );
+    assert_eq!(reuses, 1, "loser must report reuse: {results:?}");
+
+    // Family fully revoked — winner's new refresh also unusable after reuse revoke.
+    let winner_refresh = results
+        .iter()
+        .find_map(|r| r.as_ref().ok())
+        .map(|s| s.tokens.refresh_token.expose().to_string())
+        .unwrap();
+    let meta = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let follow = provider.refresh(&winner_refresh, &meta).await;
+    assert!(
+        matches!(
+            follow,
+            Err(SessionError::RefreshReuse) | Err(SessionError::InvalidRefresh)
+        ),
+        "family must be unusable after concurrent reuse: {follow:?}"
+    );
+
+    let ctx = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    let active = with_org_txn(&pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let count: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM refresh_tokens
+                     WHERE org_id = $1 AND family_id = $2 AND revoked_at IS NULL",
+                    &[&org, &family_id],
+                )
+                .await?
+                .get(0);
+            Ok(count)
+        })
+    })
+    .await
+    .unwrap();
+    assert_eq!(active, 0, "all family tokens must be revoked");
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn rotated_token_vs_active_successor_revokes_family() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool, provider, _) = boot(&base_url).await;
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let email = format!("succ-{}@example.com", user.simple());
+    let password = "successor-password";
+    seed_user(&pool, org, user, &email, password).await;
+
+    let meta = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let session = provider
+        .login_password(&email, password, &meta)
+        .await
+        .unwrap();
+    let rotated = session.tokens.refresh_token.expose().to_string();
+    let family_id = session.tokens.family_id;
+
+    // Rotate once so `rotated` is revoked/replaced and `active` is the live successor.
+    let rotated_session = provider.refresh(&rotated, &meta).await.unwrap();
+    let active = rotated_session.tokens.refresh_token.expose().to_string();
+
+    // Hold family lock, then race reuse(rotated) against refresh(active).
+    let hold = session::acquire_family_lock_for_test(&pool, org, family_id)
+        .await
+        .expect("hold family lock");
+    let meta_reuse = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let meta_active = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let provider_reuse = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+    let provider_active = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+    let handle_reuse =
+        tokio::spawn(async move { provider_reuse.refresh(&rotated, &meta_reuse).await });
+    let handle_active =
+        tokio::spawn(async move { provider_active.refresh(&active, &meta_active).await });
+
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    assert!(
+        !handle_reuse.is_finished() && !handle_active.is_finished(),
+        "both paths must block on family-first lock; without it this race can deadlock/partial-commit"
+    );
+
+    hold.release().await.expect("release");
+    let reuse_result = handle_reuse.await.expect("join reuse");
+    let active_result = handle_active.await.expect("join active");
+
+    // Reuse must be detected; active path may succeed first then get revoked, or fail as reuse.
+    assert!(
+        matches!(reuse_result, Err(SessionError::RefreshReuse)),
+        "rotated token must report reuse: {reuse_result:?}"
+    );
+    assert!(
+        matches!(
+            active_result,
+            Ok(_) | Err(SessionError::RefreshReuse) | Err(SessionError::InvalidRefresh)
+        ),
+        "active successor outcome: {active_result:?}"
+    );
+
+    let ctx = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    let active_count = with_org_txn(&pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let count: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM refresh_tokens
+                     WHERE org_id = $1 AND family_id = $2 AND revoked_at IS NULL",
+                    &[&org, &family_id],
+                )
+                .await?
+                .get(0);
+            Ok(count)
+        })
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        active_count, 0,
+        "reuse must revoke the whole family including any successor minted in the race"
+    );
+
+    // Any token the active path returned must also be dead.
+    if let Ok(session) = active_result {
+        let follow = provider
+            .refresh(
+                session.tokens.refresh_token.expose(),
+                &AuthRequestMeta {
+                    request_id: Uuid::new_v4().to_string(),
+                },
+            )
+            .await;
+        assert!(
+            matches!(
+                follow,
+                Err(SessionError::RefreshReuse) | Err(SessionError::InvalidRefresh)
+            ),
+            "successor minted during reuse race must not remain usable: {follow:?}"
+        );
+    }
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn disabled_user_and_removed_membership_deny_org_context() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool, provider, _) = boot(&base_url).await;
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let email = format!("disabled-{}@example.com", user.simple());
+    let password = "disable-me-now";
+    seed_user(&pool, org, user, &email, password).await;
+
+    let meta = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let session = provider
+        .login_password(&email, password, &meta)
+        .await
+        .unwrap();
+    let access = session.tokens.access_token.expose().to_string();
+    let refresh = session.tokens.refresh_token.expose().to_string();
+
+    // Disable user.
+    let client = pool.get().await.unwrap();
+    client
+        .execute(
+            "UPDATE users SET disabled_at = now() WHERE id = $1",
+            &[&user],
+        )
+        .await
+        .unwrap();
+    drop(client);
+
+    assert_eq!(
+        provider
+            .login_password(&email, password, &meta)
+            .await
+            .unwrap_err(),
+        SessionError::InvalidCredentials,
+        "disabled login must return the same generic error as bad credentials"
+    );
+    assert_eq!(
+        provider.refresh(&refresh, &meta).await.unwrap_err(),
+        SessionError::UserDisabled
+    );
+    assert_eq!(
+        resolve_org_context_in_txn(&pool, org, user)
+            .await
+            .unwrap_err(),
+        fileconv_server::auth::permissions::ResolveError::UserDisabled
+    );
+
+    // Re-enable, remove membership, access token still cryptographically valid but OrgContext fails.
+    let client = pool.get().await.unwrap();
+    client
+        .execute(
+            "UPDATE users SET disabled_at = NULL WHERE id = $1",
+            &[&user],
+        )
+        .await
+        .unwrap();
+    drop(client);
+
+    // Remove membership: delete refresh token rows first (FK to org_memberships).
+    let ctx = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    with_org_txn(&pool, &ctx, move |txn| {
+        Box::pin(async move {
+            txn.execute(
+                "DELETE FROM refresh_tokens WHERE org_id = $1 AND user_id = $2",
+                &[&org, &user],
+            )
+            .await?;
+            txn.execute(
+                "DELETE FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+                &[&org, &user],
+            )
+            .await?;
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    // JWT still verifies, but current-state OrgContext resolution fails.
+    let keys = JwtKeys::from_auth(&test_auth_config()).unwrap();
+    assert!(keys.verify_access_token(&access).is_ok());
+    assert_eq!(
+        resolve_org_context_in_txn(&pool, org, user)
+            .await
+            .unwrap_err(),
+        fileconv_server::auth::permissions::ResolveError::MembershipMissing
+    );
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn concurrent_refresh_and_revoke_all_leaves_no_usable_token() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool, provider, _) = boot(&base_url).await;
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let email = format!("revoke-race-{}@example.com", user.simple());
+    let password = "revoke-race-password";
+    seed_user(&pool, org, user, &email, password).await;
+
+    let meta = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let session = provider
+        .login_password(&email, password, &meta)
+        .await
+        .unwrap();
+    let refresh = session.tokens.refresh_token.expose().to_string();
+    let family_id = session.tokens.family_id;
+
+    // Hold the family-first lock so refresh blocks mid-path (after hash lookup).
+    let hold = session::acquire_family_lock_for_test(&pool, org, family_id)
+        .await
+        .expect("hold family lock");
+
+    let meta_refresh = AuthRequestMeta {
+        request_id: Uuid::new_v4().to_string(),
+    };
+    let provider_refresh = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+    let refresh_handle =
+        tokio::spawn(async move { provider_refresh.refresh(&refresh, &meta_refresh).await });
+
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    assert!(
+        !refresh_handle.is_finished(),
+        "refresh must block on family lock"
+    );
+
+    // revoke_all must also wait on the same family lock (and user lock). Without that
+    // discipline it finishes while refresh is still blocked, then refresh inserts a
+    // successor that survives the revoke snapshot.
+    let request_id = Uuid::new_v4().to_string();
+    let pool_revoke = pool.clone();
+    let revoke_handle = tokio::spawn(async move {
+        session::revoke_all_user_families(&pool_revoke, org, user, &request_id, "disable").await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    assert!(
+        !revoke_handle.is_finished(),
+        "revoke_all_user_families must block on family advisory locks; \
+         without them it races refresh and can miss the successor"
+    );
+
+    hold.release().await.expect("release family lock");
+    let refresh_result = refresh_handle.await.expect("join refresh");
+    let revoke_result = revoke_handle.await.expect("join revoke");
+    assert!(
+        revoke_result.is_ok(),
+        "revoke_all must succeed: {revoke_result:?}"
+    );
+
+    let ctx = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    let active = with_org_txn(&pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let count: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM refresh_tokens
+                     WHERE org_id = $1 AND user_id = $2 AND revoked_at IS NULL",
+                    &[&org, &user],
+                )
+                .await?
+                .get(0);
+            Ok(count)
+        })
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        active, 0,
+        "no refresh token may remain active after concurrent refresh + revoke_all"
+    );
+
+    if let Ok(session) = refresh_result {
+        let follow = provider
+            .refresh(
+                session.tokens.refresh_token.expose(),
+                &AuthRequestMeta {
+                    request_id: Uuid::new_v4().to_string(),
+                },
+            )
+            .await;
+        assert!(
+            matches!(
+                follow,
+                Err(SessionError::RefreshReuse) | Err(SessionError::InvalidRefresh)
+            ),
+            "successor from raced refresh must not be usable: {follow:?}"
+        );
+    }
+
+    ephemeral.drop().await;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue
Closes P1B-F05 (#82) — Password auth, rotating sessions và refresh transport (Phase 1B).

> **Stacked on #218 (F04) → #217 (F03).** Merge F03, then F04, then this. No new migration (F03 already provisioned `users.password_hash`, `refresh_tokens`, RBAC, `audit_log`).

## What
First-party password auth for the POC per **ADR 0010** — bearer **JWT access + opaque rotating refresh** contract (no cookies).

- **Argon2id** hashing (configured params) + rehash-on-login; constant-work dummy verify for unknown users (no enumeration timing).
- **JWT (HS256, pinned)** — rejects `alg:none`/algorithm confusion; enforces issuer/audience/kid/exp/nbf and post-decode `iat`/lifetime bounds (`exp>iat`, `exp-iat ≤ access TTL ≤ 15m`) with checked arithmetic; `JwtKeys` independently enforces key ≥32 bytes and TTL in (0,900].
- **Rotating refresh** — opaque token, stored only as SHA-256 of a 256-bit CSPRNG secret; rotates on use; **family-first advisory locking** so reuse of a rotated token revokes the whole family + audit; **user-level advisory lock** serializes login/new-family issuance with user-wide revocation so disable/password-reset can't be bypassed by a concurrent refresh.
- **OrgContext** resolved from **current PostgreSQL state** on every request (JWT claims are hints only); disabled user / removed membership fail closed.
- `AuthProvider` trait for future OIDC; `routes/auth.rs`: login/refresh/logout/me.
- Audit uses **server-generated request ids only** (client correlation headers never persisted); no token/password ever logged.

## Tests / evidence (real PostgreSQL 16, gated on `MARKHAND_TEST_DATABASE_URL`)
28 unit + 5 auth integration + 4 repo + 8 schema integration pass:
- login/me/refresh/logout + audit; JWT expiry/nbf/iss/aud/kid/alg + overlong-lifetime/future-iat/exp<iat rejection;
- refresh-reuse revokes family under **forced lock contention**; rotated-token-vs-successor; **concurrent refresh vs revoke-all leaves no usable token**;
- disabled user / removed membership deny; malicious `x-request-id` never appears in `audit_log`.

fmt, clippy (`--no-deps` knowledge+server `--all-targets -D warnings`), architecture-boundary, lint-baseline all pass.

## Review
Passed the mandatory review gate (GPT‑5.6 sol) after 3 rounds of security findings (refresh lock-ordering race, caller-controlled request-id token persistence, `iat`/TTL enforcement, then a revoke-all vs refresh race). Implementation by Grok.

## Out of scope
OIDC/MFA/account recovery; cookie transport; membership admin API.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

