### PR TITLE
feat(server): P1B-F06 fail-closed PG/Qdrant/MinIO storage adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,10 +348,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "log",
+ "rustls",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-creds"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3b85155d265df828f84e53886ed9e427aed979dd8a39f5b8b2162c77e142d7"
+dependencies = [
+ "attohttpc",
+ "home",
+ "log",
+ "quick-xml 0.38.4",
+ "rust-ini",
+ "serde",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -374,6 +407,15 @@ dependencies = [
  "dunce",
  "fs_extra",
  "pkg-config",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "838b36c8dc927b6db1b6c6b8f5d05865f2213550b9e83bf92fa99ed6525472c0"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -683,9 +725,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -1000,6 +1042,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1576,6 +1638,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "docx-rust"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2112,7 @@ dependencies = [
  "argon2",
  "axum",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "deadpool-postgres",
  "fileconv-core",
@@ -2050,6 +2122,7 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.10.2",
  "reqwest 0.13.4",
+ "rust-s3",
  "rust_decimal",
  "rustls",
  "rustls-native-certs",
@@ -2648,6 +2721,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2746,6 +2825,15 @@ dependencies = [
  "rand 0.9.4",
  "rayon",
  "serde",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3642,6 +3730,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,6 +3765,12 @@ dependencies = [
  "cfg-if",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -3856,6 +3961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -4080,6 +4194,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4202,6 +4326,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -4808,6 +4942,16 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
@@ -5115,12 +5259,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -5161,7 +5307,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -5309,6 +5455,50 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeedb13abdaa7e48d391de05b0569b37fa0a7a64a668dff6ffb2141ad0c2527e"
+dependencies = [
+ "async-trait",
+ "aws-creds",
+ "aws-region",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "futures-util",
+ "hex",
+ "hmac 0.12.1",
+ "http",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml 0.38.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.9",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "url",
 ]
 
 [[package]]
@@ -6284,6 +6474,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6814,6 +7018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6933,6 +7146,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -7516,6 +7740,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/bin/worker.rs"
 argon2 = "0.5.3"
 axum = { version = "0.8.9", features = ["json"] }
 base64 = "0.22.1"
+bytes = "1.12.1"
 chrono = { version = "0.4.45", features = ["serde", "clock"] }
 deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
 fileconv-core = { path = "../core" }
@@ -29,7 +30,8 @@ fileconv-knowledge = { path = "../knowledge" }
 hex = "0.4.3"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 rand = "0.10.2"
-reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls"] }
+rust-s3 = { version = "0.37.2", default-features = false, features = ["tokio-rustls-tls"] }
 rust_decimal = { version = "1.42.1", features = ["serde", "db-tokio-postgres"] }
 rustls = "0.23.42"
 rustls-native-certs = "0.8.4"
@@ -40,7 +42,7 @@ thiserror.workspace = true
 tokio = { version = "1.53.0", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-postgres = { version = "0.7.18", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-postgres-rustls = "0.14.0"
-uuid = { version = "1.24.0", features = ["serde", "v4"] }
+uuid = { version = "1.24.0", features = ["serde", "v4", "v8"] }
 
 [dev-dependencies]
 http-body-util = "0.1.4"

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -64,17 +64,184 @@ impl fmt::Debug for SecretString {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ServerConfig {
     role: RuntimeRole,
     profile: Profile,
     bind_addr: SocketAddr,
     database_url: Option<SecretString>,
     qdrant_url: Option<String>,
+    qdrant_api_key: Option<SecretString>,
     minio_url: Option<String>,
+    minio_access_key: Option<SecretString>,
+    minio_secret_key: Option<SecretString>,
+    minio_bucket: Option<String>,
+    minio_region: Option<String>,
+    minio_path_style: bool,
     auth: AuthConfig,
     limits: RuntimeLimits,
     index_signature: Option<String>,
+}
+
+impl fmt::Debug for ServerConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ServerConfig")
+            .field("role", &self.role)
+            .field("profile", &self.profile)
+            .field("bind_addr", &self.bind_addr)
+            .field(
+                "database_url",
+                &self.database_url.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "qdrant_url",
+                &self.qdrant_url.as_ref().map(|_| "[REDACTED_ENDPOINT]"),
+            )
+            .field(
+                "qdrant_api_key",
+                &self.qdrant_api_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "minio_url",
+                &self.minio_url.as_ref().map(|_| "[REDACTED_ENDPOINT]"),
+            )
+            .field(
+                "minio_access_key",
+                &self.minio_access_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "minio_secret_key",
+                &self.minio_secret_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("minio_bucket", &self.minio_bucket)
+            .field("minio_region", &self.minio_region)
+            .field("minio_path_style", &self.minio_path_style)
+            .field("auth", &self.auth)
+            .field("limits", &self.limits)
+            .field("index_signature", &self.index_signature)
+            .finish()
+    }
+}
+
+/// Typed MinIO/S3 connection settings (credentials redacted in Debug).
+#[derive(Clone, PartialEq, Eq)]
+pub struct MinioConfig {
+    endpoint: String,
+    access_key: SecretString,
+    secret_key: SecretString,
+    bucket: String,
+    region: String,
+    path_style: bool,
+}
+
+impl fmt::Debug for MinioConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MinioConfig")
+            .field("endpoint", &"[REDACTED_ENDPOINT]")
+            .field("access_key", &self.access_key)
+            .field("secret_key", &self.secret_key)
+            .field("bucket", &self.bucket)
+            .field("region", &self.region)
+            .field("path_style", &self.path_style)
+            .finish()
+    }
+}
+
+impl MinioConfig {
+    pub fn new(
+        endpoint: impl Into<String>,
+        access_key: SecretString,
+        secret_key: SecretString,
+        bucket: impl Into<String>,
+        region: impl Into<String>,
+        path_style: bool,
+    ) -> Result<Self, String> {
+        let endpoint_raw = endpoint.into();
+        let endpoint = required_url(Some(endpoint_raw.as_str()), "MARKHAND_MINIO_URL")?;
+        let access_key_raw = access_key.expose();
+        let secret_key_raw = secret_key.expose();
+        if access_key_raw.is_empty() || secret_key_raw.is_empty() {
+            return Err("MinIO access key and secret key must not be empty".into());
+        }
+        let bucket = bucket.into();
+        if bucket.trim().is_empty() {
+            return Err("MARKHAND_MINIO_BUCKET must not be empty".into());
+        }
+        let region = region.into();
+        if region.trim().is_empty() {
+            return Err("MARKHAND_MINIO_REGION must not be empty".into());
+        }
+        Ok(Self {
+            endpoint,
+            access_key,
+            secret_key,
+            bucket,
+            region,
+            path_style,
+        })
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub fn access_key(&self) -> &SecretString {
+        &self.access_key
+    }
+
+    pub fn secret_key(&self) -> &SecretString {
+        &self.secret_key
+    }
+
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+
+    pub const fn path_style(&self) -> bool {
+        self.path_style
+    }
+}
+
+/// Fail-closed storage adapter configuration (Qdrant + MinIO).
+#[derive(Clone, PartialEq, Eq)]
+pub struct StorageConfig {
+    qdrant_url: String,
+    qdrant_api_key: Option<SecretString>,
+    minio: MinioConfig,
+}
+
+impl fmt::Debug for StorageConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageConfig")
+            .field("qdrant_url", &"[REDACTED_ENDPOINT]")
+            .field(
+                "qdrant_api_key",
+                &self.qdrant_api_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("minio", &self.minio)
+            .finish()
+    }
+}
+
+impl StorageConfig {
+    pub fn qdrant_url(&self) -> &str {
+        &self.qdrant_url
+    }
+
+    pub fn qdrant_api_key(&self) -> Option<&SecretString> {
+        self.qdrant_api_key.as_ref()
+    }
+
+    pub fn minio(&self) -> &MinioConfig {
+        &self.minio
+    }
 }
 
 /// Pinned JWT signing algorithm. Only HS256 is supported for Phase 1B.
@@ -134,14 +301,20 @@ pub struct RuntimeLimits {
     pub job_lease_seconds: u64,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Default, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ConfigFile {
     profile: Option<String>,
     bind_addr: Option<String>,
     database_url: Option<String>,
     qdrant_url: Option<String>,
+    qdrant_api_key: Option<String>,
     minio_url: Option<String>,
+    minio_access_key: Option<String>,
+    minio_secret_key: Option<String>,
+    minio_bucket: Option<String>,
+    minio_region: Option<String>,
+    minio_path_style: Option<bool>,
     auth_issuer: Option<String>,
     auth_audience: Option<String>,
     auth_signing_key: Option<String>,
@@ -220,9 +393,34 @@ impl ServerConfig {
         let qdrant_url = optional_value(file, env, "MARKHAND_QDRANT_URL", |value| {
             value.qdrant_url.as_ref()
         });
+        let qdrant_api_key = optional_value(file, env, "MARKHAND_QDRANT_API_KEY", |value| {
+            value.qdrant_api_key.as_ref()
+        })
+        .map(SecretString::new);
         let minio_url = optional_value(file, env, "MARKHAND_MINIO_URL", |value| {
             value.minio_url.as_ref()
         });
+        let minio_access_key = optional_value(file, env, "MARKHAND_MINIO_ACCESS_KEY", |value| {
+            value.minio_access_key.as_ref()
+        })
+        .map(SecretString::new);
+        let minio_secret_key = optional_value(file, env, "MARKHAND_MINIO_SECRET_KEY", |value| {
+            value.minio_secret_key.as_ref()
+        })
+        .map(SecretString::new);
+        let minio_bucket = optional_value(file, env, "MARKHAND_MINIO_BUCKET", |value| {
+            value.minio_bucket.as_ref()
+        });
+        let minio_region = optional_value(file, env, "MARKHAND_MINIO_REGION", |value| {
+            value.minio_region.as_ref()
+        });
+        let minio_path_style = bool_value(
+            file,
+            env,
+            "MARKHAND_MINIO_PATH_STYLE",
+            |value| value.minio_path_style,
+            true,
+        )?;
         let auth = match role {
             RuntimeRole::Api => {
                 let alg = optional_value(file, env, "MARKHAND_AUTH_ALG", |value| {
@@ -324,7 +522,13 @@ impl ServerConfig {
             bind_addr,
             database_url,
             qdrant_url,
+            qdrant_api_key,
             minio_url,
+            minio_access_key,
+            minio_secret_key,
+            minio_bucket,
+            minio_region,
+            minio_path_style,
             auth,
             limits,
             index_signature,
@@ -367,7 +571,13 @@ impl ServerConfig {
             bind_addr: "127.0.0.1:8787".parse().expect("valid test address"),
             database_url: Some(endpoints.database_url),
             qdrant_url: Some(endpoints.qdrant_url),
+            qdrant_api_key: None,
             minio_url: Some(endpoints.minio_url),
+            minio_access_key: None,
+            minio_secret_key: None,
+            minio_bucket: None,
+            minio_region: None,
+            minio_path_style: true,
             auth: AuthConfig {
                 issuer: None,
                 audience: None,
@@ -395,6 +605,43 @@ impl ServerConfig {
         })
     }
 
+    /// Builds typed storage adapter config (Qdrant URL + MinIO credentials).
+    ///
+    /// Fail-closed: missing endpoint or credentials returns an error. Secrets
+    /// remain wrapped in [`SecretString`] (redacted in Debug).
+    pub fn storage_config(&self) -> Result<StorageConfig, String> {
+        let endpoints = self.runtime_endpoints()?;
+        let access_key = self
+            .minio_access_key
+            .clone()
+            .ok_or_else(|| "server requires MARKHAND_MINIO_ACCESS_KEY".to_string())?;
+        let secret_key = self
+            .minio_secret_key
+            .clone()
+            .ok_or_else(|| "server requires MARKHAND_MINIO_SECRET_KEY".to_string())?;
+        let bucket = self
+            .minio_bucket
+            .clone()
+            .unwrap_or_else(|| "markhand-documents".to_string());
+        let region = self
+            .minio_region
+            .clone()
+            .unwrap_or_else(|| "us-east-1".to_string());
+        let minio = MinioConfig::new(
+            endpoints.minio_url,
+            access_key,
+            secret_key,
+            bucket,
+            region,
+            self.minio_path_style,
+        )?;
+        Ok(StorageConfig {
+            qdrant_url: endpoints.qdrant_url,
+            qdrant_api_key: self.qdrant_api_key.clone(),
+            minio,
+        })
+    }
+
     pub(crate) fn validate(&self) -> Result<(), String> {
         self.validate_limits()?;
         self.validate_index_signature(false)?;
@@ -411,6 +658,8 @@ impl ServerConfig {
         validate_production_database_url(endpoints.database_url.expose())?;
         require_https(&endpoints.qdrant_url, "MARKHAND_QDRANT_URL")?;
         require_https(&endpoints.minio_url, "MARKHAND_MINIO_URL")?;
+        // Fail closed: production must have least-privilege MinIO credentials.
+        let _ = self.storage_config()?;
         self.validate_index_signature(true)?;
         Ok(())
     }
@@ -519,11 +768,22 @@ impl ServerConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RuntimeEndpoints {
     pub database_url: SecretString,
     pub qdrant_url: String,
     pub minio_url: String,
+}
+
+impl fmt::Debug for RuntimeEndpoints {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RuntimeEndpoints")
+            .field("database_url", &"[REDACTED]")
+            .field("qdrant_url", &"[REDACTED_ENDPOINT]")
+            .field("minio_url", &"[REDACTED_ENDPOINT]")
+            .finish()
+    }
 }
 
 fn required_database_url(value: Option<&SecretString>) -> Result<SecretString, String> {
@@ -574,14 +834,48 @@ fn u32_value(
     u32::try_from(value).map_err(|_| format!("{env_name} is out of range for u32"))
 }
 
+fn bool_value(
+    file: Option<&ConfigFile>,
+    env: &BTreeMap<String, String>,
+    env_name: &str,
+    from_file: impl FnOnce(&ConfigFile) -> Option<bool>,
+    default: bool,
+) -> Result<bool, String> {
+    match env.get(env_name) {
+        Some(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Ok(true),
+            "0" | "false" | "no" | "off" => Ok(false),
+            _ => Err(format!("{env_name} must be a boolean")),
+        },
+        None => Ok(file.and_then(from_file).unwrap_or(default)),
+    }
+}
+
 fn required_url(value: Option<&str>, name: &str) -> Result<String, String> {
     let value = value.ok_or_else(|| format!("server requires {name}"))?;
+    let trimmed = value.trim().trim_end_matches('/');
+    if trimmed.contains('?') || trimmed.contains('#') {
+        return Err(format!(
+            "{name} must not include query parameters or fragments"
+        ));
+    }
     let parsed =
-        reqwest::Url::parse(value).map_err(|_| format!("{name} must be an absolute URL"))?;
+        reqwest::Url::parse(trimmed).map_err(|_| format!("{name} must be an absolute URL"))?;
     if parsed.scheme() != "http" && parsed.scheme() != "https" {
         return Err(format!("{name} must use http or https"));
     }
-    Ok(value.trim_end_matches('/').to_string())
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(format!("{name} must not embed userinfo credentials"));
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err(format!(
+            "{name} must not include query parameters or fragments"
+        ));
+    }
+    if parsed.host_str().is_none() {
+        return Err(format!("{name} must include a host"));
+    }
+    Ok(trimmed.to_string())
 }
 
 fn validate_production_database_url(value: &str) -> Result<(), String> {
@@ -681,7 +975,13 @@ mod tests {
             bind_addr: Some("127.0.0.1:9000".into()),
             database_url: Some("postgres://file-secret".into()),
             qdrant_url: Some("http://qdrant.test".into()),
+            qdrant_api_key: None,
             minio_url: Some("http://minio.test".into()),
+            minio_access_key: None,
+            minio_secret_key: None,
+            minio_bucket: None,
+            minio_region: None,
+            minio_path_style: None,
             auth_issuer: None,
             auth_audience: None,
             auth_signing_key: None,
@@ -881,6 +1181,124 @@ mod tests {
             ServerConfig::from_sources(None, &invalid_signature).unwrap_err(),
             "MARKHAND_INDEX_SIGNATURE must be a 64-character hex digest"
         );
+    }
+
+    #[test]
+    fn storage_config_requires_minio_credentials_and_redacts_secrets() {
+        let env = BTreeMap::from([
+            (
+                "MARKHAND_DATABASE_URL".into(),
+                "postgres://markhand@localhost/markhand".into(),
+            ),
+            ("MARKHAND_QDRANT_URL".into(), "http://qdrant.test".into()),
+            ("MARKHAND_MINIO_URL".into(), "http://minio.test".into()),
+        ]);
+        let config = ServerConfig::from_sources(None, &env).unwrap();
+        assert_eq!(
+            config.storage_config().unwrap_err(),
+            "server requires MARKHAND_MINIO_ACCESS_KEY"
+        );
+
+        let env = BTreeMap::from([
+            (
+                "MARKHAND_DATABASE_URL".into(),
+                "postgres://markhand@localhost/markhand".into(),
+            ),
+            ("MARKHAND_QDRANT_URL".into(), "http://qdrant.test".into()),
+            ("MARKHAND_MINIO_URL".into(), "http://minio.test".into()),
+            ("MARKHAND_MINIO_ACCESS_KEY".into(), "access-secret".into()),
+            ("MARKHAND_MINIO_SECRET_KEY".into(), "secret-secret".into()),
+            ("MARKHAND_MINIO_BUCKET".into(), "markhand-documents".into()),
+        ]);
+        let config = ServerConfig::from_sources(None, &env).unwrap();
+        let storage = config.storage_config().unwrap();
+        let debug = format!("{storage:?}");
+        assert!(!debug.contains("access-secret"));
+        assert!(!debug.contains("secret-secret"));
+        assert!(debug.contains("[REDACTED]"));
+        assert!(storage.minio().path_style());
+        assert!(!format!("{storage:?}").contains("qdrant.test"));
+        assert!(!format!("{storage:?}").contains("minio.test"));
+    }
+
+    #[test]
+    fn endpoint_urls_reject_embedded_credentials() {
+        let env = BTreeMap::from([
+            (
+                "MARKHAND_DATABASE_URL".into(),
+                "postgres://markhand@localhost/markhand".into(),
+            ),
+            (
+                "MARKHAND_QDRANT_URL".into(),
+                "http://user:pass@qdrant.test".into(),
+            ),
+            ("MARKHAND_MINIO_URL".into(), "http://minio.test".into()),
+            ("MARKHAND_MINIO_ACCESS_KEY".into(), "access-secret".into()),
+            ("MARKHAND_MINIO_SECRET_KEY".into(), "secret-secret".into()),
+        ]);
+        let config = ServerConfig::from_sources(None, &env).unwrap();
+        assert!(config.runtime_endpoints().unwrap_err().contains("userinfo"));
+    }
+
+    #[test]
+    fn endpoint_urls_reject_any_query_or_fragment() {
+        for bad in [
+            "http://qdrant.test?sig=abc",
+            "http://qdrant.test#frag",
+            "http://qdrant.test/?x=1",
+            "http://minio.test?token=x",
+        ] {
+            let env = BTreeMap::from([
+                (
+                    "MARKHAND_DATABASE_URL".into(),
+                    "postgres://markhand@localhost/markhand".into(),
+                ),
+                ("MARKHAND_QDRANT_URL".into(), bad.into()),
+                ("MARKHAND_MINIO_URL".into(), "http://minio.test".into()),
+            ]);
+            let config = ServerConfig::from_sources(None, &env).unwrap();
+            let err = config.runtime_endpoints().unwrap_err();
+            assert!(
+                err.contains("query") || err.contains("fragment") || err.contains("userinfo"),
+                "expected rejection for {bad}, got {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn server_config_debug_redacts_endpoints_and_secrets() {
+        let env = BTreeMap::from([
+            (
+                "MARKHAND_DATABASE_URL".into(),
+                "postgres://markhand:top-secret@db.internal/markhand".into(),
+            ),
+            (
+                "MARKHAND_QDRANT_URL".into(),
+                "http://qdrant.internal:6333".into(),
+            ),
+            (
+                "MARKHAND_MINIO_URL".into(),
+                "http://minio.internal:9000".into(),
+            ),
+            ("MARKHAND_MINIO_ACCESS_KEY".into(), "access-secret".into()),
+            ("MARKHAND_MINIO_SECRET_KEY".into(), "secret-secret".into()),
+            ("MARKHAND_QDRANT_API_KEY".into(), "qdrant-secret-key".into()),
+        ]);
+        let config = ServerConfig::from_sources(None, &env).unwrap();
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("top-secret"));
+        assert!(!debug.contains("access-secret"));
+        assert!(!debug.contains("secret-secret"));
+        assert!(!debug.contains("qdrant-secret"));
+        assert!(!debug.contains("qdrant.internal"));
+        assert!(!debug.contains("minio.internal"));
+        assert!(!debug.contains("db.internal"));
+        assert!(debug.contains("[REDACTED"));
+        let endpoints = config.runtime_endpoints().unwrap();
+        let endpoints_debug = format!("{endpoints:?}");
+        assert!(!endpoints_debug.contains("qdrant.internal"));
+        assert!(!endpoints_debug.contains("minio.internal"));
+        assert!(!endpoints_debug.contains("top-secret"));
     }
 
     #[test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -10,6 +10,7 @@ pub mod http;
 pub mod routes;
 pub mod services;
 pub mod state;
+pub mod storage;
 pub mod telemetry;
 
 /// Validates the non-secret server configuration contract.

--- a/crates/server/src/services/index_signature.rs
+++ b/crates/server/src/services/index_signature.rs
@@ -1,0 +1,151 @@
+//! Index-signature → Qdrant collection naming (ADR 0006 / 0009).
+//!
+//! One shared Qdrant collection per index generation. The generation identity is
+//! `fileconv_knowledge::identity::IndexSignature::digest()`; the collection name
+//! embeds the **full** 64-hex digest so generations cannot collide.
+//!
+//! All Qdrant operations take a validated [`CollectionName`] — never a raw string.
+
+use std::fmt;
+
+use fileconv_knowledge::identity::IndexSignature;
+
+use crate::storage::error::StorageError;
+
+/// Prefix for versioned Markhand chunk collections.
+pub const COLLECTION_NAME_PREFIX: &str = "markhand_chunks_";
+/// Full SHA-256 hex digest length embedded in the collection name (256 bits).
+pub const DIGEST_HEX_LEN: usize = 64;
+
+/// Validated Qdrant collection name: `markhand_chunks_<64 lowercase hex>`.
+///
+/// Charset is restricted to `[a-z0-9_]` so the value is safe as a URL path
+/// segment. Construct only via [`collection_name_for_digest`],
+/// [`collection_name_for_signature`], or [`parse_collection_name`].
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct CollectionName(String);
+
+impl CollectionName {
+    /// Borrow the validated name string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Digest portion after the `markhand_chunks_` prefix.
+    pub fn digest(&self) -> &str {
+        &self.0[COLLECTION_NAME_PREFIX.len()..]
+    }
+}
+
+impl fmt::Debug for CollectionName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Names are generation digests (not secrets); still avoid dumping full
+        // strings in sparse logs by showing prefix only.
+        formatter
+            .debug_struct("CollectionName")
+            .field("prefix", &COLLECTION_NAME_PREFIX)
+            .field("digest_len", &DIGEST_HEX_LEN)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AsRef<str> for CollectionName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+/// Build the Qdrant collection name for a full 64-char signature digest.
+pub fn collection_name_for_digest(digest: &str) -> Result<CollectionName, StorageError> {
+    validate_signature_digest(digest)?;
+    let raw = format!("{COLLECTION_NAME_PREFIX}{digest}");
+    parse_collection_name(&raw)
+}
+
+/// Build the Qdrant collection name for an [`IndexSignature`].
+pub fn collection_name_for_signature(
+    signature: &IndexSignature<'_>,
+) -> Result<CollectionName, StorageError> {
+    collection_name_for_digest(&signature.digest())
+}
+
+/// Parse and validate `markhand_chunks_<64-hex>` (charset `[a-z0-9_]` only).
+pub fn parse_collection_name(name: &str) -> Result<CollectionName, StorageError> {
+    if name.is_empty()
+        || name.len() != COLLECTION_NAME_PREFIX.len() + DIGEST_HEX_LEN
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+    {
+        return Err(StorageError::PreconditionFailed);
+    }
+    let Some(digest) = name.strip_prefix(COLLECTION_NAME_PREFIX) else {
+        return Err(StorageError::PreconditionFailed);
+    };
+    validate_signature_digest(digest)?;
+    Ok(CollectionName(name.to_string()))
+}
+
+/// Validate a full 64-character lowercase hex index signature digest.
+pub fn validate_signature_digest(digest: &str) -> Result<(), StorageError> {
+    if digest.len() != DIGEST_HEX_LEN
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(StorageError::PreconditionFailed);
+    }
+    Ok(())
+}
+
+/// True when `collection_name` was derived from `digest`.
+pub fn collection_matches_digest(
+    collection_name: &CollectionName,
+    digest: &str,
+) -> Result<bool, StorageError> {
+    let expected = collection_name_for_digest(digest)?;
+    Ok(collection_name == &expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fileconv_knowledge::identity::{
+        BODY_TEXT_VERSION, DEFAULT_CHUNKING_VERSION, QUERY_NORMALIZATION_VERSION,
+        RUNTIME_LOCAL_HASH,
+    };
+
+    fn sample_signature() -> IndexSignature<'static> {
+        IndexSignature {
+            runtime_path: RUNTIME_LOCAL_HASH,
+            embedding_family: "test-family",
+            embedding_revision: "r1",
+            dimensions: 8,
+            normalized: true,
+            chunking_version: DEFAULT_CHUNKING_VERSION,
+            body_text_version: BODY_TEXT_VERSION,
+            query_normalization_version: QUERY_NORMALIZATION_VERSION,
+        }
+    }
+
+    #[test]
+    fn collection_name_uses_full_digest() {
+        let signature = sample_signature();
+        let digest = signature.digest();
+        let name = collection_name_for_signature(&signature).unwrap();
+        assert!(name.as_str().starts_with(COLLECTION_NAME_PREFIX));
+        assert_eq!(name.digest(), digest.as_str());
+        assert_eq!(parse_collection_name(name.as_str()).unwrap(), name);
+        assert!(collection_matches_digest(&name, &digest).unwrap());
+    }
+
+    #[test]
+    fn rejects_invalid_digest_and_name() {
+        assert!(collection_name_for_digest("short").is_err());
+        assert!(collection_name_for_digest(&"A".repeat(64)).is_err());
+        assert!(parse_collection_name("other_chunks_abcdef0123456789").is_err());
+        assert!(parse_collection_name(&format!("markhand_chunks_{}", "A".repeat(64))).is_err());
+        assert!(parse_collection_name("markhand_chunks_../etc/passwd").is_err());
+        assert!(parse_collection_name(&format!("markhand_chunks_{}?x=1", "a".repeat(64))).is_err());
+    }
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -1,3 +1,4 @@
 //! Application services (use cases over repositories).
 
 pub mod document_state;
+pub mod index_signature;

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -1,12 +1,24 @@
 //! Shared validated runtime state for API and worker processes.
 
+use std::fmt;
+
 use crate::config::{RuntimeEndpoints, ServerConfig};
 use crate::error::AppError;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RuntimeState {
     config: ServerConfig,
     endpoints: RuntimeEndpoints,
+}
+
+impl fmt::Debug for RuntimeState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RuntimeState")
+            .field("config", &self.config)
+            .field("endpoints", &self.endpoints)
+            .finish()
+    }
 }
 
 impl RuntimeState {

--- a/crates/server/src/storage/error.rs
+++ b/crates/server/src/storage/error.rs
@@ -1,0 +1,53 @@
+//! Typed storage errors (fail-closed; never stringly-typed).
+
+use thiserror::Error;
+
+/// Errors from object-key validation, MinIO, and Qdrant adapters.
+///
+/// Display messages are static and sanitized — never embed secrets, keys, or
+/// caller-controlled strings.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum StorageError {
+    #[error("storage configuration is invalid")]
+    ConfigInvalid,
+    #[error("storage credentials are missing or empty")]
+    ConfigMissingCredentials,
+    /// Caller omitted org and/or authorized collection scope (fail closed).
+    #[error("missing required org or collection scope")]
+    MissingScope,
+    #[error("object or vector point not found")]
+    NotFound,
+    #[error("storage precondition failed")]
+    PreconditionFailed,
+    #[error("invalid object key")]
+    InvalidKey,
+    #[error("object key does not belong to the authorized org")]
+    KeyOrgMismatch,
+    #[error("vector point ownership conflict")]
+    OwnershipConflict,
+    #[error("existing collection parameters do not match the index signature")]
+    CollectionMismatch,
+    #[error("storage transport error")]
+    Transport,
+    #[error("storage backend rejected the request")]
+    Backend,
+}
+
+impl StorageError {
+    /// Stable machine-facing error code (never includes secrets or keys).
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::ConfigInvalid => "storage_config",
+            Self::ConfigMissingCredentials => "storage_config_credentials",
+            Self::MissingScope => "storage_missing_scope",
+            Self::NotFound => "storage_not_found",
+            Self::PreconditionFailed => "storage_precondition",
+            Self::InvalidKey => "storage_invalid_key",
+            Self::KeyOrgMismatch => "storage_key_org_mismatch",
+            Self::OwnershipConflict => "storage_ownership_conflict",
+            Self::CollectionMismatch => "storage_collection_mismatch",
+            Self::Transport => "storage_transport",
+            Self::Backend => "storage_backend",
+        }
+    }
+}

--- a/crates/server/src/storage/keys.rs
+++ b/crates/server/src/storage/keys.rs
@@ -1,0 +1,341 @@
+//! Opaque, traversal-safe object-key builder (ADR 0007).
+//!
+//! Keys contain only a namespace plus hashed org/version identity and a
+//! server-generated object id. User filenames and raw user input never appear
+//! in the path; original names belong in object metadata only.
+//!
+//! Parsing and authorization are org-bound: a key is only usable when its
+//! org-opaque segment matches the authorized org (recomputed and compared).
+
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use super::error::StorageError;
+
+const KEY_DOMAIN: &[u8] = b"markhand-object-key-v1";
+/// Full SHA-256 hex length for opaque identity segments (256 bits).
+const OPAQUE_HEX_LEN: usize = 64;
+/// Hex length of a UUID without hyphens.
+const OBJECT_ID_HEX_LEN: usize = 32;
+
+/// Object-key namespace (quarantine vs post-conversion trusted).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObjectNamespace {
+    Quarantine,
+    Trusted,
+}
+
+impl ObjectNamespace {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Quarantine => "quarantine",
+            Self::Trusted => "trusted",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, StorageError> {
+        match value {
+            "quarantine" => Ok(Self::Quarantine),
+            "trusted" => Ok(Self::Trusted),
+            _ => Err(StorageError::InvalidKey),
+        }
+    }
+}
+
+/// Parsed, validated object key (round-trips with [`ObjectKey::as_str`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectKey {
+    namespace: ObjectNamespace,
+    org_opaque: String,
+    version_opaque: Option<String>,
+    object_id: String,
+}
+
+impl ObjectKey {
+    pub const fn namespace(&self) -> ObjectNamespace {
+        self.namespace
+    }
+
+    pub fn org_opaque(&self) -> &str {
+        &self.org_opaque
+    }
+
+    pub fn version_opaque(&self) -> Option<&str> {
+        self.version_opaque.as_deref()
+    }
+
+    pub fn object_id(&self) -> &str {
+        &self.object_id
+    }
+
+    /// Canonical key string (`namespace/...` only; never a filename).
+    pub fn as_str(&self) -> String {
+        match (&self.namespace, &self.version_opaque) {
+            (ObjectNamespace::Quarantine, None) => {
+                format!(
+                    "{}/{}/{}",
+                    self.namespace.as_str(),
+                    self.org_opaque,
+                    self.object_id
+                )
+            }
+            (ObjectNamespace::Trusted, Some(version)) => {
+                format!(
+                    "{}/{}/{}/{}",
+                    self.namespace.as_str(),
+                    self.org_opaque,
+                    version,
+                    self.object_id
+                )
+            }
+            _ => unreachable!("object key invariants enforce namespace/version pairing"),
+        }
+    }
+
+    /// True when this key's org-opaque segment matches `org_id`.
+    pub fn belongs_to_org(&self, org_id: Uuid) -> bool {
+        !org_id.is_nil() && self.org_opaque == opaque_identity("org", org_id)
+    }
+
+    /// True when a trusted key's version-opaque matches `version_id`.
+    pub fn belongs_to_version(&self, version_id: Uuid) -> bool {
+        match &self.version_opaque {
+            Some(opaque) => {
+                !version_id.is_nil() && opaque.as_str() == opaque_identity("version", version_id)
+            }
+            None => false,
+        }
+    }
+}
+
+/// Build a quarantine key: `quarantine/{org_opaque}/{object_id}`.
+///
+/// Rejects nil identities. `original_filename` is unused in the key path.
+pub fn quarantine_key(
+    org_id: Uuid,
+    object_id: Uuid,
+    _original_filename: Option<&str>,
+) -> Result<ObjectKey, StorageError> {
+    reject_nil_ids(&[org_id, object_id])?;
+    Ok(ObjectKey {
+        namespace: ObjectNamespace::Quarantine,
+        org_opaque: opaque_identity("org", org_id),
+        version_opaque: None,
+        object_id: object_id_hex(object_id),
+    })
+}
+
+/// Build a trusted (post-conversion) key: `trusted/{org_opaque}/{version_opaque}/{object_id}`.
+pub fn trusted_key(
+    org_id: Uuid,
+    version_id: Uuid,
+    object_id: Uuid,
+    _original_filename: Option<&str>,
+) -> Result<ObjectKey, StorageError> {
+    reject_nil_ids(&[org_id, version_id, object_id])?;
+    Ok(ObjectKey {
+        namespace: ObjectNamespace::Trusted,
+        org_opaque: opaque_identity("org", org_id),
+        version_opaque: Some(opaque_identity("version", version_id)),
+        object_id: object_id_hex(object_id),
+    })
+}
+
+/// Parse a key and authorize it for `org_id` (fail closed on org mismatch).
+///
+/// There is no public unbound parse that yields a usable cross-org key.
+pub fn parse_key_for_org(raw: &str, org_id: Uuid) -> Result<ObjectKey, StorageError> {
+    if org_id.is_nil() {
+        return Err(StorageError::MissingScope);
+    }
+    let key = parse_key_structure(raw)?;
+    authorize_key_for_org(&key, org_id)?;
+    Ok(key)
+}
+
+/// Verify an already-built key belongs to `org_id`.
+pub fn authorize_key_for_org(key: &ObjectKey, org_id: Uuid) -> Result<(), StorageError> {
+    if org_id.is_nil() {
+        return Err(StorageError::MissingScope);
+    }
+    if !key.belongs_to_org(org_id) {
+        return Err(StorageError::KeyOrgMismatch);
+    }
+    Ok(())
+}
+
+/// Verify a trusted key's version segment matches `version_id`.
+pub fn authorize_key_for_version(key: &ObjectKey, version_id: Uuid) -> Result<(), StorageError> {
+    if version_id.is_nil() {
+        return Err(StorageError::MissingScope);
+    }
+    match key.namespace() {
+        ObjectNamespace::Trusted => {
+            if key.belongs_to_version(version_id) {
+                Ok(())
+            } else {
+                Err(StorageError::KeyOrgMismatch)
+            }
+        }
+        ObjectNamespace::Quarantine => Ok(()),
+    }
+}
+
+/// Structural parse only (crate-private). Callers must authorize via org.
+pub(crate) fn parse_key_structure(raw: &str) -> Result<ObjectKey, StorageError> {
+    reject_malformed_input(raw)?;
+    let parts: Vec<&str> = raw.split('/').collect();
+    if parts.iter().any(|part| part.is_empty()) {
+        return Err(StorageError::InvalidKey);
+    }
+    let namespace = ObjectNamespace::parse(parts[0])?;
+    match namespace {
+        ObjectNamespace::Quarantine => {
+            if parts.len() != 3 {
+                return Err(StorageError::InvalidKey);
+            }
+            Ok(ObjectKey {
+                namespace,
+                org_opaque: require_hex(parts[1], OPAQUE_HEX_LEN)?,
+                version_opaque: None,
+                object_id: require_hex(parts[2], OBJECT_ID_HEX_LEN)?,
+            })
+        }
+        ObjectNamespace::Trusted => {
+            if parts.len() != 4 {
+                return Err(StorageError::InvalidKey);
+            }
+            Ok(ObjectKey {
+                namespace,
+                org_opaque: require_hex(parts[1], OPAQUE_HEX_LEN)?,
+                version_opaque: Some(require_hex(parts[2], OPAQUE_HEX_LEN)?),
+                object_id: require_hex(parts[3], OBJECT_ID_HEX_LEN)?,
+            })
+        }
+    }
+}
+
+pub(crate) fn opaque_identity(kind: &str, id: Uuid) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(KEY_DOMAIN);
+    hasher.update(kind.as_bytes());
+    hasher.update(id.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn object_id_hex(id: Uuid) -> String {
+    hex::encode(id.as_bytes())
+}
+
+fn reject_nil_ids(ids: &[Uuid]) -> Result<(), StorageError> {
+    if ids.iter().any(|id| id.is_nil()) {
+        Err(StorageError::MissingScope)
+    } else {
+        Ok(())
+    }
+}
+
+fn require_hex(value: &str, expected_len: usize) -> Result<String, StorageError> {
+    if value.len() != expected_len || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(StorageError::InvalidKey);
+    }
+    if value.bytes().any(|byte| byte.is_ascii_uppercase()) {
+        return Err(StorageError::InvalidKey);
+    }
+    Ok(value.to_string())
+}
+
+fn reject_malformed_input(raw: &str) -> Result<(), StorageError> {
+    if raw.is_empty()
+        || raw.starts_with('/')
+        || raw.contains('\\')
+        || raw.contains('\0')
+        || raw.chars().any(|ch| ch.is_control())
+        || raw
+            .split('/')
+            .any(|part| part == ".." || part == "." || part.contains("..") || part.contains('\\'))
+    {
+        return Err(StorageError::InvalidKey);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quarantine_and_trusted_round_trip() {
+        let org = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let version = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+        let object = Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap();
+
+        let q = quarantine_key(org, object, Some("../../etc/passwd")).unwrap();
+        let parsed_q = parse_key_for_org(&q.as_str(), org).unwrap();
+        assert_eq!(parsed_q, q);
+        assert_eq!(q.org_opaque().len(), OPAQUE_HEX_LEN);
+        assert!(!q.as_str().contains("passwd"));
+        assert!(q.as_str().starts_with("quarantine/"));
+
+        let t = trusted_key(org, version, object, Some("/abs/path/file.pdf")).unwrap();
+        let parsed_t = parse_key_for_org(&t.as_str(), org).unwrap();
+        assert_eq!(parsed_t, t);
+        authorize_key_for_version(&t, version).unwrap();
+    }
+
+    #[test]
+    fn cross_org_parse_is_rejected() {
+        let org_a = Uuid::new_v4();
+        let org_b = Uuid::new_v4();
+        let object = Uuid::new_v4();
+        let key = quarantine_key(org_a, object, None).unwrap();
+        assert!(matches!(
+            parse_key_for_org(&key.as_str(), org_b),
+            Err(StorageError::KeyOrgMismatch)
+        ));
+        assert!(matches!(
+            authorize_key_for_org(&key, org_b),
+            Err(StorageError::KeyOrgMismatch)
+        ));
+    }
+
+    #[test]
+    fn nil_identities_rejected() {
+        let org = Uuid::new_v4();
+        assert!(matches!(
+            quarantine_key(Uuid::nil(), Uuid::new_v4(), None),
+            Err(StorageError::MissingScope)
+        ));
+        assert!(matches!(
+            trusted_key(org, Uuid::nil(), Uuid::new_v4(), None),
+            Err(StorageError::MissingScope)
+        ));
+    }
+
+    #[test]
+    fn adversarial_filenames_never_enter_key() {
+        let org = Uuid::new_v4();
+        let version = Uuid::new_v4();
+        let object = Uuid::new_v4();
+        for name in ["../../etc/passwd", "/absolute/path", "file\nname.txt"] {
+            let q = quarantine_key(org, object, Some(name)).unwrap();
+            assert!(!q.as_str().contains(name));
+            parse_key_for_org(&q.as_str(), org).unwrap();
+            let t = trusted_key(org, version, object, Some(name)).unwrap();
+            parse_key_for_org(&t.as_str(), org).unwrap();
+        }
+    }
+
+    #[test]
+    fn parse_rejects_malformed_and_cross_structure() {
+        let org = Uuid::new_v4();
+        for bad in [
+            "",
+            "/quarantine/aa/bb",
+            "quarantine/../bb/cc",
+            "quarantine/not-hex/33333333333333333333333333333333",
+        ] {
+            assert!(parse_key_for_org(bad, org).is_err());
+        }
+    }
+}

--- a/crates/server/src/storage/minio.rs
+++ b/crates/server/src/storage/minio.rs
@@ -1,0 +1,304 @@
+//! MinIO (S3-compatible) adapter with opaque keys and identity metadata.
+//!
+//! Client choice: `rust-s3` (crate lib name `s3`) with `tokio-rustls-tls` and
+//! path-style addressing. Lighter than `aws-sdk-s3`, works against MinIO, and
+//! avoids anonymous/public bucket helpers (`Bucket::new_public` is never used).
+//!
+//! Every put/get/delete/exists is org-bound: the key's org-opaque segment must
+//! match the authorized org, and stored object metadata org must match on read
+//! mutation paths (fail closed).
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use s3::creds::Credentials;
+use s3::error::S3Error;
+use s3::region::Region;
+use s3::serde_types::HeadObjectResult;
+use s3::Bucket;
+use s3::BucketConfiguration;
+use uuid::Uuid;
+
+use crate::config::MinioConfig;
+use crate::storage::error::StorageError;
+use crate::storage::keys::{
+    authorize_key_for_org, authorize_key_for_version, parse_key_structure, ObjectKey,
+    ObjectNamespace,
+};
+
+/// Identity fields stored as S3 object metadata (never in the key path).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectIdentityMeta {
+    pub org_id: Uuid,
+    pub collection_id: Option<Uuid>,
+    pub document_id: Option<Uuid>,
+    pub version_id: Option<Uuid>,
+    /// Original filename for display only — never written into the object key.
+    pub original_filename: Option<String>,
+}
+
+/// Fail-closed MinIO/S3 object store client (credentials required).
+#[derive(Clone)]
+pub struct MinioClient {
+    bucket: Box<Bucket>,
+    bucket_name: String,
+}
+
+impl std::fmt::Debug for MinioClient {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MinioClient")
+            .field("bucket_name", &self.bucket_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MinioClient {
+    /// Build a client from typed config. Rejects empty credentials (fail closed).
+    pub fn from_config(config: &MinioConfig) -> Result<Self, StorageError> {
+        if config.access_key().expose().is_empty() || config.secret_key().expose().is_empty() {
+            return Err(StorageError::ConfigMissingCredentials);
+        }
+        if config.bucket().trim().is_empty() {
+            return Err(StorageError::ConfigInvalid);
+        }
+        let credentials = Credentials::new(
+            Some(config.access_key().expose()),
+            Some(config.secret_key().expose()),
+            None,
+            None,
+            None,
+        )
+        .map_err(|_| StorageError::ConfigInvalid)?;
+        let region = Region::Custom {
+            region: config.region().to_string(),
+            endpoint: config.endpoint().to_string(),
+        };
+        let mut bucket = Bucket::new(config.bucket(), region, credentials)
+            .map_err(|_| StorageError::ConfigInvalid)?;
+        if config.path_style() {
+            bucket = bucket.with_path_style();
+        }
+        Ok(Self {
+            bucket,
+            bucket_name: config.bucket().to_string(),
+        })
+    }
+
+    pub fn bucket_name(&self) -> &str {
+        &self.bucket_name
+    }
+
+    /// Create the configured bucket if missing (test / bootstrap helper).
+    pub async fn ensure_bucket(&self) -> Result<(), StorageError> {
+        let region = self.bucket.region.clone();
+        let credentials = self
+            .bucket
+            .credentials()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        let config = BucketConfiguration::default();
+        match Bucket::create_with_path_style(&self.bucket_name, region, credentials, config).await {
+            Ok(response)
+                if response.success()
+                    || response.response_code == 409
+                    || response.response_code == 200
+                    || response.response_code == 204 =>
+            {
+                Ok(())
+            }
+            Ok(_) => Err(StorageError::Backend),
+            Err(error) => {
+                if is_bucket_already_exists(&error) {
+                    Ok(())
+                } else {
+                    Err(StorageError::Transport)
+                }
+            }
+        }
+    }
+
+    /// Put bytes under an opaque key owned by `org_id`, with identity metadata.
+    pub async fn put_object(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        body: Bytes,
+        meta: &ObjectIdentityMeta,
+        content_type: &str,
+    ) -> Result<(), StorageError> {
+        authorize_key_for_org(key, org_id)?;
+        if meta.org_id != org_id || meta.org_id.is_nil() {
+            return Err(StorageError::KeyOrgMismatch);
+        }
+        if key.namespace() == ObjectNamespace::Trusted {
+            let version_id = meta.version_id.ok_or(StorageError::MissingScope)?;
+            authorize_key_for_version(key, version_id)?;
+        }
+        // Structural re-parse (defense in depth).
+        let _ = parse_key_structure(&key.as_str())?;
+
+        let path = key.as_str();
+        let mut builder = self
+            .bucket
+            .put_object_builder(&path, body.as_ref())
+            .with_content_type(content_type);
+        builder = builder
+            .with_metadata("org-id", meta.org_id.to_string())
+            .map_err(|_| StorageError::ConfigInvalid)?;
+        if let Some(collection_id) = meta.collection_id {
+            builder = builder
+                .with_metadata("collection-id", collection_id.to_string())
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(document_id) = meta.document_id {
+            builder = builder
+                .with_metadata("document-id", document_id.to_string())
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(version_id) = meta.version_id {
+            builder = builder
+                .with_metadata("version-id", version_id.to_string())
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(filename) = meta.original_filename.as_deref() {
+            let safe: String = filename
+                .chars()
+                .filter(|ch| !ch.is_control())
+                .take(255)
+                .collect();
+            if !safe.is_empty() {
+                builder = builder
+                    .with_metadata("original-filename", safe)
+                    .map_err(|_| StorageError::ConfigInvalid)?;
+            }
+        }
+        let response = builder
+            .execute()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if (200..300).contains(&response.status_code()) {
+            Ok(())
+        } else {
+            Err(StorageError::Backend)
+        }
+    }
+
+    pub async fn get_object(&self, org_id: Uuid, key: &ObjectKey) -> Result<Bytes, StorageError> {
+        authorize_key_for_org(key, org_id)?;
+        self.verify_stored_org(org_id, key).await?;
+        let path = key.as_str();
+        let response = self
+            .bucket
+            .get_object(&path)
+            .await
+            .map_err(map_s3_get_error)?;
+        let status = response.status_code();
+        if status == 404 {
+            return Err(StorageError::NotFound);
+        }
+        if !(200..300).contains(&status) {
+            return Err(StorageError::Backend);
+        }
+        Ok(Bytes::copy_from_slice(response.as_slice()))
+    }
+
+    pub async fn object_exists(&self, org_id: Uuid, key: &ObjectKey) -> Result<bool, StorageError> {
+        authorize_key_for_org(key, org_id)?;
+        match self.head_for_org(org_id, key).await {
+            Ok(_) => Ok(true),
+            Err(StorageError::NotFound) => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub async fn delete_object(&self, org_id: Uuid, key: &ObjectKey) -> Result<(), StorageError> {
+        authorize_key_for_org(key, org_id)?;
+        self.verify_stored_org(org_id, key).await?;
+        let path = key.as_str();
+        let response = self
+            .bucket
+            .delete_object(&path)
+            .await
+            .map_err(map_s3_get_error)?;
+        let status = response.status_code();
+        if status == 404 {
+            return Err(StorageError::NotFound);
+        }
+        if (200..300).contains(&status) {
+            Ok(())
+        } else {
+            Err(StorageError::Backend)
+        }
+    }
+
+    /// Read identity metadata via HEAD after org authorization.
+    pub async fn head_metadata(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+    ) -> Result<HashMap<String, String>, StorageError> {
+        authorize_key_for_org(key, org_id)?;
+        let (head, _) = self.head_for_org(org_id, key).await?;
+        Ok(metadata_map(&head))
+    }
+
+    async fn verify_stored_org(&self, org_id: Uuid, key: &ObjectKey) -> Result<(), StorageError> {
+        let _ = self.head_for_org(org_id, key).await?;
+        Ok(())
+    }
+
+    async fn head_for_org(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+    ) -> Result<(HeadObjectResult, u16), StorageError> {
+        let path = key.as_str();
+        let (head, status) = match self.bucket.head_object(&path).await {
+            Ok(pair) => pair,
+            Err(error) => return Err(map_s3_head_error(error)),
+        };
+        if status == 404 {
+            return Err(StorageError::NotFound);
+        }
+        if !(200..300).contains(&status) {
+            return Err(StorageError::Backend);
+        }
+        let meta = metadata_map(&head);
+        let Some(stored_org) = meta.get("org-id") else {
+            return Err(StorageError::OwnershipConflict);
+        };
+        let stored = Uuid::parse_str(stored_org).map_err(|_| StorageError::OwnershipConflict)?;
+        if stored != org_id {
+            return Err(StorageError::OwnershipConflict);
+        }
+        Ok((head, status))
+    }
+}
+
+fn metadata_map(head: &HeadObjectResult) -> HashMap<String, String> {
+    let mut meta = HashMap::new();
+    if let Some(map) = &head.metadata {
+        for (k, v) in map {
+            meta.insert(k.to_ascii_lowercase(), v.clone());
+        }
+    }
+    meta
+}
+
+fn map_s3_get_error(error: S3Error) -> StorageError {
+    match error {
+        S3Error::HttpFailWithBody(404, _) => StorageError::NotFound,
+        S3Error::HttpFailWithBody(_, _) => StorageError::Backend,
+        S3Error::HttpFail => StorageError::Backend,
+        _ => StorageError::Transport,
+    }
+}
+
+fn map_s3_head_error(error: S3Error) -> StorageError {
+    map_s3_get_error(error)
+}
+
+fn is_bucket_already_exists(error: &S3Error) -> bool {
+    matches!(error, S3Error::HttpFailWithBody(409, _))
+}

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -1,0 +1,22 @@
+//! Fail-closed storage adapters (MinIO object store + Qdrant vectors).
+//!
+//! Tenant-facing exports deliberately omit [`qdrant::QdrantAdminClient`] —
+//! operator collection drops require a distinct admin API key and an explicit
+//! import of `crate::storage::qdrant::{QdrantAdminClient, QdrantAdminApiKey}`.
+
+pub mod error;
+pub mod keys;
+pub mod minio;
+pub mod qdrant;
+pub mod url_safety;
+
+pub use error::StorageError;
+pub use keys::{
+    authorize_key_for_org, authorize_key_for_version, parse_key_for_org, quarantine_key,
+    trusted_key, ObjectKey, ObjectNamespace,
+};
+pub use minio::{MinioClient, ObjectIdentityMeta};
+pub use qdrant::{
+    point_id_from_org_collection_and_chunk, ChunkPointPayload, QdrantClient, SearchHit,
+    UpsertPoint, VectorScope,
+};

--- a/crates/server/src/storage/qdrant.rs
+++ b/crates/server/src/storage/qdrant.rs
@@ -1,0 +1,791 @@
+//! Qdrant REST adapter with mandatory org/collection filters (ADR 0009).
+//!
+//! Point IDs are bound to `(org_id, collection_id, chunk_identity)` so collisions
+//! across orgs **or** collections are impossible by construction. Every
+//! read/search/delete uses server-side org (+ authorized collection) filters.
+//! Collection names are always [`CollectionName`] (never raw strings).
+//!
+//! Destructive collection drops use [`QdrantAdminClient`], which requires a
+//! distinct operator admin API key and is **not** re-exported from `storage`
+//! (tenant request paths must not obtain it).
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use fileconv_knowledge::identity::IndexSignature;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::config::SecretString;
+use crate::services::index_signature::{
+    collection_name_for_digest, collection_name_for_signature, validate_signature_digest,
+    CollectionName,
+};
+use crate::storage::error::StorageError;
+use crate::storage::url_safety::normalize_service_url;
+
+const POINT_ID_DOMAIN: &[u8] = b"markhand-qdrant-point-v2";
+
+/// Mandatory tenant + authorized-collection scope for every vector operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VectorScope {
+    pub org_id: Uuid,
+    pub collection_ids: BTreeSet<Uuid>,
+}
+
+impl VectorScope {
+    pub fn new(org_id: Uuid, collection_ids: impl IntoIterator<Item = Uuid>) -> Self {
+        Self {
+            org_id,
+            collection_ids: collection_ids.into_iter().collect(),
+        }
+    }
+
+    /// Fail closed when org is nil or the authorized collection set is empty.
+    pub fn validate(&self) -> Result<(), StorageError> {
+        if self.org_id.is_nil() || self.collection_ids.is_empty() {
+            return Err(StorageError::MissingScope);
+        }
+        if self.collection_ids.iter().any(Uuid::is_nil) {
+            return Err(StorageError::MissingScope);
+        }
+        Ok(())
+    }
+}
+
+/// Identity + lifecycle markers stored on every Qdrant point payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChunkPointPayload {
+    pub org_id: Uuid,
+    pub collection_id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub chunk_id: String,
+    pub ordinal: u64,
+    pub is_current: bool,
+    pub is_effective: bool,
+    pub index_generation: u32,
+}
+
+impl ChunkPointPayload {
+    fn to_json(&self) -> Value {
+        json!({
+            "org_id": self.org_id.to_string(),
+            "collection_id": self.collection_id.to_string(),
+            "document_id": self.document_id.to_string(),
+            "version_id": self.version_id.to_string(),
+            "chunk_id": self.chunk_id,
+            "ordinal": self.ordinal,
+            "is_current": self.is_current,
+            "is_effective": self.is_effective,
+            "index_generation": self.index_generation,
+        })
+    }
+
+    fn from_json(value: &Value) -> Result<Self, StorageError> {
+        let obj = value.as_object().ok_or(StorageError::Backend)?;
+        let get_uuid = |key: &str| -> Result<Uuid, StorageError> {
+            let raw = obj
+                .get(key)
+                .and_then(Value::as_str)
+                .ok_or(StorageError::Backend)?;
+            Uuid::parse_str(raw).map_err(|_| StorageError::Backend)
+        };
+        Ok(Self {
+            org_id: get_uuid("org_id")?,
+            collection_id: get_uuid("collection_id")?,
+            document_id: get_uuid("document_id")?,
+            version_id: get_uuid("version_id")?,
+            chunk_id: obj
+                .get("chunk_id")
+                .and_then(Value::as_str)
+                .ok_or(StorageError::Backend)?
+                .to_string(),
+            ordinal: obj
+                .get("ordinal")
+                .and_then(Value::as_u64)
+                .ok_or(StorageError::Backend)?,
+            is_current: obj
+                .get("is_current")
+                .and_then(Value::as_bool)
+                .ok_or(StorageError::Backend)?,
+            is_effective: obj
+                .get("is_effective")
+                .and_then(Value::as_bool)
+                .ok_or(StorageError::Backend)?,
+            index_generation: {
+                let raw = obj
+                    .get("index_generation")
+                    .and_then(Value::as_u64)
+                    .ok_or(StorageError::Backend)?;
+                u32::try_from(raw).map_err(|_| StorageError::PreconditionFailed)?
+            },
+        })
+    }
+}
+
+/// Point to upsert into a generation-scoped collection.
+#[derive(Debug, Clone)]
+pub struct UpsertPoint {
+    pub chunk_identity: String,
+    pub vector: Vec<f32>,
+    pub payload: ChunkPointPayload,
+}
+
+/// Search hit returned under a mandatory tenant filter.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchHit {
+    pub point_id: Uuid,
+    pub score: f32,
+    pub payload: ChunkPointPayload,
+}
+
+/// Fail-closed Qdrant client using the HTTP REST API (no gRPC dependency).
+#[derive(Clone)]
+pub struct QdrantClient {
+    base_url: String,
+    api_key: Option<SecretString>,
+    http: Client,
+}
+
+impl fmt::Debug for QdrantClient {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("QdrantClient")
+            .field("base_url", &"[REDACTED_ENDPOINT]")
+            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
+impl QdrantClient {
+    pub fn new(base_url: impl Into<String>) -> Result<Self, StorageError> {
+        Self::with_api_key(base_url, None)
+    }
+
+    pub fn with_api_key(
+        base_url: impl Into<String>,
+        api_key: Option<SecretString>,
+    ) -> Result<Self, StorageError> {
+        let base_url = normalize_service_url(base_url.into())?;
+        if let Some(key) = api_key.as_ref() {
+            if key.expose().is_empty() {
+                return Err(StorageError::ConfigMissingCredentials);
+            }
+        }
+        let http = Client::builder()
+            .use_rustls_tls()
+            .build()
+            .map_err(|_| StorageError::ConfigInvalid)?;
+        Ok(Self {
+            base_url,
+            api_key,
+            http,
+        })
+    }
+
+    /// Ensure the versioned collection for `signature` exists (size + distance).
+    pub async fn ensure_collection_for_signature(
+        &self,
+        signature: &IndexSignature<'_>,
+    ) -> Result<CollectionName, StorageError> {
+        let name = collection_name_for_signature(signature)?;
+        self.ensure_collection(&name, signature.dimensions, signature.normalized)
+            .await?;
+        Ok(name)
+    }
+
+    /// Ensure a collection named from a known digest exists.
+    pub async fn ensure_collection_for_digest(
+        &self,
+        digest: &str,
+        dimensions: usize,
+        normalized: bool,
+    ) -> Result<CollectionName, StorageError> {
+        validate_signature_digest(digest)?;
+        let name = collection_name_for_digest(digest)?;
+        self.ensure_collection(&name, dimensions, normalized)
+            .await?;
+        Ok(name)
+    }
+
+    async fn ensure_collection(
+        &self,
+        name: &CollectionName,
+        dimensions: usize,
+        normalized: bool,
+    ) -> Result<(), StorageError> {
+        if dimensions == 0 {
+            return Err(StorageError::PreconditionFailed);
+        }
+        let distance = if normalized { "Cosine" } else { "Dot" };
+        if let Some((existing_size, existing_distance)) = self.get_collection_params(name).await? {
+            if existing_size != dimensions || !distance_matches(&existing_distance, distance) {
+                return Err(StorageError::CollectionMismatch);
+            }
+            return Ok(());
+        }
+        let url = format!("{}/collections/{}", self.base_url, name.as_str());
+        let body = json!({
+            "vectors": {
+                "size": dimensions,
+                "distance": distance
+            }
+        });
+        let response = self
+            .authed(self.http.put(&url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        let text = response.text().await.unwrap_or_default();
+        if status.as_u16() == 409
+            || text.contains("already exists")
+            || text.contains("AlreadyExists")
+        {
+            let Some((existing_size, existing_distance)) = self.get_collection_params(name).await?
+            else {
+                return Err(StorageError::Backend);
+            };
+            if existing_size != dimensions || !distance_matches(&existing_distance, distance) {
+                return Err(StorageError::CollectionMismatch);
+            }
+            return Ok(());
+        }
+        Err(StorageError::Backend)
+    }
+
+    async fn get_collection_params(
+        &self,
+        name: &CollectionName,
+    ) -> Result<Option<(usize, String)>, StorageError> {
+        let url = format!("{}/collections/{}", self.base_url, name.as_str());
+        let response = self
+            .authed(self.http.get(&url))
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if response.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        let body: Value = response.json().await.map_err(|_| StorageError::Backend)?;
+        let vectors = body
+            .pointer("/result/config/params/vectors")
+            .ok_or(StorageError::Backend)?;
+        let (size, distance) = if let Some(size) = vectors.get("size").and_then(Value::as_u64) {
+            let distance = vectors
+                .get("distance")
+                .and_then(Value::as_str)
+                .ok_or(StorageError::Backend)?;
+            (size as usize, distance.to_string())
+        } else if let Some(obj) = vectors.as_object() {
+            let first = obj.values().next().ok_or(StorageError::Backend)?;
+            let size = first
+                .get("size")
+                .and_then(Value::as_u64)
+                .ok_or(StorageError::Backend)? as usize;
+            let distance = first
+                .get("distance")
+                .and_then(Value::as_str)
+                .ok_or(StorageError::Backend)?
+                .to_string();
+            (size, distance)
+        } else {
+            return Err(StorageError::Backend);
+        };
+        Ok(Some((size, distance)))
+    }
+
+    /// Upsert deterministic points bound to `(org, collection, chunk)`.
+    pub async fn upsert_points(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        points: &[UpsertPoint],
+    ) -> Result<Vec<Uuid>, StorageError> {
+        scope.validate()?;
+        if points.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut ids = Vec::with_capacity(points.len());
+        let mut body_points = Vec::with_capacity(points.len());
+        for point in points {
+            self.enforce_payload_scope(scope, &point.payload)?;
+            if point.payload.chunk_id != point.chunk_identity {
+                return Err(StorageError::PreconditionFailed);
+            }
+            let point_id = point_id_from_org_collection_and_chunk(
+                scope.org_id,
+                point.payload.collection_id,
+                &point.chunk_identity,
+            )?;
+            ids.push(point_id);
+            body_points.push(json!({
+                "id": point_id.to_string(),
+                "vector": point.vector,
+                "payload": point.payload.to_json(),
+            }));
+        }
+        self.assert_owned_or_absent(collection_name, scope, &ids)
+            .await?;
+
+        let url = format!(
+            "{}/collections/{}/points?wait=true",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let response = self
+            .authed(self.http.put(&url))
+            .json(&json!({ "points": body_points }))
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        Ok(ids)
+    }
+
+    /// Search with a mandatory org + authorized collection filter.
+    pub async fn search(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        vector: &[f32],
+        limit: usize,
+    ) -> Result<Vec<SearchHit>, StorageError> {
+        scope.validate()?;
+        if limit == 0 {
+            return Err(StorageError::PreconditionFailed);
+        }
+        let url = format!(
+            "{}/collections/{}/points/query",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let body = json!({
+            "query": vector,
+            "filter": mandatory_filter(scope),
+            "limit": limit,
+            "with_payload": true,
+        });
+        let response = self
+            .authed(self.http.post(&url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if response.status().as_u16() == 404 || !response.status().is_success() {
+            return self
+                .search_legacy(collection_name, scope, vector, limit)
+                .await;
+        }
+        let payload: Value = response.json().await.map_err(|_| StorageError::Backend)?;
+        let hits = parse_search_hits(&payload)?;
+        enforce_hits_in_scope(scope, &hits)?;
+        Ok(hits)
+    }
+
+    async fn search_legacy(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        vector: &[f32],
+        limit: usize,
+    ) -> Result<Vec<SearchHit>, StorageError> {
+        let url = format!(
+            "{}/collections/{}/points/search",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let body = json!({
+            "vector": vector,
+            "filter": mandatory_filter(scope),
+            "limit": limit,
+            "with_payload": true,
+        });
+        let response = self
+            .authed(self.http.post(&url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        let payload: Value = response.json().await.map_err(|_| StorageError::Backend)?;
+        let hits = parse_search_hits(&payload)?;
+        enforce_hits_in_scope(scope, &hits)?;
+        Ok(hits)
+    }
+
+    /// Delete points matching the mandatory org/collection filter (and optional extra).
+    pub async fn delete_by_scope(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        extra_must: &[Value],
+    ) -> Result<(), StorageError> {
+        scope.validate()?;
+        let mut must = mandatory_filter_must(scope);
+        must.extend(extra_must.iter().cloned());
+        let url = format!(
+            "{}/collections/{}/points/delete?wait=true",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let response = self
+            .authed(self.http.post(&url))
+            .json(&json!({ "filter": { "must": must } }))
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        Ok(())
+    }
+
+    /// Fetch points by id using a **server-side** org + collection + has_id filter.
+    pub async fn get_points(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        point_ids: &[Uuid],
+    ) -> Result<Vec<(Uuid, ChunkPointPayload)>, StorageError> {
+        scope.validate()?;
+        if point_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut must = mandatory_filter_must(scope);
+        let ids: Vec<Value> = point_ids
+            .iter()
+            .map(|id| Value::String(id.to_string()))
+            .collect();
+        must.push(json!({ "has_id": ids }));
+        let url = format!(
+            "{}/collections/{}/points/scroll",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let response = self
+            .authed(self.http.post(&url))
+            .json(&json!({
+                "filter": { "must": must },
+                "limit": point_ids.len(),
+                "with_payload": true,
+                "with_vector": false,
+            }))
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        let body: Value = response.json().await.map_err(|_| StorageError::Backend)?;
+        let points = body
+            .pointer("/result/points")
+            .and_then(Value::as_array)
+            .ok_or(StorageError::Backend)?;
+        let mut out = Vec::new();
+        for point in points {
+            let id = parse_point_id(point.get("id").ok_or(StorageError::Backend)?)?;
+            let payload =
+                ChunkPointPayload::from_json(point.get("payload").ok_or(StorageError::Backend)?)?;
+            if payload.org_id != scope.org_id
+                || !scope.collection_ids.contains(&payload.collection_id)
+            {
+                return Err(StorageError::OwnershipConflict);
+            }
+            out.push((id, payload));
+        }
+        Ok(out)
+    }
+
+    async fn assert_owned_or_absent(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        point_ids: &[Uuid],
+    ) -> Result<(), StorageError> {
+        let existing = self.get_points(collection_name, scope, point_ids).await?;
+        for (_, payload) in existing {
+            if payload.org_id != scope.org_id
+                || !scope.collection_ids.contains(&payload.collection_id)
+            {
+                return Err(StorageError::OwnershipConflict);
+            }
+        }
+        Ok(())
+    }
+
+    fn enforce_payload_scope(
+        &self,
+        scope: &VectorScope,
+        payload: &ChunkPointPayload,
+    ) -> Result<(), StorageError> {
+        if payload.org_id != scope.org_id {
+            return Err(StorageError::MissingScope);
+        }
+        if !scope.collection_ids.contains(&payload.collection_id) {
+            return Err(StorageError::MissingScope);
+        }
+        Ok(())
+    }
+
+    fn authed(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(key) = self.api_key.as_ref() {
+            builder.header("api-key", key.expose())
+        } else {
+            builder
+        }
+    }
+}
+
+/// Operator credential for destructive Qdrant collection lifecycle.
+///
+/// Distinct from the tenant `api-key`. Never constructed from request auth.
+#[derive(Clone)]
+pub struct QdrantAdminApiKey(SecretString);
+
+impl fmt::Debug for QdrantAdminApiKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("QdrantAdminApiKey([REDACTED])")
+    }
+}
+
+impl QdrantAdminApiKey {
+    /// Build from `MARKHAND_QDRANT_ADMIN_API_KEY` (must be non-empty).
+    pub fn new(key: SecretString) -> Result<Self, StorageError> {
+        if key.expose().is_empty() {
+            return Err(StorageError::ConfigMissingCredentials);
+        }
+        Ok(Self(key))
+    }
+}
+
+/// Operator-only Qdrant admin client (collection drop).
+///
+/// **Boundary:** not re-exported from `crate::storage`. Tenant HTTP/worker paths
+/// must not import or construct this type. Requires [`QdrantAdminApiKey`] —
+/// never reuses the tenant client's credentials.
+#[derive(Clone)]
+pub struct QdrantAdminClient {
+    base_url: String,
+    admin_api_key: SecretString,
+    http: Client,
+}
+
+impl fmt::Debug for QdrantAdminClient {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("QdrantAdminClient")
+            .field("base_url", &"[REDACTED_ENDPOINT]")
+            .field("admin_api_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl QdrantAdminClient {
+    /// Construct with a distinct operator admin API key (not the tenant key).
+    pub fn new(
+        base_url: impl Into<String>,
+        admin_key: QdrantAdminApiKey,
+    ) -> Result<Self, StorageError> {
+        let base_url = normalize_service_url(base_url.into())?;
+        let http = Client::builder()
+            .use_rustls_tls()
+            .build()
+            .map_err(|_| StorageError::ConfigInvalid)?;
+        Ok(Self {
+            base_url,
+            admin_api_key: admin_key.0,
+            http,
+        })
+    }
+
+    /// Drop an entire Qdrant collection. Operator-only.
+    pub async fn delete_collection(
+        &self,
+        collection_name: &CollectionName,
+    ) -> Result<(), StorageError> {
+        let url = format!("{}/collections/{}", self.base_url, collection_name.as_str());
+        let response = self
+            .http
+            .delete(&url)
+            .header("api-key", self.admin_api_key.expose())
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if response.status().is_success() || response.status().as_u16() == 404 {
+            return Ok(());
+        }
+        Err(StorageError::Backend)
+    }
+}
+
+/// Deterministic UUIDv8 from `(org_id, collection_id, chunk_identity)`.
+pub fn point_id_from_org_collection_and_chunk(
+    org_id: Uuid,
+    collection_id: Uuid,
+    chunk_identity_hex: &str,
+) -> Result<Uuid, StorageError> {
+    if org_id.is_nil() || collection_id.is_nil() {
+        return Err(StorageError::MissingScope);
+    }
+    if chunk_identity_hex.len() != 64
+        || !chunk_identity_hex.bytes().all(|byte| {
+            // Canonical lowercase hex only — casing must never fork point ids.
+            matches!(byte, b'0'..=b'9' | b'a'..=b'f')
+        })
+    {
+        return Err(StorageError::PreconditionFailed);
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(POINT_ID_DOMAIN);
+    hasher.update(org_id.as_bytes());
+    hasher.update(collection_id.as_bytes());
+    hasher.update(chunk_identity_hex.as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    Ok(Uuid::new_v8(bytes))
+}
+
+fn distance_matches(existing: &str, expected: &str) -> bool {
+    existing.eq_ignore_ascii_case(expected)
+}
+
+fn mandatory_filter(scope: &VectorScope) -> Value {
+    json!({ "must": mandatory_filter_must(scope) })
+}
+
+fn mandatory_filter_must(scope: &VectorScope) -> Vec<Value> {
+    let collection_values: Vec<String> = scope.collection_ids.iter().map(Uuid::to_string).collect();
+    vec![
+        json!({
+            "key": "org_id",
+            "match": { "value": scope.org_id.to_string() }
+        }),
+        json!({
+            "key": "collection_id",
+            "match": { "any": collection_values }
+        }),
+    ]
+}
+
+fn enforce_hits_in_scope(scope: &VectorScope, hits: &[SearchHit]) -> Result<(), StorageError> {
+    for hit in hits {
+        if hit.payload.org_id != scope.org_id
+            || !scope.collection_ids.contains(&hit.payload.collection_id)
+        {
+            return Err(StorageError::OwnershipConflict);
+        }
+    }
+    Ok(())
+}
+
+fn parse_search_hits(body: &Value) -> Result<Vec<SearchHit>, StorageError> {
+    let points = body
+        .pointer("/result/points")
+        .and_then(Value::as_array)
+        .or_else(|| body.pointer("/result").and_then(Value::as_array))
+        .ok_or(StorageError::Backend)?;
+    let mut hits = Vec::with_capacity(points.len());
+    for point in points {
+        let point_id = parse_point_id(point.get("id").ok_or(StorageError::Backend)?)?;
+        let score = point.get("score").and_then(Value::as_f64).unwrap_or(0.0) as f32;
+        let payload =
+            ChunkPointPayload::from_json(point.get("payload").ok_or(StorageError::Backend)?)?;
+        hits.push(SearchHit {
+            point_id,
+            score,
+            payload,
+        });
+    }
+    Ok(hits)
+}
+
+fn parse_point_id(value: &Value) -> Result<Uuid, StorageError> {
+    match value {
+        Value::String(text) => Uuid::parse_str(text).map_err(|_| StorageError::Backend),
+        Value::Number(_) => Err(StorageError::Backend),
+        _ => Err(StorageError::Backend),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_scope_is_rejected() {
+        let empty_org = VectorScope::new(Uuid::nil(), [Uuid::new_v4()]);
+        assert!(matches!(
+            empty_org.validate(),
+            Err(StorageError::MissingScope)
+        ));
+        let empty_collections = VectorScope::new(Uuid::new_v4(), []);
+        assert!(matches!(
+            empty_collections.validate(),
+            Err(StorageError::MissingScope)
+        ));
+    }
+
+    #[test]
+    fn point_id_binds_org_and_collection() {
+        let identity = "d54db7b6de20b51a416670927eeab346256c9b891732965e51586fac333c1835";
+        let org = Uuid::new_v4();
+        let col_a = Uuid::new_v4();
+        let col_b = Uuid::new_v4();
+        let a1 = point_id_from_org_collection_and_chunk(org, col_a, identity).unwrap();
+        let a2 = point_id_from_org_collection_and_chunk(org, col_a, identity).unwrap();
+        let b = point_id_from_org_collection_and_chunk(org, col_b, identity).unwrap();
+        let other_org =
+            point_id_from_org_collection_and_chunk(Uuid::new_v4(), col_a, identity).unwrap();
+        assert_eq!(a1, a2);
+        assert_ne!(a1, b);
+        assert_ne!(a1, other_org);
+        assert_eq!(a1.get_version(), Some(uuid::Version::Custom));
+    }
+
+    #[test]
+    fn point_id_rejects_uppercase_chunk_digest() {
+        let org = Uuid::new_v4();
+        let col = Uuid::new_v4();
+        let upper = "D54DB7B6DE20B51A416670927EEAB346256C9B891732965E51586FAC333C1835";
+        assert!(matches!(
+            point_id_from_org_collection_and_chunk(org, col, upper),
+            Err(StorageError::PreconditionFailed)
+        ));
+        let mixed =
+            "d54db7b6de20b51a416670927eeab346256c9b891732965e51586fac333c1835".to_ascii_uppercase();
+        assert!(matches!(
+            point_id_from_org_collection_and_chunk(org, col, &mixed),
+            Err(StorageError::PreconditionFailed)
+        ));
+    }
+
+    #[test]
+    fn debug_redacts_endpoint_and_api_key() {
+        let client = QdrantClient::with_api_key(
+            "http://127.0.0.1:6333",
+            Some(SecretString::new("super-secret-qdrant-key")),
+        )
+        .unwrap();
+        let debug = format!("{client:?}");
+        assert!(!debug.contains("127.0.0.1"));
+        assert!(!debug.contains("super-secret"));
+        assert!(debug.contains("[REDACTED"));
+    }
+}

--- a/crates/server/src/storage/url_safety.rs
+++ b/crates/server/src/storage/url_safety.rs
@@ -1,0 +1,54 @@
+//! Reject credentialed or parameterized service base URLs (fail closed).
+//!
+//! Service base URLs must be `scheme://host[:port][/path]` only — no userinfo,
+//! query, or fragment.
+
+use crate::storage::error::StorageError;
+
+/// Normalize an absolute http(s) base URL and reject credentials / query / fragment.
+pub fn normalize_service_url(url: impl AsRef<str>) -> Result<String, StorageError> {
+    let trimmed = url.as_ref().trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Err(StorageError::ConfigInvalid);
+    }
+    // Fail closed on raw markers before parse edge cases.
+    if trimmed.contains('?') || trimmed.contains('#') {
+        return Err(StorageError::ConfigInvalid);
+    }
+    let parsed = reqwest::Url::parse(trimmed).map_err(|_| StorageError::ConfigInvalid)?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(StorageError::ConfigInvalid);
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(StorageError::ConfigInvalid);
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err(StorageError::ConfigInvalid);
+    }
+    if parsed.host_str().is_none() {
+        return Err(StorageError::ConfigInvalid);
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_userinfo_query_and_fragment() {
+        assert!(normalize_service_url("http://user:pass@127.0.0.1:9000").is_err());
+        assert!(normalize_service_url("http://127.0.0.1:9000?api_key=secret").is_err());
+        assert!(normalize_service_url("http://127.0.0.1:9000?sig=abc").is_err());
+        assert!(normalize_service_url("http://127.0.0.1:9000#frag").is_err());
+        assert!(normalize_service_url("http://127.0.0.1:9000/?x=1").is_err());
+        assert_eq!(
+            normalize_service_url("http://127.0.0.1:9000/").unwrap(),
+            "http://127.0.0.1:9000"
+        );
+        assert_eq!(
+            normalize_service_url("http://127.0.0.1:9000/minio").unwrap(),
+            "http://127.0.0.1:9000/minio"
+        );
+    }
+}

--- a/crates/server/tests/storage.rs
+++ b/crates/server/tests/storage.rs
@@ -1,0 +1,750 @@
+//! Storage adapter integration tests (Qdrant + MinIO).
+//!
+//! Live-service tests skip cleanly when `MARKHAND_TEST_QDRANT_URL` /
+//! `MARKHAND_TEST_MINIO_*` are unset. The missing-scope test does **not**
+//! require live services (unreachable endpoint proves no network call).
+
+use std::collections::BTreeSet;
+
+use bytes::Bytes;
+use fileconv_knowledge::identity::{
+    chunk_identity, IndexSignature, BODY_TEXT_VERSION, DEFAULT_CHUNKING_VERSION,
+    QUERY_NORMALIZATION_VERSION, RUNTIME_LOCAL_HASH,
+};
+use fileconv_server::config::{MinioConfig, SecretString};
+use fileconv_server::services::index_signature::parse_collection_name;
+use fileconv_server::storage::keys::{parse_key_for_org, quarantine_key, trusted_key};
+use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
+use fileconv_server::storage::qdrant::{
+    point_id_from_org_collection_and_chunk, ChunkPointPayload, QdrantAdminApiKey,
+    QdrantAdminClient, QdrantClient, UpsertPoint, VectorScope,
+};
+use fileconv_server::storage::StorageError;
+use uuid::Uuid;
+
+fn test_qdrant_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_QDRANT_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!(
+                "skipped: MARKHAND_TEST_QDRANT_URL unset — Qdrant integration tests require a live instance"
+            );
+            None
+        }
+    }
+}
+
+fn test_admin_client(url: &str) -> QdrantAdminClient {
+    // Local Qdrant ignores api-key when auth is disabled; construction still
+    // requires a distinct non-empty operator credential.
+    let key = std::env::var("MARKHAND_TEST_QDRANT_ADMIN_API_KEY")
+        .unwrap_or_else(|_| "test-operator-admin-key".into());
+    QdrantAdminClient::new(url, QdrantAdminApiKey::new(SecretString::new(key)).unwrap())
+        .expect("admin client")
+}
+
+struct TestMinioEnv {
+    endpoint: String,
+    access_key: String,
+    secret_key: String,
+    region: String,
+}
+
+fn test_minio_env() -> Option<TestMinioEnv> {
+    let endpoint = match std::env::var("MARKHAND_TEST_MINIO_ENDPOINT") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!(
+                "skipped: MARKHAND_TEST_MINIO_ENDPOINT unset — MinIO integration tests require a live instance"
+            );
+            return None;
+        }
+    };
+    let access_key = std::env::var("MARKHAND_TEST_MINIO_ACCESS_KEY").ok()?;
+    let secret_key = std::env::var("MARKHAND_TEST_MINIO_SECRET_KEY").ok()?;
+    if access_key.is_empty() || secret_key.is_empty() {
+        eprintln!("skipped: MinIO test credentials empty");
+        return None;
+    }
+    let region = std::env::var("MARKHAND_TEST_MINIO_REGION").unwrap_or_else(|_| "us-east-1".into());
+    Some(TestMinioEnv {
+        endpoint,
+        access_key,
+        secret_key,
+        region,
+    })
+}
+
+fn unit_vector(dimensions: usize, hot: usize) -> Vec<f32> {
+    let mut vector = vec![0.0; dimensions];
+    if dimensions > 0 {
+        vector[hot % dimensions] = 1.0;
+    }
+    vector
+}
+
+/// Missing scope must fail closed **without** any network I/O.
+#[tokio::test]
+async fn missing_scope_rejects_without_network_side_effects() {
+    let client = QdrantClient::new("http://127.0.0.1:1").expect("client builds");
+    let collection = parse_collection_name(
+        "markhand_chunks_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    )
+    .unwrap();
+    let empty_org = VectorScope::new(Uuid::nil(), [Uuid::new_v4()]);
+    let empty_collections = VectorScope::new(Uuid::new_v4(), BTreeSet::new());
+    let vector = unit_vector(8, 0);
+    let org = Uuid::new_v4();
+    let collection_id = Uuid::new_v4();
+    let payload = ChunkPointPayload {
+        org_id: org,
+        collection_id,
+        document_id: Uuid::new_v4(),
+        version_id: Uuid::new_v4(),
+        chunk_id: "d54db7b6de20b51a416670927eeab346256c9b891732965e51586fac333c1835".into(),
+        ordinal: 0,
+        is_current: true,
+        is_effective: true,
+        index_generation: 1,
+    };
+    let points = [UpsertPoint {
+        chunk_identity: payload.chunk_id.clone(),
+        vector: vector.clone(),
+        payload,
+    }];
+
+    assert!(matches!(
+        client.upsert_points(&collection, &empty_org, &points).await,
+        Err(StorageError::MissingScope)
+    ));
+    assert!(matches!(
+        client
+            .upsert_points(&collection, &empty_collections, &points)
+            .await,
+        Err(StorageError::MissingScope)
+    ));
+    assert!(matches!(
+        client.search(&collection, &empty_org, &vector, 5).await,
+        Err(StorageError::MissingScope)
+    ));
+    assert!(matches!(
+        client
+            .search(&collection, &empty_collections, &vector, 5)
+            .await,
+        Err(StorageError::MissingScope)
+    ));
+    assert!(matches!(
+        client.delete_by_scope(&collection, &empty_org, &[]).await,
+        Err(StorageError::MissingScope)
+    ));
+    assert!(matches!(
+        client
+            .delete_by_scope(&collection, &empty_collections, &[])
+            .await,
+        Err(StorageError::MissingScope)
+    ));
+    assert!(matches!(
+        client.get_points(&collection, &empty_org, &[]).await,
+        Err(StorageError::MissingScope)
+    ));
+}
+
+#[tokio::test]
+async fn qdrant_tenant_isolation_and_deterministic_points() {
+    let Some(url) = test_qdrant_url() else {
+        return;
+    };
+    let client = QdrantClient::new(&url).expect("qdrant client");
+    let admin = test_admin_client(&url);
+    let unique_family = format!("storage-itest-{}", Uuid::new_v4().simple());
+    let signature = IndexSignature {
+        runtime_path: RUNTIME_LOCAL_HASH,
+        embedding_family: &unique_family,
+        embedding_revision: "r1",
+        dimensions: 8,
+        normalized: true,
+        chunking_version: DEFAULT_CHUNKING_VERSION,
+        body_text_version: BODY_TEXT_VERSION,
+        query_normalization_version: QUERY_NORMALIZATION_VERSION,
+    };
+    let digest = signature.digest();
+    let collection = client
+        .ensure_collection_for_digest(&digest, signature.dimensions, signature.normalized)
+        .await
+        .expect("ensure collection");
+    assert!(collection.as_str().contains(&digest));
+
+    let org_a = Uuid::new_v4();
+    let org_b = Uuid::new_v4();
+    let collection_a = Uuid::new_v4();
+    let collection_b = Uuid::new_v4();
+    let document_a = Uuid::new_v4();
+    let version_a = Uuid::new_v4();
+    let document_b = Uuid::new_v4();
+    let version_b = Uuid::new_v4();
+
+    let chunk_a = chunk_identity(
+        &document_a.to_string(),
+        &version_a.to_string(),
+        0,
+        "Chương I",
+        "Nội dung org A",
+        BODY_TEXT_VERSION,
+    );
+    let chunk_b = chunk_identity(
+        &document_b.to_string(),
+        &version_b.to_string(),
+        0,
+        "Chương I",
+        "Nội dung org B",
+        BODY_TEXT_VERSION,
+    );
+
+    let scope_a = VectorScope::new(org_a, [collection_a]);
+    let scope_b = VectorScope::new(org_b, [collection_b]);
+
+    let point_a = UpsertPoint {
+        chunk_identity: chunk_a.clone(),
+        vector: unit_vector(8, 0),
+        payload: ChunkPointPayload {
+            org_id: org_a,
+            collection_id: collection_a,
+            document_id: document_a,
+            version_id: version_a,
+            chunk_id: chunk_a.clone(),
+            ordinal: 0,
+            is_current: true,
+            is_effective: true,
+            index_generation: 1,
+        },
+    };
+    let point_b = UpsertPoint {
+        chunk_identity: chunk_b.clone(),
+        vector: unit_vector(8, 1),
+        payload: ChunkPointPayload {
+            org_id: org_b,
+            collection_id: collection_b,
+            document_id: document_b,
+            version_id: version_b,
+            chunk_id: chunk_b.clone(),
+            ordinal: 0,
+            is_current: true,
+            is_effective: true,
+            index_generation: 1,
+        },
+    };
+
+    let ids_a1 = client
+        .upsert_points(&collection, &scope_a, &[point_a.clone()])
+        .await
+        .expect("upsert A");
+    let ids_a2 = client
+        .upsert_points(&collection, &scope_a, &[point_a.clone()])
+        .await
+        .expect("idempotent upsert A");
+    assert_eq!(ids_a1, ids_a2);
+    assert_eq!(
+        ids_a1[0],
+        point_id_from_org_collection_and_chunk(org_a, collection_a, &chunk_a).expect("point id")
+    );
+
+    client
+        .upsert_points(&collection, &scope_b, &[point_b])
+        .await
+        .expect("upsert B");
+
+    let fetched = client
+        .get_points(&collection, &scope_a, &ids_a1)
+        .await
+        .expect("get points");
+    assert_eq!(fetched.len(), 1);
+    assert_eq!(fetched[0].1.org_id, org_a);
+    assert_eq!(fetched[0].1.collection_id, collection_a);
+
+    let hits_a = client
+        .search(&collection, &scope_a, &unit_vector(8, 0), 10)
+        .await
+        .expect("search A");
+    assert!(hits_a.iter().all(|hit| hit.payload.org_id == org_a));
+    assert!(hits_a.iter().any(|hit| hit.payload.chunk_id == chunk_a));
+
+    client
+        .delete_by_scope(&collection, &scope_a, &[])
+        .await
+        .expect("delete A");
+    assert!(client
+        .search(&collection, &scope_a, &unit_vector(8, 0), 10)
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(client
+        .search(&collection, &scope_b, &unit_vector(8, 1), 10)
+        .await
+        .unwrap()
+        .iter()
+        .any(|hit| hit.payload.chunk_id == chunk_b));
+
+    admin
+        .delete_collection(&collection)
+        .await
+        .expect("admin cleanup");
+}
+
+#[tokio::test]
+async fn cross_org_point_overwrite_rejected() {
+    let Some(url) = test_qdrant_url() else {
+        return;
+    };
+    let client = QdrantClient::new(&url).expect("qdrant client");
+    let admin = test_admin_client(&url);
+    let unique_family = format!("storage-xorg-{}", Uuid::new_v4().simple());
+    let signature = IndexSignature {
+        runtime_path: RUNTIME_LOCAL_HASH,
+        embedding_family: &unique_family,
+        embedding_revision: "r1",
+        dimensions: 8,
+        normalized: true,
+        chunking_version: DEFAULT_CHUNKING_VERSION,
+        body_text_version: BODY_TEXT_VERSION,
+        query_normalization_version: QUERY_NORMALIZATION_VERSION,
+    };
+    let digest = signature.digest();
+    let collection = client
+        .ensure_collection_for_digest(&digest, 8, true)
+        .await
+        .expect("ensure");
+
+    let org_a = Uuid::new_v4();
+    let org_b = Uuid::new_v4();
+    let col_a = Uuid::new_v4();
+    let col_b = Uuid::new_v4();
+    let doc = Uuid::new_v4();
+    let version = Uuid::new_v4();
+    let chunk = chunk_identity(
+        &doc.to_string(),
+        &version.to_string(),
+        0,
+        "H",
+        "shared body",
+        BODY_TEXT_VERSION,
+    );
+
+    let scope_a = VectorScope::new(org_a, [col_a]);
+    let scope_b = VectorScope::new(org_b, [col_b]);
+
+    let point_a = UpsertPoint {
+        chunk_identity: chunk.clone(),
+        vector: unit_vector(8, 0),
+        payload: ChunkPointPayload {
+            org_id: org_a,
+            collection_id: col_a,
+            document_id: doc,
+            version_id: version,
+            chunk_id: chunk.clone(),
+            ordinal: 0,
+            is_current: true,
+            is_effective: true,
+            index_generation: 1,
+        },
+    };
+    let ids_a = client
+        .upsert_points(&collection, &scope_a, &[point_a])
+        .await
+        .expect("upsert A");
+
+    let id_a = point_id_from_org_collection_and_chunk(org_a, col_a, &chunk).unwrap();
+    let id_b = point_id_from_org_collection_and_chunk(org_b, col_b, &chunk).unwrap();
+    assert_ne!(id_a, id_b);
+    assert_eq!(ids_a[0], id_a);
+
+    let forged = UpsertPoint {
+        chunk_identity: chunk.clone(),
+        vector: unit_vector(8, 7),
+        payload: ChunkPointPayload {
+            org_id: org_a,
+            collection_id: col_a,
+            document_id: doc,
+            version_id: version,
+            chunk_id: chunk.clone(),
+            ordinal: 0,
+            is_current: true,
+            is_effective: true,
+            index_generation: 1,
+        },
+    };
+    assert!(matches!(
+        client.upsert_points(&collection, &scope_b, &[forged]).await,
+        Err(StorageError::MissingScope)
+    ));
+
+    let point_b = UpsertPoint {
+        chunk_identity: chunk.clone(),
+        vector: unit_vector(8, 1),
+        payload: ChunkPointPayload {
+            org_id: org_b,
+            collection_id: col_b,
+            document_id: doc,
+            version_id: version,
+            chunk_id: chunk.clone(),
+            ordinal: 0,
+            is_current: true,
+            is_effective: true,
+            index_generation: 1,
+        },
+    };
+    client
+        .upsert_points(&collection, &scope_b, &[point_b])
+        .await
+        .expect("upsert B");
+
+    let still_a = client
+        .get_points(&collection, &scope_a, &ids_a)
+        .await
+        .expect("get A");
+    assert_eq!(still_a.len(), 1);
+    assert_eq!(still_a[0].1.org_id, org_a);
+
+    admin.delete_collection(&collection).await.ok();
+}
+
+#[tokio::test]
+async fn same_org_different_collection_cannot_overwrite() {
+    let Some(url) = test_qdrant_url() else {
+        return;
+    };
+    let client = QdrantClient::new(&url).expect("qdrant client");
+    let admin = test_admin_client(&url);
+    let unique_family = format!("storage-xcol-{}", Uuid::new_v4().simple());
+    let signature = IndexSignature {
+        runtime_path: RUNTIME_LOCAL_HASH,
+        embedding_family: &unique_family,
+        embedding_revision: "r1",
+        dimensions: 8,
+        normalized: true,
+        chunking_version: DEFAULT_CHUNKING_VERSION,
+        body_text_version: BODY_TEXT_VERSION,
+        query_normalization_version: QUERY_NORMALIZATION_VERSION,
+    };
+    let collection = client
+        .ensure_collection_for_digest(&signature.digest(), 8, true)
+        .await
+        .expect("ensure");
+
+    let org = Uuid::new_v4();
+    let col_a = Uuid::new_v4();
+    let col_b = Uuid::new_v4();
+    let doc = Uuid::new_v4();
+    let version = Uuid::new_v4();
+    let chunk = chunk_identity(
+        &doc.to_string(),
+        &version.to_string(),
+        0,
+        "H",
+        "same org shared chunk",
+        BODY_TEXT_VERSION,
+    );
+
+    let id_a = point_id_from_org_collection_and_chunk(org, col_a, &chunk).unwrap();
+    let id_b = point_id_from_org_collection_and_chunk(org, col_b, &chunk).unwrap();
+    assert_ne!(
+        id_a, id_b,
+        "same org + same chunk must still differ by collection_id"
+    );
+
+    let scope_a = VectorScope::new(org, [col_a]);
+    let scope_b = VectorScope::new(org, [col_b]);
+    // Unauthorized: org has col_a in scope only — cannot write col_b payload.
+    let scope_a_only = VectorScope::new(org, [col_a]);
+
+    let point_a = UpsertPoint {
+        chunk_identity: chunk.clone(),
+        vector: unit_vector(8, 0),
+        payload: ChunkPointPayload {
+            org_id: org,
+            collection_id: col_a,
+            document_id: doc,
+            version_id: version,
+            chunk_id: chunk.clone(),
+            ordinal: 0,
+            is_current: true,
+            is_effective: true,
+            index_generation: 1,
+        },
+    };
+    let ids_a = client
+        .upsert_points(&collection, &scope_a, &[point_a])
+        .await
+        .expect("upsert A");
+    assert_eq!(ids_a[0], id_a);
+
+    // Attempt to write col_b payload under scope that only authorizes col_a.
+    let forged = UpsertPoint {
+        chunk_identity: chunk.clone(),
+        vector: unit_vector(8, 7),
+        payload: ChunkPointPayload {
+            org_id: org,
+            collection_id: col_b,
+            document_id: doc,
+            version_id: version,
+            chunk_id: chunk.clone(),
+            ordinal: 0,
+            is_current: true,
+            is_effective: true,
+            index_generation: 1,
+        },
+    };
+    assert!(matches!(
+        client
+            .upsert_points(&collection, &scope_a_only, &[forged.clone()])
+            .await,
+        Err(StorageError::MissingScope)
+    ));
+
+    // Legitimate col_b upsert uses a different point id; col_a point unchanged.
+    client
+        .upsert_points(&collection, &scope_b, &[forged])
+        .await
+        .expect("upsert B");
+    let still_a = client
+        .get_points(&collection, &scope_a, &ids_a)
+        .await
+        .expect("get A");
+    assert_eq!(still_a.len(), 1);
+    assert_eq!(still_a[0].1.collection_id, col_a);
+    let hits_a = client
+        .search(&collection, &scope_a, &unit_vector(8, 0), 5)
+        .await
+        .unwrap();
+    assert!(hits_a.iter().all(|h| h.payload.collection_id == col_a));
+    assert!(hits_a.iter().all(|h| h.point_id != id_b));
+
+    admin.delete_collection(&collection).await.ok();
+}
+
+#[tokio::test]
+async fn existing_collection_dimension_mismatch_rejected() {
+    let Some(url) = test_qdrant_url() else {
+        return;
+    };
+    let client = QdrantClient::new(&url).expect("qdrant client");
+    let admin = test_admin_client(&url);
+    let unique_family = format!("storage-mismatch-{}", Uuid::new_v4().simple());
+    let signature = IndexSignature {
+        runtime_path: RUNTIME_LOCAL_HASH,
+        embedding_family: &unique_family,
+        embedding_revision: "r1",
+        dimensions: 8,
+        normalized: true,
+        chunking_version: DEFAULT_CHUNKING_VERSION,
+        body_text_version: BODY_TEXT_VERSION,
+        query_normalization_version: QUERY_NORMALIZATION_VERSION,
+    };
+    let digest = signature.digest();
+    let collection = client
+        .ensure_collection_for_digest(&digest, 8, true)
+        .await
+        .expect("create 8-dim cosine");
+
+    assert!(matches!(
+        client.ensure_collection_for_digest(&digest, 16, true).await,
+        Err(StorageError::CollectionMismatch)
+    ));
+    assert!(matches!(
+        client.ensure_collection_for_digest(&digest, 8, false).await,
+        Err(StorageError::CollectionMismatch)
+    ));
+    client
+        .ensure_collection_for_digest(&digest, 8, true)
+        .await
+        .expect("idempotent ensure");
+
+    admin.delete_collection(&collection).await.ok();
+}
+
+#[tokio::test]
+async fn minio_put_exists_get_delete_round_trip() {
+    let Some(env) = test_minio_env() else {
+        return;
+    };
+    std::env::set_var("RUST_S3_SKIP_LOCATION_CONSTRAINT", "true");
+
+    let bucket_name = format!("markhand-storage-it-{}", Uuid::new_v4().simple());
+    let config = MinioConfig::new(
+        env.endpoint,
+        SecretString::new(env.access_key),
+        SecretString::new(env.secret_key),
+        bucket_name,
+        env.region,
+        true,
+    )
+    .expect("minio config");
+    let debug = format!("{config:?}");
+    assert!(!debug.contains("minioadmin"));
+    assert!(debug.contains("[REDACTED]"));
+    assert!(!debug.contains("127.0.0.1"));
+
+    let client = MinioClient::from_config(&config).expect("minio client");
+    client.ensure_bucket().await.expect("ensure bucket");
+
+    let org = Uuid::new_v4();
+    let version = Uuid::new_v4();
+    let object = Uuid::new_v4();
+    let key = quarantine_key(org, object, Some("../../etc/passwd")).unwrap();
+    assert_eq!(parse_key_for_org(&key.as_str(), org).unwrap(), key);
+
+    let meta = ObjectIdentityMeta {
+        org_id: org,
+        collection_id: Some(Uuid::new_v4()),
+        document_id: Some(Uuid::new_v4()),
+        version_id: Some(version),
+        original_filename: Some("../../etc/passwd".into()),
+    };
+    let body = Bytes::from_static(b"markhand-storage-bytes");
+    client
+        .put_object(org, &key, body.clone(), &meta, "application/octet-stream")
+        .await
+        .expect("put");
+    assert!(client.object_exists(org, &key).await.expect("exists"));
+    assert_eq!(client.get_object(org, &key).await.expect("get"), body);
+
+    client.delete_object(org, &key).await.expect("delete");
+    assert!(!client
+        .object_exists(org, &key)
+        .await
+        .expect("exists after delete"));
+    assert!(matches!(
+        client.get_object(org, &key).await,
+        Err(StorageError::NotFound)
+    ));
+
+    let trusted = trusted_key(org, version, Uuid::new_v4(), Some("/abs/evil.pdf")).unwrap();
+    client
+        .put_object(
+            org,
+            &trusted,
+            Bytes::from_static(b"trusted"),
+            &meta,
+            "text/markdown",
+        )
+        .await
+        .expect("put trusted");
+    client
+        .delete_object(org, &trusted)
+        .await
+        .expect("delete trusted");
+}
+
+#[tokio::test]
+async fn cross_org_object_key_operation_rejected() {
+    let Some(env) = test_minio_env() else {
+        return;
+    };
+    std::env::set_var("RUST_S3_SKIP_LOCATION_CONSTRAINT", "true");
+
+    let config = MinioConfig::new(
+        env.endpoint,
+        SecretString::new(env.access_key),
+        SecretString::new(env.secret_key),
+        format!("markhand-xorg-{}", Uuid::new_v4().simple()),
+        env.region,
+        true,
+    )
+    .expect("minio config");
+    let client = MinioClient::from_config(&config).expect("client");
+    client.ensure_bucket().await.expect("bucket");
+
+    let org_a = Uuid::new_v4();
+    let org_b = Uuid::new_v4();
+    let key_a = quarantine_key(org_a, Uuid::new_v4(), None).unwrap();
+    let meta_a = ObjectIdentityMeta {
+        org_id: org_a,
+        collection_id: None,
+        document_id: None,
+        version_id: None,
+        original_filename: None,
+    };
+    client
+        .put_object(
+            org_a,
+            &key_a,
+            Bytes::from_static(b"secret-a"),
+            &meta_a,
+            "application/octet-stream",
+        )
+        .await
+        .expect("put A");
+
+    assert!(matches!(
+        parse_key_for_org(&key_a.as_str(), org_b),
+        Err(StorageError::KeyOrgMismatch)
+    ));
+    assert!(matches!(
+        client.get_object(org_b, &key_a).await,
+        Err(StorageError::KeyOrgMismatch)
+    ));
+    assert!(matches!(
+        client.delete_object(org_b, &key_a).await,
+        Err(StorageError::KeyOrgMismatch)
+    ));
+    assert!(matches!(
+        client.object_exists(org_b, &key_a).await,
+        Err(StorageError::KeyOrgMismatch)
+    ));
+    let forged_meta = ObjectIdentityMeta {
+        org_id: org_b,
+        collection_id: None,
+        document_id: None,
+        version_id: None,
+        original_filename: None,
+    };
+    assert!(matches!(
+        client
+            .put_object(
+                org_b,
+                &key_a,
+                Bytes::from_static(b"evil"),
+                &forged_meta,
+                "application/octet-stream",
+            )
+            .await,
+        Err(StorageError::KeyOrgMismatch)
+    ));
+
+    assert_eq!(
+        client
+            .get_object(org_a, &key_a)
+            .await
+            .expect("get A")
+            .as_ref(),
+        b"secret-a"
+    );
+    client.delete_object(org_a, &key_a).await.expect("cleanup");
+}
+
+#[test]
+fn object_keys_reject_traversal_and_omit_filenames() {
+    let org = Uuid::new_v4();
+    let version = Uuid::new_v4();
+    let object = Uuid::new_v4();
+    for name in [
+        "../../etc/passwd",
+        "/absolute/path",
+        "C:\\Windows\\system32",
+        "file\nname.txt",
+        "unicode-файл.docx",
+    ] {
+        let q = quarantine_key(org, object, Some(name)).unwrap();
+        let t = trusted_key(org, version, object, Some(name)).unwrap();
+        assert!(!q.as_str().contains(name));
+        parse_key_for_org(&q.as_str(), org).unwrap();
+        parse_key_for_org(&t.as_str(), org).unwrap();
+    }
+    assert!(parse_key_for_org("quarantine/../aa/bb", org).is_err());
+}
+
+#[test]
+fn collection_name_rejects_path_injection() {
+    assert!(parse_collection_name("markhand_chunks_../passwd").is_err());
+    assert!(parse_collection_name(&format!("markhand_chunks_{}?x=1", "a".repeat(64))).is_err());
+    assert!(parse_collection_name(&format!("markhand_chunks_{}#x", "a".repeat(64))).is_err());
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-F06 — Fail-closed storage adapters

Closes P1B-F06 (#83). Stacked on F05 (→F04→F03).

### What
Storage adapters that fail closed by construction: opaque object-key builder, index-signature-driven Qdrant collections with mandatory tenant filters, deterministic points, typed errors, least privilege.

### Highlights
- **Object keys** (`storage/keys.rs`): `quarantine/` + `trusted/` namespaces; segments are SHA-256-derived opaque hex; filenames live only in object metadata, never in the path; parse/authorize is bound to an authorized org and traversal-safe (rejects `..`, absolute, control chars, non-hex, wrong arity).
- **Qdrant** (`storage/qdrant.rs`): shared collection per **index generation** (ADR 0009) with a **mandatory `org_id` + authorized-collection filter on every scroll/search/upsert/delete** — empty scope returns `MissingScope` before any network call. Point ids are tenant+collection-bound and derived from the canonical chunk identity (ADR 0006), so cross-org/cross-collection overwrite is impossible by construction. `CollectionName` newtype validates `markhand_chunks_<64hex>`; collection-drop/scan is behind an operator-credential admin client unreachable from tenant paths.
- **MinIO** (`storage/minio.rs`): `rust-s3` (path-style, rustls); every op is org-bound and verifies object metadata org; typed not-found via status; credentials are `SecretString`, redacted in `Debug`.
- **Index signature** (`services/index_signature.rs`): full-digest generation naming + dimension/distance verification of existing collections (reject mismatches).
- **Config**: typed `StorageConfig`/`MinioConfig` + optional Qdrant api-key (`SecretString`); fail-closed in production; rejects credential-bearing service URLs (userinfo/query/fragment); redacted `Debug` on all endpoint/secret-bearing structs.
- **Errors**: typed `StorageError` with static, secret-free messages.

### Tests (real Qdrant + MinIO, env-gated; skip cleanly when unset)
`crates/server/tests/storage.rs` (9) + unit tests:
- traversal/fuzz keys omit filenames and can't escape the namespace
- MinIO put→exists→get→delete round-trip; not-found after delete
- missing-scope proven with an **unreachable endpoint** (asserts `MissingScope`, not transport → no network)
- Qdrant tenant isolation (org A search never sees org B; scoped delete), deterministic idempotent points
- cross-org point overwrite rejected; same-org different-collection can't overwrite; existing-collection dimension/distance mismatch rejected; credential-bearing URLs rejected; Debug redaction

### Review
Passed strict security review after 2 rounds of blocking fixes (unfiltered read/global delete, cross-tenant point overwrite, forgeable keys, digest-collision + unverified collections, credential-in-Debug/URL, weak missing-scope test → all resolved) plus canonical-digest/checked-conversion hardening.

### Gates (local, mirror CI)
`cargo fmt --check`, `clippy --all-targets -D warnings`, architecture-boundaries, rust-lint-baseline (+self-test), dependency-policy — all pass. Full `cargo test -p fileconv-server` green against live Postgres + Qdrant + MinIO.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

