### PR TITLE
feat(server): P1B-I01 streaming quarantine upload validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -2117,6 +2118,8 @@ dependencies = [
  "deadpool-postgres",
  "fileconv-core",
  "fileconv-knowledge",
+ "futures",
+ "futures-util",
  "hex",
  "http-body-util",
  "jsonwebtoken",
@@ -2129,12 +2132,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
+ "tokio-util",
  "tower",
  "uuid",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -2257,9 +2263,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2272,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2282,15 +2288,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2299,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -2318,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2329,21 +2335,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3873,6 +3879,23 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,14 +2115,16 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc32fast",
  "deadpool-postgres",
  "fileconv-core",
  "fileconv-knowledge",
  "futures",
- "futures-util",
  "hex",
  "http-body-util",
+ "image",
  "jsonwebtoken",
+ "quick-xml 0.41.0",
  "rand 0.10.2",
  "reqwest 0.13.4",
  "rust-s3",
@@ -2132,12 +2134,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "symphonia",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
- "tokio-util",
  "tower",
  "uuid",
  "zip 2.4.2",
@@ -4980,6 +4982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
  "memchr",
 ]
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -20,13 +20,14 @@ path = "src/bin/worker.rs"
 
 [dependencies]
 argon2 = "0.5.3"
-axum = { version = "0.8.9", features = ["json"] }
+axum = { version = "0.8.9", features = ["json", "multipart"] }
 base64 = "0.22.1"
 bytes = "1.12.1"
 chrono = { version = "0.4.45", features = ["serde", "clock"] }
 deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
 fileconv-core = { path = "../core" }
 fileconv-knowledge = { path = "../knowledge" }
+futures = "0.3.33"
 hex = "0.4.3"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 rand = "0.10.2"
@@ -38,12 +39,16 @@ rustls-native-certs = "0.8.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11.0"
+tempfile = "3.27.0"
 thiserror.workspace = true
 tokio = { version = "1.53.0", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-postgres = { version = "0.7.18", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-postgres-rustls = "0.14.0"
+tokio-util = { version = "0.7.18", features = ["io"] }
 uuid = { version = "1.24.0", features = ["serde", "v4", "v8"] }
+zip = "2.2"
 
 [dev-dependencies]
+futures-util = "0.3.33"
 http-body-util = "0.1.4"
 tower = { version = "0.5.3", features = ["util"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -24,14 +24,17 @@ axum = { version = "0.8.9", features = ["json", "multipart"] }
 base64 = "0.22.1"
 bytes = "1.12.1"
 chrono = { version = "0.4.45", features = ["serde", "clock"] }
+crc32fast = "1.5.0"
 deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
 fileconv-core = { path = "../core" }
 fileconv-knowledge = { path = "../knowledge" }
 futures = "0.3.33"
 hex = "0.4.3"
+image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "bmp", "webp", "tiff"] }
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+quick-xml = "0.41.0"
 rand = "0.10.2"
-reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
 rust-s3 = { version = "0.37.2", default-features = false, features = ["tokio-rustls-tls"] }
 rust_decimal = { version = "1.42.1", features = ["serde", "db-tokio-postgres"] }
 rustls = "0.23.42"
@@ -39,16 +42,15 @@ rustls-native-certs = "0.8.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11.0"
+symphonia = { version = "0.5", features = ["mp3", "aac", "isomp4", "flac", "wav", "pcm", "ogg", "vorbis", "alac"] }
 tempfile = "3.27.0"
 thiserror.workspace = true
 tokio = { version = "1.53.0", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-postgres = { version = "0.7.18", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-postgres-rustls = "0.14.0"
-tokio-util = { version = "0.7.18", features = ["io"] }
 uuid = { version = "1.24.0", features = ["serde", "v4", "v8"] }
 zip = "2.2"
 
 [dev-dependencies]
-futures-util = "0.3.33"
 http-body-util = "0.1.4"
 tower = { version = "0.5.3", features = ["util"] }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -11,6 +11,8 @@ use crate::services::upload::{LimitsConfig, UploadConfig};
 
 const DEFAULT_MAX_UPLOAD_BYTES: u64 = 200 * 1024 * 1024;
 const DEFAULT_JOB_LEASE_SECONDS: u64 = 60;
+const DEFAULT_MINIO_OPERATION_TIMEOUT_SECS: u64 = 30;
+const MAX_MINIO_OPERATION_TIMEOUT_SECS: u64 = 300;
 const DEFAULT_ACCESS_TOKEN_TTL_SECS: u64 = 900;
 const DEFAULT_REFRESH_TOKEN_TTL_SECS: u64 = 60 * 60 * 24 * 7;
 const DEFAULT_ARGON2_MEMORY_KIB: u32 = 19_456;
@@ -80,6 +82,7 @@ pub struct ServerConfig {
     minio_bucket: Option<String>,
     minio_region: Option<String>,
     minio_path_style: bool,
+    minio_operation_timeout_secs: u64,
     auth: AuthConfig,
     limits: RuntimeLimits,
     upload: UploadConfig,
@@ -120,6 +123,10 @@ impl fmt::Debug for ServerConfig {
             .field("minio_bucket", &self.minio_bucket)
             .field("minio_region", &self.minio_region)
             .field("minio_path_style", &self.minio_path_style)
+            .field(
+                "minio_operation_timeout_secs",
+                &self.minio_operation_timeout_secs,
+            )
             .field("auth", &self.auth)
             .field("limits", &self.limits)
             .field("upload", &self.upload)
@@ -137,6 +144,7 @@ pub struct MinioConfig {
     bucket: String,
     region: String,
     path_style: bool,
+    operation_timeout_secs: u64,
 }
 
 impl fmt::Debug for MinioConfig {
@@ -149,6 +157,7 @@ impl fmt::Debug for MinioConfig {
             .field("bucket", &self.bucket)
             .field("region", &self.region)
             .field("path_style", &self.path_style)
+            .field("operation_timeout_secs", &self.operation_timeout_secs)
             .finish()
     }
 }
@@ -161,6 +170,26 @@ impl MinioConfig {
         bucket: impl Into<String>,
         region: impl Into<String>,
         path_style: bool,
+    ) -> Result<Self, String> {
+        Self::new_with_timeout(
+            endpoint,
+            access_key,
+            secret_key,
+            bucket,
+            region,
+            path_style,
+            DEFAULT_MINIO_OPERATION_TIMEOUT_SECS,
+        )
+    }
+
+    pub fn new_with_timeout(
+        endpoint: impl Into<String>,
+        access_key: SecretString,
+        secret_key: SecretString,
+        bucket: impl Into<String>,
+        region: impl Into<String>,
+        path_style: bool,
+        operation_timeout_secs: u64,
     ) -> Result<Self, String> {
         let endpoint_raw = endpoint.into();
         let endpoint = required_url(Some(endpoint_raw.as_str()), "MARKHAND_MINIO_URL")?;
@@ -177,6 +206,12 @@ impl MinioConfig {
         if region.trim().is_empty() {
             return Err("MARKHAND_MINIO_REGION must not be empty".into());
         }
+        if operation_timeout_secs == 0 || operation_timeout_secs > MAX_MINIO_OPERATION_TIMEOUT_SECS
+        {
+            return Err(format!(
+                "MARKHAND_MINIO_OPERATION_TIMEOUT_SECS must be between 1 and {MAX_MINIO_OPERATION_TIMEOUT_SECS}"
+            ));
+        }
         Ok(Self {
             endpoint,
             access_key,
@@ -184,6 +219,7 @@ impl MinioConfig {
             bucket,
             region,
             path_style,
+            operation_timeout_secs,
         })
     }
 
@@ -209,6 +245,10 @@ impl MinioConfig {
 
     pub const fn path_style(&self) -> bool {
         self.path_style
+    }
+
+    pub const fn operation_timeout_secs(&self) -> u64 {
+        self.operation_timeout_secs
     }
 }
 
@@ -319,6 +359,7 @@ struct ConfigFile {
     minio_bucket: Option<String>,
     minio_region: Option<String>,
     minio_path_style: Option<bool>,
+    minio_operation_timeout_secs: Option<u64>,
     auth_issuer: Option<String>,
     auth_audience: Option<String>,
     auth_signing_key: Option<String>,
@@ -434,6 +475,13 @@ impl ServerConfig {
             "MARKHAND_MINIO_PATH_STYLE",
             |value| value.minio_path_style,
             true,
+        )?;
+        let minio_operation_timeout_secs = numeric_value(
+            file,
+            env,
+            "MARKHAND_MINIO_OPERATION_TIMEOUT_SECS",
+            |value| value.minio_operation_timeout_secs,
+            DEFAULT_MINIO_OPERATION_TIMEOUT_SECS,
         )?;
         let auth = match role {
             RuntimeRole::Api => {
@@ -619,6 +667,7 @@ impl ServerConfig {
             minio_bucket,
             minio_region,
             minio_path_style,
+            minio_operation_timeout_secs,
             auth,
             limits,
             upload,
@@ -679,6 +728,7 @@ impl ServerConfig {
             minio_bucket: None,
             minio_region: None,
             minio_path_style: true,
+            minio_operation_timeout_secs: DEFAULT_MINIO_OPERATION_TIMEOUT_SECS,
             auth: AuthConfig {
                 issuer: None,
                 audience: None,
@@ -729,13 +779,14 @@ impl ServerConfig {
             .minio_region
             .clone()
             .unwrap_or_else(|| "us-east-1".to_string());
-        let minio = MinioConfig::new(
+        let minio = MinioConfig::new_with_timeout(
             endpoints.minio_url,
             access_key,
             secret_key,
             bucket,
             region,
             self.minio_path_style,
+            self.minio_operation_timeout_secs,
         )?;
         Ok(StorageConfig {
             qdrant_url: endpoints.qdrant_url,
@@ -852,6 +903,13 @@ impl ServerConfig {
         }
         if self.limits.job_lease_seconds == 0 || self.limits.job_lease_seconds > 3600 {
             return Err("MARKHAND_JOB_LEASE_SECONDS must be between 1 and 3600".into());
+        }
+        if self.minio_operation_timeout_secs == 0
+            || self.minio_operation_timeout_secs > MAX_MINIO_OPERATION_TIMEOUT_SECS
+        {
+            return Err(format!(
+                "MARKHAND_MINIO_OPERATION_TIMEOUT_SECS must be between 1 and {MAX_MINIO_OPERATION_TIMEOUT_SECS}"
+            ));
         }
         Ok(())
     }
@@ -1096,6 +1154,7 @@ mod tests {
             minio_bucket: None,
             minio_region: None,
             minio_path_style: None,
+            minio_operation_timeout_secs: None,
             auth_issuer: None,
             auth_audience: None,
             auth_signing_key: None,

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -337,6 +337,10 @@ struct ConfigFile {
     max_pdf_pages: Option<u64>,
     max_image_pixels: Option<u64>,
     max_audio_duration_secs: Option<u64>,
+    max_multipart_parts: Option<u64>,
+    max_part_header_bytes: Option<u64>,
+    upload_timeout_secs: Option<u64>,
+    upload_idle_timeout_secs: Option<u64>,
     index_signature: Option<String>,
 }
 
@@ -565,6 +569,34 @@ impl ServerConfig {
                 "MARKHAND_MAX_AUDIO_DURATION_SECS",
                 |value| value.max_audio_duration_secs,
                 LimitsConfig::policy_defaults().max_audio_duration_secs,
+            )?,
+            max_multipart_parts: u32_value(
+                file,
+                env,
+                "MARKHAND_MAX_MULTIPART_PARTS",
+                |value| value.max_multipart_parts,
+                LimitsConfig::policy_defaults().max_multipart_parts,
+            )?,
+            max_part_header_bytes: usize_value(
+                file,
+                env,
+                "MARKHAND_MAX_PART_HEADER_BYTES",
+                |value| value.max_part_header_bytes,
+                LimitsConfig::policy_defaults().max_part_header_bytes,
+            )?,
+            upload_timeout_secs: numeric_value(
+                file,
+                env,
+                "MARKHAND_UPLOAD_TIMEOUT_SECS",
+                |value| value.upload_timeout_secs,
+                LimitsConfig::policy_defaults().upload_timeout_secs,
+            )?,
+            upload_idle_timeout_secs: numeric_value(
+                file,
+                env,
+                "MARKHAND_UPLOAD_IDLE_TIMEOUT_SECS",
+                |value| value.upload_idle_timeout_secs,
+                LimitsConfig::policy_defaults().upload_idle_timeout_secs,
             )?,
         };
         let upload = UploadConfig {
@@ -905,6 +937,17 @@ fn u32_value(
     u32::try_from(value).map_err(|_| format!("{env_name} is out of range for u32"))
 }
 
+fn usize_value(
+    file: Option<&ConfigFile>,
+    env: &BTreeMap<String, String>,
+    env_name: &str,
+    from_file: impl FnOnce(&ConfigFile) -> Option<u64>,
+    default: usize,
+) -> Result<usize, String> {
+    let value = numeric_value(file, env, env_name, from_file, default as u64)?;
+    usize::try_from(value).map_err(|_| format!("{env_name} is out of range for usize"))
+}
+
 fn bool_value(
     file: Option<&ConfigFile>,
     env: &BTreeMap<String, String>,
@@ -1071,6 +1114,10 @@ mod tests {
             max_pdf_pages: None,
             max_image_pixels: None,
             max_audio_duration_secs: None,
+            max_multipart_parts: None,
+            max_part_header_bytes: None,
+            upload_timeout_secs: None,
+            upload_idle_timeout_secs: None,
             index_signature: None,
         };
         let env = BTreeMap::from([

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -7,6 +7,8 @@ use std::path::Path;
 
 use serde::Deserialize;
 
+use crate::services::upload::{LimitsConfig, UploadConfig};
+
 const DEFAULT_MAX_UPLOAD_BYTES: u64 = 200 * 1024 * 1024;
 const DEFAULT_JOB_LEASE_SECONDS: u64 = 60;
 const DEFAULT_ACCESS_TOKEN_TTL_SECS: u64 = 900;
@@ -80,6 +82,7 @@ pub struct ServerConfig {
     minio_path_style: bool,
     auth: AuthConfig,
     limits: RuntimeLimits,
+    upload: UploadConfig,
     index_signature: Option<String>,
 }
 
@@ -119,6 +122,7 @@ impl fmt::Debug for ServerConfig {
             .field("minio_path_style", &self.minio_path_style)
             .field("auth", &self.auth)
             .field("limits", &self.limits)
+            .field("upload", &self.upload)
             .field("index_signature", &self.index_signature)
             .finish()
     }
@@ -327,6 +331,12 @@ struct ConfigFile {
     auth_argon2_parallelism: Option<u64>,
     max_upload_bytes: Option<u64>,
     job_lease_seconds: Option<u64>,
+    max_archive_entries: Option<u64>,
+    max_archive_uncompressed_bytes: Option<u64>,
+    max_archive_compression_ratio: Option<u64>,
+    max_pdf_pages: Option<u64>,
+    max_image_pixels: Option<u64>,
+    max_audio_duration_secs: Option<u64>,
     index_signature: Option<String>,
 }
 
@@ -512,6 +522,54 @@ impl ServerConfig {
                 DEFAULT_JOB_LEASE_SECONDS,
             )?,
         };
+        let upload_limits = LimitsConfig {
+            max_upload_bytes: limits.max_upload_bytes,
+            max_archive_entries: numeric_value(
+                file,
+                env,
+                "MARKHAND_MAX_ARCHIVE_ENTRIES",
+                |value| value.max_archive_entries,
+                LimitsConfig::policy_defaults().max_archive_entries,
+            )?,
+            max_archive_uncompressed_bytes: numeric_value(
+                file,
+                env,
+                "MARKHAND_MAX_ARCHIVE_UNCOMPRESSED_BYTES",
+                |value| value.max_archive_uncompressed_bytes,
+                LimitsConfig::policy_defaults().max_archive_uncompressed_bytes,
+            )?,
+            max_archive_compression_ratio: numeric_value(
+                file,
+                env,
+                "MARKHAND_MAX_ARCHIVE_COMPRESSION_RATIO",
+                |value| value.max_archive_compression_ratio,
+                LimitsConfig::policy_defaults().max_archive_compression_ratio,
+            )?,
+            max_pdf_pages: u32_value(
+                file,
+                env,
+                "MARKHAND_MAX_PDF_PAGES",
+                |value| value.max_pdf_pages,
+                LimitsConfig::policy_defaults().max_pdf_pages,
+            )?,
+            max_image_pixels: numeric_value(
+                file,
+                env,
+                "MARKHAND_MAX_IMAGE_PIXELS",
+                |value| value.max_image_pixels,
+                LimitsConfig::policy_defaults().max_image_pixels,
+            )?,
+            max_audio_duration_secs: numeric_value(
+                file,
+                env,
+                "MARKHAND_MAX_AUDIO_DURATION_SECS",
+                |value| value.max_audio_duration_secs,
+                LimitsConfig::policy_defaults().max_audio_duration_secs,
+            )?,
+        };
+        let upload = UploadConfig {
+            limits: upload_limits,
+        };
         let index_signature = optional_value(file, env, "MARKHAND_INDEX_SIGNATURE", |value| {
             value.index_signature.as_ref()
         });
@@ -531,6 +589,7 @@ impl ServerConfig {
             minio_path_style,
             auth,
             limits,
+            upload,
             index_signature,
         };
         config.validate()?;
@@ -548,6 +607,16 @@ impl ServerConfig {
     /// Authentication configuration (API role). Worker configs leave credentials unset.
     pub const fn auth(&self) -> &AuthConfig {
         &self.auth
+    }
+
+    /// Upload intake limits (P0-09 policy defaults unless overridden).
+    pub const fn upload(&self) -> &UploadConfig {
+        &self.upload
+    }
+
+    /// Legacy runtime limits (max upload + job lease).
+    pub const fn limits(&self) -> RuntimeLimits {
+        self.limits
     }
 
     pub(crate) fn is_api_role(&self) -> bool {
@@ -592,6 +661,7 @@ impl ServerConfig {
                 max_upload_bytes: DEFAULT_MAX_UPLOAD_BYTES,
                 job_lease_seconds: DEFAULT_JOB_LEASE_SECONDS,
             },
+            upload: UploadConfig::policy_defaults(),
             index_signature: None,
         }
     }
@@ -644,6 +714,7 @@ impl ServerConfig {
 
     pub(crate) fn validate(&self) -> Result<(), String> {
         self.validate_limits()?;
+        self.upload.validate()?;
         self.validate_index_signature(false)?;
         if self.role == RuntimeRole::Api {
             self.validate_auth()?;
@@ -994,6 +1065,12 @@ mod tests {
             auth_argon2_parallelism: None,
             max_upload_bytes: None,
             job_lease_seconds: None,
+            max_archive_entries: None,
+            max_archive_uncompressed_bytes: None,
+            max_archive_compression_ratio: None,
+            max_pdf_pages: None,
+            max_image_pixels: None,
+            max_audio_duration_secs: None,
             index_signature: None,
         };
         let env = BTreeMap::from([

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::{DefaultBodyLimit, State};
+use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
@@ -139,8 +139,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/v1/health/live", get(liveness))
         .route("/api/v1/health/ready", get(readiness))
         .merge(routes::auth::router())
-        .merge(routes::uploads::router())
-        .layer(DefaultBodyLimit::max(max_upload_bytes))
+        .merge(routes::uploads::router(max_upload_bytes))
         .with_state(Arc::new(state))
 }
 

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -30,6 +30,8 @@ pub struct AppState {
     readiness: tokio::sync::Mutex<Option<CachedReadiness>>,
     pool: Pool,
     auth_provider: Option<PasswordAuthProvider>,
+    /// Object store adapter (optional when credentials are absent in tests).
+    object_store: Option<crate::storage::MinioClient>,
 }
 
 struct CachedReadiness {
@@ -57,12 +59,20 @@ impl AppState {
             Err(crate::auth::jwt::JwtError::NotConfigured) => None,
             Err(error) => return Err(format!("cannot configure authentication: {error}")),
         };
+        let object_store = match runtime.config().storage_config() {
+            Ok(storage) => Some(
+                crate::storage::MinioClient::from_config(storage.minio())
+                    .map_err(|error| format!("cannot configure object store: {error}"))?,
+            ),
+            Err(_) => None,
+        };
         Ok(Self {
             runtime,
             http_client,
             readiness: tokio::sync::Mutex::new(None),
             pool,
             auth_provider,
+            object_store,
         })
     }
 
@@ -71,6 +81,16 @@ impl AppState {
         runtime: RuntimeState,
         pool: Pool,
         auth_provider: Option<PasswordAuthProvider>,
+    ) -> Result<Self, String> {
+        Self::from_parts_with_store(runtime, pool, auth_provider, None)
+    }
+
+    /// Builds state for tests that exercise object-store-backed routes.
+    pub fn from_parts_with_store(
+        runtime: RuntimeState,
+        pool: Pool,
+        auth_provider: Option<PasswordAuthProvider>,
+        object_store: Option<crate::storage::MinioClient>,
     ) -> Result<Self, String> {
         if !runtime.is_api_role() {
             return Err("HTTP application requires API runtime configuration".into());
@@ -85,6 +105,7 @@ impl AppState {
             readiness: tokio::sync::Mutex::new(None),
             pool,
             auth_provider,
+            object_store,
         })
     }
 
@@ -98,6 +119,10 @@ impl AppState {
 
     pub fn runtime(&self) -> &RuntimeState {
         &self.runtime
+    }
+
+    pub fn object_store(&self) -> Option<&crate::storage::MinioClient> {
+        self.object_store.as_ref()
     }
 }
 
@@ -113,6 +138,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/v1/health/live", get(liveness))
         .route("/api/v1/health/ready", get(readiness))
         .merge(routes::auth::router())
+        .merge(routes::uploads::router())
         .with_state(Arc::new(state))
 }
 

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::State;
+use axum::extract::{DefaultBodyLimit, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
@@ -134,11 +134,13 @@ struct Health {
 }
 
 pub fn router(state: AppState) -> Router {
+    let max_upload_bytes = state.runtime.config().upload().limits.max_upload_bytes as usize;
     Router::new()
         .route("/api/v1/health/live", get(liveness))
         .route("/api/v1/health/ready", get(readiness))
         .merge(routes::auth::router())
         .merge(routes::uploads::router())
+        .layer(DefaultBodyLimit::max(max_upload_bytes))
         .with_state(Arc::new(state))
 }
 

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,3 +1,4 @@
 //! HTTP route modules.
 
 pub mod auth;
+pub mod uploads;

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -150,6 +150,9 @@ struct PendingUpload {
 }
 
 fn enforce_part_header_limit(field: &Field<'_>, limits: &LimitsConfig) -> Result<(), UploadError> {
+    // Secondary per-part metadata bound: the route-level `DefaultBodyLimit`
+    // remains the primary whole-request cap, and this check runs before any
+    // field body is buffered to disk.
     let header_bytes = field.name().map_or(0, str::len)
         + field.file_name().map_or(0, str::len)
         + field.content_type().map_or(0, str::len);

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -4,7 +4,9 @@
 //! `services::upload` (no direct object-store client types here).
 
 use std::sync::Arc;
+use std::time::Duration;
 
+use axum::extract::multipart::Field;
 use axum::extract::{Multipart, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -16,8 +18,8 @@ use crate::auth::middleware::AuthenticatedOrg;
 use crate::auth::permissions::require_permission;
 use crate::http::AppState;
 use crate::services::upload::{
-    stream_to_tempfile, validate_and_quarantine, Disposition, ReasonCode, ThreatClass, UploadError,
-    UploadOutcome,
+    stream_to_tempfile_with_idle_timeout, validate_and_quarantine, Disposition, LimitsConfig,
+    ReasonCode, StreamedUpload, ThreatClass, UploadError, UploadOutcome,
 };
 
 pub fn router() -> Router<Arc<AppState>> {
@@ -45,72 +47,150 @@ struct UploadResponse {
 async fn create_upload(
     State(state): State<Arc<AppState>>,
     auth: AuthenticatedOrg,
-    mut multipart: Multipart,
+    multipart: Multipart,
 ) -> Result<Response, UploadRouteError> {
     let request_id = auth.request_id.clone();
     require_permission(&auth.context, "doc.upload")
         .map_err(|_| UploadRouteError(UploadError::PermissionDenied, request_id.clone()))?;
 
-    let Some(storage) = state.object_store() else {
+    if state.object_store().is_none() {
         return Err(UploadRouteError(
             UploadError::StorageUnavailable,
             request_id.clone(),
         ));
     };
     let limits = state.runtime().config().upload().limits;
+    let upload_timeout = Duration::from_secs(limits.upload_timeout_secs);
 
-    let mut saw_file = false;
-    let mut outcome: Option<UploadOutcome> = None;
-
-    while let Some(field) = multipart.next_field().await.map_err(|_| {
+    tokio::time::timeout(upload_timeout, async {
+        create_upload_inner(state, auth, multipart, limits).await
+    })
+    .await
+    .map_err(|_| {
         UploadRouteError(
             UploadError::MultipartInvalid {
-                reason: ReasonCode::MultipartMissingFile,
+                reason: ReasonCode::MultipartTimeout,
             },
             request_id.clone(),
         )
-    })? {
+    })?
+    .map_err(|error| UploadRouteError(error, request_id.clone()))
+    .map(|outcome| success_response(outcome, &request_id))
+}
+
+async fn create_upload_inner(
+    state: Arc<AppState>,
+    auth: AuthenticatedOrg,
+    mut multipart: Multipart,
+    limits: LimitsConfig,
+) -> Result<UploadOutcome, UploadError> {
+    let storage = state
+        .object_store()
+        .ok_or(UploadError::StorageUnavailable)?;
+    let mut saw_file = false;
+    let mut pending: Option<PendingUpload> = None;
+    let mut parts_seen = 0_u32;
+    let idle_timeout = Duration::from_secs(limits.upload_idle_timeout_secs);
+
+    while let Some(field) =
+        multipart
+            .next_field()
+            .await
+            .map_err(|_| UploadError::MultipartInvalid {
+                reason: ReasonCode::MultipartMissingFile,
+            })?
+    {
+        parts_seen = parts_seen.saturating_add(1);
+        if parts_seen > limits.max_multipart_parts {
+            return Err(UploadError::MultipartInvalid {
+                reason: ReasonCode::MultipartTooManyParts,
+            });
+        }
+        enforce_part_header_limit(&field, &limits)?;
         let is_file = field.file_name().is_some()
             || field
                 .name()
                 .is_some_and(|name| name == "file" || name == "upload" || name == "document");
         if !is_file {
-            let _ = field.bytes().await;
+            drain_non_file_field(field, &limits, idle_timeout).await?;
             continue;
         }
         if saw_file {
-            return Err(UploadRouteError(
-                UploadError::MultipartInvalid {
-                    reason: ReasonCode::MultipartTooManyFiles,
-                },
-                request_id.clone(),
-            ));
+            return Err(UploadError::MultipartInvalid {
+                reason: ReasonCode::MultipartTooManyFiles,
+            });
         }
         saw_file = true;
         // Filename is metadata only — never used as a key or filesystem path.
         let declared = field.file_name().map(str::to_owned);
-        let streamed = stream_to_tempfile(field, &limits)
-            .await
-            .map_err(|error| UploadRouteError(error, request_id.clone()))?;
-        let result = validate_and_quarantine(
-            &auth.context,
-            storage,
-            &limits,
+        let declared_content_type = field.content_type().map(str::to_owned);
+        let streamed = stream_to_tempfile_with_idle_timeout(field, &limits, idle_timeout).await?;
+        pending = Some(PendingUpload {
             streamed,
-            declared.as_deref(),
-        )
-        .await
-        .map_err(|error| UploadRouteError(error, request_id.clone()))?;
-        outcome = Some(result);
+            declared_filename: declared,
+            declared_content_type,
+        });
     }
 
-    let outcome = outcome.ok_or(UploadRouteError(
-        UploadError::MultipartInvalid {
-            reason: ReasonCode::MultipartMissingFile,
-        },
-        request_id.clone(),
-    ))?;
-    Ok(success_response(outcome, &request_id))
+    let pending = pending.ok_or(UploadError::MultipartInvalid {
+        reason: ReasonCode::MultipartMissingFile,
+    })?;
+    validate_and_quarantine(
+        &auth.context,
+        storage,
+        &limits,
+        pending.streamed,
+        pending.declared_filename.as_deref(),
+        pending.declared_content_type.as_deref(),
+    )
+    .await
+}
+
+struct PendingUpload {
+    streamed: StreamedUpload,
+    declared_filename: Option<String>,
+    declared_content_type: Option<String>,
+}
+
+fn enforce_part_header_limit(field: &Field<'_>, limits: &LimitsConfig) -> Result<(), UploadError> {
+    let header_bytes = field.name().map_or(0, str::len)
+        + field.file_name().map_or(0, str::len)
+        + field.content_type().map_or(0, str::len);
+    if header_bytes > limits.max_part_header_bytes {
+        return Err(UploadError::MultipartInvalid {
+            reason: ReasonCode::MultipartHeaderTooLarge,
+        });
+    }
+    Ok(())
+}
+
+async fn drain_non_file_field(
+    mut field: Field<'_>,
+    limits: &LimitsConfig,
+    idle_timeout: Duration,
+) -> Result<(), UploadError> {
+    let mut bytes = 0_u64;
+    loop {
+        let chunk = tokio::time::timeout(idle_timeout, field.chunk())
+            .await
+            .map_err(|_| UploadError::MultipartInvalid {
+                reason: ReasonCode::MultipartTimeout,
+            })?
+            .map_err(|_| UploadError::MultipartInvalid {
+                reason: ReasonCode::MultipartMissingFile,
+            })?;
+        let Some(chunk) = chunk else {
+            break;
+        };
+        bytes = bytes.saturating_add(chunk.len() as u64);
+        if bytes > limits.max_upload_bytes {
+            return Err(UploadError::rejected(
+                ThreatClass::Oversize,
+                ReasonCode::UploadTooLarge,
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn success_response(outcome: UploadOutcome, request_id: &str) -> Response {

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::extract::multipart::Field;
+use axum::extract::DefaultBodyLimit;
 use axum::extract::{Multipart, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -22,8 +23,11 @@ use crate::services::upload::{
     ReasonCode, StreamedUpload, ThreatClass, UploadError, UploadOutcome,
 };
 
-pub fn router() -> Router<Arc<AppState>> {
-    Router::new().route("/api/v1/uploads", post(create_upload))
+pub fn router(max_upload_bytes: usize) -> Router<Arc<AppState>> {
+    Router::new().route(
+        "/api/v1/uploads",
+        post(create_upload).layer(DefaultBodyLimit::max(max_upload_bytes)),
+    )
 }
 
 #[derive(Debug, Serialize)]
@@ -53,52 +57,54 @@ async fn create_upload(
     require_permission(&auth.context, "doc.upload")
         .map_err(|_| UploadRouteError(UploadError::PermissionDenied, request_id.clone()))?;
 
-    if state.object_store().is_none() {
-        return Err(UploadRouteError(
-            UploadError::StorageUnavailable,
-            request_id.clone(),
-        ));
-    };
     let limits = state.runtime().config().upload().limits;
     let upload_timeout = Duration::from_secs(limits.upload_timeout_secs);
 
-    tokio::time::timeout(upload_timeout, async {
-        create_upload_inner(state, auth, multipart, limits).await
-    })
+    let pending = tokio::time::timeout(upload_timeout, read_multipart(multipart, limits))
+        .await
+        .map_err(|_| {
+            UploadRouteError(
+                UploadError::MultipartInvalid {
+                    reason: ReasonCode::MultipartTimeout,
+                },
+                request_id.clone(),
+            )
+        })?
+        .map_err(|error| UploadRouteError(error, request_id.clone()))?;
+
+    let storage = state
+        .object_store()
+        .ok_or_else(|| UploadRouteError(UploadError::StorageUnavailable, request_id.clone()))?;
+    validate_and_quarantine(
+        &auth.context,
+        storage,
+        &limits,
+        pending.streamed,
+        pending.declared_filename.as_deref(),
+        pending.declared_content_type.as_deref(),
+    )
     .await
-    .map_err(|_| {
-        UploadRouteError(
-            UploadError::MultipartInvalid {
-                reason: ReasonCode::MultipartTimeout,
-            },
-            request_id.clone(),
-        )
-    })?
     .map_err(|error| UploadRouteError(error, request_id.clone()))
     .map(|outcome| success_response(outcome, &request_id))
 }
 
-async fn create_upload_inner(
-    state: Arc<AppState>,
-    auth: AuthenticatedOrg,
+async fn read_multipart(
     mut multipart: Multipart,
     limits: LimitsConfig,
-) -> Result<UploadOutcome, UploadError> {
-    let storage = state
-        .object_store()
-        .ok_or(UploadError::StorageUnavailable)?;
+) -> Result<PendingUpload, UploadError> {
     let mut saw_file = false;
     let mut pending: Option<PendingUpload> = None;
     let mut parts_seen = 0_u32;
     let idle_timeout = Duration::from_secs(limits.upload_idle_timeout_secs);
 
-    while let Some(field) =
-        multipart
-            .next_field()
-            .await
-            .map_err(|_| UploadError::MultipartInvalid {
-                reason: ReasonCode::MultipartMissingFile,
-            })?
+    while let Some(field) = tokio::time::timeout(idle_timeout, multipart.next_field())
+        .await
+        .map_err(|_| UploadError::MultipartInvalid {
+            reason: ReasonCode::MultipartTimeout,
+        })?
+        .map_err(|_| UploadError::MultipartInvalid {
+            reason: ReasonCode::MultipartMissingFile,
+        })?
     {
         parts_seen = parts_seen.saturating_add(1);
         if parts_seen > limits.max_multipart_parts {
@@ -132,18 +138,9 @@ async fn create_upload_inner(
         });
     }
 
-    let pending = pending.ok_or(UploadError::MultipartInvalid {
+    pending.ok_or(UploadError::MultipartInvalid {
         reason: ReasonCode::MultipartMissingFile,
-    })?;
-    validate_and_quarantine(
-        &auth.context,
-        storage,
-        &limits,
-        pending.streamed,
-        pending.declared_filename.as_deref(),
-        pending.declared_content_type.as_deref(),
-    )
-    .await
+    })
 }
 
 struct PendingUpload {

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -1,0 +1,146 @@
+//! `POST /api/v1/uploads` — streaming quarantine upload intake.
+//!
+//! Route layer: auth + multipart parse only. Persistence goes through
+//! `services::upload` (no direct object-store client types here).
+
+use std::sync::Arc;
+
+use axum::extract::{Multipart, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::Serialize;
+
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::auth::permissions::require_permission;
+use crate::http::AppState;
+use crate::services::upload::{
+    stream_to_tempfile, validate_and_quarantine, Disposition, ReasonCode, ThreatClass, UploadError,
+    UploadOutcome,
+};
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().route("/api/v1/uploads", post(create_upload))
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UploadResponse {
+    disposition: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    threat_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason_code: Option<String>,
+    object_key: String,
+    object_id: String,
+    sha256: String,
+    size_bytes: u64,
+    canonical_format: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    original_filename: Option<String>,
+    request_id: String,
+}
+
+async fn create_upload(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    mut multipart: Multipart,
+) -> Result<Response, UploadRouteError> {
+    let request_id = auth.request_id.clone();
+    require_permission(&auth.context, "doc.upload")
+        .map_err(|_| UploadRouteError(UploadError::PermissionDenied, request_id.clone()))?;
+
+    let Some(storage) = state.object_store() else {
+        return Err(UploadRouteError(
+            UploadError::StorageUnavailable,
+            request_id.clone(),
+        ));
+    };
+    let limits = state.runtime().config().upload().limits;
+
+    let mut saw_file = false;
+    let mut outcome: Option<UploadOutcome> = None;
+
+    while let Some(field) = multipart.next_field().await.map_err(|_| {
+        UploadRouteError(
+            UploadError::MultipartInvalid {
+                reason: ReasonCode::MultipartMissingFile,
+            },
+            request_id.clone(),
+        )
+    })? {
+        let is_file = field.file_name().is_some()
+            || field
+                .name()
+                .is_some_and(|name| name == "file" || name == "upload" || name == "document");
+        if !is_file {
+            let _ = field.bytes().await;
+            continue;
+        }
+        if saw_file {
+            return Err(UploadRouteError(
+                UploadError::MultipartInvalid {
+                    reason: ReasonCode::MultipartTooManyFiles,
+                },
+                request_id.clone(),
+            ));
+        }
+        saw_file = true;
+        // Filename is metadata only — never used as a key or filesystem path.
+        let declared = field.file_name().map(str::to_owned);
+        let streamed = stream_to_tempfile(field, &limits)
+            .await
+            .map_err(|error| UploadRouteError(error, request_id.clone()))?;
+        let result = validate_and_quarantine(
+            &auth.context,
+            storage,
+            &limits,
+            streamed,
+            declared.as_deref(),
+        )
+        .await
+        .map_err(|error| UploadRouteError(error, request_id.clone()))?;
+        outcome = Some(result);
+    }
+
+    let outcome = outcome.ok_or(UploadRouteError(
+        UploadError::MultipartInvalid {
+            reason: ReasonCode::MultipartMissingFile,
+        },
+        request_id.clone(),
+    ))?;
+    Ok(success_response(outcome, &request_id))
+}
+
+fn success_response(outcome: UploadOutcome, request_id: &str) -> Response {
+    let status = match outcome.disposition {
+        Disposition::Accepted | Disposition::Quarantined => StatusCode::CREATED,
+        Disposition::Rejected => StatusCode::BAD_REQUEST,
+    };
+    let body = UploadResponse {
+        disposition: outcome.disposition.as_str().to_string(),
+        threat_class: outcome
+            .threat_class
+            .map(|threat: ThreatClass| threat.as_str().to_string()),
+        reason_code: outcome
+            .reason_code
+            .map(|reason| reason.as_str().to_string()),
+        object_key: outcome.object_key.as_str(),
+        object_id: outcome.object_id.to_string(),
+        sha256: outcome.sha256_hex,
+        size_bytes: outcome.size_bytes,
+        canonical_format: outcome.canonical_format.as_str().to_string(),
+        original_filename: outcome.original_filename,
+        request_id: request_id.to_string(),
+    };
+    (status, Json(body)).into_response()
+}
+
+struct UploadRouteError(UploadError, String);
+
+impl IntoResponse for UploadRouteError {
+    fn into_response(self) -> Response {
+        self.0.into_response_with_request_id(&self.1)
+    }
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod document_state;
 pub mod index_signature;
+pub mod upload;

--- a/crates/server/src/services/upload/archive.rs
+++ b/crates/server/src/services/upload/archive.rs
@@ -3,7 +3,7 @@
 //! Every member is inflated through a fixed-size buffer. Central-directory sizes
 //! are treated as claims to verify, not as authority for policy decisions.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
@@ -19,10 +19,12 @@ const CONTENT_TYPES: &str = "[Content_Types].xml";
 const WORD_DOCUMENT: &str = "word/document.xml";
 const PPT_PRESENTATION: &str = "ppt/presentation.xml";
 const XL_WORKBOOK: &str = "xl/workbook.xml";
+const XL_WORKBOOK_BIN: &str = "xl/workbook.bin";
 const ODS_MIMETYPE: &str = "mimetype";
 
 const ODS_SPREADSHEET_MIMETYPE: &[u8] = b"application/vnd.oasis.opendocument.spreadsheet";
 const NESTED_MAGIC_BYTES: usize = 512;
+const XML_ENTRY_PARSE_LIMIT: u64 = 256 * 1024;
 
 /// Result of archive preflight for ZIP-based formats.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,7 +52,7 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
     provisional: CanonicalFormat,
     limits: &LimitsConfig,
 ) -> Result<ArchiveCheck, UploadError> {
-    reject_duplicate_central_directory_names(&mut reader)?;
+    let compressed_spans = scan_central_directory_names_and_spans(&mut reader)?;
     reader.seek(SeekFrom::Start(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
@@ -74,7 +76,8 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
     let mut has_content_types = false;
     let mut has_word = false;
     let mut has_ppt = false;
-    let mut has_xl = false;
+    let mut has_xlsx = false;
+    let mut has_xlsb = false;
     let mut has_ods_mimetype = false;
     let mut content_types = ContentTypesSeen::default();
     let mut seen_names = HashSet::new();
@@ -99,24 +102,32 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
         if name == CONTENT_TYPES {
             has_content_types = true;
         }
-        if name == WORD_DOCUMENT || name.starts_with("word/") {
+        if name == WORD_DOCUMENT {
             has_word = true;
         }
-        if name == PPT_PRESENTATION || name.starts_with("ppt/") {
+        if name == PPT_PRESENTATION {
             has_ppt = true;
         }
-        if name == XL_WORKBOOK || name.starts_with("xl/") {
-            has_xl = true;
+        if name == XL_WORKBOOK {
+            has_xlsx = true;
+        }
+        if name == XL_WORKBOOK_BIN {
+            has_xlsb = true;
         }
         if name == ODS_MIMETYPE {
             has_ods_mimetype = true;
         }
 
+        let actual_compressed = compressed_spans
+            .get(name.trim_end_matches('/'))
+            .copied()
+            .unwrap_or_else(|| entry.compressed_size());
         let scanned = if entry.is_dir() {
             EntryScan::default()
         } else if name == CONTENT_TYPES {
             scan_content_types_xml(
                 &mut entry,
+                actual_compressed,
                 limits,
                 &mut uncompressed_bytes,
                 &mut compressed_bytes,
@@ -129,6 +140,7 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
         {
             scan_required_xml(
                 &mut entry,
+                actual_compressed,
                 limits,
                 &mut uncompressed_bytes,
                 &mut compressed_bytes,
@@ -136,6 +148,7 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
         } else if name == ODS_MIMETYPE {
             scan_ods_mimetype(
                 &mut entry,
+                actual_compressed,
                 limits,
                 &mut uncompressed_bytes,
                 &mut compressed_bytes,
@@ -143,6 +156,7 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
         } else {
             drain_checked_entry(
                 &mut entry,
+                actual_compressed,
                 limits,
                 &mut uncompressed_bytes,
                 &mut compressed_bytes,
@@ -159,7 +173,7 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
         }
     }
 
-    if [has_word, has_ppt, has_xl]
+    if [has_word, has_ppt, has_xlsx, has_xlsb, has_ods_mimetype]
         .into_iter()
         .filter(|present| *present)
         .count()
@@ -175,11 +189,13 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
         has_content_types,
         has_word,
         has_ppt,
-        has_xl,
+        has_xlsx,
+        has_xlsb,
         has_ods_mimetype,
     )?;
 
-    // Require canonical member paths for OOXML.
+    // Require canonical main members only. Full OPC relationship/namespace validation is
+    // intentionally deferred: accepted uploads still stay quarantined until conversion.
     match format {
         CanonicalFormat::Docx if !has_content_types || !has_word => {
             return Err(UploadError::rejected(
@@ -193,7 +209,13 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
                 ReasonCode::MissingFormatPaths,
             ));
         }
-        CanonicalFormat::Xlsx if !has_content_types || !has_xl => {
+        CanonicalFormat::Xlsx if !has_content_types || !has_xlsx => {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MissingFormatPaths,
+            ));
+        }
+        CanonicalFormat::Xlsb if !has_content_types || !has_xlsb => {
             return Err(UploadError::rejected(
                 ThreatClass::MalformedOoxml,
                 ReasonCode::MissingFormatPaths,
@@ -223,6 +245,7 @@ struct ContentTypesSeen {
     word_document: bool,
     ppt_presentation: bool,
     xl_workbook: bool,
+    xlsb_workbook: bool,
 }
 
 #[derive(Debug, Default)]
@@ -233,15 +256,22 @@ struct EntryScan {
 
 fn scan_content_types_xml(
     entry: &mut ZipFile<'_>,
+    actual_compressed: u64,
     limits: &LimitsConfig,
     aggregate_uncompressed: &mut u64,
     aggregate_compressed: &mut u64,
 ) -> Result<EntryScan, UploadError> {
-    let mut checked =
-        CheckedEntryReader::new(entry, limits, aggregate_uncompressed, aggregate_compressed);
-    let content_types = parse_content_types_xml(&mut checked)?;
+    let mut checked = CheckedEntryReader::new(
+        entry,
+        actual_compressed,
+        limits,
+        aggregate_uncompressed,
+        aggregate_compressed,
+    );
+    let xml = read_xml_entry_capped(&mut checked)?;
     checked.drain_to_end()?;
     checked.finish()?;
+    let content_types = parse_content_types_xml(xml.as_slice())?;
     Ok(EntryScan {
         content_types,
         ods_mimetype_ok: false,
@@ -250,26 +280,39 @@ fn scan_content_types_xml(
 
 fn scan_required_xml(
     entry: &mut ZipFile<'_>,
+    actual_compressed: u64,
     limits: &LimitsConfig,
     aggregate_uncompressed: &mut u64,
     aggregate_compressed: &mut u64,
 ) -> Result<EntryScan, UploadError> {
-    let mut checked =
-        CheckedEntryReader::new(entry, limits, aggregate_uncompressed, aggregate_compressed);
-    parse_well_formed_xml(&mut checked)?;
+    let mut checked = CheckedEntryReader::new(
+        entry,
+        actual_compressed,
+        limits,
+        aggregate_uncompressed,
+        aggregate_compressed,
+    );
+    let xml = read_xml_entry_capped(&mut checked)?;
     checked.drain_to_end()?;
     checked.finish()?;
+    parse_well_formed_xml(xml.as_slice())?;
     Ok(EntryScan::default())
 }
 
 fn scan_ods_mimetype(
     entry: &mut ZipFile<'_>,
+    actual_compressed: u64,
     limits: &LimitsConfig,
     aggregate_uncompressed: &mut u64,
     aggregate_compressed: &mut u64,
 ) -> Result<EntryScan, UploadError> {
-    let mut checked =
-        CheckedEntryReader::new(entry, limits, aggregate_uncompressed, aggregate_compressed);
+    let mut checked = CheckedEntryReader::new(
+        entry,
+        actual_compressed,
+        limits,
+        aggregate_uncompressed,
+        aggregate_compressed,
+    );
     let mut actual = Vec::with_capacity(ODS_SPREADSHEET_MIMETYPE.len());
     let mut buf = [0_u8; STREAM_CHUNK_BYTES];
     loop {
@@ -291,12 +334,18 @@ fn scan_ods_mimetype(
 
 fn drain_checked_entry(
     entry: &mut ZipFile<'_>,
+    actual_compressed: u64,
     limits: &LimitsConfig,
     aggregate_uncompressed: &mut u64,
     aggregate_compressed: &mut u64,
 ) -> Result<EntryScan, UploadError> {
-    let mut checked =
-        CheckedEntryReader::new(entry, limits, aggregate_uncompressed, aggregate_compressed);
+    let mut checked = CheckedEntryReader::new(
+        entry,
+        actual_compressed,
+        limits,
+        aggregate_uncompressed,
+        aggregate_compressed,
+    );
     checked.drain_to_end()?;
     checked.finish()?;
     Ok(EntryScan::default())
@@ -308,7 +357,7 @@ struct CheckedEntryReader<'a, 'b> {
     aggregate_uncompressed: &'a mut u64,
     aggregate_compressed: &'a mut u64,
     declared_uncompressed: u64,
-    declared_compressed: u64,
+    actual_compressed: u64,
     declared_crc32: u32,
     actual_uncompressed: u64,
     crc32: crc32fast::Hasher,
@@ -318,13 +367,14 @@ struct CheckedEntryReader<'a, 'b> {
 impl<'a, 'b> CheckedEntryReader<'a, 'b> {
     fn new(
         entry: &'a mut ZipFile<'b>,
+        actual_compressed: u64,
         limits: &'a LimitsConfig,
         aggregate_uncompressed: &'a mut u64,
         aggregate_compressed: &'a mut u64,
     ) -> Self {
         Self {
             declared_uncompressed: entry.size(),
-            declared_compressed: entry.compressed_size(),
+            actual_compressed,
             declared_crc32: entry.crc32(),
             entry,
             limits,
@@ -387,8 +437,8 @@ impl Read for CheckedEntryReader<'_, '_> {
         if self.actual_uncompressed == n as u64 {
             *self.aggregate_compressed = self
                 .aggregate_compressed
-                .saturating_add(self.declared_compressed);
-            if self.declared_compressed == 0 && self.declared_uncompressed > 0 {
+                .saturating_add(self.actual_compressed);
+            if self.actual_compressed == 0 && self.declared_uncompressed > 0 {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     "invalid compression ratio",
@@ -399,7 +449,7 @@ impl Read for CheckedEntryReader<'_, '_> {
         enforce_archive_limits(
             self.limits,
             self.actual_uncompressed,
-            self.declared_compressed,
+            self.actual_compressed,
             *self.aggregate_uncompressed,
             *self.aggregate_compressed,
         )
@@ -444,6 +494,26 @@ fn enforce_archive_limits(
     Ok(())
 }
 
+fn read_xml_entry_capped<R: Read>(reader: &mut R) -> Result<Vec<u8>, UploadError> {
+    let mut xml = Vec::new();
+    let mut buf = [0_u8; STREAM_CHUNK_BYTES];
+    while (xml.len() as u64) < XML_ENTRY_PARSE_LIMIT {
+        let remaining = (XML_ENTRY_PARSE_LIMIT as usize).saturating_sub(xml.len());
+        let take = buf.len().min(remaining);
+        let n = reader
+            .read(&mut buf[..take])
+            .map_err(map_entry_read_error)?;
+        if n == 0 {
+            return Ok(xml);
+        }
+        xml.extend_from_slice(&buf[..n]);
+    }
+    Err(UploadError::rejected(
+        ThreatClass::MalformedOoxml,
+        ReasonCode::MalformedXml,
+    ))
+}
+
 fn parse_content_types_xml<R: Read>(reader: R) -> Result<ContentTypesSeen, UploadError> {
     let mut xml =
         quick_xml::Reader::from_reader(BufReader::with_capacity(STREAM_CHUNK_BYTES, reader));
@@ -474,6 +544,9 @@ fn parse_content_types_xml<R: Read>(reader: R) -> Result<ContentTypesSeen, Uploa
                         && kind.contains("presentationml.presentation.main+xml");
                     seen.xl_workbook |=
                         part == "/xl/workbook.xml" && kind.contains("spreadsheetml.sheet.main+xml");
+                    seen.xlsb_workbook |= part == "/xl/workbook.bin"
+                        && kind.contains("sheet.binary")
+                        && kind.contains("main");
                 }
             }
             Ok(quick_xml::events::Event::Eof) => break,
@@ -535,6 +608,7 @@ fn verify_content_types(
         CanonicalFormat::Docx => content_types.word_document,
         CanonicalFormat::Pptx => content_types.ppt_presentation,
         CanonicalFormat::Xlsx => content_types.xl_workbook,
+        CanonicalFormat::Xlsb => content_types.xlsb_workbook,
         CanonicalFormat::Ods => true,
         _ => true,
     };
@@ -580,9 +654,9 @@ pub fn reject_dangerous_entry_name(name: &str) -> Result<(), UploadError> {
     Ok(())
 }
 
-fn reject_duplicate_central_directory_names<R: Read + Seek>(
+fn scan_central_directory_names_and_spans<R: Read + Seek>(
     reader: &mut R,
-) -> Result<(), UploadError> {
+) -> Result<HashMap<String, u64>, UploadError> {
     let len = reader.seek(SeekFrom::End(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
@@ -597,32 +671,34 @@ fn reject_duplicate_central_directory_names<R: Read + Seek>(
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
     let Some(eocd_pos) = tail.windows(4).rposition(|w| w == b"PK\x05\x06") else {
-        return Ok(());
+        return Ok(HashMap::new());
     };
     if eocd_pos + 22 > tail.len() {
-        return Ok(());
+        return Ok(HashMap::new());
     }
     let entries = u16::from_le_bytes(tail[eocd_pos + 10..eocd_pos + 12].try_into().unwrap());
     let central_offset =
         u32::from_le_bytes(tail[eocd_pos + 16..eocd_pos + 20].try_into().unwrap()) as u64;
     if entries == u16::MAX {
-        return Ok(());
+        return Ok(HashMap::new());
     }
     reader.seek(SeekFrom::Start(central_offset)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
     let mut seen = HashSet::new();
+    let mut central_entries = Vec::new();
     for _ in 0..entries {
         let mut header = [0_u8; 46];
         reader.read_exact(&mut header).map_err(|_| {
             UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
         })?;
         if &header[0..4] != b"PK\x01\x02" {
-            return Ok(());
+            return Ok(HashMap::new());
         }
         let name_len = u16::from_le_bytes(header[28..30].try_into().unwrap()) as usize;
         let extra_len = u16::from_le_bytes(header[30..32].try_into().unwrap()) as u64;
         let comment_len = u16::from_le_bytes(header[32..34].try_into().unwrap()) as u64;
+        let local_header_offset = u32::from_le_bytes(header[42..46].try_into().unwrap()) as u64;
         if name_len == 0 || name_len > 4096 {
             return Err(UploadError::rejected(
                 ThreatClass::MalformedOoxml,
@@ -642,13 +718,47 @@ fn reject_duplicate_central_directory_names<R: Read + Seek>(
                 ReasonCode::MalformedArchive,
             ));
         }
+        central_entries.push((name.trim_end_matches('/').to_string(), local_header_offset));
         reader
             .seek(SeekFrom::Current((extra_len + comment_len) as i64))
             .map_err(|_| {
                 UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
             })?;
     }
-    Ok(())
+    central_entries.sort_by_key(|(_, offset)| *offset);
+    let mut spans = HashMap::new();
+    for index in 0..central_entries.len() {
+        let (name, local_header_offset) = &central_entries[index];
+        let next_offset = central_entries
+            .get(index + 1)
+            .map(|(_, offset)| *offset)
+            .unwrap_or(central_offset);
+        if next_offset <= *local_header_offset {
+            continue;
+        }
+        reader
+            .seek(SeekFrom::Start(*local_header_offset))
+            .map_err(|_| {
+                UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+            })?;
+        let mut local = [0_u8; 30];
+        reader.read_exact(&mut local).map_err(|_| {
+            UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+        })?;
+        if &local[0..4] != b"PK\x03\x04" {
+            continue;
+        }
+        let local_name_len = u16::from_le_bytes(local[26..28].try_into().unwrap()) as u64;
+        let local_extra_len = u16::from_le_bytes(local[28..30].try_into().unwrap()) as u64;
+        let data_start = local_header_offset
+            .saturating_add(30)
+            .saturating_add(local_name_len)
+            .saturating_add(local_extra_len);
+        if next_offset > data_start {
+            spans.insert(name.clone(), next_offset - data_start);
+        }
+    }
+    Ok(spans)
 }
 
 fn map_zip_open_error(error: ZipError) -> UploadError {

--- a/crates/server/src/services/upload/archive.rs
+++ b/crates/server/src/services/upload/archive.rs
@@ -118,10 +118,16 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
             has_ods_mimetype = true;
         }
 
-        let actual_compressed = compressed_spans
-            .get(name.trim_end_matches('/'))
-            .copied()
-            .unwrap_or_else(|| entry.compressed_size());
+        let actual_compressed = if entry.is_dir() {
+            0
+        } else {
+            compressed_spans
+                .get(name.trim_end_matches('/'))
+                .copied()
+                .ok_or_else(|| {
+                    UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+                })?
+        };
         let scanned = if entry.is_dir() {
             EntryScan::default()
         } else if name == CONTENT_TYPES {
@@ -671,16 +677,25 @@ fn scan_central_directory_names_and_spans<R: Read + Seek>(
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
     let Some(eocd_pos) = tail.windows(4).rposition(|w| w == b"PK\x05\x06") else {
-        return Ok(HashMap::new());
+        return Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MalformedArchive,
+        ));
     };
     if eocd_pos + 22 > tail.len() {
-        return Ok(HashMap::new());
+        return Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MalformedArchive,
+        ));
     }
     let entries = u16::from_le_bytes(tail[eocd_pos + 10..eocd_pos + 12].try_into().unwrap());
     let central_offset =
         u32::from_le_bytes(tail[eocd_pos + 16..eocd_pos + 20].try_into().unwrap()) as u64;
     if entries == u16::MAX {
-        return Ok(HashMap::new());
+        return Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MalformedArchive,
+        ));
     }
     reader.seek(SeekFrom::Start(central_offset)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
@@ -693,7 +708,10 @@ fn scan_central_directory_names_and_spans<R: Read + Seek>(
             UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
         })?;
         if &header[0..4] != b"PK\x01\x02" {
-            return Ok(HashMap::new());
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
+            ));
         }
         let name_len = u16::from_le_bytes(header[28..30].try_into().unwrap()) as usize;
         let extra_len = u16::from_le_bytes(header[30..32].try_into().unwrap()) as u64;
@@ -734,7 +752,10 @@ fn scan_central_directory_names_and_spans<R: Read + Seek>(
             .map(|(_, offset)| *offset)
             .unwrap_or(central_offset);
         if next_offset <= *local_header_offset {
-            continue;
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
+            ));
         }
         reader
             .seek(SeekFrom::Start(*local_header_offset))
@@ -746,7 +767,10 @@ fn scan_central_directory_names_and_spans<R: Read + Seek>(
             UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
         })?;
         if &local[0..4] != b"PK\x03\x04" {
-            continue;
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
+            ));
         }
         let local_name_len = u16::from_le_bytes(local[26..28].try_into().unwrap()) as u64;
         let local_extra_len = u16::from_le_bytes(local[28..30].try_into().unwrap()) as u64;
@@ -754,9 +778,13 @@ fn scan_central_directory_names_and_spans<R: Read + Seek>(
             .saturating_add(30)
             .saturating_add(local_name_len)
             .saturating_add(local_extra_len);
-        if next_offset > data_start {
-            spans.insert(name.clone(), next_offset - data_start);
+        if next_offset < data_start {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
+            ));
         }
+        spans.insert(name.clone(), next_offset - data_start);
     }
     Ok(spans)
 }

--- a/crates/server/src/services/upload/archive.rs
+++ b/crates/server/src/services/upload/archive.rs
@@ -1,10 +1,10 @@
 //! ZIP/OOXML archive safety: bomb, traversal, nested, required members.
 //!
-//! Compression-ratio and uncompressed caps are enforced from the ZIP **central
-//! directory** declared sizes (no unbounded decompression). Membership checks
-//! read individual entries through a bounded decompressor.
+//! Every member is inflated through a fixed-size buffer. Central-directory sizes
+//! are treated as claims to verify, not as authority for policy decisions.
 
-use std::io::{Read, Seek};
+use std::collections::HashSet;
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use zip::read::ZipFile;
@@ -12,7 +12,7 @@ use zip::result::ZipError;
 use zip::ZipArchive;
 
 use super::error::{ReasonCode, ThreatClass, UploadError};
-use super::limits::{LimitsConfig, MAX_SINGLE_ENTRY_READ_BYTES};
+use super::limits::{LimitsConfig, MAX_SINGLE_ENTRY_READ_BYTES, STREAM_CHUNK_BYTES};
 use super::sniff::{refine_zip_format, CanonicalFormat};
 
 const CONTENT_TYPES: &str = "[Content_Types].xml";
@@ -21,10 +21,8 @@ const PPT_PRESENTATION: &str = "ppt/presentation.xml";
 const XL_WORKBOOK: &str = "xl/workbook.xml";
 const ODS_MIMETYPE: &str = "mimetype";
 
-const NESTED_ARCHIVE_SUFFIXES: &[&str] = &[
-    ".zip", ".jar", ".7z", ".rar", ".gz", ".tgz", ".tar", ".bz2", ".xz", ".docx", ".pptx", ".xlsx",
-    ".ods",
-];
+const ODS_SPREADSHEET_MIMETYPE: &[u8] = b"application/vnd.oasis.opendocument.spreadsheet";
+const NESTED_MAGIC_BYTES: usize = 512;
 
 /// Result of archive preflight for ZIP-based formats.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,11 +45,15 @@ pub fn validate_zip_archive(
     validate_zip_reader(file, provisional, limits)
 }
 
-fn validate_zip_reader<R: Read + Seek>(
-    reader: R,
+pub(crate) fn validate_zip_reader<R: Read + Seek>(
+    mut reader: R,
     provisional: CanonicalFormat,
     limits: &LimitsConfig,
 ) -> Result<ArchiveCheck, UploadError> {
+    reject_duplicate_central_directory_names(&mut reader)?;
+    reader.seek(SeekFrom::Start(0)).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
     let mut archive = ZipArchive::new(reader).map_err(map_zip_open_error)?;
     let entry_count = archive.len() as u64;
     if entry_count == 0 {
@@ -74,25 +76,26 @@ fn validate_zip_reader<R: Read + Seek>(
     let mut has_ppt = false;
     let mut has_xl = false;
     let mut has_ods_mimetype = false;
+    let mut content_types = ContentTypesSeen::default();
+    let mut seen_names = HashSet::new();
 
     for index in 0..archive.len() {
-        let entry = archive.by_index(index).map_err(map_zip_entry_error)?;
+        let mut entry = archive.by_index(index).map_err(map_zip_entry_error)?;
         let name = entry.name().to_string();
         reject_dangerous_entry_name(&name)?;
-        reject_nested_archive_name(&name)?;
-
-        let declared_uncomp = entry.size();
-        let declared_comp = entry.compressed_size();
-        uncompressed_bytes = uncompressed_bytes.saturating_add(declared_uncomp);
-        compressed_bytes = compressed_bytes.saturating_add(declared_comp);
-
-        if uncompressed_bytes > limits.max_archive_uncompressed_bytes {
+        let normalized = name.trim_end_matches('/').to_string();
+        if !seen_names.insert(normalized) {
             return Err(UploadError::rejected(
-                ThreatClass::ArchiveBomb,
-                ReasonCode::ArchiveUncompressedLimit,
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
             ));
         }
-
+        if entry.is_symlink() {
+            return Err(UploadError::rejected(
+                ThreatClass::ArchiveTraversal,
+                ReasonCode::ArchivePathTraversal,
+            ));
+        }
         if name == CONTENT_TYPES {
             has_content_types = true;
         }
@@ -108,25 +111,65 @@ fn validate_zip_reader<R: Read + Seek>(
         if name == ODS_MIMETYPE {
             has_ods_mimetype = true;
         }
-        drop(entry);
-    }
 
-    // Ratio from central-directory declared sizes — no full decompress.
-    if compressed_bytes > 0 {
-        let ratio = uncompressed_bytes / compressed_bytes;
-        if ratio > limits.max_archive_compression_ratio {
+        let scanned = if entry.is_dir() {
+            EntryScan::default()
+        } else if name == CONTENT_TYPES {
+            scan_content_types_xml(
+                &mut entry,
+                limits,
+                &mut uncompressed_bytes,
+                &mut compressed_bytes,
+            )?
+        } else if matches!(
+            name.as_str(),
+            WORD_DOCUMENT | PPT_PRESENTATION | XL_WORKBOOK
+        ) || (matches!(provisional, CanonicalFormat::Ods)
+            && matches!(name.as_str(), "content.xml" | "META-INF/manifest.xml"))
+        {
+            scan_required_xml(
+                &mut entry,
+                limits,
+                &mut uncompressed_bytes,
+                &mut compressed_bytes,
+            )?
+        } else if name == ODS_MIMETYPE {
+            scan_ods_mimetype(
+                &mut entry,
+                limits,
+                &mut uncompressed_bytes,
+                &mut compressed_bytes,
+            )?
+        } else {
+            drain_checked_entry(
+                &mut entry,
+                limits,
+                &mut uncompressed_bytes,
+                &mut compressed_bytes,
+            )?
+        };
+        if name == CONTENT_TYPES {
+            content_types = scanned.content_types;
+        }
+        if name == ODS_MIMETYPE && !scanned.ods_mimetype_ok {
             return Err(UploadError::rejected(
-                ThreatClass::ArchiveBomb,
-                ReasonCode::ArchiveCompressionRatio,
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MissingFormatPaths,
             ));
         }
-    } else if uncompressed_bytes > 0 {
-        return Err(UploadError::rejected(
-            ThreatClass::ArchiveBomb,
-            ReasonCode::ArchiveCompressionRatio,
-        ));
     }
 
+    if [has_word, has_ppt, has_xl]
+        .into_iter()
+        .filter(|present| *present)
+        .count()
+        > 1
+    {
+        return Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MissingFormatPaths,
+        ));
+    }
     let format = refine_zip_format(
         provisional,
         has_content_types,
@@ -165,8 +208,7 @@ fn validate_zip_reader<R: Read + Seek>(
         _ => {}
     }
 
-    // Bounded well-formedness checks on required XML (fail closed).
-    verify_required_xml(&mut archive, format)?;
+    verify_content_types(format, &content_types)?;
 
     Ok(ArchiveCheck {
         format,
@@ -176,79 +218,346 @@ fn validate_zip_reader<R: Read + Seek>(
     })
 }
 
-fn verify_required_xml<R: Read + Seek>(
-    archive: &mut ZipArchive<R>,
-    format: CanonicalFormat,
-) -> Result<(), UploadError> {
-    let required: &[&str] = match format {
-        CanonicalFormat::Docx => &[CONTENT_TYPES, WORD_DOCUMENT],
-        CanonicalFormat::Pptx => &[CONTENT_TYPES, PPT_PRESENTATION],
-        CanonicalFormat::Xlsx => &[CONTENT_TYPES, XL_WORKBOOK],
-        CanonicalFormat::Ods => &["content.xml", "META-INF/manifest.xml"],
-        _ => return Ok(()),
-    };
-    for name in required {
-        let mut entry = match archive.by_name(name) {
-            Ok(entry) => entry,
-            Err(ZipError::FileNotFound) => {
-                return Err(UploadError::rejected(
-                    ThreatClass::MalformedOoxml,
-                    ReasonCode::MissingFormatPaths,
-                ));
+#[derive(Debug, Default, Clone, Copy)]
+struct ContentTypesSeen {
+    word_document: bool,
+    ppt_presentation: bool,
+    xl_workbook: bool,
+}
+
+#[derive(Debug, Default)]
+struct EntryScan {
+    content_types: ContentTypesSeen,
+    ods_mimetype_ok: bool,
+}
+
+fn scan_content_types_xml(
+    entry: &mut ZipFile<'_>,
+    limits: &LimitsConfig,
+    aggregate_uncompressed: &mut u64,
+    aggregate_compressed: &mut u64,
+) -> Result<EntryScan, UploadError> {
+    let mut checked =
+        CheckedEntryReader::new(entry, limits, aggregate_uncompressed, aggregate_compressed);
+    let content_types = parse_content_types_xml(&mut checked)?;
+    checked.drain_to_end()?;
+    checked.finish()?;
+    Ok(EntryScan {
+        content_types,
+        ods_mimetype_ok: false,
+    })
+}
+
+fn scan_required_xml(
+    entry: &mut ZipFile<'_>,
+    limits: &LimitsConfig,
+    aggregate_uncompressed: &mut u64,
+    aggregate_compressed: &mut u64,
+) -> Result<EntryScan, UploadError> {
+    let mut checked =
+        CheckedEntryReader::new(entry, limits, aggregate_uncompressed, aggregate_compressed);
+    parse_well_formed_xml(&mut checked)?;
+    checked.drain_to_end()?;
+    checked.finish()?;
+    Ok(EntryScan::default())
+}
+
+fn scan_ods_mimetype(
+    entry: &mut ZipFile<'_>,
+    limits: &LimitsConfig,
+    aggregate_uncompressed: &mut u64,
+    aggregate_compressed: &mut u64,
+) -> Result<EntryScan, UploadError> {
+    let mut checked =
+        CheckedEntryReader::new(entry, limits, aggregate_uncompressed, aggregate_compressed);
+    let mut actual = Vec::with_capacity(ODS_SPREADSHEET_MIMETYPE.len());
+    let mut buf = [0_u8; STREAM_CHUNK_BYTES];
+    loop {
+        let n = checked.read(&mut buf).map_err(map_entry_read_error)?;
+        if n == 0 {
+            break;
+        }
+        let remaining = ODS_SPREADSHEET_MIMETYPE.len().saturating_sub(actual.len());
+        if remaining > 0 {
+            actual.extend_from_slice(&buf[..n.min(remaining)]);
+        }
+    }
+    checked.finish()?;
+    Ok(EntryScan {
+        content_types: ContentTypesSeen::default(),
+        ods_mimetype_ok: actual == ODS_SPREADSHEET_MIMETYPE,
+    })
+}
+
+fn drain_checked_entry(
+    entry: &mut ZipFile<'_>,
+    limits: &LimitsConfig,
+    aggregate_uncompressed: &mut u64,
+    aggregate_compressed: &mut u64,
+) -> Result<EntryScan, UploadError> {
+    let mut checked =
+        CheckedEntryReader::new(entry, limits, aggregate_uncompressed, aggregate_compressed);
+    checked.drain_to_end()?;
+    checked.finish()?;
+    Ok(EntryScan::default())
+}
+
+struct CheckedEntryReader<'a, 'b> {
+    entry: &'a mut ZipFile<'b>,
+    limits: &'a LimitsConfig,
+    aggregate_uncompressed: &'a mut u64,
+    aggregate_compressed: &'a mut u64,
+    declared_uncompressed: u64,
+    declared_compressed: u64,
+    declared_crc32: u32,
+    actual_uncompressed: u64,
+    crc32: crc32fast::Hasher,
+    first_bytes: Vec<u8>,
+}
+
+impl<'a, 'b> CheckedEntryReader<'a, 'b> {
+    fn new(
+        entry: &'a mut ZipFile<'b>,
+        limits: &'a LimitsConfig,
+        aggregate_uncompressed: &'a mut u64,
+        aggregate_compressed: &'a mut u64,
+    ) -> Self {
+        Self {
+            declared_uncompressed: entry.size(),
+            declared_compressed: entry.compressed_size(),
+            declared_crc32: entry.crc32(),
+            entry,
+            limits,
+            aggregate_uncompressed,
+            aggregate_compressed,
+            actual_uncompressed: 0,
+            crc32: crc32fast::Hasher::new(),
+            first_bytes: Vec::with_capacity(NESTED_MAGIC_BYTES),
+        }
+    }
+
+    fn drain_to_end(&mut self) -> Result<(), UploadError> {
+        let mut buf = [0_u8; STREAM_CHUNK_BYTES];
+        loop {
+            let n = self.read(&mut buf).map_err(map_entry_read_error)?;
+            if n == 0 {
+                break;
             }
-            Err(_) => {
-                return Err(UploadError::rejected(
-                    ThreatClass::MalformedOoxml,
-                    ReasonCode::MalformedArchive,
-                ));
-            }
-        };
-        let bytes = read_entry_bounded(&mut entry)?;
-        if name.ends_with(".xml") && !looks_like_well_formed_xml(&bytes) {
+        }
+        Ok(())
+    }
+
+    fn finish(self) -> Result<(), UploadError> {
+        if looks_like_nested_archive_magic(&self.first_bytes) {
             return Err(UploadError::rejected(
-                ThreatClass::MalformedOoxml,
-                ReasonCode::MalformedXml,
+                ThreatClass::NestedArchive,
+                ReasonCode::NestedArchiveEntry,
             ));
         }
+        if self.actual_uncompressed != self.declared_uncompressed {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
+            ));
+        }
+        if self.crc32.finalize() != self.declared_crc32 {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Read for CheckedEntryReader<'_, '_> {
+    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.entry.read(out)?;
+        if n == 0 {
+            return Ok(0);
+        }
+        let chunk = &out[..n];
+        if self.first_bytes.len() < NESTED_MAGIC_BYTES {
+            let need = NESTED_MAGIC_BYTES - self.first_bytes.len();
+            self.first_bytes
+                .extend_from_slice(&chunk[..chunk.len().min(need)]);
+        }
+        self.actual_uncompressed = self.actual_uncompressed.saturating_add(n as u64);
+        *self.aggregate_uncompressed = self.aggregate_uncompressed.saturating_add(n as u64);
+        if self.actual_uncompressed == n as u64 {
+            *self.aggregate_compressed = self
+                .aggregate_compressed
+                .saturating_add(self.declared_compressed);
+            if self.declared_compressed == 0 && self.declared_uncompressed > 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "invalid compression ratio",
+                ));
+            }
+        }
+        self.crc32.update(chunk);
+        enforce_archive_limits(
+            self.limits,
+            self.actual_uncompressed,
+            self.declared_compressed,
+            *self.aggregate_uncompressed,
+            *self.aggregate_compressed,
+        )
+        .map_err(|error| {
+            let message = match error.reason_code() {
+                ReasonCode::ArchiveCompressionRatio => "archive compression ratio",
+                _ => "archive uncompressed limit",
+            };
+            std::io::Error::new(std::io::ErrorKind::InvalidData, message)
+        })?;
+        Ok(n)
+    }
+}
+
+fn enforce_archive_limits(
+    limits: &LimitsConfig,
+    entry_uncompressed: u64,
+    entry_compressed: u64,
+    aggregate_uncompressed: u64,
+    aggregate_compressed: u64,
+) -> Result<(), UploadError> {
+    if entry_uncompressed > MAX_SINGLE_ENTRY_READ_BYTES
+        || aggregate_uncompressed > limits.max_archive_uncompressed_bytes
+    {
+        return Err(UploadError::rejected(
+            ThreatClass::ArchiveBomb,
+            ReasonCode::ArchiveUncompressedLimit,
+        ));
+    }
+    if (entry_compressed > 0
+        && entry_uncompressed
+            > entry_compressed.saturating_mul(limits.max_archive_compression_ratio))
+        || (aggregate_compressed > 0
+            && aggregate_uncompressed
+                > aggregate_compressed.saturating_mul(limits.max_archive_compression_ratio))
+    {
+        return Err(UploadError::rejected(
+            ThreatClass::ArchiveBomb,
+            ReasonCode::ArchiveCompressionRatio,
+        ));
     }
     Ok(())
 }
 
-/// Read an entry with a hard uncompressed byte bound (zip-bomb defense).
-fn read_entry_bounded(entry: &mut ZipFile<'_>) -> Result<Vec<u8>, UploadError> {
-    let declared = entry.size();
-    if declared > MAX_SINGLE_ENTRY_READ_BYTES {
+fn parse_content_types_xml<R: Read>(reader: R) -> Result<ContentTypesSeen, UploadError> {
+    let mut xml =
+        quick_xml::Reader::from_reader(BufReader::with_capacity(STREAM_CHUNK_BYTES, reader));
+    xml.config_mut().trim_text(true);
+    let mut buf = Vec::with_capacity(1024);
+    let mut seen = ContentTypesSeen::default();
+    let mut saw_event = false;
+    loop {
+        match xml.read_event_into(&mut buf) {
+            Ok(quick_xml::events::Event::Start(event))
+            | Ok(quick_xml::events::Event::Empty(event)) => {
+                saw_event = true;
+                let mut part_name = None;
+                let mut content_type = None;
+                for attr in event.attributes().flatten() {
+                    match attr.key.as_ref() {
+                        b"PartName" => part_name = Some(attr.value.into_owned()),
+                        b"ContentType" => content_type = Some(attr.value.into_owned()),
+                        _ => {}
+                    }
+                }
+                if let (Some(part), Some(kind)) = (part_name, content_type) {
+                    let part = String::from_utf8_lossy(&part).to_ascii_lowercase();
+                    let kind = String::from_utf8_lossy(&kind).to_ascii_lowercase();
+                    seen.word_document |= part == "/word/document.xml"
+                        && kind.contains("wordprocessingml.document.main+xml");
+                    seen.ppt_presentation |= part == "/ppt/presentation.xml"
+                        && kind.contains("presentationml.presentation.main+xml");
+                    seen.xl_workbook |=
+                        part == "/xl/workbook.xml" && kind.contains("spreadsheetml.sheet.main+xml");
+                }
+            }
+            Ok(quick_xml::events::Event::Eof) => break,
+            Ok(_) => {}
+            Err(_) => {
+                return Err(UploadError::rejected(
+                    ThreatClass::MalformedOoxml,
+                    ReasonCode::MalformedXml,
+                ));
+            }
+        }
+        buf.clear();
+    }
+    if !saw_event {
         return Err(UploadError::rejected(
-            ThreatClass::ArchiveBomb,
-            ReasonCode::ArchiveUncompressedLimit,
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MalformedXml,
         ));
     }
-    let mut buf = Vec::new();
-    let mut limited = entry.take(MAX_SINGLE_ENTRY_READ_BYTES + 1);
-    limited
-        .read_to_end(&mut buf)
-        .map_err(|_| UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::FailClosed))?;
-    if buf.len() as u64 > MAX_SINGLE_ENTRY_READ_BYTES {
-        return Err(UploadError::rejected(
-            ThreatClass::ArchiveBomb,
-            ReasonCode::ArchiveUncompressedLimit,
-        ));
-    }
-    Ok(buf)
+    Ok(seen)
 }
 
-fn looks_like_well_formed_xml(bytes: &[u8]) -> bool {
-    let Ok(text) = std::str::from_utf8(bytes) else {
-        return false;
-    };
-    let trimmed = text.trim();
-    if !trimmed.starts_with('<') || !trimmed.ends_with('>') {
-        return false;
+fn parse_well_formed_xml<R: Read>(reader: R) -> Result<(), UploadError> {
+    let mut xml =
+        quick_xml::Reader::from_reader(BufReader::with_capacity(STREAM_CHUNK_BYTES, reader));
+    xml.config_mut().trim_text(true);
+    let mut buf = Vec::with_capacity(1024);
+    let mut saw_event = false;
+    loop {
+        match xml.read_event_into(&mut buf) {
+            Ok(quick_xml::events::Event::Start(_))
+            | Ok(quick_xml::events::Event::Empty(_))
+            | Ok(quick_xml::events::Event::Text(_)) => saw_event = true,
+            Ok(quick_xml::events::Event::Eof) => break,
+            Ok(_) => {}
+            Err(_) => {
+                return Err(UploadError::rejected(
+                    ThreatClass::MalformedOoxml,
+                    ReasonCode::MalformedXml,
+                ));
+            }
+        }
+        buf.clear();
     }
-    // Cheap balance check: opens should not wildly exceed closes (truncation).
-    let open = trimmed.matches('<').count();
-    let close = trimmed.matches("</").count() + trimmed.matches("/>").count();
-    open > 0 && close > 0 && open <= close * 3
+    if !saw_event {
+        return Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MalformedXml,
+        ));
+    }
+    Ok(())
+}
+
+fn verify_content_types(
+    format: CanonicalFormat,
+    content_types: &ContentTypesSeen,
+) -> Result<(), UploadError> {
+    let ok = match format {
+        CanonicalFormat::Docx => content_types.word_document,
+        CanonicalFormat::Pptx => content_types.ppt_presentation,
+        CanonicalFormat::Xlsx => content_types.xl_workbook,
+        CanonicalFormat::Ods => true,
+        _ => true,
+    };
+    if ok {
+        Ok(())
+    } else {
+        Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MissingFormatPaths,
+        ))
+    }
+}
+
+fn looks_like_nested_archive_magic(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"PK\x03\x04")
+        || bytes.starts_with(b"PK\x05\x06")
+        || bytes.starts_with(b"PK\x07\x08")
+        || bytes.starts_with(b"Rar!\x1a\x07")
+        || bytes.starts_with(b"7z\xbc\xaf\x27\x1c")
+        || bytes.starts_with(&[0x1f, 0x8b])
+        || bytes.starts_with(b"BZh")
+        || bytes.starts_with(&[0xfd, b'7', b'z', b'X', b'Z', 0x00])
+        || bytes.get(257..263).is_some_and(|magic| magic == b"ustar\0")
 }
 
 pub fn reject_dangerous_entry_name(name: &str) -> Result<(), UploadError> {
@@ -271,24 +580,73 @@ pub fn reject_dangerous_entry_name(name: &str) -> Result<(), UploadError> {
     Ok(())
 }
 
-fn reject_nested_archive_name(name: &str) -> Result<(), UploadError> {
-    // Allow the OOXML package members; reject nested archive-looking names.
-    let lower = name.to_ascii_lowercase();
-    // Skip directory entries.
-    if lower.ends_with('/') {
+fn reject_duplicate_central_directory_names<R: Read + Seek>(
+    reader: &mut R,
+) -> Result<(), UploadError> {
+    let len = reader.seek(SeekFrom::End(0)).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let tail_len = len.min(66 * 1024) as usize;
+    reader
+        .seek(SeekFrom::End(-(tail_len as i64)))
+        .map_err(|_| {
+            UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+        })?;
+    let mut tail = vec![0_u8; tail_len];
+    reader.read_exact(&mut tail).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let Some(eocd_pos) = tail.windows(4).rposition(|w| w == b"PK\x05\x06") else {
+        return Ok(());
+    };
+    if eocd_pos + 22 > tail.len() {
         return Ok(());
     }
-    let base = lower.rsplit('/').next().unwrap_or(lower.as_str());
-    // Nested archives inside word/media etc.
-    if NESTED_ARCHIVE_SUFFIXES
-        .iter()
-        .any(|suffix| base.ends_with(suffix))
-    {
-        // The outer package is the format; members named *.docx etc. are nested.
-        return Err(UploadError::rejected(
-            ThreatClass::NestedArchive,
-            ReasonCode::NestedArchiveEntry,
-        ));
+    let entries = u16::from_le_bytes(tail[eocd_pos + 10..eocd_pos + 12].try_into().unwrap());
+    let central_offset =
+        u32::from_le_bytes(tail[eocd_pos + 16..eocd_pos + 20].try_into().unwrap()) as u64;
+    if entries == u16::MAX {
+        return Ok(());
+    }
+    reader.seek(SeekFrom::Start(central_offset)).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let mut seen = HashSet::new();
+    for _ in 0..entries {
+        let mut header = [0_u8; 46];
+        reader.read_exact(&mut header).map_err(|_| {
+            UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+        })?;
+        if &header[0..4] != b"PK\x01\x02" {
+            return Ok(());
+        }
+        let name_len = u16::from_le_bytes(header[28..30].try_into().unwrap()) as usize;
+        let extra_len = u16::from_le_bytes(header[30..32].try_into().unwrap()) as u64;
+        let comment_len = u16::from_le_bytes(header[32..34].try_into().unwrap()) as u64;
+        if name_len == 0 || name_len > 4096 {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
+            ));
+        }
+        let mut name = vec![0_u8; name_len];
+        reader.read_exact(&mut name).map_err(|_| {
+            UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+        })?;
+        let name = String::from_utf8(name).map_err(|_| {
+            UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+        })?;
+        if !seen.insert(name.trim_end_matches('/').to_string()) {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
+            ));
+        }
+        reader
+            .seek(SeekFrom::Current((extra_len + comment_len) as i64))
+            .map_err(|_| {
+                UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+            })?;
     }
     Ok(())
 }
@@ -306,12 +664,31 @@ fn map_zip_entry_error(_error: ZipError) -> UploadError {
     UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
 }
 
+fn map_entry_read_error(error: std::io::Error) -> UploadError {
+    let message = error.to_string();
+    if message.contains("compression") {
+        UploadError::rejected(
+            ThreatClass::ArchiveBomb,
+            ReasonCode::ArchiveCompressionRatio,
+        )
+    } else if error.kind() == std::io::ErrorKind::InvalidData {
+        UploadError::rejected(
+            ThreatClass::ArchiveBomb,
+            ReasonCode::ArchiveUncompressedLimit,
+        )
+    } else {
+        UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
     use zip::write::SimpleFileOptions;
     use zip::CompressionMethod;
+
+    const DOCX_CONTENT_TYPES_XML: &[u8] = br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#;
 
     fn write_zip(path: &Path, entries: &[(&str, &[u8])]) {
         let file = std::fs::File::create(path).unwrap();
@@ -341,8 +718,7 @@ mod tests {
         let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
         // Include minimal OOXML markers so we fail on entry count first.
         zip.start_file(CONTENT_TYPES, options).unwrap();
-        zip.write_all(b"<?xml version=\"1.0\"?><Types></Types>")
-            .unwrap();
+        zip.write_all(DOCX_CONTENT_TYPES_XML).unwrap();
         zip.start_file(WORD_DOCUMENT, options).unwrap();
         zip.write_all(b"<?xml version=\"1.0\"?><w:document></w:document>")
             .unwrap();
@@ -367,7 +743,7 @@ mod tests {
             &[
                 (
                     CONTENT_TYPES,
-                    br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"></Types>"#,
+                    DOCX_CONTENT_TYPES_XML,
                 ),
                 (
                     WORD_DOCUMENT,

--- a/crates/server/src/services/upload/archive.rs
+++ b/crates/server/src/services/upload/archive.rs
@@ -1,0 +1,382 @@
+//! ZIP/OOXML archive safety: bomb, traversal, nested, required members.
+//!
+//! Compression-ratio and uncompressed caps are enforced from the ZIP **central
+//! directory** declared sizes (no unbounded decompression). Membership checks
+//! read individual entries through a bounded decompressor.
+
+use std::io::{Read, Seek};
+use std::path::Path;
+
+use zip::read::ZipFile;
+use zip::result::ZipError;
+use zip::ZipArchive;
+
+use super::error::{ReasonCode, ThreatClass, UploadError};
+use super::limits::{LimitsConfig, MAX_SINGLE_ENTRY_READ_BYTES};
+use super::sniff::{refine_zip_format, CanonicalFormat};
+
+const CONTENT_TYPES: &str = "[Content_Types].xml";
+const WORD_DOCUMENT: &str = "word/document.xml";
+const PPT_PRESENTATION: &str = "ppt/presentation.xml";
+const XL_WORKBOOK: &str = "xl/workbook.xml";
+const ODS_MIMETYPE: &str = "mimetype";
+
+const NESTED_ARCHIVE_SUFFIXES: &[&str] = &[
+    ".zip", ".jar", ".7z", ".rar", ".gz", ".tgz", ".tar", ".bz2", ".xz", ".docx", ".pptx", ".xlsx",
+    ".ods",
+];
+
+/// Result of archive preflight for ZIP-based formats.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArchiveCheck {
+    pub format: CanonicalFormat,
+    pub entry_count: u64,
+    pub uncompressed_bytes: u64,
+    pub compressed_bytes: u64,
+}
+
+/// Validate a ZIP/OOXML/ODS archive without unbounded decompression.
+pub fn validate_zip_archive(
+    path: &Path,
+    provisional: CanonicalFormat,
+    limits: &LimitsConfig,
+) -> Result<ArchiveCheck, UploadError> {
+    let file = std::fs::File::open(path).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    validate_zip_reader(file, provisional, limits)
+}
+
+fn validate_zip_reader<R: Read + Seek>(
+    reader: R,
+    provisional: CanonicalFormat,
+    limits: &LimitsConfig,
+) -> Result<ArchiveCheck, UploadError> {
+    let mut archive = ZipArchive::new(reader).map_err(map_zip_open_error)?;
+    let entry_count = archive.len() as u64;
+    if entry_count == 0 {
+        return Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MalformedArchive,
+        ));
+    }
+    if entry_count > limits.max_archive_entries {
+        return Err(UploadError::rejected(
+            ThreatClass::ArchiveBomb,
+            ReasonCode::ArchiveEntryLimit,
+        ));
+    }
+
+    let mut uncompressed_bytes: u64 = 0;
+    let mut compressed_bytes: u64 = 0;
+    let mut has_content_types = false;
+    let mut has_word = false;
+    let mut has_ppt = false;
+    let mut has_xl = false;
+    let mut has_ods_mimetype = false;
+
+    for index in 0..archive.len() {
+        let entry = archive.by_index(index).map_err(map_zip_entry_error)?;
+        let name = entry.name().to_string();
+        reject_dangerous_entry_name(&name)?;
+        reject_nested_archive_name(&name)?;
+
+        let declared_uncomp = entry.size();
+        let declared_comp = entry.compressed_size();
+        uncompressed_bytes = uncompressed_bytes.saturating_add(declared_uncomp);
+        compressed_bytes = compressed_bytes.saturating_add(declared_comp);
+
+        if uncompressed_bytes > limits.max_archive_uncompressed_bytes {
+            return Err(UploadError::rejected(
+                ThreatClass::ArchiveBomb,
+                ReasonCode::ArchiveUncompressedLimit,
+            ));
+        }
+
+        if name == CONTENT_TYPES {
+            has_content_types = true;
+        }
+        if name == WORD_DOCUMENT || name.starts_with("word/") {
+            has_word = true;
+        }
+        if name == PPT_PRESENTATION || name.starts_with("ppt/") {
+            has_ppt = true;
+        }
+        if name == XL_WORKBOOK || name.starts_with("xl/") {
+            has_xl = true;
+        }
+        if name == ODS_MIMETYPE {
+            has_ods_mimetype = true;
+        }
+        drop(entry);
+    }
+
+    // Ratio from central-directory declared sizes — no full decompress.
+    if compressed_bytes > 0 {
+        let ratio = uncompressed_bytes / compressed_bytes;
+        if ratio > limits.max_archive_compression_ratio {
+            return Err(UploadError::rejected(
+                ThreatClass::ArchiveBomb,
+                ReasonCode::ArchiveCompressionRatio,
+            ));
+        }
+    } else if uncompressed_bytes > 0 {
+        return Err(UploadError::rejected(
+            ThreatClass::ArchiveBomb,
+            ReasonCode::ArchiveCompressionRatio,
+        ));
+    }
+
+    let format = refine_zip_format(
+        provisional,
+        has_content_types,
+        has_word,
+        has_ppt,
+        has_xl,
+        has_ods_mimetype,
+    )?;
+
+    // Require canonical member paths for OOXML.
+    match format {
+        CanonicalFormat::Docx if !has_content_types || !has_word => {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MissingFormatPaths,
+            ));
+        }
+        CanonicalFormat::Pptx if !has_content_types || !has_ppt => {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MissingFormatPaths,
+            ));
+        }
+        CanonicalFormat::Xlsx if !has_content_types || !has_xl => {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MissingFormatPaths,
+            ));
+        }
+        CanonicalFormat::Ods if !has_ods_mimetype => {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MissingFormatPaths,
+            ));
+        }
+        _ => {}
+    }
+
+    // Bounded well-formedness checks on required XML (fail closed).
+    verify_required_xml(&mut archive, format)?;
+
+    Ok(ArchiveCheck {
+        format,
+        entry_count,
+        uncompressed_bytes,
+        compressed_bytes,
+    })
+}
+
+fn verify_required_xml<R: Read + Seek>(
+    archive: &mut ZipArchive<R>,
+    format: CanonicalFormat,
+) -> Result<(), UploadError> {
+    let required: &[&str] = match format {
+        CanonicalFormat::Docx => &[CONTENT_TYPES, WORD_DOCUMENT],
+        CanonicalFormat::Pptx => &[CONTENT_TYPES, PPT_PRESENTATION],
+        CanonicalFormat::Xlsx => &[CONTENT_TYPES, XL_WORKBOOK],
+        CanonicalFormat::Ods => &["content.xml", "META-INF/manifest.xml"],
+        _ => return Ok(()),
+    };
+    for name in required {
+        let mut entry = match archive.by_name(name) {
+            Ok(entry) => entry,
+            Err(ZipError::FileNotFound) => {
+                return Err(UploadError::rejected(
+                    ThreatClass::MalformedOoxml,
+                    ReasonCode::MissingFormatPaths,
+                ));
+            }
+            Err(_) => {
+                return Err(UploadError::rejected(
+                    ThreatClass::MalformedOoxml,
+                    ReasonCode::MalformedArchive,
+                ));
+            }
+        };
+        let bytes = read_entry_bounded(&mut entry)?;
+        if name.ends_with(".xml") && !looks_like_well_formed_xml(&bytes) {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedXml,
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Read an entry with a hard uncompressed byte bound (zip-bomb defense).
+fn read_entry_bounded(entry: &mut ZipFile<'_>) -> Result<Vec<u8>, UploadError> {
+    let declared = entry.size();
+    if declared > MAX_SINGLE_ENTRY_READ_BYTES {
+        return Err(UploadError::rejected(
+            ThreatClass::ArchiveBomb,
+            ReasonCode::ArchiveUncompressedLimit,
+        ));
+    }
+    let mut buf = Vec::new();
+    let mut limited = entry.take(MAX_SINGLE_ENTRY_READ_BYTES + 1);
+    limited
+        .read_to_end(&mut buf)
+        .map_err(|_| UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::FailClosed))?;
+    if buf.len() as u64 > MAX_SINGLE_ENTRY_READ_BYTES {
+        return Err(UploadError::rejected(
+            ThreatClass::ArchiveBomb,
+            ReasonCode::ArchiveUncompressedLimit,
+        ));
+    }
+    Ok(buf)
+}
+
+fn looks_like_well_formed_xml(bytes: &[u8]) -> bool {
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+    let trimmed = text.trim();
+    if !trimmed.starts_with('<') || !trimmed.ends_with('>') {
+        return false;
+    }
+    // Cheap balance check: opens should not wildly exceed closes (truncation).
+    let open = trimmed.matches('<').count();
+    let close = trimmed.matches("</").count() + trimmed.matches("/>").count();
+    open > 0 && close > 0 && open <= close * 3
+}
+
+pub fn reject_dangerous_entry_name(name: &str) -> Result<(), UploadError> {
+    if name.is_empty()
+        || name.contains('\0')
+        || name.contains('\\')
+        || name.starts_with('/')
+        || name.starts_with('\\')
+        || name.contains("../")
+        || name.contains("..\\")
+        || name.split('/').any(|part| part == "..")
+        || name.contains(':')
+    // drive / URL schemes
+    {
+        return Err(UploadError::rejected(
+            ThreatClass::ArchiveTraversal,
+            ReasonCode::ArchivePathTraversal,
+        ));
+    }
+    Ok(())
+}
+
+fn reject_nested_archive_name(name: &str) -> Result<(), UploadError> {
+    // Allow the OOXML package members; reject nested archive-looking names.
+    let lower = name.to_ascii_lowercase();
+    // Skip directory entries.
+    if lower.ends_with('/') {
+        return Ok(());
+    }
+    let base = lower.rsplit('/').next().unwrap_or(lower.as_str());
+    // Nested archives inside word/media etc.
+    if NESTED_ARCHIVE_SUFFIXES
+        .iter()
+        .any(|suffix| base.ends_with(suffix))
+    {
+        // The outer package is the format; members named *.docx etc. are nested.
+        return Err(UploadError::rejected(
+            ThreatClass::NestedArchive,
+            ReasonCode::NestedArchiveEntry,
+        ));
+    }
+    Ok(())
+}
+
+fn map_zip_open_error(error: ZipError) -> UploadError {
+    match error {
+        ZipError::InvalidArchive(_) | ZipError::UnsupportedArchive(_) => {
+            UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+        }
+        _ => UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed),
+    }
+}
+
+fn map_zip_entry_error(_error: ZipError) -> UploadError {
+    UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+    use zip::CompressionMethod;
+
+    fn write_zip(path: &Path, entries: &[(&str, &[u8])]) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        for (name, data) in entries {
+            zip.start_file(*name, options).unwrap();
+            zip.write_all(data).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    #[test]
+    fn rejects_traversal_names() {
+        assert!(reject_dangerous_entry_name("../../etc/passwd").is_err());
+        assert!(reject_dangerous_entry_name("/absolute/path").is_err());
+        assert!(reject_dangerous_entry_name("C:/windows/system32").is_err());
+        assert!(reject_dangerous_entry_name("word/document.xml").is_ok());
+    }
+
+    #[test]
+    fn rejects_entry_count_bomb_without_decompressing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bomb.zip");
+        let file = std::fs::File::create(&path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        // Include minimal OOXML markers so we fail on entry count first.
+        zip.start_file(CONTENT_TYPES, options).unwrap();
+        zip.write_all(b"<?xml version=\"1.0\"?><Types></Types>")
+            .unwrap();
+        zip.start_file(WORD_DOCUMENT, options).unwrap();
+        zip.write_all(b"<?xml version=\"1.0\"?><w:document></w:document>")
+            .unwrap();
+        for i in 0..5_000 {
+            zip.start_file(format!("pad/{i}.txt"), options).unwrap();
+            zip.write_all(b"x").unwrap();
+        }
+        zip.finish().unwrap();
+
+        let limits = LimitsConfig::policy_defaults();
+        let err = validate_zip_archive(&path, CanonicalFormat::Docx, &limits).unwrap_err();
+        assert_eq!(err.threat_class(), Some(ThreatClass::ArchiveBomb));
+        assert_eq!(err.reason_code(), ReasonCode::ArchiveEntryLimit);
+    }
+
+    #[test]
+    fn accepts_minimal_docx() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ok.docx");
+        write_zip(
+            &path,
+            &[
+                (
+                    CONTENT_TYPES,
+                    br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"></Types>"#,
+                ),
+                (
+                    WORD_DOCUMENT,
+                    br#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:document>"#,
+                ),
+            ],
+        );
+        let limits = LimitsConfig::policy_defaults();
+        let check = validate_zip_archive(&path, CanonicalFormat::Docx, &limits).unwrap();
+        assert_eq!(check.format, CanonicalFormat::Docx);
+    }
+}

--- a/crates/server/src/services/upload/archive.rs
+++ b/crates/server/src/services/upload/archive.rs
@@ -52,7 +52,7 @@ pub(crate) fn validate_zip_reader<R: Read + Seek>(
     provisional: CanonicalFormat,
     limits: &LimitsConfig,
 ) -> Result<ArchiveCheck, UploadError> {
-    let compressed_spans = scan_central_directory_names_and_spans(&mut reader)?;
+    let compressed_spans = scan_central_directory_names_and_spans(&mut reader, limits)?;
     reader.seek(SeekFrom::Start(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
@@ -662,6 +662,7 @@ pub fn reject_dangerous_entry_name(name: &str) -> Result<(), UploadError> {
 
 fn scan_central_directory_names_and_spans<R: Read + Seek>(
     reader: &mut R,
+    limits: &LimitsConfig,
 ) -> Result<HashMap<String, u64>, UploadError> {
     let len = reader.seek(SeekFrom::End(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
@@ -697,12 +698,23 @@ fn scan_central_directory_names_and_spans<R: Read + Seek>(
             ReasonCode::MalformedArchive,
         ));
     }
+    if u64::from(entries) > limits.max_archive_entries {
+        return Err(UploadError::rejected(
+            ThreatClass::ArchiveBomb,
+            ReasonCode::ArchiveEntryLimit,
+        ));
+    }
     reader.seek(SeekFrom::Start(central_offset)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
-    let mut seen = HashSet::new();
-    let mut central_entries = Vec::new();
-    for _ in 0..entries {
+    let mut central_entries = Vec::with_capacity(entries as usize);
+    for index in 0..entries {
+        if u64::from(index) >= limits.max_archive_entries {
+            return Err(UploadError::rejected(
+                ThreatClass::ArchiveBomb,
+                ReasonCode::ArchiveEntryLimit,
+            ));
+        }
         let mut header = [0_u8; 46];
         reader.read_exact(&mut header).map_err(|_| {
             UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
@@ -730,12 +742,6 @@ fn scan_central_directory_names_and_spans<R: Read + Seek>(
         let name = String::from_utf8(name).map_err(|_| {
             UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
         })?;
-        if !seen.insert(name.trim_end_matches('/').to_string()) {
-            return Err(UploadError::rejected(
-                ThreatClass::MalformedOoxml,
-                ReasonCode::MalformedArchive,
-            ));
-        }
         central_entries.push((name.trim_end_matches('/').to_string(), local_header_offset));
         reader
             .seek(SeekFrom::Current((extra_len + comment_len) as i64))
@@ -744,21 +750,21 @@ fn scan_central_directory_names_and_spans<R: Read + Seek>(
             })?;
     }
     central_entries.sort_by_key(|(_, offset)| *offset);
-    let mut spans = HashMap::new();
-    for index in 0..central_entries.len() {
-        let (name, local_header_offset) = &central_entries[index];
+    let mut spans = HashMap::with_capacity(central_entries.len());
+    let mut central_entries = central_entries.into_iter().peekable();
+    while let Some((name, local_header_offset)) = central_entries.next() {
         let next_offset = central_entries
-            .get(index + 1)
+            .peek()
             .map(|(_, offset)| *offset)
             .unwrap_or(central_offset);
-        if next_offset <= *local_header_offset {
+        if next_offset <= local_header_offset {
             return Err(UploadError::rejected(
                 ThreatClass::MalformedOoxml,
                 ReasonCode::MalformedArchive,
             ));
         }
         reader
-            .seek(SeekFrom::Start(*local_header_offset))
+            .seek(SeekFrom::Start(local_header_offset))
             .map_err(|_| {
                 UploadError::rejected(ThreatClass::MalformedOoxml, ReasonCode::MalformedArchive)
             })?;
@@ -784,7 +790,12 @@ fn scan_central_directory_names_and_spans<R: Read + Seek>(
                 ReasonCode::MalformedArchive,
             ));
         }
-        spans.insert(name.clone(), next_offset - data_start);
+        if spans.insert(name, next_offset - data_start).is_some() {
+            return Err(UploadError::rejected(
+                ThreatClass::MalformedOoxml,
+                ReasonCode::MalformedArchive,
+            ));
+        }
     }
     Ok(spans)
 }

--- a/crates/server/src/services/upload/error.rs
+++ b/crates/server/src/services/upload/error.rs
@@ -1,0 +1,277 @@
+//! Typed upload errors, dispositions, and redacted reason codes.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::api::ApiError;
+
+/// Terminal intake disposition (P0-09 §7 + Accepted for benign controls).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Disposition {
+    /// Syntactically valid and policy-clean; stored in quarantine for conversion.
+    Accepted,
+    /// Stored for review; must not be indexed until a later policy promotes it.
+    Quarantined,
+    /// Do not store/index; return a user-safe error.
+    Rejected,
+}
+
+impl Disposition {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::Quarantined => "quarantined",
+            Self::Rejected => "rejected",
+        }
+    }
+}
+
+/// Threat classification for audit (redacted; never includes filenames/content).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThreatClass {
+    ExtensionSpoof,
+    MimeMismatch,
+    UnsupportedFormat,
+    ArchiveBomb,
+    ArchiveTraversal,
+    NestedArchive,
+    MalformedOoxml,
+    ParserCorruption,
+    Oversize,
+    TruncatedUpload,
+    PdfPageBomb,
+    ImagePixelBomb,
+    AudioDurationLimit,
+    CsvFormula,
+    PromptInjection,
+    ActiveContent,
+    PermissionDenied,
+    StorageFailure,
+    MultipartInvalid,
+    Internal,
+}
+
+impl ThreatClass {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExtensionSpoof => "extension_spoof",
+            Self::MimeMismatch => "mime_mismatch",
+            Self::UnsupportedFormat => "unsupported_format",
+            Self::ArchiveBomb => "archive_bomb",
+            Self::ArchiveTraversal => "archive_path_traversal",
+            Self::NestedArchive => "nested_archive",
+            Self::MalformedOoxml => "malformed_ooxml",
+            Self::ParserCorruption => "parser_corruption",
+            Self::Oversize => "oversize",
+            Self::TruncatedUpload => "truncated_upload",
+            Self::PdfPageBomb => "pdf_page_bomb",
+            Self::ImagePixelBomb => "image_pixel_bomb",
+            Self::AudioDurationLimit => "audio_duration_limit",
+            Self::CsvFormula => "csv_formula",
+            Self::PromptInjection => "prompt_injection",
+            Self::ActiveContent => "active_content",
+            Self::PermissionDenied => "permission_denied",
+            Self::StorageFailure => "storage_failure",
+            Self::MultipartInvalid => "multipart_invalid",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+/// Stable, redacted reason codes (safe for logs and API details).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReasonCode {
+    ExtensionMagicMismatch,
+    MagicUnrecognized,
+    UploadTooLarge,
+    StreamInterrupted,
+    ArchiveEntryLimit,
+    ArchiveUncompressedLimit,
+    ArchiveCompressionRatio,
+    ArchivePathTraversal,
+    NestedArchiveEntry,
+    MissingContentTypes,
+    MissingFormatPaths,
+    MalformedArchive,
+    MalformedXml,
+    PdfMissingEof,
+    PdfPageLimit,
+    ImagePixelLimit,
+    AudioDurationReview,
+    CsvFormulaReview,
+    PromptInjectionReview,
+    HtmlActiveContent,
+    PermissionDenied,
+    StorageUnavailable,
+    MultipartMissingFile,
+    MultipartTooManyFiles,
+    FailClosed,
+}
+
+impl ReasonCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExtensionMagicMismatch => "extension_magic_mismatch",
+            Self::MagicUnrecognized => "magic_unrecognized",
+            Self::UploadTooLarge => "upload_too_large",
+            Self::StreamInterrupted => "stream_interrupted",
+            Self::ArchiveEntryLimit => "archive_entry_limit",
+            Self::ArchiveUncompressedLimit => "archive_uncompressed_limit",
+            Self::ArchiveCompressionRatio => "archive_compression_ratio",
+            Self::ArchivePathTraversal => "archive_path_traversal",
+            Self::NestedArchiveEntry => "nested_archive_entry",
+            Self::MissingContentTypes => "missing_content_types",
+            Self::MissingFormatPaths => "missing_format_paths",
+            Self::MalformedArchive => "malformed_archive",
+            Self::MalformedXml => "malformed_xml",
+            Self::PdfMissingEof => "pdf_missing_eof",
+            Self::PdfPageLimit => "pdf_page_limit",
+            Self::ImagePixelLimit => "image_pixel_limit",
+            Self::AudioDurationReview => "audio_duration_review",
+            Self::CsvFormulaReview => "csv_formula_review",
+            Self::PromptInjectionReview => "prompt_injection_review",
+            Self::HtmlActiveContent => "html_active_content",
+            Self::PermissionDenied => "permission_denied",
+            Self::StorageUnavailable => "storage_unavailable",
+            Self::MultipartMissingFile => "multipart_missing_file",
+            Self::MultipartTooManyFiles => "multipart_too_many_files",
+            Self::FailClosed => "fail_closed",
+        }
+    }
+}
+
+/// Typed upload failure (never carries raw filenames or content).
+#[derive(Debug, Error)]
+pub enum UploadError {
+    #[error("upload rejected")]
+    Rejected {
+        threat: ThreatClass,
+        reason: ReasonCode,
+    },
+    #[error("permission denied")]
+    PermissionDenied,
+    #[error("storage unavailable")]
+    StorageUnavailable,
+    #[error("multipart invalid")]
+    MultipartInvalid { reason: ReasonCode },
+    #[error("internal upload error")]
+    Internal,
+}
+
+impl UploadError {
+    pub const fn rejected(threat: ThreatClass, reason: ReasonCode) -> Self {
+        Self::Rejected { threat, reason }
+    }
+
+    pub fn threat_class(&self) -> Option<ThreatClass> {
+        match self {
+            Self::Rejected { threat, .. } => Some(*threat),
+            Self::PermissionDenied => Some(ThreatClass::PermissionDenied),
+            Self::StorageUnavailable => Some(ThreatClass::StorageFailure),
+            Self::MultipartInvalid { .. } => Some(ThreatClass::MultipartInvalid),
+            Self::Internal => Some(ThreatClass::Internal),
+        }
+    }
+
+    pub fn reason_code(&self) -> ReasonCode {
+        match self {
+            Self::Rejected { reason, .. } => *reason,
+            Self::PermissionDenied => ReasonCode::PermissionDenied,
+            Self::StorageUnavailable => ReasonCode::StorageUnavailable,
+            Self::MultipartInvalid { reason } => *reason,
+            Self::Internal => ReasonCode::FailClosed,
+        }
+    }
+
+    pub fn status_code(&self) -> StatusCode {
+        match self {
+            Self::Rejected {
+                threat: ThreatClass::Oversize,
+                ..
+            } => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::Rejected { .. } | Self::MultipartInvalid { .. } => StatusCode::BAD_REQUEST,
+            Self::PermissionDenied => StatusCode::FORBIDDEN,
+            Self::StorageUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+            Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    pub fn api_code(&self) -> &'static str {
+        match self {
+            Self::Rejected {
+                threat: ThreatClass::Oversize,
+                ..
+            } => "upload_too_large",
+            Self::Rejected { .. } => "upload_rejected",
+            Self::PermissionDenied => "permission_denied",
+            Self::StorageUnavailable => "storage_unavailable",
+            Self::MultipartInvalid { .. } => "multipart_invalid",
+            Self::Internal => "internal_error",
+        }
+    }
+
+    pub fn user_message(&self) -> &'static str {
+        match self {
+            Self::Rejected {
+                threat: ThreatClass::Oversize,
+                ..
+            } => "Upload exceeds the maximum allowed size",
+            Self::Rejected { .. } => "Upload was rejected by security policy",
+            Self::PermissionDenied => "Permission denied",
+            Self::StorageUnavailable => "Object storage is unavailable",
+            Self::MultipartInvalid { .. } => "Multipart upload is invalid",
+            Self::Internal => "Upload failed",
+        }
+    }
+
+    pub fn into_response_with_request_id(self, request_id: &str) -> Response {
+        let details = serde_json::json!({
+            "disposition": Disposition::Rejected.as_str(),
+            "threatClass": self.threat_class().map(|t| t.as_str()),
+            "reasonCode": self.reason_code().as_str(),
+        });
+        (
+            self.status_code(),
+            Json(ApiError {
+                code: self.api_code().into(),
+                message: self.user_message().into(),
+                request_id: request_id.to_string(),
+                details: Some(details),
+            }),
+        )
+            .into_response()
+    }
+}
+
+impl IntoResponse for UploadError {
+    fn into_response(self) -> Response {
+        self.into_response_with_request_id(&Uuid::new_v4().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejected_errors_never_embed_filenames() {
+        let err = UploadError::rejected(
+            ThreatClass::ExtensionSpoof,
+            ReasonCode::ExtensionMagicMismatch,
+        );
+        let rendered = format!("{err:?}");
+        assert!(!rendered.contains("passwd"));
+        assert!(!rendered.contains(".pdf"));
+        assert_eq!(err.api_code(), "upload_rejected");
+        assert_eq!(err.status_code(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn oversize_maps_to_413() {
+        let err = UploadError::rejected(ThreatClass::Oversize, ReasonCode::UploadTooLarge);
+        assert_eq!(err.status_code(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+}

--- a/crates/server/src/services/upload/error.rs
+++ b/crates/server/src/services/upload/error.rs
@@ -108,6 +108,9 @@ pub enum ReasonCode {
     StorageUnavailable,
     MultipartMissingFile,
     MultipartTooManyFiles,
+    MultipartTooManyParts,
+    MultipartHeaderTooLarge,
+    MultipartTimeout,
     FailClosed,
 }
 
@@ -138,6 +141,9 @@ impl ReasonCode {
             Self::StorageUnavailable => "storage_unavailable",
             Self::MultipartMissingFile => "multipart_missing_file",
             Self::MultipartTooManyFiles => "multipart_too_many_files",
+            Self::MultipartTooManyParts => "multipart_too_many_parts",
+            Self::MultipartHeaderTooLarge => "multipart_header_too_large",
+            Self::MultipartTimeout => "multipart_timeout",
             Self::FailClosed => "fail_closed",
         }
     }

--- a/crates/server/src/services/upload/limits.rs
+++ b/crates/server/src/services/upload/limits.rs
@@ -1,0 +1,126 @@
+//! Upload security limits from `docs/markhand-web-upload-policy.md` §2.
+
+/// Max upload object size: 200 MiB.
+pub const MAX_UPLOAD_BYTES: u64 = 200 * 1024 * 1024;
+/// Max archive entries: 4,096.
+pub const MAX_ARCHIVE_ENTRIES: u64 = 4_096;
+/// Max archive uncompressed bytes: 1 GiB.
+pub const MAX_ARCHIVE_UNCOMPRESSED_BYTES: u64 = 1024 * 1024 * 1024;
+/// Max archive compression ratio: 100:1.
+pub const MAX_ARCHIVE_COMPRESSION_RATIO: u64 = 100;
+/// Max PDF pages (header-level preflight).
+pub const MAX_PDF_PAGES: u32 = 500;
+/// Max image pixels (header-level preflight).
+pub const MAX_IMAGE_PIXELS: u64 = 80_000_000;
+/// Max audio duration seconds (header-level preflight).
+pub const MAX_AUDIO_DURATION_SECS: u64 = 3_600;
+/// Streaming read chunk size (bounded memory).
+pub const STREAM_CHUNK_BYTES: usize = 64 * 1024;
+/// Bytes retained from the head for magic sniffing.
+pub const MAGIC_SNIFF_BYTES: usize = 512;
+/// Bound for a single archive entry decompression during membership checks.
+pub const MAX_SINGLE_ENTRY_READ_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Typed upload limits (policy defaults; overridable via config).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LimitsConfig {
+    pub max_upload_bytes: u64,
+    pub max_archive_entries: u64,
+    pub max_archive_uncompressed_bytes: u64,
+    pub max_archive_compression_ratio: u64,
+    pub max_pdf_pages: u32,
+    pub max_image_pixels: u64,
+    pub max_audio_duration_secs: u64,
+}
+
+impl LimitsConfig {
+    /// Policy defaults from P0-09 upload policy §2.
+    pub const fn policy_defaults() -> Self {
+        Self {
+            max_upload_bytes: MAX_UPLOAD_BYTES,
+            max_archive_entries: MAX_ARCHIVE_ENTRIES,
+            max_archive_uncompressed_bytes: MAX_ARCHIVE_UNCOMPRESSED_BYTES,
+            max_archive_compression_ratio: MAX_ARCHIVE_COMPRESSION_RATIO,
+            max_pdf_pages: MAX_PDF_PAGES,
+            max_image_pixels: MAX_IMAGE_PIXELS,
+            max_audio_duration_secs: MAX_AUDIO_DURATION_SECS,
+        }
+    }
+
+    /// Fail-closed validation of configured limits (must not exceed policy caps).
+    pub fn validate(&self) -> Result<(), String> {
+        if self.max_upload_bytes == 0 || self.max_upload_bytes > MAX_UPLOAD_BYTES {
+            return Err(format!(
+                "upload max_upload_bytes must be between 1 and {MAX_UPLOAD_BYTES}"
+            ));
+        }
+        if self.max_archive_entries == 0 || self.max_archive_entries > MAX_ARCHIVE_ENTRIES {
+            return Err(format!(
+                "upload max_archive_entries must be between 1 and {MAX_ARCHIVE_ENTRIES}"
+            ));
+        }
+        if self.max_archive_uncompressed_bytes == 0
+            || self.max_archive_uncompressed_bytes > MAX_ARCHIVE_UNCOMPRESSED_BYTES
+        {
+            return Err(format!(
+                "upload max_archive_uncompressed_bytes must be between 1 and {MAX_ARCHIVE_UNCOMPRESSED_BYTES}"
+            ));
+        }
+        if self.max_archive_compression_ratio == 0
+            || self.max_archive_compression_ratio > MAX_ARCHIVE_COMPRESSION_RATIO
+        {
+            return Err(format!(
+                "upload max_archive_compression_ratio must be between 1 and {MAX_ARCHIVE_COMPRESSION_RATIO}"
+            ));
+        }
+        if self.max_pdf_pages == 0 || self.max_pdf_pages > MAX_PDF_PAGES {
+            return Err(format!(
+                "upload max_pdf_pages must be between 1 and {MAX_PDF_PAGES}"
+            ));
+        }
+        if self.max_image_pixels == 0 || self.max_image_pixels > MAX_IMAGE_PIXELS {
+            return Err(format!(
+                "upload max_image_pixels must be between 1 and {MAX_IMAGE_PIXELS}"
+            ));
+        }
+        if self.max_audio_duration_secs == 0
+            || self.max_audio_duration_secs > MAX_AUDIO_DURATION_SECS
+        {
+            return Err(format!(
+                "upload max_audio_duration_secs must be between 1 and {MAX_AUDIO_DURATION_SECS}"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Default for LimitsConfig {
+    fn default() -> Self {
+        Self::policy_defaults()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_defaults_match_documented_caps() {
+        let limits = LimitsConfig::policy_defaults();
+        assert_eq!(limits.max_upload_bytes, 200 * 1024 * 1024);
+        assert_eq!(limits.max_archive_entries, 4_096);
+        assert_eq!(limits.max_archive_uncompressed_bytes, 1024 * 1024 * 1024);
+        assert_eq!(limits.max_archive_compression_ratio, 100);
+        assert_eq!(limits.max_pdf_pages, 500);
+        assert_eq!(limits.max_image_pixels, 80_000_000);
+        assert_eq!(limits.max_audio_duration_secs, 3_600);
+        limits.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_limits_above_policy_caps() {
+        let mut limits = LimitsConfig::policy_defaults();
+        limits.max_upload_bytes = MAX_UPLOAD_BYTES + 1;
+        assert!(limits.validate().is_err());
+    }
+}

--- a/crates/server/src/services/upload/limits.rs
+++ b/crates/server/src/services/upload/limits.rs
@@ -14,6 +14,14 @@ pub const MAX_PDF_PAGES: u32 = 500;
 pub const MAX_IMAGE_PIXELS: u64 = 80_000_000;
 /// Max audio duration seconds (header-level preflight).
 pub const MAX_AUDIO_DURATION_SECS: u64 = 3_600;
+/// Max multipart parts accepted per upload request.
+pub const MAX_MULTIPART_PARTS: u32 = 8;
+/// Max bytes allowed in per-part disposition/type metadata captured by Axum.
+pub const MAX_PART_HEADER_BYTES: usize = 8 * 1024;
+/// Whole upload request timeout.
+pub const UPLOAD_TIMEOUT_SECS: u64 = 120;
+/// Idle timeout while waiting for the next multipart field/chunk.
+pub const UPLOAD_IDLE_TIMEOUT_SECS: u64 = 15;
 /// Streaming read chunk size (bounded memory).
 pub const STREAM_CHUNK_BYTES: usize = 64 * 1024;
 /// Bytes retained from the head for magic sniffing.
@@ -31,6 +39,10 @@ pub struct LimitsConfig {
     pub max_pdf_pages: u32,
     pub max_image_pixels: u64,
     pub max_audio_duration_secs: u64,
+    pub max_multipart_parts: u32,
+    pub max_part_header_bytes: usize,
+    pub upload_timeout_secs: u64,
+    pub upload_idle_timeout_secs: u64,
 }
 
 impl LimitsConfig {
@@ -44,6 +56,10 @@ impl LimitsConfig {
             max_pdf_pages: MAX_PDF_PAGES,
             max_image_pixels: MAX_IMAGE_PIXELS,
             max_audio_duration_secs: MAX_AUDIO_DURATION_SECS,
+            max_multipart_parts: MAX_MULTIPART_PARTS,
+            max_part_header_bytes: MAX_PART_HEADER_BYTES,
+            upload_timeout_secs: UPLOAD_TIMEOUT_SECS,
+            upload_idle_timeout_secs: UPLOAD_IDLE_TIMEOUT_SECS,
         }
     }
 
@@ -90,6 +106,29 @@ impl LimitsConfig {
                 "upload max_audio_duration_secs must be between 1 and {MAX_AUDIO_DURATION_SECS}"
             ));
         }
+        if self.max_multipart_parts == 0 || self.max_multipart_parts > MAX_MULTIPART_PARTS {
+            return Err(format!(
+                "upload max_multipart_parts must be between 1 and {MAX_MULTIPART_PARTS}"
+            ));
+        }
+        if self.max_part_header_bytes == 0 || self.max_part_header_bytes > MAX_PART_HEADER_BYTES {
+            return Err(format!(
+                "upload max_part_header_bytes must be between 1 and {MAX_PART_HEADER_BYTES}"
+            ));
+        }
+        if self.upload_timeout_secs == 0 || self.upload_timeout_secs > UPLOAD_TIMEOUT_SECS {
+            return Err(format!(
+                "upload upload_timeout_secs must be between 1 and {UPLOAD_TIMEOUT_SECS}"
+            ));
+        }
+        if self.upload_idle_timeout_secs == 0
+            || self.upload_idle_timeout_secs > UPLOAD_IDLE_TIMEOUT_SECS
+            || self.upload_idle_timeout_secs > self.upload_timeout_secs
+        {
+            return Err(format!(
+                "upload upload_idle_timeout_secs must be between 1 and min(upload_timeout_secs, {UPLOAD_IDLE_TIMEOUT_SECS})"
+            ));
+        }
         Ok(())
     }
 }
@@ -114,6 +153,10 @@ mod tests {
         assert_eq!(limits.max_pdf_pages, 500);
         assert_eq!(limits.max_image_pixels, 80_000_000);
         assert_eq!(limits.max_audio_duration_secs, 3_600);
+        assert_eq!(limits.max_multipart_parts, 8);
+        assert_eq!(limits.max_part_header_bytes, 8 * 1024);
+        assert_eq!(limits.upload_timeout_secs, 120);
+        assert_eq!(limits.upload_idle_timeout_secs, 15);
         limits.validate().unwrap();
     }
 

--- a/crates/server/src/services/upload/mod.rs
+++ b/crates/server/src/services/upload/mod.rs
@@ -1,0 +1,575 @@
+//! Quarantine upload intake (P1B-I01): auth → stream → hash → allowlist → disposition.
+//!
+//! Quota reservation is intentionally not implemented here (P1B-I02). Callers must
+//! invoke [`quota_reserve_hook`] which currently logs a TODO and returns Ok.
+
+mod archive;
+mod error;
+mod limits;
+mod sniff;
+mod stream;
+
+pub use archive::{reject_dangerous_entry_name, validate_zip_archive, ArchiveCheck};
+pub use error::{Disposition, ReasonCode, ThreatClass, UploadError};
+pub use limits::{LimitsConfig, STREAM_CHUNK_BYTES};
+pub use sniff::{detect_magic, resolve_canonical_format, CanonicalFormat};
+pub use stream::{stream_async_read_to_tempfile, stream_to_tempfile, StreamedUpload};
+
+use std::io::Read;
+use std::path::Path;
+
+use tokio::fs::File as TokioFile;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::auth::permissions::{require_permission, ResolveError};
+use crate::storage::keys::quarantine_key;
+use crate::storage::minio::{MinioClient, ObjectIdentityMeta};
+use crate::storage::ObjectKey;
+
+/// Upload policy + limits configuration section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UploadConfig {
+    pub limits: LimitsConfig,
+}
+
+impl UploadConfig {
+    pub const fn policy_defaults() -> Self {
+        Self {
+            limits: LimitsConfig::policy_defaults(),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        self.limits.validate()
+    }
+}
+
+impl Default for UploadConfig {
+    fn default() -> Self {
+        Self::policy_defaults()
+    }
+}
+
+/// Successful intake result (Accepted or Quarantined). Rejected paths use [`UploadError`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UploadOutcome {
+    pub disposition: Disposition,
+    pub threat_class: Option<ThreatClass>,
+    pub reason_code: Option<ReasonCode>,
+    pub object_key: ObjectKey,
+    pub object_id: Uuid,
+    pub sha256_hex: String,
+    pub size_bytes: u64,
+    pub canonical_format: CanonicalFormat,
+    /// Original filename retained as metadata only (never in the key).
+    pub original_filename: Option<String>,
+}
+
+/// Integration hook for P1B-I02 quota reservation (not implemented).
+///
+/// Callers must invoke this before streaming bytes. Today it is a no-op success
+/// so intake remains fail-open on quota until I02 lands — the hook exists so the
+/// call site is unambiguous.
+pub fn quota_reserve_hook(_org: &OrgContext, _idempotency_key: &str, _bytes: Option<u64>) {
+    // TODO(P1B-I02): atomically reserve tenant quota with an idempotency key
+    // before accepting upload bytes; release on rejection/timeout.
+}
+
+/// Validate a fully-received tempfile and optionally persist to quarantine storage.
+pub async fn validate_and_quarantine(
+    org: &OrgContext,
+    storage: &MinioClient,
+    limits: &LimitsConfig,
+    streamed: StreamedUpload,
+    declared_filename: Option<&str>,
+) -> Result<UploadOutcome, UploadError> {
+    require_permission(org, "doc.upload").map_err(|error| match error {
+        ResolveError::PermissionDenied => UploadError::PermissionDenied,
+        _ => UploadError::Internal,
+    })?;
+
+    // TODO(P1B-I02): pass expected size into quota_reserve_hook once implemented.
+    quota_reserve_hook(org, "upload", Some(streamed.size_bytes));
+
+    let path = streamed.tempfile.path();
+    let validation = match validate_bytes(path, &streamed.head, declared_filename, limits) {
+        Ok(result) => result,
+        Err(error) => {
+            // Rejected: never leave a quarantine object.
+            return Err(error);
+        }
+    };
+
+    let object_id = Uuid::new_v4();
+    // Filename is metadata only — quarantine_key ignores it for the path.
+    let key = quarantine_key(org.org_id(), object_id, declared_filename)
+        .map_err(|_| UploadError::Internal)?;
+
+    // Defense in depth: key must never contain the client filename.
+    if let Some(name) = declared_filename {
+        let key_str = key.as_str();
+        if !name.is_empty() && key_str.contains(name) {
+            return Err(UploadError::Internal);
+        }
+    }
+
+    let safe_filename = declared_filename.map(sanitize_filename_metadata);
+    let meta = ObjectIdentityMeta {
+        org_id: org.org_id(),
+        collection_id: None,
+        document_id: None,
+        version_id: None,
+        original_filename: safe_filename.clone(),
+        canonical_format: Some(validation.format.as_str().to_string()),
+        content_sha256: Some(streamed.sha256_hex.clone()),
+        content_length: Some(streamed.size_bytes),
+        disposition: Some(validation.disposition.as_str().to_string()),
+    };
+
+    let file = TokioFile::open(path)
+        .await
+        .map_err(|_| UploadError::Internal)?;
+    storage
+        .put_object_stream(
+            org.org_id(),
+            &key,
+            file,
+            &meta,
+            content_type_for(validation.format),
+        )
+        .await
+        .map_err(|_| UploadError::StorageUnavailable)?;
+
+    Ok(UploadOutcome {
+        disposition: validation.disposition,
+        threat_class: validation.threat_class,
+        reason_code: validation.reason_code,
+        object_key: key,
+        object_id,
+        sha256_hex: streamed.sha256_hex,
+        size_bytes: streamed.size_bytes,
+        canonical_format: validation.format,
+        original_filename: safe_filename,
+    })
+}
+
+/// Stream a multipart field to tempfile then validate + quarantine.
+pub async fn intake_field<R>(
+    org: &OrgContext,
+    storage: &MinioClient,
+    limits: &LimitsConfig,
+    reader: R,
+    declared_filename: Option<&str>,
+) -> Result<UploadOutcome, UploadError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let streamed = stream_async_read_to_tempfile(reader, limits).await?;
+    validate_and_quarantine(org, storage, limits, streamed, declared_filename).await
+}
+
+#[derive(Debug)]
+struct ValidationResult {
+    format: CanonicalFormat,
+    disposition: Disposition,
+    threat_class: Option<ThreatClass>,
+    reason_code: Option<ReasonCode>,
+}
+
+fn validate_bytes(
+    path: &Path,
+    head: &[u8],
+    declared_filename: Option<&str>,
+    limits: &LimitsConfig,
+) -> Result<ValidationResult, UploadError> {
+    let mut format = resolve_canonical_format(head, declared_filename)?;
+
+    if format.is_zip_container() || head.starts_with(b"PK") {
+        let check = validate_zip_archive(path, format, limits)?;
+        format = check.format;
+        // Re-check extension consistency against refined format.
+        if let Some(name) = declared_filename {
+            let ext = name
+                .rsplit(['/', '\\'])
+                .next()
+                .and_then(|base| base.rsplit_once('.'))
+                .map(|(_, ext)| ext.to_ascii_lowercase())
+                .unwrap_or_default();
+            let ok = match format {
+                CanonicalFormat::Docx => ext == "docx",
+                CanonicalFormat::Pptx => ext == "pptx",
+                CanonicalFormat::Xlsx => ext == "xlsx",
+                CanonicalFormat::Ods => ext == "ods",
+                _ => true,
+            };
+            if !ok {
+                return Err(UploadError::rejected(
+                    ThreatClass::ExtensionSpoof,
+                    ReasonCode::ExtensionMagicMismatch,
+                ));
+            }
+        }
+    }
+
+    match format {
+        CanonicalFormat::Pdf => preflight_pdf(path, limits)?,
+        CanonicalFormat::Png
+        | CanonicalFormat::Jpeg
+        | CanonicalFormat::Webp
+        | CanonicalFormat::Tiff
+        | CanonicalFormat::Bmp => preflight_image(path, format, limits)?,
+        CanonicalFormat::Wav
+        | CanonicalFormat::Mp3
+        | CanonicalFormat::Ogg
+        | CanonicalFormat::Flac
+        | CanonicalFormat::M4a => {
+            if let Some(review) = preflight_audio(path, format, limits)? {
+                return Ok(review);
+            }
+        }
+        CanonicalFormat::Csv => {
+            if let Some(review) = preflight_csv(path)? {
+                return Ok(review);
+            }
+        }
+        CanonicalFormat::Html => {
+            if let Some(outcome) = preflight_html(path)? {
+                return Ok(outcome);
+            }
+        }
+        CanonicalFormat::PlainText
+        | CanonicalFormat::Docx
+        | CanonicalFormat::Pptx
+        | CanonicalFormat::Xlsx
+        | CanonicalFormat::Ods
+        | CanonicalFormat::Xls
+        | CanonicalFormat::Xlsb
+        | CanonicalFormat::ZipContainer => {}
+    }
+
+    Ok(ValidationResult {
+        format,
+        disposition: Disposition::Accepted,
+        threat_class: None,
+        reason_code: None,
+    })
+}
+
+fn preflight_pdf(path: &Path, limits: &LimitsConfig) -> Result<(), UploadError> {
+    let mut file = std::fs::File::open(path).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let mut buf = Vec::new();
+    // Cap PDF preflight read at upload limit (already enforced) but stream in chunks.
+    file.read_to_end(&mut buf).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    if !buf.windows(5).any(|w| w == b"%%EOF") && !buf.ends_with(b"%%EOF\n") {
+        // Allow %%EOF with trailing whitespace.
+        let trimmed = trim_ascii_end(&buf);
+        if !trimmed.ends_with(b"%%EOF") {
+            return Err(UploadError::rejected(
+                ThreatClass::ParserCorruption,
+                ReasonCode::PdfMissingEof,
+            ));
+        }
+    }
+    // Cheap page-count heuristic (not a full PDF parser).
+    let pages = count_pdf_pages_heuristic(&buf);
+    if pages > limits.max_pdf_pages {
+        return Err(UploadError::rejected(
+            ThreatClass::PdfPageBomb,
+            ReasonCode::PdfPageLimit,
+        ));
+    }
+    Ok(())
+}
+
+fn count_pdf_pages_heuristic(data: &[u8]) -> u32 {
+    // Count `/Type /Page` not followed by `s` (Page vs Pages).
+    let mut count = 0_u32;
+    let mut i = 0;
+    while i + 10 < data.len() {
+        if &data[i..i + 5] == b"/Type" {
+            let mut j = i + 5;
+            while j < data.len() && data[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if data[j..].starts_with(b"/Page") {
+                let after = j + 5;
+                if after >= data.len() || data[after] != b's' {
+                    count = count.saturating_add(1);
+                }
+            }
+        }
+        i += 1;
+    }
+    count
+}
+
+fn preflight_image(
+    path: &Path,
+    format: CanonicalFormat,
+    limits: &LimitsConfig,
+) -> Result<(), UploadError> {
+    let mut file = std::fs::File::open(path).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let mut head = [0_u8; 64];
+    let n = file.read(&mut head).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let pixels = image_pixel_count(&head[..n], format).unwrap_or(0);
+    if pixels > limits.max_image_pixels {
+        return Err(UploadError::rejected(
+            ThreatClass::ImagePixelBomb,
+            ReasonCode::ImagePixelLimit,
+        ));
+    }
+    Ok(())
+}
+
+fn image_pixel_count(head: &[u8], format: CanonicalFormat) -> Option<u64> {
+    match format {
+        CanonicalFormat::Png if head.len() >= 24 => {
+            let w = u32::from_be_bytes(head[16..20].try_into().ok()?);
+            let h = u32::from_be_bytes(head[20..24].try_into().ok()?);
+            Some(u64::from(w).saturating_mul(u64::from(h)))
+        }
+        CanonicalFormat::Bmp if head.len() >= 26 => {
+            let w = i32::from_le_bytes(head[18..22].try_into().ok()?).unsigned_abs();
+            let h = i32::from_le_bytes(head[22..26].try_into().ok()?).unsigned_abs();
+            Some(u64::from(w).saturating_mul(u64::from(h)))
+        }
+        // JPEG/WebP/TIFF: defer deep decode to sandbox; header presence is enough here.
+        _ => Some(0),
+    }
+}
+
+fn preflight_audio(
+    path: &Path,
+    format: CanonicalFormat,
+    limits: &LimitsConfig,
+) -> Result<Option<ValidationResult>, UploadError> {
+    if format != CanonicalFormat::Wav {
+        return Ok(None);
+    }
+    let mut file = std::fs::File::open(path).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let mut head = [0_u8; 44];
+    file.read_exact(&mut head).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    if &head[0..4] != b"RIFF" || &head[8..12] != b"WAVE" {
+        return Err(UploadError::rejected(
+            ThreatClass::MimeMismatch,
+            ReasonCode::ExtensionMagicMismatch,
+        ));
+    }
+    let byte_rate = u32::from_le_bytes(head[28..32].try_into().unwrap_or([0; 4]));
+    let meta = file.metadata().map_err(|_| UploadError::Internal)?;
+    let data_bytes = meta.len().saturating_sub(44);
+    if byte_rate == 0 {
+        return Ok(None);
+    }
+    let duration_secs = data_bytes / u64::from(byte_rate);
+    if duration_secs > limits.max_audio_duration_secs {
+        return Ok(Some(ValidationResult {
+            format,
+            disposition: Disposition::Quarantined,
+            threat_class: Some(ThreatClass::AudioDurationLimit),
+            reason_code: Some(ReasonCode::AudioDurationReview),
+        }));
+    }
+    Ok(None)
+}
+
+fn preflight_csv(path: &Path) -> Result<Option<ValidationResult>, UploadError> {
+    let mut file = std::fs::File::open(path).map_err(|_| UploadError::Internal)?;
+    let mut buf = String::new();
+    // Bound CSV preflight text read.
+    let mut limited = (&mut file).take(1024 * 1024);
+    limited.read_to_string(&mut buf).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    for line in buf.lines().skip(1) {
+        for cell in line.split([',', '\t']) {
+            let trimmed = cell.trim().trim_matches('"');
+            if trimmed.starts_with(['=', '+', '-', '@']) {
+                return Ok(Some(ValidationResult {
+                    format: CanonicalFormat::Csv,
+                    disposition: Disposition::Quarantined,
+                    threat_class: Some(ThreatClass::CsvFormula),
+                    reason_code: Some(ReasonCode::CsvFormulaReview),
+                }));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn preflight_html(path: &Path) -> Result<Option<ValidationResult>, UploadError> {
+    let mut file = std::fs::File::open(path).map_err(|_| UploadError::Internal)?;
+    let mut buf = String::new();
+    let mut limited = (&mut file).take(1024 * 1024);
+    limited.read_to_string(&mut buf).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let lower = buf.to_ascii_lowercase();
+    if lower.contains("<script")
+        || lower.contains("javascript:")
+        || lower.contains("onerror=")
+        || lower.contains("onload=")
+    {
+        return Err(UploadError::rejected(
+            ThreatClass::ActiveContent,
+            ReasonCode::HtmlActiveContent,
+        ));
+    }
+    if lower.contains("ignore previous")
+        || lower.contains("system prompt")
+        || lower.contains("bỏ qua")
+        || lower.contains("bo qua")
+        || lower.contains("tiết lộ")
+        || lower.contains("tiet lo")
+    {
+        return Ok(Some(ValidationResult {
+            format: CanonicalFormat::Html,
+            disposition: Disposition::Quarantined,
+            threat_class: Some(ThreatClass::PromptInjection),
+            reason_code: Some(ReasonCode::PromptInjectionReview),
+        }));
+    }
+    Ok(None)
+}
+
+fn sanitize_filename_metadata(name: &str) -> String {
+    name.chars()
+        .filter(|ch| !ch.is_control())
+        .take(255)
+        .collect()
+}
+
+fn content_type_for(format: CanonicalFormat) -> &'static str {
+    match format {
+        CanonicalFormat::Pdf => "application/pdf",
+        CanonicalFormat::Docx => {
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        }
+        CanonicalFormat::Pptx => {
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        }
+        CanonicalFormat::Xlsx => {
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        }
+        CanonicalFormat::Ods => "application/vnd.oasis.opendocument.spreadsheet",
+        CanonicalFormat::Csv => "text/csv",
+        CanonicalFormat::Html => "text/html",
+        CanonicalFormat::PlainText => "text/plain",
+        CanonicalFormat::Png => "image/png",
+        CanonicalFormat::Jpeg => "image/jpeg",
+        CanonicalFormat::Webp => "image/webp",
+        CanonicalFormat::Tiff => "image/tiff",
+        CanonicalFormat::Bmp => "image/bmp",
+        CanonicalFormat::Wav => "audio/wav",
+        CanonicalFormat::Mp3 => "audio/mpeg",
+        CanonicalFormat::Ogg => "audio/ogg",
+        CanonicalFormat::Flac => "audio/flac",
+        CanonicalFormat::M4a => "audio/mp4",
+        CanonicalFormat::Xls => "application/vnd.ms-excel",
+        CanonicalFormat::Xlsb => "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+        CanonicalFormat::ZipContainer => "application/zip",
+    }
+}
+
+fn trim_ascii_end(buf: &[u8]) -> &[u8] {
+    let mut end = buf.len();
+    while end > 0 && buf[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+    &buf[..end]
+}
+
+/// Property-style helper: disposition is always one of the typed outcomes.
+pub fn assert_disposition_is_typed(disposition: Disposition) {
+    match disposition {
+        Disposition::Accepted | Disposition::Quarantined | Disposition::Rejected => {}
+    }
+}
+
+/// Validate streamed bytes without persisting (unit / adversarial harness).
+pub fn validate_streamed_bytes(
+    streamed: &StreamedUpload,
+    declared_filename: Option<&str>,
+    limits: &LimitsConfig,
+) -> Result<
+    (
+        CanonicalFormat,
+        Disposition,
+        Option<ThreatClass>,
+        Option<ReasonCode>,
+    ),
+    UploadError,
+> {
+    let result = validate_bytes(
+        streamed.tempfile.path(),
+        &streamed.head,
+        declared_filename,
+        limits,
+    )?;
+    Ok((
+        result.format,
+        result.disposition,
+        result.threat_class,
+        result.reason_code,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::upload::stream::stream_to_tempfile;
+    use bytes::Bytes;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn spoof_pdf_rejects() {
+        let limits = LimitsConfig::policy_defaults();
+        let streamed = stream_to_tempfile(
+            stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from_static(
+                b"not a pdf",
+            ))]),
+            &limits,
+        )
+        .await
+        .unwrap();
+        let err = validate_bytes(
+            streamed.tempfile.path(),
+            &streamed.head,
+            Some("plain-text.pdf"),
+            &limits,
+        )
+        .unwrap_err();
+        assert_eq!(err.threat_class(), Some(ThreatClass::ExtensionSpoof));
+    }
+
+    #[test]
+    fn filename_sanitizer_strips_controls() {
+        let safe = sanitize_filename_metadata("a\nb\0c.pdf");
+        assert!(!safe.contains('\n'));
+        assert!(!safe.contains('\0'));
+    }
+
+    #[test]
+    fn dispositions_are_typed() {
+        for d in [
+            Disposition::Accepted,
+            Disposition::Quarantined,
+            Disposition::Rejected,
+        ] {
+            assert_disposition_is_typed(d);
+        }
+    }
+}

--- a/crates/server/src/services/upload/mod.rs
+++ b/crates/server/src/services/upload/mod.rs
@@ -12,20 +12,29 @@ mod stream;
 pub use archive::{reject_dangerous_entry_name, validate_zip_archive, ArchiveCheck};
 pub use error::{Disposition, ReasonCode, ThreatClass, UploadError};
 pub use limits::{LimitsConfig, STREAM_CHUNK_BYTES};
-pub use sniff::{detect_magic, resolve_canonical_format, CanonicalFormat};
-pub use stream::{stream_async_read_to_tempfile, stream_to_tempfile, StreamedUpload};
+pub use sniff::{
+    declared_extension, detect_magic, extension_matches, mime_matches, resolve_canonical_format,
+    CanonicalFormat,
+};
+pub use stream::{
+    stream_async_read_to_tempfile, stream_to_tempfile, stream_to_tempfile_with_idle_timeout,
+    StreamedUpload,
+};
 
-use std::io::Read;
-use std::path::Path;
+use std::fs::File;
+use std::io::{BufReader, Read, Seek, SeekFrom};
 
 use tokio::fs::File as TokioFile;
+use tokio::io::{AsyncSeekExt, SeekFrom as TokioSeekFrom};
 use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
 use crate::auth::permissions::{require_permission, ResolveError};
 use crate::storage::keys::quarantine_key;
-use crate::storage::minio::{MinioClient, ObjectIdentityMeta};
+use crate::storage::minio::{MinioClient, ObjectIdentityMeta, ObjectPutVerification};
 use crate::storage::ObjectKey;
+
+use self::archive::validate_zip_reader;
 
 /// Upload policy + limits configuration section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -83,6 +92,7 @@ pub async fn validate_and_quarantine(
     limits: &LimitsConfig,
     streamed: StreamedUpload,
     declared_filename: Option<&str>,
+    declared_content_type: Option<&str>,
 ) -> Result<UploadOutcome, UploadError> {
     require_permission(org, "doc.upload").map_err(|error| match error {
         ResolveError::PermissionDenied => UploadError::PermissionDenied,
@@ -92,14 +102,22 @@ pub async fn validate_and_quarantine(
     // TODO(P1B-I02): pass expected size into quota_reserve_hook once implemented.
     quota_reserve_hook(org, "upload", Some(streamed.size_bytes));
 
-    let path = streamed.tempfile.path();
-    let validation = match validate_bytes(path, &streamed.head, declared_filename, limits) {
-        Ok(result) => result,
-        Err(error) => {
-            // Rejected: never leave a quarantine object.
-            return Err(error);
-        }
-    };
+    let mut validation_file = streamed.rewinded_file_clone()?;
+    let head = streamed.head.clone();
+    let declared_filename_owned = declared_filename.map(str::to_owned);
+    let declared_content_type_owned = declared_content_type.map(str::to_owned);
+    let limits_for_validation = *limits;
+    let validation = tokio::task::spawn_blocking(move || {
+        validate_file(
+            &mut validation_file,
+            &head,
+            declared_filename_owned.as_deref(),
+            declared_content_type_owned.as_deref(),
+            &limits_for_validation,
+        )
+    })
+    .await
+    .map_err(|_| UploadError::Internal)??;
 
     let object_id = Uuid::new_v4();
     // Filename is metadata only — quarantine_key ignores it for the path.
@@ -127,7 +145,8 @@ pub async fn validate_and_quarantine(
         disposition: Some(validation.disposition.as_str().to_string()),
     };
 
-    let file = TokioFile::open(path)
+    let mut file = TokioFile::from_std(streamed.rewinded_file_clone()?);
+    file.seek(TokioSeekFrom::Start(0))
         .await
         .map_err(|_| UploadError::Internal)?;
     storage
@@ -137,6 +156,10 @@ pub async fn validate_and_quarantine(
             file,
             &meta,
             content_type_for(validation.format),
+            ObjectPutVerification {
+                expected_len: streamed.size_bytes,
+                expected_sha256: &streamed.sha256_hex,
+            },
         )
         .await
         .map_err(|_| UploadError::StorageUnavailable)?;
@@ -161,12 +184,21 @@ pub async fn intake_field<R>(
     limits: &LimitsConfig,
     reader: R,
     declared_filename: Option<&str>,
+    declared_content_type: Option<&str>,
 ) -> Result<UploadOutcome, UploadError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let streamed = stream_async_read_to_tempfile(reader, limits).await?;
-    validate_and_quarantine(org, storage, limits, streamed, declared_filename).await
+    validate_and_quarantine(
+        org,
+        storage,
+        limits,
+        streamed,
+        declared_filename,
+        declared_content_type,
+    )
+    .await
 }
 
 #[derive(Debug)]
@@ -177,33 +209,24 @@ struct ValidationResult {
     reason_code: Option<ReasonCode>,
 }
 
-fn validate_bytes(
-    path: &Path,
+fn validate_file(
+    file: &mut File,
     head: &[u8],
     declared_filename: Option<&str>,
+    declared_content_type: Option<&str>,
     limits: &LimitsConfig,
 ) -> Result<ValidationResult, UploadError> {
     let mut format = resolve_canonical_format(head, declared_filename)?;
 
     if format.is_zip_container() || head.starts_with(b"PK") {
-        let check = validate_zip_archive(path, format, limits)?;
+        file.seek(SeekFrom::Start(0)).map_err(|_| {
+            UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+        })?;
+        let check = validate_zip_reader(&mut *file, format, limits)?;
         format = check.format;
         // Re-check extension consistency against refined format.
         if let Some(name) = declared_filename {
-            let ext = name
-                .rsplit(['/', '\\'])
-                .next()
-                .and_then(|base| base.rsplit_once('.'))
-                .map(|(_, ext)| ext.to_ascii_lowercase())
-                .unwrap_or_default();
-            let ok = match format {
-                CanonicalFormat::Docx => ext == "docx",
-                CanonicalFormat::Pptx => ext == "pptx",
-                CanonicalFormat::Xlsx => ext == "xlsx",
-                CanonicalFormat::Ods => ext == "ods",
-                _ => true,
-            };
-            if !ok {
+            if declared_extension(name).is_none_or(|ext| !extension_matches(format, ext)) {
                 return Err(UploadError::rejected(
                     ThreatClass::ExtensionSpoof,
                     ReasonCode::ExtensionMagicMismatch,
@@ -211,30 +234,38 @@ fn validate_bytes(
             }
         }
     }
+    if let Some(content_type) = declared_content_type {
+        if !mime_matches(format, content_type) {
+            return Err(UploadError::rejected(
+                ThreatClass::MimeMismatch,
+                ReasonCode::ExtensionMagicMismatch,
+            ));
+        }
+    }
 
     match format {
-        CanonicalFormat::Pdf => preflight_pdf(path, limits)?,
+        CanonicalFormat::Pdf => preflight_pdf(file, limits)?,
         CanonicalFormat::Png
         | CanonicalFormat::Jpeg
         | CanonicalFormat::Webp
         | CanonicalFormat::Tiff
-        | CanonicalFormat::Bmp => preflight_image(path, format, limits)?,
+        | CanonicalFormat::Bmp => preflight_image(file, limits)?,
         CanonicalFormat::Wav
         | CanonicalFormat::Mp3
         | CanonicalFormat::Ogg
         | CanonicalFormat::Flac
         | CanonicalFormat::M4a => {
-            if let Some(review) = preflight_audio(path, format, limits)? {
+            if let Some(review) = preflight_audio(file, format, limits)? {
                 return Ok(review);
             }
         }
         CanonicalFormat::Csv => {
-            if let Some(review) = preflight_csv(path)? {
+            if let Some(review) = preflight_csv(file)? {
                 return Ok(review);
             }
         }
         CanonicalFormat::Html => {
-            if let Some(outcome) = preflight_html(path)? {
+            if let Some(outcome) = preflight_html(file)? {
                 return Ok(outcome);
             }
         }
@@ -256,38 +287,69 @@ fn validate_bytes(
     })
 }
 
-fn preflight_pdf(path: &Path, limits: &LimitsConfig) -> Result<(), UploadError> {
-    let mut file = std::fs::File::open(path).map_err(|_| {
+fn preflight_pdf(file: &mut File, limits: &LimitsConfig) -> Result<(), UploadError> {
+    file.seek(SeekFrom::Start(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
-    let mut buf = Vec::new();
-    // Cap PDF preflight read at upload limit (already enforced) but stream in chunks.
-    file.read_to_end(&mut buf).map_err(|_| {
-        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
-    })?;
-    if !buf.windows(5).any(|w| w == b"%%EOF") && !buf.ends_with(b"%%EOF\n") {
-        // Allow %%EOF with trailing whitespace.
-        let trimmed = trim_ascii_end(&buf);
-        if !trimmed.ends_with(b"%%EOF") {
+    let mut buf = [0_u8; STREAM_CHUNK_BYTES];
+    let mut overlap = Vec::new();
+    let mut tail = Vec::new();
+    let mut pages = 0_u32;
+    let mut saw_header = false;
+    let mut saw_startxref = false;
+    let mut saw_xref_table = false;
+    let mut saw_xref_stream = false;
+    let mut saw_obj_stream = false;
+    const TAIL_LIMIT: usize = 1024 * 1024;
+    loop {
+        let n = file.read(&mut buf).map_err(|_| {
+            UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+        })?;
+        if n == 0 {
+            break;
+        }
+        if !saw_header {
+            saw_header = buf[..n].starts_with(b"%PDF-");
+        }
+        let mut window = Vec::with_capacity(overlap.len() + n);
+        window.extend_from_slice(&overlap);
+        window.extend_from_slice(&buf[..n]);
+        pages = pages.saturating_add(count_pdf_pages_heuristic(&window));
+        saw_startxref |= window.windows(9).any(|w| w == b"startxref");
+        saw_xref_table |= window.windows(5).any(|w| w == b"\nxref" || w == b"\rxref");
+        saw_xref_stream |= window.windows(10).any(|w| w == b"/Type/XRef")
+            || window.windows(11).any(|w| w == b"/Type /XRef");
+        saw_obj_stream |= window.windows(7).any(|w| w == b"/ObjStm");
+        if pages > limits.max_pdf_pages {
             return Err(UploadError::rejected(
-                ThreatClass::ParserCorruption,
-                ReasonCode::PdfMissingEof,
+                ThreatClass::PdfPageBomb,
+                ReasonCode::PdfPageLimit,
             ));
         }
+        tail.extend_from_slice(&buf[..n]);
+        if tail.len() > TAIL_LIMIT {
+            let excess = tail.len() - TAIL_LIMIT;
+            tail.drain(..excess);
+        }
+        let keep = window.len().min(64);
+        overlap.clear();
+        overlap.extend_from_slice(&window[window.len() - keep..]);
     }
-    // Cheap page-count heuristic (not a full PDF parser).
-    let pages = count_pdf_pages_heuristic(&buf);
-    if pages > limits.max_pdf_pages {
+    let trimmed = trim_ascii_end(&tail);
+    if !saw_header
+        || !trimmed.ends_with(b"%%EOF")
+        || !saw_startxref
+        || !(saw_xref_table || saw_xref_stream || saw_obj_stream)
+    {
         return Err(UploadError::rejected(
-            ThreatClass::PdfPageBomb,
-            ReasonCode::PdfPageLimit,
+            ThreatClass::ParserCorruption,
+            ReasonCode::PdfMissingEof,
         ));
     }
     Ok(())
 }
 
 fn count_pdf_pages_heuristic(data: &[u8]) -> u32 {
-    // Count `/Type /Page` not followed by `s` (Page vs Pages).
     let mut count = 0_u32;
     let mut i = 0;
     while i + 10 < data.len() {
@@ -308,19 +370,28 @@ fn count_pdf_pages_heuristic(data: &[u8]) -> u32 {
     count
 }
 
-fn preflight_image(
-    path: &Path,
-    format: CanonicalFormat,
-    limits: &LimitsConfig,
-) -> Result<(), UploadError> {
-    let mut file = std::fs::File::open(path).map_err(|_| {
+fn preflight_image(file: &mut File, limits: &LimitsConfig) -> Result<(), UploadError> {
+    file.seek(SeekFrom::Start(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
-    let mut head = [0_u8; 64];
-    let n = file.read(&mut head).map_err(|_| {
+    let clone = file.try_clone().map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
-    let pixels = image_pixel_count(&head[..n], format).unwrap_or(0);
+    let reader = image::ImageReader::new(BufReader::new(clone))
+        .with_guessed_format()
+        .map_err(|_| {
+            UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+        })?;
+    let (width, height) = reader.into_dimensions().map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let pixels = u64::from(width).saturating_mul(u64::from(height));
+    if pixels == 0 {
+        return Err(UploadError::rejected(
+            ThreatClass::ParserCorruption,
+            ReasonCode::FailClosed,
+        ));
+    }
     if pixels > limits.max_image_pixels {
         return Err(UploadError::rejected(
             ThreatClass::ImagePixelBomb,
@@ -330,51 +401,19 @@ fn preflight_image(
     Ok(())
 }
 
-fn image_pixel_count(head: &[u8], format: CanonicalFormat) -> Option<u64> {
-    match format {
-        CanonicalFormat::Png if head.len() >= 24 => {
-            let w = u32::from_be_bytes(head[16..20].try_into().ok()?);
-            let h = u32::from_be_bytes(head[20..24].try_into().ok()?);
-            Some(u64::from(w).saturating_mul(u64::from(h)))
-        }
-        CanonicalFormat::Bmp if head.len() >= 26 => {
-            let w = i32::from_le_bytes(head[18..22].try_into().ok()?).unsigned_abs();
-            let h = i32::from_le_bytes(head[22..26].try_into().ok()?).unsigned_abs();
-            Some(u64::from(w).saturating_mul(u64::from(h)))
-        }
-        // JPEG/WebP/TIFF: defer deep decode to sandbox; header presence is enough here.
-        _ => Some(0),
-    }
-}
-
 fn preflight_audio(
-    path: &Path,
+    file: &mut File,
     format: CanonicalFormat,
     limits: &LimitsConfig,
 ) -> Result<Option<ValidationResult>, UploadError> {
-    if format != CanonicalFormat::Wav {
-        return Ok(None);
-    }
-    let mut file = std::fs::File::open(path).map_err(|_| {
+    file.seek(SeekFrom::Start(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
-    let mut head = [0_u8; 44];
-    file.read_exact(&mut head).map_err(|_| {
-        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
-    })?;
-    if &head[0..4] != b"RIFF" || &head[8..12] != b"WAVE" {
-        return Err(UploadError::rejected(
-            ThreatClass::MimeMismatch,
-            ReasonCode::ExtensionMagicMismatch,
-        ));
-    }
-    let byte_rate = u32::from_le_bytes(head[28..32].try_into().unwrap_or([0; 4]));
-    let meta = file.metadata().map_err(|_| UploadError::Internal)?;
-    let data_bytes = meta.len().saturating_sub(44);
-    if byte_rate == 0 {
-        return Ok(None);
-    }
-    let duration_secs = data_bytes / u64::from(byte_rate);
+    let duration_secs = if format == CanonicalFormat::Wav {
+        validate_wav_duration(file)?
+    } else {
+        validate_symphonia_duration(file, format)?
+    };
     if duration_secs > limits.max_audio_duration_secs {
         return Ok(Some(ValidationResult {
             format,
@@ -386,11 +425,136 @@ fn preflight_audio(
     Ok(None)
 }
 
-fn preflight_csv(path: &Path) -> Result<Option<ValidationResult>, UploadError> {
-    let mut file = std::fs::File::open(path).map_err(|_| UploadError::Internal)?;
+fn validate_wav_duration(file: &mut File) -> Result<u64, UploadError> {
+    file.seek(SeekFrom::Start(0)).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let mut header = [0_u8; 12];
+    file.read_exact(&mut header).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    if &header[0..4] != b"RIFF" || &header[8..12] != b"WAVE" {
+        return Err(UploadError::rejected(
+            ThreatClass::ParserCorruption,
+            ReasonCode::FailClosed,
+        ));
+    }
+    let mut byte_rate = None;
+    let mut data_bytes = None;
+    let mut scanned = 12_u64;
+    while scanned < 1024 * 1024 {
+        let mut chunk = [0_u8; 8];
+        file.read_exact(&mut chunk).map_err(|_| {
+            UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+        })?;
+        scanned = scanned.saturating_add(8);
+        let id = &chunk[0..4];
+        let len = u32::from_le_bytes(chunk[4..8].try_into().unwrap_or([0; 4])) as u64;
+        if id == b"fmt " {
+            let mut fmt = vec![0_u8; len.min(64) as usize];
+            file.read_exact(&mut fmt).map_err(|_| {
+                UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+            })?;
+            if len > 64 {
+                file.seek(SeekFrom::Current((len - 64) as i64))
+                    .map_err(|_| {
+                        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+                    })?;
+            }
+            if fmt.len() < 16 {
+                return Err(UploadError::rejected(
+                    ThreatClass::ParserCorruption,
+                    ReasonCode::FailClosed,
+                ));
+            }
+            byte_rate = Some(u32::from_le_bytes(fmt[8..12].try_into().unwrap_or([0; 4])));
+        } else if id == b"data" {
+            data_bytes = Some(len);
+            file.seek(SeekFrom::Current(len as i64)).map_err(|_| {
+                UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+            })?;
+        } else {
+            file.seek(SeekFrom::Current(len as i64)).map_err(|_| {
+                UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+            })?;
+        }
+        if len % 2 == 1 {
+            file.seek(SeekFrom::Current(1)).map_err(|_| {
+                UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+            })?;
+        }
+        scanned = scanned.saturating_add(len + (len % 2));
+        if byte_rate.is_some() && data_bytes.is_some() {
+            break;
+        }
+    }
+    let byte_rate = byte_rate.ok_or_else(|| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let data_bytes = data_bytes.ok_or_else(|| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    if byte_rate == 0 || data_bytes == 0 {
+        return Err(UploadError::rejected(
+            ThreatClass::ParserCorruption,
+            ReasonCode::FailClosed,
+        ));
+    }
+    Ok(data_bytes / u64::from(byte_rate))
+}
+
+fn validate_symphonia_duration(
+    file: &mut File,
+    format: CanonicalFormat,
+) -> Result<u64, UploadError> {
+    file.seek(SeekFrom::Start(0)).map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let source = file.try_clone().map_err(|_| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let mss = symphonia::core::io::MediaSourceStream::new(Box::new(source), Default::default());
+    let mut hint = symphonia::core::probe::Hint::new();
+    hint.with_extension(format.canonical_extension());
+    let probed = symphonia::default::get_probe()
+        .format(
+            &hint,
+            mss,
+            &symphonia::core::formats::FormatOptions::default(),
+            &symphonia::core::meta::MetadataOptions::default(),
+        )
+        .map_err(|_| {
+            UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+        })?;
+    let track = probed.format.default_track().ok_or_else(|| {
+        UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+    })?;
+    let params = &track.codec_params;
+    let duration = params
+        .time_base
+        .zip(params.n_frames)
+        .map(|(base, frames)| base.calc_time(frames));
+    let Some(duration) = duration else {
+        return Err(UploadError::rejected(
+            ThreatClass::ParserCorruption,
+            ReasonCode::FailClosed,
+        ));
+    };
+    if duration.seconds == 0 && duration.frac <= 0.0 {
+        return Err(UploadError::rejected(
+            ThreatClass::ParserCorruption,
+            ReasonCode::FailClosed,
+        ));
+    }
+    Ok(duration.seconds + u64::from(duration.frac > 0.0))
+}
+
+fn preflight_csv(file: &mut File) -> Result<Option<ValidationResult>, UploadError> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|_| UploadError::Internal)?;
     let mut buf = String::new();
     // Bound CSV preflight text read.
-    let mut limited = (&mut file).take(1024 * 1024);
+    let mut limited = file.take(1024 * 1024);
     limited.read_to_string(&mut buf).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
@@ -410,10 +574,11 @@ fn preflight_csv(path: &Path) -> Result<Option<ValidationResult>, UploadError> {
     Ok(None)
 }
 
-fn preflight_html(path: &Path) -> Result<Option<ValidationResult>, UploadError> {
-    let mut file = std::fs::File::open(path).map_err(|_| UploadError::Internal)?;
+fn preflight_html(file: &mut File) -> Result<Option<ValidationResult>, UploadError> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|_| UploadError::Internal)?;
     let mut buf = String::new();
-    let mut limited = (&mut file).take(1024 * 1024);
+    let mut limited = file.take(1024 * 1024);
     limited.read_to_string(&mut buf).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
@@ -503,6 +668,7 @@ pub fn assert_disposition_is_typed(disposition: Disposition) {
 pub fn validate_streamed_bytes(
     streamed: &StreamedUpload,
     declared_filename: Option<&str>,
+    declared_content_type: Option<&str>,
     limits: &LimitsConfig,
 ) -> Result<
     (
@@ -513,10 +679,12 @@ pub fn validate_streamed_bytes(
     ),
     UploadError,
 > {
-    let result = validate_bytes(
-        streamed.tempfile.path(),
+    let mut file = streamed.rewinded_file_clone()?;
+    let result = validate_file(
+        &mut file,
         &streamed.head,
         declared_filename,
+        declared_content_type,
         limits,
     )?;
     Ok((
@@ -545,10 +713,10 @@ mod tests {
         )
         .await
         .unwrap();
-        let err = validate_bytes(
-            streamed.tempfile.path(),
-            &streamed.head,
+        let err = validate_streamed_bytes(
+            &streamed,
             Some("plain-text.pdf"),
+            Some("text/plain"),
             &limits,
         )
         .unwrap_err();

--- a/crates/server/src/services/upload/mod.rs
+++ b/crates/server/src/services/upload/mod.rs
@@ -291,6 +291,8 @@ fn preflight_pdf(file: &mut File, limits: &LimitsConfig) -> Result<(), UploadErr
     file.seek(SeekFrom::Start(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
+    // This is a bounded structural sniff only; accepted PDFs remain quarantined and the
+    // converter stage performs deeper format validation.
     let mut buf = [0_u8; STREAM_CHUNK_BYTES];
     let mut overlap = Vec::new();
     let mut tail = Vec::new();
@@ -429,6 +431,10 @@ fn validate_wav_duration(file: &mut File) -> Result<u64, UploadError> {
     file.seek(SeekFrom::Start(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;
+    let file_len = file
+        .metadata()
+        .map_err(|_| UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed))?
+        .len();
     let mut header = [0_u8; 12];
     file.read_exact(&mut header).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
@@ -439,10 +445,18 @@ fn validate_wav_duration(file: &mut File) -> Result<u64, UploadError> {
             ReasonCode::FailClosed,
         ));
     }
+    let riff_size = u32::from_le_bytes(header[4..8].try_into().unwrap_or([0; 4])) as u64;
+    if riff_size < 4 || riff_size.saturating_add(8) > file_len {
+        return Err(UploadError::rejected(
+            ThreatClass::ParserCorruption,
+            ReasonCode::FailClosed,
+        ));
+    }
     let mut byte_rate = None;
     let mut data_bytes = None;
     let mut scanned = 12_u64;
-    while scanned < 1024 * 1024 {
+    let riff_end = riff_size.saturating_add(8).min(file_len);
+    while scanned < 1024 * 1024 && scanned + 8 <= riff_end {
         let mut chunk = [0_u8; 8];
         file.read_exact(&mut chunk).map_err(|_| {
             UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
@@ -450,6 +464,15 @@ fn validate_wav_duration(file: &mut File) -> Result<u64, UploadError> {
         scanned = scanned.saturating_add(8);
         let id = &chunk[0..4];
         let len = u32::from_le_bytes(chunk[4..8].try_into().unwrap_or([0; 4])) as u64;
+        let padded_len = len.saturating_add(len % 2);
+        let chunk_data_end = scanned.saturating_add(len);
+        let chunk_end = scanned.saturating_add(padded_len);
+        if chunk_data_end > riff_end || chunk_end > file_len {
+            return Err(UploadError::rejected(
+                ThreatClass::ParserCorruption,
+                ReasonCode::FailClosed,
+            ));
+        }
         if id == b"fmt " {
             let mut fmt = vec![0_u8; len.min(64) as usize];
             file.read_exact(&mut fmt).map_err(|_| {
@@ -478,12 +501,13 @@ fn validate_wav_duration(file: &mut File) -> Result<u64, UploadError> {
                 UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
             })?;
         }
-        if len % 2 == 1 {
-            file.seek(SeekFrom::Current(1)).map_err(|_| {
-                UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
-            })?;
+        if padded_len > len {
+            file.seek(SeekFrom::Current((padded_len - len) as i64))
+                .map_err(|_| {
+                    UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
+                })?;
         }
-        scanned = scanned.saturating_add(len + (len % 2));
+        scanned = chunk_end;
         if byte_rate.is_some() && data_bytes.is_some() {
             break;
         }
@@ -507,6 +531,8 @@ fn validate_symphonia_duration(
     file: &mut File,
     format: CanonicalFormat,
 ) -> Result<u64, UploadError> {
+    // Non-WAV audio gets a bounded container probe here; full packet/decode validation is
+    // intentionally left to the converter while the object remains quarantined.
     file.seek(SeekFrom::Start(0)).map_err(|_| {
         UploadError::rejected(ThreatClass::ParserCorruption, ReasonCode::FailClosed)
     })?;

--- a/crates/server/src/services/upload/sniff.rs
+++ b/crates/server/src/services/upload/sniff.rs
@@ -111,7 +111,11 @@ fn extension_of(filename: &str) -> Option<&str> {
     Some(ext)
 }
 
-fn extension_matches(format: CanonicalFormat, ext: &str) -> bool {
+pub fn declared_extension(filename: &str) -> Option<&str> {
+    extension_of(filename)
+}
+
+pub fn extension_matches(format: CanonicalFormat, ext: &str) -> bool {
     let ext = ext.to_ascii_lowercase();
     match format {
         CanonicalFormat::Pdf => ext == "pdf",
@@ -137,6 +141,52 @@ fn extension_matches(format: CanonicalFormat, ext: &str) -> bool {
         CanonicalFormat::Ogg => ext == "ogg",
         CanonicalFormat::Flac => ext == "flac",
         CanonicalFormat::M4a => matches!(ext.as_str(), "m4a" | "mp4"),
+    }
+}
+
+pub fn mime_matches(format: CanonicalFormat, content_type: &str) -> bool {
+    let mime = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase();
+    if mime.is_empty()
+        || matches!(
+            mime.as_str(),
+            "application/octet-stream" | "binary/octet-stream"
+        )
+    {
+        return true;
+    }
+    match format {
+        CanonicalFormat::Pdf => mime == "application/pdf",
+        CanonicalFormat::Docx => {
+            mime == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        }
+        CanonicalFormat::Pptx => {
+            mime == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        }
+        CanonicalFormat::Xlsx => {
+            mime == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        }
+        CanonicalFormat::Ods => mime == "application/vnd.oasis.opendocument.spreadsheet",
+        CanonicalFormat::Xls => mime == "application/vnd.ms-excel",
+        CanonicalFormat::Xlsb => mime == "application/vnd.ms-excel.sheet.binary.macroenabled.12",
+        CanonicalFormat::Csv => matches!(mime.as_str(), "text/csv" | "text/tab-separated-values"),
+        CanonicalFormat::Html => matches!(mime.as_str(), "text/html" | "application/xhtml+xml"),
+        CanonicalFormat::PlainText => matches!(mime.as_str(), "text/plain" | "text/markdown"),
+        CanonicalFormat::Png => mime == "image/png",
+        CanonicalFormat::Jpeg => mime == "image/jpeg",
+        CanonicalFormat::Webp => mime == "image/webp",
+        CanonicalFormat::Tiff => mime == "image/tiff",
+        CanonicalFormat::Bmp => mime == "image/bmp",
+        CanonicalFormat::Wav => matches!(mime.as_str(), "audio/wav" | "audio/x-wav"),
+        CanonicalFormat::Mp3 => matches!(mime.as_str(), "audio/mpeg" | "audio/mp3"),
+        CanonicalFormat::Ogg => matches!(mime.as_str(), "audio/ogg" | "application/ogg"),
+        CanonicalFormat::Flac => mime == "audio/flac",
+        CanonicalFormat::M4a => matches!(mime.as_str(), "audio/mp4" | "audio/x-m4a" | "video/mp4"),
+        CanonicalFormat::ZipContainer => mime == "application/zip",
     }
 }
 
@@ -266,7 +316,7 @@ fn looks_like_csv(head: &[u8]) -> bool {
 
 /// Map a ZIP container to a specific OOXML/ODS format using required member paths.
 pub fn refine_zip_format(
-    provisional: CanonicalFormat,
+    _provisional: CanonicalFormat,
     has_content_types: bool,
     has_word: bool,
     has_ppt: bool,
@@ -286,23 +336,10 @@ pub fn refine_zip_format(
         (true, false, false) => Ok(CanonicalFormat::Docx),
         (false, true, false) => Ok(CanonicalFormat::Pptx),
         (false, false, true) => Ok(CanonicalFormat::Xlsx),
-        _ => {
-            // Ambiguous or empty OOXML — fail closed unless provisional was set by extension.
-            if matches!(
-                provisional,
-                CanonicalFormat::Docx
-                    | CanonicalFormat::Pptx
-                    | CanonicalFormat::Xlsx
-                    | CanonicalFormat::Ods
-            ) {
-                Ok(provisional)
-            } else {
-                Err(UploadError::rejected(
-                    ThreatClass::MalformedOoxml,
-                    ReasonCode::MissingFormatPaths,
-                ))
-            }
-        }
+        _ => Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MissingFormatPaths,
+        )),
     }
 }
 

--- a/crates/server/src/services/upload/sniff.rs
+++ b/crates/server/src/services/upload/sniff.rs
@@ -1,0 +1,348 @@
+//! Magic-byte + extension → canonical format (fail closed on spoof).
+
+use super::error::{ReasonCode, ThreatClass, UploadError};
+
+/// Server-derived canonical format (authoritative for downstream).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CanonicalFormat {
+    Pdf,
+    Docx,
+    Pptx,
+    Xlsx,
+    Ods,
+    Xls,
+    Xlsb,
+    Csv,
+    Html,
+    PlainText,
+    Png,
+    Jpeg,
+    Webp,
+    Tiff,
+    Bmp,
+    Wav,
+    Mp3,
+    Ogg,
+    Flac,
+    M4a,
+    /// Provisional ZIP magic before OOXML/ODS path refinement.
+    ZipContainer,
+}
+
+impl CanonicalFormat {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pdf => "pdf",
+            Self::Docx => "docx",
+            Self::Pptx => "pptx",
+            Self::Xlsx => "xlsx",
+            Self::Ods => "ods",
+            Self::Xls => "xls",
+            Self::Xlsb => "xlsb",
+            Self::Csv => "csv",
+            Self::Html => "html",
+            Self::PlainText => "txt",
+            Self::Png => "png",
+            Self::Jpeg => "jpeg",
+            Self::Webp => "webp",
+            Self::Tiff => "tiff",
+            Self::Bmp => "bmp",
+            Self::Wav => "wav",
+            Self::Mp3 => "mp3",
+            Self::Ogg => "ogg",
+            Self::Flac => "flac",
+            Self::M4a => "m4a",
+            Self::ZipContainer => "zip",
+        }
+    }
+
+    pub const fn is_zip_container(self) -> bool {
+        matches!(
+            self,
+            Self::Docx | Self::Pptx | Self::Xlsx | Self::Ods | Self::ZipContainer
+        )
+    }
+
+    /// Canonical extension used for server-side behavior (never trust client).
+    pub const fn canonical_extension(self) -> &'static str {
+        match self {
+            Self::Jpeg => "jpg",
+            Self::ZipContainer => "zip",
+            other => other.as_str(),
+        }
+    }
+}
+
+/// Resolve canonical format from magic bytes; require declared extension consistency.
+pub fn resolve_canonical_format(
+    head: &[u8],
+    declared_filename: Option<&str>,
+) -> Result<CanonicalFormat, UploadError> {
+    let magic = detect_magic(head).ok_or_else(|| {
+        UploadError::rejected(
+            ThreatClass::UnsupportedFormat,
+            ReasonCode::MagicUnrecognized,
+        )
+    })?;
+
+    let declared_ext = declared_filename.and_then(extension_of);
+    if let Some(ext) = declared_ext {
+        if !extension_matches(magic, ext) {
+            return Err(UploadError::rejected(
+                ThreatClass::ExtensionSpoof,
+                ReasonCode::ExtensionMagicMismatch,
+            ));
+        }
+        // Prefer extension-specific spreadsheet variants when magic is OLE/ZIP.
+        if let Some(refined) = refine_from_extension(magic, ext) {
+            return Ok(refined);
+        }
+    }
+
+    Ok(magic)
+}
+
+fn extension_of(filename: &str) -> Option<&str> {
+    let name = filename.rsplit(['/', '\\']).next().unwrap_or(filename);
+    let (_, ext) = name.rsplit_once('.')?;
+    if ext.is_empty() || ext.len() > 16 {
+        return None;
+    }
+    Some(ext)
+}
+
+fn extension_matches(format: CanonicalFormat, ext: &str) -> bool {
+    let ext = ext.to_ascii_lowercase();
+    match format {
+        CanonicalFormat::Pdf => ext == "pdf",
+        CanonicalFormat::Docx => ext == "docx",
+        CanonicalFormat::Pptx => ext == "pptx",
+        CanonicalFormat::Xlsx => ext == "xlsx",
+        CanonicalFormat::Ods => ext == "ods",
+        CanonicalFormat::ZipContainer => {
+            matches!(ext.as_str(), "docx" | "pptx" | "xlsx" | "ods")
+        }
+        CanonicalFormat::Xls => ext == "xls",
+        CanonicalFormat::Xlsb => ext == "xlsb",
+        CanonicalFormat::Csv => matches!(ext.as_str(), "csv" | "tsv"),
+        CanonicalFormat::Html => matches!(ext.as_str(), "html" | "htm"),
+        CanonicalFormat::PlainText => matches!(ext.as_str(), "txt" | "md"),
+        CanonicalFormat::Png => ext == "png",
+        CanonicalFormat::Jpeg => matches!(ext.as_str(), "jpg" | "jpeg"),
+        CanonicalFormat::Webp => ext == "webp",
+        CanonicalFormat::Tiff => matches!(ext.as_str(), "tif" | "tiff"),
+        CanonicalFormat::Bmp => ext == "bmp",
+        CanonicalFormat::Wav => ext == "wav",
+        CanonicalFormat::Mp3 => ext == "mp3",
+        CanonicalFormat::Ogg => ext == "ogg",
+        CanonicalFormat::Flac => ext == "flac",
+        CanonicalFormat::M4a => matches!(ext.as_str(), "m4a" | "mp4"),
+    }
+}
+
+fn refine_from_extension(magic: CanonicalFormat, ext: &str) -> Option<CanonicalFormat> {
+    let ext = ext.to_ascii_lowercase();
+    match (magic, ext.as_str()) {
+        (CanonicalFormat::ZipContainer, "docx") => Some(CanonicalFormat::Docx),
+        (CanonicalFormat::ZipContainer, "pptx") => Some(CanonicalFormat::Pptx),
+        (CanonicalFormat::ZipContainer, "xlsx") => Some(CanonicalFormat::Xlsx),
+        (CanonicalFormat::ZipContainer, "ods") => Some(CanonicalFormat::Ods),
+        (CanonicalFormat::Xls | CanonicalFormat::Xlsb, "xls") => Some(CanonicalFormat::Xls),
+        (CanonicalFormat::Xls | CanonicalFormat::Xlsb, "xlsb") => Some(CanonicalFormat::Xlsb),
+        (CanonicalFormat::Csv, "tsv") => Some(CanonicalFormat::Csv),
+        (CanonicalFormat::PlainText, "md") => Some(CanonicalFormat::PlainText),
+        (CanonicalFormat::Jpeg, "jpeg") => Some(CanonicalFormat::Jpeg),
+        (CanonicalFormat::Tiff, "tif") => Some(CanonicalFormat::Tiff),
+        _ => None,
+    }
+}
+
+/// Detect format from magic / first-bytes only (no filename trust).
+pub fn detect_magic(head: &[u8]) -> Option<CanonicalFormat> {
+    if head.starts_with(b"%PDF-") {
+        return Some(CanonicalFormat::Pdf);
+    }
+    if head.starts_with(&[0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']) {
+        return Some(CanonicalFormat::Png);
+    }
+    if head.len() >= 3 && head[0] == 0xff && head[1] == 0xd8 && head[2] == 0xff {
+        return Some(CanonicalFormat::Jpeg);
+    }
+    if head.starts_with(b"BM") {
+        return Some(CanonicalFormat::Bmp);
+    }
+    if head.starts_with(b"II*\0") || head.starts_with(b"MM\0*") {
+        return Some(CanonicalFormat::Tiff);
+    }
+    if head.len() >= 12 && head.starts_with(b"RIFF") && &head[8..12] == b"WEBP" {
+        return Some(CanonicalFormat::Webp);
+    }
+    if head.len() >= 12 && head.starts_with(b"RIFF") && &head[8..12] == b"WAVE" {
+        return Some(CanonicalFormat::Wav);
+    }
+    if head.starts_with(b"OggS") {
+        return Some(CanonicalFormat::Ogg);
+    }
+    if head.starts_with(b"fLaC") {
+        return Some(CanonicalFormat::Flac);
+    }
+    if head.starts_with(b"ID3") || is_mp3_frame(head) {
+        return Some(CanonicalFormat::Mp3);
+    }
+    if is_m4a(head) {
+        return Some(CanonicalFormat::M4a);
+    }
+    // OLE Compound Document (XLS / XLSB family).
+    if head.starts_with(&[0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]) {
+        return Some(CanonicalFormat::Xls);
+    }
+    // ZIP / OOXML / ODS — refined by extension then archive membership.
+    if head.starts_with(b"PK\x03\x04")
+        || head.starts_with(b"PK\x05\x06")
+        || head.starts_with(b"PK\x07\x08")
+    {
+        return Some(CanonicalFormat::ZipContainer);
+    }
+    if looks_like_html(head) {
+        return Some(CanonicalFormat::Html);
+    }
+    if looks_like_text(head) {
+        // CSV vs plain: delimiter heuristic when commas/tabs dominate early bytes.
+        if looks_like_csv(head) {
+            return Some(CanonicalFormat::Csv);
+        }
+        return Some(CanonicalFormat::PlainText);
+    }
+    None
+}
+
+fn is_mp3_frame(head: &[u8]) -> bool {
+    head.len() >= 2 && head[0] == 0xff && (head[1] & 0xe0) == 0xe0
+}
+
+fn is_m4a(head: &[u8]) -> bool {
+    head.len() >= 12 && &head[4..8] == b"ftyp"
+}
+
+fn looks_like_html(head: &[u8]) -> bool {
+    let lower: Vec<u8> = head
+        .iter()
+        .take(256)
+        .map(|b| b.to_ascii_lowercase())
+        .collect();
+    lower.starts_with(b"<!doctype html")
+        || lower.starts_with(b"<html")
+        || lower.windows(6).any(|w| w == b"<html>")
+        || lower.windows(5).any(|w| w == b"<head")
+        || lower.windows(5).any(|w| w == b"<body")
+}
+
+fn looks_like_text(head: &[u8]) -> bool {
+    if head.is_empty() {
+        return false;
+    }
+    let sample = &head[..head.len().min(512)];
+    if sample.contains(&0) {
+        return false;
+    }
+    // Accept UTF-8 (Vietnamese documents). Reject high binary density.
+    let Ok(text) = std::str::from_utf8(sample) else {
+        return false;
+    };
+    let non_text = text
+        .chars()
+        .filter(|ch| !(ch.is_alphanumeric() || ch.is_whitespace() || ch.is_ascii_punctuation()))
+        .count();
+    non_text * 10 <= text.chars().count()
+}
+
+fn looks_like_csv(head: &[u8]) -> bool {
+    let Ok(text) = std::str::from_utf8(&head[..head.len().min(512)]) else {
+        return false;
+    };
+    let first_line = text.lines().next().unwrap_or("");
+    first_line.contains(',') || first_line.contains('\t')
+}
+
+/// Map a ZIP container to a specific OOXML/ODS format using required member paths.
+pub fn refine_zip_format(
+    provisional: CanonicalFormat,
+    has_content_types: bool,
+    has_word: bool,
+    has_ppt: bool,
+    has_xl: bool,
+    has_ods_mimetype: bool,
+) -> Result<CanonicalFormat, UploadError> {
+    if has_ods_mimetype {
+        return Ok(CanonicalFormat::Ods);
+    }
+    if !has_content_types {
+        return Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MissingContentTypes,
+        ));
+    }
+    match (has_word, has_ppt, has_xl) {
+        (true, false, false) => Ok(CanonicalFormat::Docx),
+        (false, true, false) => Ok(CanonicalFormat::Pptx),
+        (false, false, true) => Ok(CanonicalFormat::Xlsx),
+        _ => {
+            // Ambiguous or empty OOXML — fail closed unless provisional was set by extension.
+            if matches!(
+                provisional,
+                CanonicalFormat::Docx
+                    | CanonicalFormat::Pptx
+                    | CanonicalFormat::Xlsx
+                    | CanonicalFormat::Ods
+            ) {
+                Ok(provisional)
+            } else {
+                Err(UploadError::rejected(
+                    ThreatClass::MalformedOoxml,
+                    ReasonCode::MissingFormatPaths,
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pdf_magic_and_spoof() {
+        assert_eq!(detect_magic(b"%PDF-1.4"), Some(CanonicalFormat::Pdf));
+        let err = resolve_canonical_format(b"not a pdf", Some("doc.pdf")).unwrap_err();
+        assert!(matches!(
+            err.threat_class(),
+            Some(ThreatClass::ExtensionSpoof) | Some(ThreatClass::UnsupportedFormat) | _
+        ));
+        // Text named pdf → spoof once magic resolves to text.
+        let err = resolve_canonical_format(b"hello world\n", Some("x.pdf")).unwrap_err();
+        assert_eq!(err.threat_class(), Some(ThreatClass::ExtensionSpoof));
+    }
+
+    #[test]
+    fn png_and_jpeg_ok() {
+        let png = [
+            0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n', 0, 0, 0, 0,
+        ];
+        assert_eq!(
+            resolve_canonical_format(&png, Some("a.png")).unwrap(),
+            CanonicalFormat::Png
+        );
+        let jpeg = [0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0];
+        assert_eq!(
+            resolve_canonical_format(&jpeg, Some("a.jpg")).unwrap(),
+            CanonicalFormat::Jpeg
+        );
+    }
+
+    #[test]
+    fn html_named_pdf_is_spoof() {
+        let err =
+            resolve_canonical_format(b"<html><body>x</body></html>", Some("x.pdf")).unwrap_err();
+        assert_eq!(err.threat_class(), Some(ThreatClass::ExtensionSpoof));
+    }
+}

--- a/crates/server/src/services/upload/sniff.rs
+++ b/crates/server/src/services/upload/sniff.rs
@@ -59,7 +59,7 @@ impl CanonicalFormat {
     pub const fn is_zip_container(self) -> bool {
         matches!(
             self,
-            Self::Docx | Self::Pptx | Self::Xlsx | Self::Ods | Self::ZipContainer
+            Self::Docx | Self::Pptx | Self::Xlsx | Self::Xlsb | Self::Ods | Self::ZipContainer
         )
     }
 
@@ -124,7 +124,7 @@ pub fn extension_matches(format: CanonicalFormat, ext: &str) -> bool {
         CanonicalFormat::Xlsx => ext == "xlsx",
         CanonicalFormat::Ods => ext == "ods",
         CanonicalFormat::ZipContainer => {
-            matches!(ext.as_str(), "docx" | "pptx" | "xlsx" | "ods")
+            matches!(ext.as_str(), "docx" | "pptx" | "xlsx" | "xlsb" | "ods")
         }
         CanonicalFormat::Xls => ext == "xls",
         CanonicalFormat::Xlsb => ext == "xlsb",
@@ -196,6 +196,7 @@ fn refine_from_extension(magic: CanonicalFormat, ext: &str) -> Option<CanonicalF
         (CanonicalFormat::ZipContainer, "docx") => Some(CanonicalFormat::Docx),
         (CanonicalFormat::ZipContainer, "pptx") => Some(CanonicalFormat::Pptx),
         (CanonicalFormat::ZipContainer, "xlsx") => Some(CanonicalFormat::Xlsx),
+        (CanonicalFormat::ZipContainer, "xlsb") => Some(CanonicalFormat::Xlsb),
         (CanonicalFormat::ZipContainer, "ods") => Some(CanonicalFormat::Ods),
         (CanonicalFormat::Xls | CanonicalFormat::Xlsb, "xls") => Some(CanonicalFormat::Xls),
         (CanonicalFormat::Xls | CanonicalFormat::Xlsb, "xlsb") => Some(CanonicalFormat::Xlsb),
@@ -242,7 +243,8 @@ pub fn detect_magic(head: &[u8]) -> Option<CanonicalFormat> {
     if is_m4a(head) {
         return Some(CanonicalFormat::M4a);
     }
-    // OLE Compound Document (XLS / XLSB family).
+    // OLE Compound Document is kept as XLS here; deeper spreadsheet structure parsing
+    // is deferred while accepted uploads remain quarantined for converter validation.
     if head.starts_with(&[0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]) {
         return Some(CanonicalFormat::Xls);
     }
@@ -321,21 +323,34 @@ pub fn refine_zip_format(
     has_word: bool,
     has_ppt: bool,
     has_xl: bool,
+    has_xlsb: bool,
     has_ods_mimetype: bool,
 ) -> Result<CanonicalFormat, UploadError> {
-    if has_ods_mimetype {
-        return Ok(CanonicalFormat::Ods);
-    }
     if !has_content_types {
+        if has_ods_mimetype {
+            return Ok(CanonicalFormat::Ods);
+        }
         return Err(UploadError::rejected(
             ThreatClass::MalformedOoxml,
             ReasonCode::MissingContentTypes,
         ));
     }
-    match (has_word, has_ppt, has_xl) {
-        (true, false, false) => Ok(CanonicalFormat::Docx),
-        (false, true, false) => Ok(CanonicalFormat::Pptx),
-        (false, false, true) => Ok(CanonicalFormat::Xlsx),
+    let families = [has_word, has_ppt, has_xl, has_xlsb, has_ods_mimetype]
+        .into_iter()
+        .filter(|present| *present)
+        .count();
+    if families != 1 {
+        return Err(UploadError::rejected(
+            ThreatClass::MalformedOoxml,
+            ReasonCode::MissingFormatPaths,
+        ));
+    }
+    match (has_word, has_ppt, has_xl, has_xlsb, has_ods_mimetype) {
+        (true, false, false, false, false) => Ok(CanonicalFormat::Docx),
+        (false, true, false, false, false) => Ok(CanonicalFormat::Pptx),
+        (false, false, true, false, false) => Ok(CanonicalFormat::Xlsx),
+        (false, false, false, true, false) => Ok(CanonicalFormat::Xlsb),
+        (false, false, false, false, true) => Ok(CanonicalFormat::Ods),
         _ => Err(UploadError::rejected(
             ThreatClass::MalformedOoxml,
             ReasonCode::MissingFormatPaths,

--- a/crates/server/src/services/upload/stream.rs
+++ b/crates/server/src/services/upload/stream.rs
@@ -1,0 +1,160 @@
+//! Bounded streaming intake: size cap + SHA-256 without full-file buffering.
+
+use std::io::Write;
+
+use futures::StreamExt;
+use sha2::{Digest, Sha256};
+use tempfile::NamedTempFile;
+use tokio::io::AsyncReadExt;
+
+use super::error::{ReasonCode, ThreatClass, UploadError};
+use super::limits::{LimitsConfig, MAGIC_SNIFF_BYTES, STREAM_CHUNK_BYTES};
+
+/// Result of streaming an upload body to a temporary file.
+#[derive(Debug)]
+pub struct StreamedUpload {
+    pub tempfile: NamedTempFile,
+    pub sha256_hex: String,
+    pub size_bytes: u64,
+    pub head: Vec<u8>,
+}
+
+/// Consume an async byte stream into a tempfile while hashing and enforcing the size cap.
+///
+/// Memory use is O(chunk size): never buffers the whole object. Aborts with
+/// [`ThreatClass::Oversize`] as soon as the cap is exceeded.
+pub async fn stream_to_tempfile<S, E>(
+    mut stream: S,
+    limits: &LimitsConfig,
+) -> Result<StreamedUpload, UploadError>
+where
+    S: futures::Stream<Item = Result<bytes::Bytes, E>> + Unpin,
+    E: std::fmt::Debug,
+{
+    let mut tempfile = NamedTempFile::new().map_err(|_| UploadError::Internal)?;
+    let mut hasher = Sha256::new();
+    let mut size_bytes: u64 = 0;
+    let mut head = Vec::with_capacity(MAGIC_SNIFF_BYTES);
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|_| {
+            UploadError::rejected(ThreatClass::TruncatedUpload, ReasonCode::StreamInterrupted)
+        })?;
+        if chunk.is_empty() {
+            continue;
+        }
+        let next = size_bytes.saturating_add(chunk.len() as u64);
+        if next > limits.max_upload_bytes {
+            // Best-effort cleanup; NamedTempFile drops on return.
+            let _ = tempfile.close();
+            return Err(UploadError::rejected(
+                ThreatClass::Oversize,
+                ReasonCode::UploadTooLarge,
+            ));
+        }
+        size_bytes = next;
+        hasher.update(&chunk);
+        if head.len() < MAGIC_SNIFF_BYTES {
+            let need = MAGIC_SNIFF_BYTES - head.len();
+            head.extend_from_slice(&chunk[..chunk.len().min(need)]);
+        }
+        tempfile
+            .write_all(&chunk)
+            .map_err(|_| UploadError::Internal)?;
+    }
+
+    tempfile.flush().map_err(|_| UploadError::Internal)?;
+    let sha256_hex = hex::encode(hasher.finalize());
+    Ok(StreamedUpload {
+        tempfile,
+        sha256_hex,
+        size_bytes,
+        head,
+    })
+}
+
+/// Stream from an `AsyncRead` (e.g. multipart field) with the same bounds.
+pub async fn stream_async_read_to_tempfile<R>(
+    mut reader: R,
+    limits: &LimitsConfig,
+) -> Result<StreamedUpload, UploadError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut tempfile = NamedTempFile::new().map_err(|_| UploadError::Internal)?;
+    let mut hasher = Sha256::new();
+    let mut size_bytes: u64 = 0;
+    let mut head = Vec::with_capacity(MAGIC_SNIFF_BYTES);
+    let mut buf = vec![0_u8; STREAM_CHUNK_BYTES];
+
+    loop {
+        let n = reader.read(&mut buf).await.map_err(|_| {
+            UploadError::rejected(ThreatClass::TruncatedUpload, ReasonCode::StreamInterrupted)
+        })?;
+        if n == 0 {
+            break;
+        }
+        let chunk = &buf[..n];
+        let next = size_bytes.saturating_add(n as u64);
+        if next > limits.max_upload_bytes {
+            let _ = tempfile.close();
+            return Err(UploadError::rejected(
+                ThreatClass::Oversize,
+                ReasonCode::UploadTooLarge,
+            ));
+        }
+        size_bytes = next;
+        hasher.update(chunk);
+        if head.len() < MAGIC_SNIFF_BYTES {
+            let need = MAGIC_SNIFF_BYTES - head.len();
+            head.extend_from_slice(&chunk[..chunk.len().min(need)]);
+        }
+        tempfile
+            .write_all(chunk)
+            .map_err(|_| UploadError::Internal)?;
+    }
+
+    tempfile.flush().map_err(|_| UploadError::Internal)?;
+    Ok(StreamedUpload {
+        tempfile,
+        sha256_hex: hex::encode(hasher.finalize()),
+        size_bytes,
+        head,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn rejects_oversize_before_buffering_all() {
+        let limits = LimitsConfig {
+            max_upload_bytes: 1_024,
+            ..LimitsConfig::policy_defaults()
+        };
+        let chunks = (0..20).map(|_| Ok::<_, std::io::Error>(Bytes::from(vec![0_u8; 100])));
+        let stream = stream::iter(chunks);
+        let err = stream_to_tempfile(stream, &limits).await.unwrap_err();
+        assert_eq!(err.threat_class(), Some(ThreatClass::Oversize));
+        assert_eq!(err.status_code(), axum::http::StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn hashes_small_stream() {
+        let limits = LimitsConfig::policy_defaults();
+        let stream = stream::iter(vec![
+            Ok::<_, std::io::Error>(Bytes::from_static(b"hello ")),
+            Ok(Bytes::from_static(b"world")),
+        ]);
+        let uploaded = stream_to_tempfile(stream, &limits).await.unwrap();
+        assert_eq!(uploaded.size_bytes, 11);
+        assert_eq!(
+            uploaded.sha256_hex,
+            hex::encode(Sha256::digest(b"hello world"))
+        );
+        assert_eq!(&uploaded.head, b"hello world");
+    }
+}

--- a/crates/server/src/services/upload/stream.rs
+++ b/crates/server/src/services/upload/stream.rs
@@ -1,6 +1,8 @@
 //! Bounded streaming intake: size cap + SHA-256 without full-file buffering.
 
-use std::io::Write;
+use std::fs::File;
+use std::io::{Seek, SeekFrom, Write};
+use std::time::Duration;
 
 use futures::StreamExt;
 use sha2::{Digest, Sha256};
@@ -17,6 +19,20 @@ pub struct StreamedUpload {
     pub sha256_hex: String,
     pub size_bytes: u64,
     pub head: Vec<u8>,
+}
+
+impl StreamedUpload {
+    /// Clone and rewind the already-held tempfile descriptor; callers must not reopen by path.
+    pub fn rewinded_file_clone(&self) -> Result<File, UploadError> {
+        let mut file = self
+            .tempfile
+            .as_file()
+            .try_clone()
+            .map_err(|_| UploadError::Internal)?;
+        file.seek(SeekFrom::Start(0))
+            .map_err(|_| UploadError::Internal)?;
+        Ok(file)
+    }
 }
 
 /// Consume an async byte stream into a tempfile while hashing and enforcing the size cap.
@@ -68,6 +84,64 @@ where
     Ok(StreamedUpload {
         tempfile,
         sha256_hex,
+        size_bytes,
+        head,
+    })
+}
+
+/// Same as [`stream_to_tempfile`], with an idle timeout applied to each chunk wait.
+pub async fn stream_to_tempfile_with_idle_timeout<S, E>(
+    mut stream: S,
+    limits: &LimitsConfig,
+    idle_timeout: Duration,
+) -> Result<StreamedUpload, UploadError>
+where
+    S: futures::Stream<Item = Result<bytes::Bytes, E>> + Unpin,
+    E: std::fmt::Debug,
+{
+    let mut tempfile = NamedTempFile::new().map_err(|_| UploadError::Internal)?;
+    let mut hasher = Sha256::new();
+    let mut size_bytes: u64 = 0;
+    let mut head = Vec::with_capacity(MAGIC_SNIFF_BYTES);
+
+    loop {
+        let chunk = tokio::time::timeout(idle_timeout, stream.next())
+            .await
+            .map_err(|_| UploadError::MultipartInvalid {
+                reason: ReasonCode::MultipartTimeout,
+            })?;
+        let Some(chunk) = chunk else {
+            break;
+        };
+        let chunk = chunk.map_err(|_| {
+            UploadError::rejected(ThreatClass::TruncatedUpload, ReasonCode::StreamInterrupted)
+        })?;
+        if chunk.is_empty() {
+            continue;
+        }
+        let next = size_bytes.saturating_add(chunk.len() as u64);
+        if next > limits.max_upload_bytes {
+            let _ = tempfile.close();
+            return Err(UploadError::rejected(
+                ThreatClass::Oversize,
+                ReasonCode::UploadTooLarge,
+            ));
+        }
+        size_bytes = next;
+        hasher.update(&chunk);
+        if head.len() < MAGIC_SNIFF_BYTES {
+            let need = MAGIC_SNIFF_BYTES - head.len();
+            head.extend_from_slice(&chunk[..chunk.len().min(need)]);
+        }
+        tempfile
+            .write_all(&chunk)
+            .map_err(|_| UploadError::Internal)?;
+    }
+
+    tempfile.flush().map_err(|_| UploadError::Internal)?;
+    Ok(StreamedUpload {
+        tempfile,
+        sha256_hex: hex::encode(hasher.finalize()),
         size_bytes,
         head,
     })

--- a/crates/server/src/services/upload/stream.rs
+++ b/crates/server/src/services/upload/stream.rs
@@ -1,13 +1,14 @@
 //! Bounded streaming intake: size cap + SHA-256 without full-file buffering.
 
 use std::fs::File;
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{Seek, SeekFrom};
 use std::time::Duration;
 
 use futures::StreamExt;
 use sha2::{Digest, Sha256};
 use tempfile::NamedTempFile;
-use tokio::io::AsyncReadExt;
+use tokio::fs::File as TokioFile;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::error::{ReasonCode, ThreatClass, UploadError};
 use super::limits::{LimitsConfig, MAGIC_SNIFF_BYTES, STREAM_CHUNK_BYTES};
@@ -47,7 +48,13 @@ where
     S: futures::Stream<Item = Result<bytes::Bytes, E>> + Unpin,
     E: std::fmt::Debug,
 {
-    let mut tempfile = NamedTempFile::new().map_err(|_| UploadError::Internal)?;
+    let tempfile = NamedTempFile::new().map_err(|_| UploadError::Internal)?;
+    let mut writer = TokioFile::from_std(
+        tempfile
+            .as_file()
+            .try_clone()
+            .map_err(|_| UploadError::Internal)?,
+    );
     let mut hasher = Sha256::new();
     let mut size_bytes: u64 = 0;
     let mut head = Vec::with_capacity(MAGIC_SNIFF_BYTES);
@@ -74,12 +81,13 @@ where
             let need = MAGIC_SNIFF_BYTES - head.len();
             head.extend_from_slice(&chunk[..chunk.len().min(need)]);
         }
-        tempfile
+        writer
             .write_all(&chunk)
+            .await
             .map_err(|_| UploadError::Internal)?;
     }
 
-    tempfile.flush().map_err(|_| UploadError::Internal)?;
+    writer.flush().await.map_err(|_| UploadError::Internal)?;
     let sha256_hex = hex::encode(hasher.finalize());
     Ok(StreamedUpload {
         tempfile,
@@ -99,7 +107,13 @@ where
     S: futures::Stream<Item = Result<bytes::Bytes, E>> + Unpin,
     E: std::fmt::Debug,
 {
-    let mut tempfile = NamedTempFile::new().map_err(|_| UploadError::Internal)?;
+    let tempfile = NamedTempFile::new().map_err(|_| UploadError::Internal)?;
+    let mut writer = TokioFile::from_std(
+        tempfile
+            .as_file()
+            .try_clone()
+            .map_err(|_| UploadError::Internal)?,
+    );
     let mut hasher = Sha256::new();
     let mut size_bytes: u64 = 0;
     let mut head = Vec::with_capacity(MAGIC_SNIFF_BYTES);
@@ -133,12 +147,13 @@ where
             let need = MAGIC_SNIFF_BYTES - head.len();
             head.extend_from_slice(&chunk[..chunk.len().min(need)]);
         }
-        tempfile
+        writer
             .write_all(&chunk)
+            .await
             .map_err(|_| UploadError::Internal)?;
     }
 
-    tempfile.flush().map_err(|_| UploadError::Internal)?;
+    writer.flush().await.map_err(|_| UploadError::Internal)?;
     Ok(StreamedUpload {
         tempfile,
         sha256_hex: hex::encode(hasher.finalize()),
@@ -155,7 +170,13 @@ pub async fn stream_async_read_to_tempfile<R>(
 where
     R: tokio::io::AsyncRead + Unpin,
 {
-    let mut tempfile = NamedTempFile::new().map_err(|_| UploadError::Internal)?;
+    let tempfile = NamedTempFile::new().map_err(|_| UploadError::Internal)?;
+    let mut writer = TokioFile::from_std(
+        tempfile
+            .as_file()
+            .try_clone()
+            .map_err(|_| UploadError::Internal)?,
+    );
     let mut hasher = Sha256::new();
     let mut size_bytes: u64 = 0;
     let mut head = Vec::with_capacity(MAGIC_SNIFF_BYTES);
@@ -183,12 +204,13 @@ where
             let need = MAGIC_SNIFF_BYTES - head.len();
             head.extend_from_slice(&chunk[..chunk.len().min(need)]);
         }
-        tempfile
+        writer
             .write_all(chunk)
+            .await
             .map_err(|_| UploadError::Internal)?;
     }
 
-    tempfile.flush().map_err(|_| UploadError::Internal)?;
+    writer.flush().await.map_err(|_| UploadError::Internal)?;
     Ok(StreamedUpload {
         tempfile,
         sha256_hex: hex::encode(hasher.finalize()),

--- a/crates/server/src/storage/minio.rs
+++ b/crates/server/src/storage/minio.rs
@@ -58,6 +58,15 @@ pub struct ObjectPutVerification<'a> {
     pub expected_sha256: &'a str,
 }
 
+struct OwnedPutRequest {
+    org_id: Uuid,
+    key: ObjectKey,
+    meta: ObjectIdentityMeta,
+    content_type: String,
+    expected_len: u64,
+    expected_sha256: String,
+}
+
 /// Fail-closed MinIO/S3 object store client (credentials required).
 #[derive(Clone)]
 pub struct MinioClient {
@@ -227,7 +236,7 @@ impl MinioClient {
         }
     }
 
-    /// Stream an `AsyncRead` into an opaque key (bounded memory; S3 multipart under the hood).
+    /// Stream an `AsyncRead` into an opaque key with fixed-memory single-PUT upload.
     pub async fn put_object_stream<R>(
         &self,
         org_id: Uuid,
@@ -240,30 +249,52 @@ impl MinioClient {
     where
         R: AsyncRead + Unpin + Send + 'static,
     {
-        authorize_key_for_org(key, org_id)?;
-        if meta.org_id != org_id || meta.org_id.is_nil() {
+        let client = self.clone();
+        let request = OwnedPutRequest {
+            org_id,
+            key: key.clone(),
+            meta: meta.clone(),
+            content_type: content_type.to_string(),
+            expected_len: verification.expected_len,
+            expected_sha256: verification.expected_sha256.to_string(),
+        };
+        let handle =
+            tokio::spawn(async move { client.put_object_stream_owned(reader, request).await });
+        handle.await.map_err(|_| StorageError::Transport)?
+    }
+
+    async fn put_object_stream_owned<R>(
+        &self,
+        reader: R,
+        request: OwnedPutRequest,
+    ) -> Result<(), StorageError>
+    where
+        R: AsyncRead + Unpin + Send + 'static,
+    {
+        authorize_key_for_org(&request.key, request.org_id)?;
+        if request.meta.org_id != request.org_id || request.meta.org_id.is_nil() {
             return Err(StorageError::KeyOrgMismatch);
         }
-        if key.namespace() == ObjectNamespace::Trusted {
-            let version_id = meta.version_id.ok_or(StorageError::MissingScope)?;
-            authorize_key_for_version(key, version_id)?;
+        if request.key.namespace() == ObjectNamespace::Trusted {
+            let version_id = request.meta.version_id.ok_or(StorageError::MissingScope)?;
+            authorize_key_for_version(&request.key, version_id)?;
         }
-        let _ = parse_key_structure(&key.as_str())?;
-        if meta.content_length != Some(verification.expected_len)
-            || meta.content_sha256.as_deref() != Some(verification.expected_sha256)
+        let _ = parse_key_structure(&request.key.as_str())?;
+        if request.meta.content_length != Some(request.expected_len)
+            || request.meta.content_sha256.as_deref() != Some(request.expected_sha256.as_str())
         {
             return Err(StorageError::ConfigInvalid);
         }
-        let path = key.as_str();
-        let mut headers = identity_headers(meta, content_type)?;
+        let path = request.key.as_str();
+        let mut headers = identity_headers(&request.meta, &request.content_type)?;
         headers.insert(
             CONTENT_LENGTH,
-            HeaderValue::from_str(&verification.expected_len.to_string())
+            HeaderValue::from_str(&request.expected_len.to_string())
                 .map_err(|_| StorageError::ConfigInvalid)?,
         );
         let presigned = self
             .bucket
-            .presign_put(path, 300, Some(headers.clone()), None)
+            .presign_put(&path, 300, Some(headers.clone()), None)
             .await
             .map_err(|_| StorageError::Transport)?;
         let uploaded = Arc::new(AtomicU64::new(0));
@@ -293,24 +324,27 @@ impl MinioClient {
             .await
             .map_err(|_| StorageError::Transport)?;
         if !response.status().is_success() {
-            let _ = self.delete_object(org_id, key).await;
+            self.cleanup_after_failed_put(request.org_id, &request.key, StorageError::Backend)
+                .await?;
             return Err(StorageError::Backend);
         }
-        if uploaded.load(Ordering::Relaxed) != verification.expected_len {
-            let _ = self.delete_object(org_id, key).await;
+        if uploaded.load(Ordering::Relaxed) != request.expected_len {
+            self.cleanup_after_failed_put(request.org_id, &request.key, StorageError::Backend)
+                .await?;
             return Err(StorageError::Backend);
         }
         if let Err(error) = self
             .verify_stored_object(
-                org_id,
-                key,
-                verification.expected_len,
-                verification.expected_sha256,
+                request.org_id,
+                &request.key,
+                request.expected_len,
+                &request.expected_sha256,
             )
             .await
         {
-            let _ = self.delete_object(org_id, key).await;
-            return Err(error);
+            return self
+                .cleanup_after_failed_put(request.org_id, &request.key, error)
+                .await;
         }
         Ok(())
     }
@@ -346,6 +380,28 @@ impl MinioClient {
     pub async fn delete_object(&self, org_id: Uuid, key: &ObjectKey) -> Result<(), StorageError> {
         authorize_key_for_org(key, org_id)?;
         self.verify_stored_org(org_id, key).await?;
+        self.delete_object_authorized_key(key, false).await
+    }
+
+    /// Internal cleanup for objects whose key was just generated for `org_id`.
+    ///
+    /// This intentionally authorizes by the generated key instead of stored metadata so
+    /// verification-failed objects with missing/mismatched metadata can still be removed.
+    pub async fn cleanup_generated_object(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+    ) -> Result<(), StorageError> {
+        authorize_key_for_org(key, org_id)?;
+        let _ = parse_key_structure(&key.as_str())?;
+        self.delete_object_authorized_key(key, true).await
+    }
+
+    async fn delete_object_authorized_key(
+        &self,
+        key: &ObjectKey,
+        missing_ok: bool,
+    ) -> Result<(), StorageError> {
         let path = key.as_str();
         let response = self
             .bucket
@@ -354,7 +410,11 @@ impl MinioClient {
             .map_err(map_s3_get_error)?;
         let status = response.status_code();
         if status == 404 {
-            return Err(StorageError::NotFound);
+            return if missing_ok {
+                Ok(())
+            } else {
+                Err(StorageError::NotFound)
+            };
         }
         if (200..300).contains(&status) {
             Ok(())
@@ -377,6 +437,24 @@ impl MinioClient {
     async fn verify_stored_org(&self, org_id: Uuid, key: &ObjectKey) -> Result<(), StorageError> {
         let _ = self.head_for_org(org_id, key).await?;
         Ok(())
+    }
+
+    async fn cleanup_after_failed_put(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        cause: StorageError,
+    ) -> Result<(), StorageError> {
+        match self.cleanup_generated_object(org_id, key).await {
+            Ok(()) => Err(cause),
+            Err(cleanup_error) => {
+                eprintln!(
+                    "fileconv-server: cleanup of failed upload object failed: {}",
+                    cleanup_error.code()
+                );
+                Err(cleanup_error)
+            }
+        }
     }
 
     async fn verify_stored_object(

--- a/crates/server/src/storage/minio.rs
+++ b/crates/server/src/storage/minio.rs
@@ -35,6 +35,14 @@ pub struct ObjectIdentityMeta {
     pub version_id: Option<Uuid>,
     /// Original filename for display only — never written into the object key.
     pub original_filename: Option<String>,
+    /// Server-derived canonical format (upload intake).
+    pub canonical_format: Option<String>,
+    /// Hex SHA-256 of object bytes.
+    pub content_sha256: Option<String>,
+    /// Declared content length in bytes.
+    pub content_length: Option<u64>,
+    /// Intake disposition (`accepted` / `quarantined`).
+    pub disposition: Option<String>,
 }
 
 /// Fail-closed MinIO/S3 object store client (credentials required).
@@ -173,8 +181,117 @@ impl MinioClient {
                     .map_err(|_| StorageError::ConfigInvalid)?;
             }
         }
+        if let Some(format) = meta.canonical_format.as_deref() {
+            builder = builder
+                .with_metadata("canonical-format", format)
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(sha) = meta.content_sha256.as_deref() {
+            builder = builder
+                .with_metadata("content-sha256", sha)
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(len) = meta.content_length {
+            builder = builder
+                .with_metadata("content-length-bytes", len.to_string())
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(disposition) = meta.disposition.as_deref() {
+            builder = builder
+                .with_metadata("disposition", disposition)
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
         let response = builder
             .execute()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if (200..300).contains(&response.status_code()) {
+            Ok(())
+        } else {
+            Err(StorageError::Backend)
+        }
+    }
+
+    /// Stream an `AsyncRead` into an opaque key (bounded memory; S3 multipart under the hood).
+    pub async fn put_object_stream<R>(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        mut reader: R,
+        meta: &ObjectIdentityMeta,
+        content_type: &str,
+    ) -> Result<(), StorageError>
+    where
+        R: tokio::io::AsyncRead + Unpin + Send,
+    {
+        authorize_key_for_org(key, org_id)?;
+        if meta.org_id != org_id || meta.org_id.is_nil() {
+            return Err(StorageError::KeyOrgMismatch);
+        }
+        if key.namespace() == ObjectNamespace::Trusted {
+            let version_id = meta.version_id.ok_or(StorageError::MissingScope)?;
+            authorize_key_for_version(key, version_id)?;
+        }
+        let _ = parse_key_structure(&key.as_str())?;
+        let path = key.as_str();
+
+        let mut builder = self
+            .bucket
+            .put_object_stream_builder(&path)
+            .with_content_type(content_type);
+        builder = builder
+            .with_metadata("org-id", meta.org_id.to_string())
+            .map_err(|_| StorageError::ConfigInvalid)?;
+        if let Some(collection_id) = meta.collection_id {
+            builder = builder
+                .with_metadata("collection-id", collection_id.to_string())
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(document_id) = meta.document_id {
+            builder = builder
+                .with_metadata("document-id", document_id.to_string())
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(version_id) = meta.version_id {
+            builder = builder
+                .with_metadata("version-id", version_id.to_string())
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(filename) = meta.original_filename.as_deref() {
+            let safe: String = filename
+                .chars()
+                .filter(|ch| !ch.is_control())
+                .take(255)
+                .collect();
+            if !safe.is_empty() {
+                builder = builder
+                    .with_metadata("original-filename", safe)
+                    .map_err(|_| StorageError::ConfigInvalid)?;
+            }
+        }
+        if let Some(format) = meta.canonical_format.as_deref() {
+            builder = builder
+                .with_metadata("canonical-format", format)
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(sha) = meta.content_sha256.as_deref() {
+            builder = builder
+                .with_metadata("content-sha256", sha)
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(len) = meta.content_length {
+            builder = builder
+                .with_metadata("content-length-bytes", len.to_string())
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+        if let Some(disposition) = meta.disposition.as_deref() {
+            builder = builder
+                .with_metadata("disposition", disposition)
+                .map_err(|_| StorageError::ConfigInvalid)?;
+        }
+
+        let response = builder
+            .execute_stream(&mut reader)
             .await
             .map_err(|_| StorageError::Transport)?;
         if (200..300).contains(&response.status_code()) {

--- a/crates/server/src/storage/minio.rs
+++ b/crates/server/src/storage/minio.rs
@@ -9,8 +9,10 @@
 //! mutation paths (fail closed).
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use futures::TryStreamExt;
@@ -23,6 +25,7 @@ use s3::Bucket;
 use s3::BucketConfiguration;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::time::timeout;
 use uuid::Uuid;
 
 use crate::config::MinioConfig;
@@ -73,6 +76,7 @@ pub struct MinioClient {
     bucket: Box<Bucket>,
     bucket_name: String,
     http_client: reqwest::Client,
+    operation_timeout: Duration,
 }
 
 impl std::fmt::Debug for MinioClient {
@@ -80,6 +84,7 @@ impl std::fmt::Debug for MinioClient {
         formatter
             .debug_struct("MinioClient")
             .field("bucket_name", &self.bucket_name)
+            .field("operation_timeout", &self.operation_timeout)
             .finish_non_exhaustive()
     }
 }
@@ -110,10 +115,17 @@ impl MinioClient {
         if config.path_style() {
             bucket = bucket.with_path_style();
         }
+        let operation_timeout = Duration::from_secs(config.operation_timeout_secs());
+        let http_client = reqwest::Client::builder()
+            .connect_timeout(operation_timeout)
+            .timeout(operation_timeout)
+            .build()
+            .map_err(|_| StorageError::ConfigInvalid)?;
         Ok(Self {
             bucket,
             bucket_name: config.bucket().to_string(),
-            http_client: reqwest::Client::new(),
+            http_client,
+            operation_timeout,
         })
     }
 
@@ -125,12 +137,16 @@ impl MinioClient {
     pub async fn ensure_bucket(&self) -> Result<(), StorageError> {
         let region = self.bucket.region.clone();
         let credentials = self
-            .bucket
-            .credentials()
-            .await
-            .map_err(|_| StorageError::Transport)?;
+            .with_s3_timeout(self.bucket.credentials(), |_| StorageError::Transport)
+            .await?;
         let config = BucketConfiguration::default();
-        match Bucket::create_with_path_style(&self.bucket_name, region, credentials, config).await {
+        match timeout(
+            self.operation_timeout,
+            Bucket::create_with_path_style(&self.bucket_name, region, credentials, config),
+        )
+        .await
+        .map_err(|_| StorageError::Transport)?
+        {
             Ok(response)
                 if response.success()
                     || response.response_code == 409
@@ -225,10 +241,9 @@ impl MinioClient {
                 .with_metadata("disposition", disposition)
                 .map_err(|_| StorageError::ConfigInvalid)?;
         }
-        let response = builder
-            .execute()
-            .await
-            .map_err(|_| StorageError::Transport)?;
+        let response = self
+            .with_s3_timeout(builder.execute(), |_| StorageError::Transport)
+            .await?;
         if (200..300).contains(&response.status_code()) {
             Ok(())
         } else {
@@ -285,7 +300,10 @@ impl MinioClient {
         {
             return Err(StorageError::ConfigInvalid);
         }
-        let path = request.key.as_str();
+        let generated_key = request.key.clone();
+        // TODO(I07): persist pending generated keys in the durable outbox/GC so crash
+        // recovery can reconcile objects beyond this live bounded task.
+        let path = generated_key.as_str();
         let mut headers = identity_headers(&request.meta, &request.content_type)?;
         headers.insert(
             CONTENT_LENGTH,
@@ -293,10 +311,12 @@ impl MinioClient {
                 .map_err(|_| StorageError::ConfigInvalid)?,
         );
         let presigned = self
-            .bucket
-            .presign_put(&path, 300, Some(headers.clone()), None)
-            .await
-            .map_err(|_| StorageError::Transport)?;
+            .with_s3_timeout(
+                self.bucket
+                    .presign_put(&path, 300, Some(headers.clone()), None),
+                |_| StorageError::Transport,
+            )
+            .await?;
         let uploaded = Arc::new(AtomicU64::new(0));
         let uploaded_for_stream = Arc::clone(&uploaded);
         let body_stream = futures::stream::try_unfold(reader, move |mut reader| {
@@ -315,35 +335,48 @@ impl MinioClient {
                 Ok::<_, std::io::Error>(Some((Bytes::from(buf), reader)))
             }
         });
-        let response = self
-            .http_client
-            .put(presigned)
-            .headers(headers)
-            .body(reqwest::Body::wrap_stream(body_stream))
-            .send()
-            .await
-            .map_err(|_| StorageError::Transport)?;
+        let response = match timeout(
+            self.operation_timeout,
+            self.http_client
+                .put(presigned)
+                .headers(headers)
+                .body(reqwest::Body::wrap_stream(body_stream))
+                .send(),
+        )
+        .await
+        {
+            Ok(Ok(response)) => response,
+            Ok(Err(_)) | Err(_) => {
+                return self
+                    .cleanup_after_failed_put(
+                        request.org_id,
+                        &generated_key,
+                        StorageError::Transport,
+                    )
+                    .await;
+            }
+        };
         if !response.status().is_success() {
-            self.cleanup_after_failed_put(request.org_id, &request.key, StorageError::Backend)
+            self.cleanup_after_failed_put(request.org_id, &generated_key, StorageError::Backend)
                 .await?;
             return Err(StorageError::Backend);
         }
         if uploaded.load(Ordering::Relaxed) != request.expected_len {
-            self.cleanup_after_failed_put(request.org_id, &request.key, StorageError::Backend)
+            self.cleanup_after_failed_put(request.org_id, &generated_key, StorageError::Backend)
                 .await?;
             return Err(StorageError::Backend);
         }
         if let Err(error) = self
             .verify_stored_object(
                 request.org_id,
-                &request.key,
+                &generated_key,
                 request.expected_len,
                 &request.expected_sha256,
             )
             .await
         {
             return self
-                .cleanup_after_failed_put(request.org_id, &request.key, error)
+                .cleanup_after_failed_put(request.org_id, &generated_key, error)
                 .await;
         }
         Ok(())
@@ -354,10 +387,8 @@ impl MinioClient {
         self.verify_stored_org(org_id, key).await?;
         let path = key.as_str();
         let response = self
-            .bucket
-            .get_object(&path)
-            .await
-            .map_err(map_s3_get_error)?;
+            .with_s3_timeout(self.bucket.get_object(&path), map_s3_get_error)
+            .await?;
         let status = response.status_code();
         if status == 404 {
             return Err(StorageError::NotFound);
@@ -387,7 +418,7 @@ impl MinioClient {
     ///
     /// This intentionally authorizes by the generated key instead of stored metadata so
     /// verification-failed objects with missing/mismatched metadata can still be removed.
-    pub async fn cleanup_generated_object(
+    pub(crate) async fn cleanup_generated_object(
         &self,
         org_id: Uuid,
         key: &ObjectKey,
@@ -404,10 +435,8 @@ impl MinioClient {
     ) -> Result<(), StorageError> {
         let path = key.as_str();
         let response = self
-            .bucket
-            .delete_object(&path)
-            .await
-            .map_err(map_s3_get_error)?;
+            .with_s3_timeout(self.bucket.delete_object(&path), map_s3_get_error)
+            .await?;
         let status = response.status_code();
         if status == 404 {
             return if missing_ok {
@@ -452,7 +481,7 @@ impl MinioClient {
                     "fileconv-server: cleanup of failed upload object failed: {}",
                     cleanup_error.code()
                 );
-                Err(cleanup_error)
+                Err(cause)
             }
         }
     }
@@ -475,15 +504,13 @@ impl MinioClient {
         }
         let path = key.as_str();
         let url = self
-            .bucket
-            .presign_get(path, 300, None)
+            .with_s3_timeout(self.bucket.presign_get(path, 300, None), |_| {
+                StorageError::Transport
+            })
+            .await?;
+        let response = timeout(self.operation_timeout, self.http_client.get(url).send())
             .await
-            .map_err(|_| StorageError::Transport)?;
-        let response = self
-            .http_client
-            .get(url)
-            .send()
-            .await
+            .map_err(|_| StorageError::Transport)?
             .map_err(|_| StorageError::Transport)?;
         if !response.status().is_success() {
             return Err(StorageError::Backend);
@@ -514,9 +541,12 @@ impl MinioClient {
         key: &ObjectKey,
     ) -> Result<(HeadObjectResult, u16), StorageError> {
         let path = key.as_str();
-        let (head, status) = match self.bucket.head_object(&path).await {
+        let (head, status) = match self
+            .with_s3_timeout(self.bucket.head_object(&path), map_s3_head_error)
+            .await
+        {
             Ok(pair) => pair,
-            Err(error) => return Err(map_s3_head_error(error)),
+            Err(error) => return Err(error),
         };
         if status == 404 {
             return Err(StorageError::NotFound);
@@ -533,6 +563,17 @@ impl MinioClient {
             return Err(StorageError::OwnershipConflict);
         }
         Ok((head, status))
+    }
+
+    async fn with_s3_timeout<T, F, M>(&self, future: F, map_error: M) -> Result<T, StorageError>
+    where
+        F: Future<Output = Result<T, S3Error>>,
+        M: FnOnce(S3Error) -> StorageError,
+    {
+        timeout(self.operation_timeout, future)
+            .await
+            .map_err(|_| StorageError::Transport)?
+            .map_err(map_error)
     }
 }
 

--- a/crates/server/src/storage/minio.rs
+++ b/crates/server/src/storage/minio.rs
@@ -9,17 +9,24 @@
 //! mutation paths (fail closed).
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use bytes::Bytes;
+use futures::TryStreamExt;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_LENGTH, CONTENT_TYPE};
 use s3::creds::Credentials;
 use s3::error::S3Error;
 use s3::region::Region;
 use s3::serde_types::HeadObjectResult;
 use s3::Bucket;
 use s3::BucketConfiguration;
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncRead, AsyncReadExt};
 use uuid::Uuid;
 
 use crate::config::MinioConfig;
+use crate::services::upload::STREAM_CHUNK_BYTES;
 use crate::storage::error::StorageError;
 use crate::storage::keys::{
     authorize_key_for_org, authorize_key_for_version, parse_key_structure, ObjectKey,
@@ -45,11 +52,18 @@ pub struct ObjectIdentityMeta {
     pub disposition: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ObjectPutVerification<'a> {
+    pub expected_len: u64,
+    pub expected_sha256: &'a str,
+}
+
 /// Fail-closed MinIO/S3 object store client (credentials required).
 #[derive(Clone)]
 pub struct MinioClient {
     bucket: Box<Bucket>,
     bucket_name: String,
+    http_client: reqwest::Client,
 }
 
 impl std::fmt::Debug for MinioClient {
@@ -90,6 +104,7 @@ impl MinioClient {
         Ok(Self {
             bucket,
             bucket_name: config.bucket().to_string(),
+            http_client: reqwest::Client::new(),
         })
     }
 
@@ -217,12 +232,13 @@ impl MinioClient {
         &self,
         org_id: Uuid,
         key: &ObjectKey,
-        mut reader: R,
+        reader: R,
         meta: &ObjectIdentityMeta,
         content_type: &str,
+        verification: ObjectPutVerification<'_>,
     ) -> Result<(), StorageError>
     where
-        R: tokio::io::AsyncRead + Unpin + Send,
+        R: AsyncRead + Unpin + Send + 'static,
     {
         authorize_key_for_org(key, org_id)?;
         if meta.org_id != org_id || meta.org_id.is_nil() {
@@ -233,72 +249,70 @@ impl MinioClient {
             authorize_key_for_version(key, version_id)?;
         }
         let _ = parse_key_structure(&key.as_str())?;
+        if meta.content_length != Some(verification.expected_len)
+            || meta.content_sha256.as_deref() != Some(verification.expected_sha256)
+        {
+            return Err(StorageError::ConfigInvalid);
+        }
         let path = key.as_str();
-
-        let mut builder = self
+        let mut headers = identity_headers(meta, content_type)?;
+        headers.insert(
+            CONTENT_LENGTH,
+            HeaderValue::from_str(&verification.expected_len.to_string())
+                .map_err(|_| StorageError::ConfigInvalid)?,
+        );
+        let presigned = self
             .bucket
-            .put_object_stream_builder(&path)
-            .with_content_type(content_type);
-        builder = builder
-            .with_metadata("org-id", meta.org_id.to_string())
-            .map_err(|_| StorageError::ConfigInvalid)?;
-        if let Some(collection_id) = meta.collection_id {
-            builder = builder
-                .with_metadata("collection-id", collection_id.to_string())
-                .map_err(|_| StorageError::ConfigInvalid)?;
-        }
-        if let Some(document_id) = meta.document_id {
-            builder = builder
-                .with_metadata("document-id", document_id.to_string())
-                .map_err(|_| StorageError::ConfigInvalid)?;
-        }
-        if let Some(version_id) = meta.version_id {
-            builder = builder
-                .with_metadata("version-id", version_id.to_string())
-                .map_err(|_| StorageError::ConfigInvalid)?;
-        }
-        if let Some(filename) = meta.original_filename.as_deref() {
-            let safe: String = filename
-                .chars()
-                .filter(|ch| !ch.is_control())
-                .take(255)
-                .collect();
-            if !safe.is_empty() {
-                builder = builder
-                    .with_metadata("original-filename", safe)
-                    .map_err(|_| StorageError::ConfigInvalid)?;
-            }
-        }
-        if let Some(format) = meta.canonical_format.as_deref() {
-            builder = builder
-                .with_metadata("canonical-format", format)
-                .map_err(|_| StorageError::ConfigInvalid)?;
-        }
-        if let Some(sha) = meta.content_sha256.as_deref() {
-            builder = builder
-                .with_metadata("content-sha256", sha)
-                .map_err(|_| StorageError::ConfigInvalid)?;
-        }
-        if let Some(len) = meta.content_length {
-            builder = builder
-                .with_metadata("content-length-bytes", len.to_string())
-                .map_err(|_| StorageError::ConfigInvalid)?;
-        }
-        if let Some(disposition) = meta.disposition.as_deref() {
-            builder = builder
-                .with_metadata("disposition", disposition)
-                .map_err(|_| StorageError::ConfigInvalid)?;
-        }
-
-        let response = builder
-            .execute_stream(&mut reader)
+            .presign_put(path, 300, Some(headers.clone()), None)
             .await
             .map_err(|_| StorageError::Transport)?;
-        if (200..300).contains(&response.status_code()) {
-            Ok(())
-        } else {
-            Err(StorageError::Backend)
+        let uploaded = Arc::new(AtomicU64::new(0));
+        let uploaded_for_stream = Arc::clone(&uploaded);
+        let body_stream = futures::stream::try_unfold(reader, move |mut reader| {
+            let uploaded = Arc::clone(&uploaded_for_stream);
+            async move {
+                let mut buf = vec![0_u8; STREAM_CHUNK_BYTES];
+                let n = reader
+                    .read(&mut buf)
+                    .await
+                    .map_err(|_| std::io::Error::other("upload stream failed"))?;
+                if n == 0 {
+                    return Ok(None);
+                }
+                buf.truncate(n);
+                uploaded.fetch_add(n as u64, Ordering::Relaxed);
+                Ok::<_, std::io::Error>(Some((Bytes::from(buf), reader)))
+            }
+        });
+        let response = self
+            .http_client
+            .put(presigned)
+            .headers(headers)
+            .body(reqwest::Body::wrap_stream(body_stream))
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if !response.status().is_success() {
+            let _ = self.delete_object(org_id, key).await;
+            return Err(StorageError::Backend);
         }
+        if uploaded.load(Ordering::Relaxed) != verification.expected_len {
+            let _ = self.delete_object(org_id, key).await;
+            return Err(StorageError::Backend);
+        }
+        if let Err(error) = self
+            .verify_stored_object(
+                org_id,
+                key,
+                verification.expected_len,
+                verification.expected_sha256,
+            )
+            .await
+        {
+            let _ = self.delete_object(org_id, key).await;
+            return Err(error);
+        }
+        Ok(())
     }
 
     pub async fn get_object(&self, org_id: Uuid, key: &ObjectKey) -> Result<Bytes, StorageError> {
@@ -365,6 +379,57 @@ impl MinioClient {
         Ok(())
     }
 
+    async fn verify_stored_object(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        expected_len: u64,
+        expected_sha256: &str,
+    ) -> Result<(), StorageError> {
+        let (head, _) = self.head_for_org(org_id, key).await?;
+        let stored_len = head.content_length.ok_or(StorageError::Backend)?;
+        if stored_len < 0 || stored_len as u64 != expected_len {
+            return Err(StorageError::Backend);
+        }
+        let meta = metadata_map(&head);
+        if meta.get("content-sha256").map(String::as_str) != Some(expected_sha256) {
+            return Err(StorageError::Backend);
+        }
+        let path = key.as_str();
+        let url = self
+            .bucket
+            .presign_get(path, 300, None)
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        let response = self
+            .http_client
+            .get(url)
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        let mut hasher = Sha256::new();
+        let mut total = 0_u64;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream
+            .try_next()
+            .await
+            .map_err(|_| StorageError::Transport)?
+        {
+            total = total.saturating_add(chunk.len() as u64);
+            if total > expected_len {
+                return Err(StorageError::Backend);
+            }
+            hasher.update(&chunk);
+        }
+        if total != expected_len || hex::encode(hasher.finalize()) != expected_sha256 {
+            return Err(StorageError::Backend);
+        }
+        Ok(())
+    }
+
     async fn head_for_org(
         &self,
         org_id: Uuid,
@@ -391,6 +456,78 @@ impl MinioClient {
         }
         Ok((head, status))
     }
+}
+
+fn identity_headers(
+    meta: &ObjectIdentityMeta,
+    content_type: &str,
+) -> Result<HeaderMap, StorageError> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_str(content_type).map_err(|_| StorageError::ConfigInvalid)?,
+    );
+    insert_header(&mut headers, "x-amz-meta-org-id", &meta.org_id.to_string())?;
+    if let Some(collection_id) = meta.collection_id {
+        insert_header(
+            &mut headers,
+            "x-amz-meta-collection-id",
+            &collection_id.to_string(),
+        )?;
+    }
+    if let Some(document_id) = meta.document_id {
+        insert_header(
+            &mut headers,
+            "x-amz-meta-document-id",
+            &document_id.to_string(),
+        )?;
+    }
+    if let Some(version_id) = meta.version_id {
+        insert_header(
+            &mut headers,
+            "x-amz-meta-version-id",
+            &version_id.to_string(),
+        )?;
+    }
+    if let Some(filename) = meta.original_filename.as_deref() {
+        let safe: String = filename
+            .chars()
+            .filter(|ch| !ch.is_control())
+            .take(255)
+            .collect();
+        if !safe.is_empty() {
+            insert_header(&mut headers, "x-amz-meta-original-filename", &safe)?;
+        }
+    }
+    if let Some(format) = meta.canonical_format.as_deref() {
+        insert_header(&mut headers, "x-amz-meta-canonical-format", format)?;
+    }
+    if let Some(sha) = meta.content_sha256.as_deref() {
+        insert_header(&mut headers, "x-amz-meta-content-sha256", sha)?;
+    }
+    if let Some(len) = meta.content_length {
+        insert_header(
+            &mut headers,
+            "x-amz-meta-content-length-bytes",
+            &len.to_string(),
+        )?;
+    }
+    if let Some(disposition) = meta.disposition.as_deref() {
+        insert_header(&mut headers, "x-amz-meta-disposition", disposition)?;
+    }
+    Ok(headers)
+}
+
+fn insert_header(
+    headers: &mut HeaderMap,
+    name: &'static str,
+    value: &str,
+) -> Result<(), StorageError> {
+    headers.insert(
+        HeaderName::from_static(name),
+        HeaderValue::from_str(value).map_err(|_| StorageError::ConfigInvalid)?,
+    );
+    Ok(())
 }
 
 fn metadata_map(head: &HeadObjectResult) -> HashMap<String, String> {

--- a/crates/server/tests/storage.rs
+++ b/crates/server/tests/storage.rs
@@ -598,6 +598,10 @@ async fn minio_put_exists_get_delete_round_trip() {
         document_id: Some(Uuid::new_v4()),
         version_id: Some(version),
         original_filename: Some("../../etc/passwd".into()),
+        canonical_format: None,
+        content_sha256: None,
+        content_length: None,
+        disposition: None,
     };
     let body = Bytes::from_static(b"markhand-storage-bytes");
     client
@@ -662,6 +666,10 @@ async fn cross_org_object_key_operation_rejected() {
         document_id: None,
         version_id: None,
         original_filename: None,
+        canonical_format: None,
+        content_sha256: None,
+        content_length: None,
+        disposition: None,
     };
     client
         .put_object(
@@ -696,6 +704,10 @@ async fn cross_org_object_key_operation_rejected() {
         document_id: None,
         version_id: None,
         original_filename: None,
+        canonical_format: None,
+        content_sha256: None,
+        content_length: None,
+        disposition: None,
     };
     assert!(matches!(
         client

--- a/crates/server/tests/uploads.rs
+++ b/crates/server/tests/uploads.rs
@@ -4,8 +4,10 @@
 //! gated on `MARKHAND_TEST_MINIO_*` and skip cleanly when unset. Auth-backed
 //! HTTP tests also need `MARKHAND_TEST_DATABASE_URL`.
 
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -31,7 +33,7 @@ use fileconv_server::services::upload::{
 };
 use fileconv_server::state::RuntimeState;
 use fileconv_server::storage::keys::{parse_key_for_org, quarantine_key};
-use fileconv_server::storage::minio::MinioClient;
+use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta, ObjectPutVerification};
 use futures::stream;
 use http_body_util::BodyExt;
 use sha2::{Digest, Sha256};
@@ -39,6 +41,66 @@ use tower::ServiceExt;
 use uuid::Uuid;
 use zip::write::SimpleFileOptions;
 use zip::CompressionMethod;
+
+struct TrackingAllocator;
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static CURRENT_ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+static PEAK_ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            let current =
+                CURRENT_ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            record_peak(current);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        CURRENT_ALLOCATED.fetch_sub(layout.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !ptr.is_null() {
+            let old_size = layout.size();
+            let current = if new_size >= old_size {
+                CURRENT_ALLOCATED.fetch_add(new_size - old_size, Ordering::Relaxed)
+                    + (new_size - old_size)
+            } else {
+                CURRENT_ALLOCATED.fetch_sub(old_size - new_size, Ordering::Relaxed)
+                    - (old_size - new_size)
+            };
+            record_peak(current);
+        }
+        ptr
+    }
+}
+
+fn record_peak(current: usize) {
+    if !TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+        return;
+    }
+    let mut peak = PEAK_ALLOCATED.load(Ordering::Relaxed);
+    while current > peak {
+        match PEAK_ALLOCATED.compare_exchange_weak(
+            peak,
+            current,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(next) => peak = next,
+        }
+    }
+}
 
 const DOCX_CONTENT_TYPES_XML: &[u8] = br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#;
 
@@ -249,6 +311,18 @@ fn write_docx_zip(path: &Path, entries: &[(&str, &[u8])], compression: Compressi
     zip.finish().unwrap();
 }
 
+fn write_xlsb_zip(path: &Path) {
+    let file = std::fs::File::create(path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    zip.start_file("[Content_Types].xml", options).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/xl/workbook.bin" ContentType="application/vnd.ms-excel.sheet.binary.macroEnabled.main"/></Types>"#)
+        .unwrap();
+    zip.start_file("xl/workbook.bin", options).unwrap();
+    zip.write_all(b"binary workbook placeholder").unwrap();
+    zip.finish().unwrap();
+}
+
 fn write_manual_stored_zip(path: &Path, entries: &[(&str, &[u8])]) {
     let mut bytes = Vec::new();
     let mut central = Vec::new();
@@ -368,28 +442,21 @@ async fn zip_bomb_rejects_without_unbounded_decompress() {
 #[tokio::test]
 async fn large_lazy_stream_keeps_memory_bounded() {
     let limits = LimitsConfig::policy_defaults();
-    let before = current_rss_kib();
+    let base = CURRENT_ALLOCATED.load(Ordering::Relaxed);
+    PEAK_ALLOCATED.store(base, Ordering::Relaxed);
+    TRACK_ALLOCATIONS.store(true, Ordering::Relaxed);
     let chunks = (0..1024).map(|_| Ok::<_, std::io::Error>(Bytes::from(vec![b'a'; 64 * 1024])));
     let streamed = stream_to_tempfile(stream::iter(chunks), &limits)
         .await
         .expect("stream large lazy body");
-    let after = current_rss_kib();
+    TRACK_ALLOCATIONS.store(false, Ordering::Relaxed);
+    let peak_delta = PEAK_ALLOCATED.load(Ordering::Relaxed).saturating_sub(base);
     assert_eq!(streamed.size_bytes, 64 * 1024 * 1024);
     assert!(streamed.head.len() <= 512);
-    if let (Some(before), Some(after)) = (before, after) {
-        assert!(
-            after.saturating_sub(before) < 32 * 1024,
-            "RSS grew from {before} KiB to {after} KiB"
-        );
-    }
-}
-
-fn current_rss_kib() -> Option<u64> {
-    let status = std::fs::read_to_string("/proc/self/status").ok()?;
-    status.lines().find_map(|line| {
-        let value = line.strip_prefix("VmRSS:")?.trim();
-        value.split_whitespace().next()?.parse().ok()
-    })
+    assert!(
+        peak_delta < 32 * 1024 * 1024,
+        "peak allocation grew by {peak_delta} bytes"
+    );
 }
 
 #[tokio::test]
@@ -420,6 +487,21 @@ async fn hidden_nested_polyglot_duplicate_and_symlink_reject() {
         .unwrap();
     zip.finish().unwrap();
     let err = validate_zip_archive(&polyglot, CanonicalFormat::Docx, &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::MalformedOoxml));
+
+    let ods_polyglot = dir.path().join("ods-polyglot.ods");
+    let file = std::fs::File::create(&ods_polyglot).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    zip.start_file("mimetype", options).unwrap();
+    zip.write_all(b"application/vnd.oasis.opendocument.spreadsheet")
+        .unwrap();
+    zip.start_file("[Content_Types].xml", options).unwrap();
+    zip.write_all(DOCX_CONTENT_TYPES_XML).unwrap();
+    zip.start_file("word/document.xml", options).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><w:document></w:document>"#)
+        .unwrap();
+    zip.finish().unwrap();
+    let err = validate_zip_archive(&ods_polyglot, CanonicalFormat::Ods, &limits).unwrap_err();
     assert_eq!(err.threat_class(), Some(ThreatClass::MalformedOoxml));
 
     let duplicate = dir.path().join("duplicate.docx");
@@ -471,6 +553,24 @@ async fn hidden_nested_polyglot_duplicate_and_symlink_reject() {
     std::fs::write(&symlink, bytes).unwrap();
     let err = validate_zip_archive(&symlink, CanonicalFormat::Docx, &limits).unwrap_err();
     assert_eq!(err.threat_class(), Some(ThreatClass::ArchiveTraversal));
+}
+
+#[tokio::test]
+async fn valid_zip_based_xlsb_is_accepted() {
+    let limits = LimitsConfig::policy_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("book.xlsb");
+    write_xlsb_zip(&path);
+    let streamed = stream_file(&path).await;
+    let (format, disposition, _, _) = validate_streamed_bytes(
+        &streamed,
+        Some("book.xlsb"),
+        Some("application/vnd.ms-excel.sheet.binary.macroEnabled.12"),
+        &limits,
+    )
+    .unwrap();
+    assert_eq!(format, CanonicalFormat::Xlsb);
+    assert_eq!(disposition, Disposition::Accepted);
 }
 
 #[tokio::test]
@@ -593,6 +693,35 @@ async fn mime_mismatch_and_malformed_audio_reject() {
     .unwrap();
     let err = validate_streamed_bytes(&zero_rate, Some("zero.wav"), Some("audio/wav"), &limits)
         .unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::ParserCorruption));
+
+    let mut truncated_wav = Vec::new();
+    truncated_wav.extend_from_slice(b"RIFF");
+    truncated_wav.extend_from_slice(&140_u32.to_le_bytes());
+    truncated_wav.extend_from_slice(b"WAVEfmt ");
+    truncated_wav.extend_from_slice(&16_u32.to_le_bytes());
+    truncated_wav.extend_from_slice(&1_u16.to_le_bytes());
+    truncated_wav.extend_from_slice(&1_u16.to_le_bytes());
+    truncated_wav.extend_from_slice(&16_000_u32.to_le_bytes());
+    truncated_wav.extend_from_slice(&32_000_u32.to_le_bytes());
+    truncated_wav.extend_from_slice(&2_u16.to_le_bytes());
+    truncated_wav.extend_from_slice(&16_u16.to_le_bytes());
+    truncated_wav.extend_from_slice(b"data");
+    truncated_wav.extend_from_slice(&100_u32.to_le_bytes());
+    truncated_wav.extend_from_slice(&[0_u8; 4]);
+    let truncated = stream_to_tempfile(
+        stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(truncated_wav))]),
+        &limits,
+    )
+    .await
+    .unwrap();
+    let err = validate_streamed_bytes(
+        &truncated,
+        Some("truncated.wav"),
+        Some("audio/wav"),
+        &limits,
+    )
+    .unwrap_err();
     assert_eq!(err.threat_class(), Some(ThreatClass::ParserCorruption));
 }
 
@@ -852,6 +981,50 @@ async fn rejected_upload_is_not_stored() {
 }
 
 #[tokio::test]
+async fn verification_failed_upload_is_cleaned_by_generated_key() {
+    let Some((client, _bucket)) = test_minio_client() else {
+        return;
+    };
+    client.ensure_bucket().await.expect("bucket");
+    let org = Uuid::new_v4();
+    let object_id = Uuid::new_v4();
+    let key = quarantine_key(org, object_id, Some("bad.bin")).unwrap();
+    let payload: &'static [u8] = b"actual object bytes";
+    let wrong_sha = hex::encode(Sha256::digest(b"different bytes"));
+    let meta = ObjectIdentityMeta {
+        org_id: org,
+        collection_id: None,
+        document_id: None,
+        version_id: None,
+        original_filename: Some("bad.bin".into()),
+        canonical_format: Some("txt".into()),
+        content_sha256: Some(wrong_sha.clone()),
+        content_length: Some(payload.len() as u64),
+        disposition: Some("accepted".into()),
+    };
+    let err = client
+        .put_object_stream(
+            org,
+            &key,
+            payload,
+            &meta,
+            "text/plain",
+            ObjectPutVerification {
+                expected_len: payload.len() as u64,
+                expected_sha256: &wrong_sha,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        fileconv_server::storage::error::StorageError::Backend
+            | fileconv_server::storage::error::StorageError::Transport
+    ));
+    assert!(!client.object_exists(org, &key).await.expect("exists"));
+}
+
+#[tokio::test]
 async fn http_upload_happy_and_spoof() {
     let Some(db_url) = test_database_url() else {
         return;
@@ -895,6 +1068,20 @@ async fn http_upload_happy_and_spoof() {
     let state = AppState::from_parts_with_store(runtime, pool, Some(state_auth), Some(store))
         .expect("state");
     let app = router(state);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/login")
+                .header("content-type", "application/json")
+                .body(Body::from(vec![b'a'; 3 * 1024 * 1024]))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
 
     let login = auth
         .login_password(

--- a/crates/server/tests/uploads.rs
+++ b/crates/server/tests/uploads.rs
@@ -1,0 +1,649 @@
+//! Upload intake integration tests (P1B-I01).
+//!
+//! Adversarial / unit-style validation runs without MinIO. Persistence paths are
+//! gated on `MARKHAND_TEST_MINIO_*` and skip cleanly when unset. Auth-backed
+//! HTTP tests also need `MARKHAND_TEST_DATABASE_URL`.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use bytes::Bytes;
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::auth::jwt::JwtKeys;
+use fileconv_server::auth::provider::{AuthProvider, AuthRequestMeta, PasswordAuthProvider};
+use fileconv_server::auth::session;
+use fileconv_server::config::{
+    Argon2Config, AuthConfig, JwtAlgorithm, MinioConfig, RuntimeEndpoints, SecretString,
+    ServerConfig,
+};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::http::{router, AppState};
+use fileconv_server::services::upload::{
+    assert_disposition_is_typed, detect_magic, quota_reserve_hook, reject_dangerous_entry_name,
+    resolve_canonical_format, stream_to_tempfile, validate_and_quarantine, validate_streamed_bytes,
+    validate_zip_archive, CanonicalFormat, Disposition, LimitsConfig, ReasonCode, ThreatClass,
+    UploadError,
+};
+use fileconv_server::state::RuntimeState;
+use fileconv_server::storage::keys::quarantine_key;
+use fileconv_server::storage::minio::MinioClient;
+use futures::stream;
+use http_body_util::BodyExt;
+use sha2::{Digest, Sha256};
+use tower::ServiceExt;
+use uuid::Uuid;
+use zip::write::SimpleFileOptions;
+use zip::CompressionMethod;
+
+fn adversarial_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../bench/markhand_web/adversarial/files")
+}
+
+fn golden_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../bench/markhand_web/golden/documents")
+}
+
+fn test_minio_client() -> Option<(MinioClient, String)> {
+    let endpoint = match std::env::var("MARKHAND_TEST_MINIO_ENDPOINT") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ENDPOINT unset");
+            return None;
+        }
+    };
+    let access_key = std::env::var("MARKHAND_TEST_MINIO_ACCESS_KEY").ok()?;
+    let secret_key = std::env::var("MARKHAND_TEST_MINIO_SECRET_KEY").ok()?;
+    if access_key.is_empty() || secret_key.is_empty() {
+        eprintln!("skipped: MinIO test credentials empty");
+        return None;
+    }
+    let region = std::env::var("MARKHAND_TEST_MINIO_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let bucket = format!("markhand-upload-{}", Uuid::new_v4().simple());
+    std::env::set_var("RUST_S3_SKIP_LOCATION_CONSTRAINT", "true");
+    let config = MinioConfig::new(
+        endpoint,
+        SecretString::new(access_key),
+        SecretString::new(secret_key),
+        bucket.clone(),
+        region,
+        true,
+    )
+    .expect("minio config");
+    let client = MinioClient::from_config(&config).expect("client");
+    Some((client, bucket))
+}
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, tokio_postgres::NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("connect failed for {database_url}: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_upload_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+fn test_auth_config() -> AuthConfig {
+    AuthConfig {
+        issuer: Some("https://issuer.markhand.test".into()),
+        audience: Some("markhand-api".into()),
+        signing_key: Some(SecretString::new("integration-test-signing-key-32b!")),
+        alg: JwtAlgorithm::Hs256,
+        kid: Some("test-kid-1".into()),
+        access_token_ttl_secs: 900,
+        refresh_token_ttl_secs: 3_600,
+        argon2: Argon2Config {
+            memory_kib: 8_192,
+            time_cost: 1,
+            parallelism: 1,
+        },
+    }
+}
+
+async fn seed_uploader(pool: &Pool, org: Uuid, user: Uuid, email: &str, password: &str) {
+    let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
+    let email = email.to_string();
+    with_org_txn(pool, &ctx, {
+        let owned = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &owned, "uploadorg", "Upload Org").await?;
+                orgs::ensure_user(txn, &owned, user, &email, "Uploader").await?;
+                orgs::ensure_membership(txn, &owned).await?;
+                txn.execute(
+                    "INSERT INTO permissions (id, code, description)
+                     VALUES ($1, 'doc.upload', 'Upload')
+                     ON CONFLICT (code) DO NOTHING",
+                    &[&Uuid::new_v4()],
+                )
+                .await?;
+                let role_id = Uuid::new_v4();
+                txn.execute(
+                    "INSERT INTO roles (id, org_id, code, name, is_system)
+                     VALUES ($1, $2, 'owner', 'Owner', true)
+                     ON CONFLICT (org_id, code) DO NOTHING",
+                    &[&role_id, &org],
+                )
+                .await?;
+                let role_id: Uuid = txn
+                    .query_one(
+                        "SELECT id FROM roles WHERE org_id = $1 AND code = 'owner'",
+                        &[&org],
+                    )
+                    .await?
+                    .get(0);
+                let perm_id: Uuid = txn
+                    .query_one("SELECT id FROM permissions WHERE code = 'doc.upload'", &[])
+                    .await?
+                    .get(0);
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     VALUES ($1, $2, $3)
+                     ON CONFLICT DO NOTHING",
+                    &[&org, &role_id, &perm_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed org");
+
+    session::set_password_hash(pool, user, password, &test_auth_config().argon2)
+        .await
+        .expect("set password");
+}
+
+async fn stream_file(path: &Path) -> fileconv_server::services::upload::StreamedUpload {
+    let data = std::fs::read(path).expect("read fixture");
+    let limits = LimitsConfig::policy_defaults();
+    stream_to_tempfile(
+        stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(data))]),
+        &limits,
+    )
+    .await
+    .expect("stream")
+}
+
+#[tokio::test]
+async fn spoof_pdf_and_html_pdf_reject() {
+    let limits = LimitsConfig::policy_defaults();
+    for name in ["plain-text.pdf", "actually-html.pdf"] {
+        let path = adversarial_dir().join(name);
+        let streamed = stream_file(&path).await;
+        let err = validate_streamed_bytes(&streamed, Some(name), &limits).unwrap_err();
+        assert_eq!(err.threat_class(), Some(ThreatClass::ExtensionSpoof));
+        assert_eq!(err.reason_code(), ReasonCode::ExtensionMagicMismatch);
+    }
+}
+
+#[tokio::test]
+async fn malformed_and_traversal_docx_reject() {
+    let limits = LimitsConfig::policy_defaults();
+    let malformed = stream_file(&adversarial_dir().join("malformed.docx")).await;
+    let err = validate_streamed_bytes(&malformed, Some("malformed.docx"), &limits).unwrap_err();
+    assert!(matches!(
+        err.threat_class(),
+        Some(ThreatClass::MalformedOoxml)
+    ));
+
+    let traversal = stream_file(&adversarial_dir().join("traversal.docx")).await;
+    let err = validate_streamed_bytes(&traversal, Some("traversal.docx"), &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::ArchiveTraversal));
+}
+
+#[tokio::test]
+async fn zip_bomb_rejects_without_unbounded_decompress() {
+    let limits = LimitsConfig::policy_defaults();
+    let streamed = stream_file(&adversarial_dir().join("compressed-bomb.docx")).await;
+    // Memory bound: we only hold the small on-disk fixture + CD metadata.
+    assert!(streamed.size_bytes < 64 * 1024);
+    let err =
+        validate_streamed_bytes(&streamed, Some("compressed-bomb.docx"), &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::ArchiveBomb));
+    assert_eq!(err.reason_code(), ReasonCode::ArchiveCompressionRatio);
+}
+
+#[tokio::test]
+async fn entry_count_bomb_rejects() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("many.docx");
+    let file = std::fs::File::create(&path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    zip.start_file("[Content_Types].xml", options).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><Types></Types>"#)
+        .unwrap();
+    zip.start_file("word/document.xml", options).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><w:document></w:document>"#)
+        .unwrap();
+    for i in 0..5_000 {
+        zip.start_file(format!("pad/{i}.bin"), options).unwrap();
+        zip.write_all(b"x").unwrap();
+    }
+    zip.finish().unwrap();
+
+    let err = validate_zip_archive(
+        &path,
+        CanonicalFormat::Docx,
+        &LimitsConfig::policy_defaults(),
+    )
+    .unwrap_err();
+    assert_eq!(err.reason_code(), ReasonCode::ArchiveEntryLimit);
+}
+
+#[tokio::test]
+async fn oversize_stream_rejects_early() {
+    let limits = LimitsConfig {
+        max_upload_bytes: 2_048,
+        ..LimitsConfig::policy_defaults()
+    };
+    let chunks = (0..40).map(|_| Ok::<_, std::io::Error>(Bytes::from(vec![0_u8; 128])));
+    let err = stream_to_tempfile(stream::iter(chunks), &limits)
+        .await
+        .unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::Oversize));
+    assert_eq!(err.status_code(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn truncated_stream_is_not_accepted() {
+    let limits = LimitsConfig::policy_defaults();
+    // Empty body after interruption-style empty stream → magic unrecognized / reject.
+    let streamed = stream_to_tempfile(
+        stream::iter(Vec::<Result<Bytes, std::io::Error>>::new()),
+        &limits,
+    )
+    .await
+    .unwrap();
+    assert_eq!(streamed.size_bytes, 0);
+    let err = validate_streamed_bytes(&streamed, Some("empty.pdf"), &limits).unwrap_err();
+    assert!(matches!(
+        err.threat_class(),
+        Some(ThreatClass::UnsupportedFormat) | Some(ThreatClass::ExtensionSpoof)
+    ));
+}
+
+#[tokio::test]
+async fn corrupt_and_page_bomb_pdf_reject() {
+    let limits = LimitsConfig::policy_defaults();
+    let corrupt = stream_file(&adversarial_dir().join("corrupt.pdf")).await;
+    let err = validate_streamed_bytes(&corrupt, Some("corrupt.pdf"), &limits).unwrap_err();
+    assert!(matches!(
+        err.threat_class(),
+        Some(ThreatClass::ParserCorruption) | Some(ThreatClass::PdfPageBomb)
+    ));
+
+    let page_bomb = stream_file(&adversarial_dir().join("page-bomb.pdf")).await;
+    let err = validate_streamed_bytes(&page_bomb, Some("page-bomb.pdf"), &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::PdfPageBomb));
+}
+
+#[tokio::test]
+async fn formula_csv_and_prompt_html_quarantine() {
+    let limits = LimitsConfig::policy_defaults();
+    let csv = stream_file(&adversarial_dir().join("formula.csv")).await;
+    let (format, disposition, threat, _) =
+        validate_streamed_bytes(&csv, Some("formula.csv"), &limits).unwrap();
+    assert_eq!(format, CanonicalFormat::Csv);
+    assert_eq!(disposition, Disposition::Quarantined);
+    assert_eq!(threat, Some(ThreatClass::CsvFormula));
+
+    let html = stream_file(&adversarial_dir().join("prompt-injection.html")).await;
+    let (format, disposition, threat, _) =
+        validate_streamed_bytes(&html, Some("prompt-injection.html"), &limits).unwrap();
+    assert_eq!(format, CanonicalFormat::Html);
+    assert_eq!(disposition, Disposition::Quarantined);
+    assert_eq!(threat, Some(ThreatClass::PromptInjection));
+}
+
+#[tokio::test]
+async fn happy_path_small_fixtures_accepted() {
+    let limits = LimitsConfig::policy_defaults();
+    let cases = [
+        ("gold-004.pdf", CanonicalFormat::Pdf),
+        ("gold-006.docx", CanonicalFormat::Docx),
+        ("gold-014.csv", CanonicalFormat::Csv),
+        ("gold-020.png", CanonicalFormat::Png),
+    ];
+    for (name, expected) in cases {
+        let streamed = stream_file(&golden_dir().join(name)).await;
+        let (format, disposition, _, _) =
+            validate_streamed_bytes(&streamed, Some(name), &limits).unwrap();
+        assert_eq!(format, expected, "{name}");
+        assert_eq!(disposition, Disposition::Accepted, "{name}");
+        assert_disposition_is_typed(disposition);
+    }
+}
+
+#[tokio::test]
+async fn malicious_filename_never_enters_object_key() {
+    let org = Uuid::new_v4();
+    let object = Uuid::new_v4();
+    for name in ["../../etc/passwd", "/abs/evil.pdf", "file\nname.docx"] {
+        let key = quarantine_key(org, object, Some(name)).unwrap();
+        let key_str = key.as_str();
+        assert!(!key_str.contains("passwd"));
+        assert!(!key_str.contains("evil"));
+        assert!(!key_str.contains('\n'));
+        assert!(key_str.starts_with("quarantine/"));
+    }
+    assert!(reject_dangerous_entry_name("../../etc/passwd").is_err());
+}
+
+#[tokio::test]
+async fn property_filename_and_magic_never_panic() {
+    let limits = LimitsConfig::policy_defaults();
+    let names = [
+        "",
+        ".",
+        "..",
+        "a.pdf",
+        "a.docx",
+        "../../x.pdf",
+        "file\0.pdf",
+        "x.html",
+        "x.csv",
+        "noext",
+    ];
+    let payloads: &[&[u8]] = &[
+        b"%PDF-1.4\n%%EOF\n",
+        b"PK\x03\x04",
+        b"not a pdf",
+        b"<html>hi</html>",
+        b"a,b\n1,2\n",
+        &[0xff, 0xd8, 0xff, 0xe0],
+        &[],
+    ];
+    for name in names {
+        for payload in payloads {
+            let streamed = stream_to_tempfile(
+                stream::iter(vec![Ok::<_, std::io::Error>(Bytes::copy_from_slice(
+                    payload,
+                ))]),
+                &limits,
+            )
+            .await
+            .unwrap();
+            let result = validate_streamed_bytes(&streamed, Some(name), &limits);
+            match result {
+                Ok((_, disposition, _, _)) => assert_disposition_is_typed(disposition),
+                Err(error) => {
+                    assert!(error.threat_class().is_some());
+                    let _ = error.reason_code();
+                }
+            }
+            let _ = detect_magic(payload);
+            let _ = resolve_canonical_format(payload, Some(name));
+        }
+    }
+}
+
+#[tokio::test]
+async fn quota_hook_is_callable() {
+    let org = OrgContext::try_new(Uuid::new_v4(), Uuid::new_v4(), ["doc.upload"], []).unwrap();
+    quota_reserve_hook(&org, "test-idem", Some(12));
+}
+
+#[tokio::test]
+async fn happy_path_persists_to_quarantine_with_metadata() {
+    let Some((client, _bucket)) = test_minio_client() else {
+        return;
+    };
+    client.ensure_bucket().await.expect("bucket");
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
+    let limits = LimitsConfig::policy_defaults();
+    let path = golden_dir().join("gold-004.pdf");
+    let streamed = stream_file(&path).await;
+    let expected_sha = streamed.sha256_hex.clone();
+    let outcome = validate_and_quarantine(&ctx, &client, &limits, streamed, Some("report.pdf"))
+        .await
+        .expect("accepted");
+    assert_eq!(outcome.disposition, Disposition::Accepted);
+    assert_eq!(outcome.canonical_format, CanonicalFormat::Pdf);
+    assert_eq!(outcome.sha256_hex, expected_sha);
+    assert!(!outcome.object_key.as_str().contains("report.pdf"));
+    assert!(outcome.object_key.as_str().starts_with("quarantine/"));
+
+    let meta = client
+        .head_metadata(org, &outcome.object_key)
+        .await
+        .expect("head");
+    assert_eq!(
+        meta.get("original-filename").map(String::as_str),
+        Some("report.pdf")
+    );
+    assert_eq!(
+        meta.get("canonical-format").map(String::as_str),
+        Some("pdf")
+    );
+    assert_eq!(
+        meta.get("content-sha256").map(String::as_str),
+        Some(expected_sha.as_str())
+    );
+    client
+        .delete_object(org, &outcome.object_key)
+        .await
+        .expect("cleanup");
+}
+
+#[tokio::test]
+async fn rejected_upload_is_not_stored() {
+    let Some((client, _bucket)) = test_minio_client() else {
+        return;
+    };
+    client.ensure_bucket().await.expect("bucket");
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
+    let limits = LimitsConfig::policy_defaults();
+    let streamed = stream_file(&adversarial_dir().join("plain-text.pdf")).await;
+    let err = validate_and_quarantine(&ctx, &client, &limits, streamed, Some("plain-text.pdf"))
+        .await
+        .unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::ExtensionSpoof));
+    // No object should have been created; a random key lookup stays NotFound-ish after auth.
+    let probe = quarantine_key(org, Uuid::new_v4(), Some("plain-text.pdf")).unwrap();
+    assert!(!client.object_exists(org, &probe).await.expect("exists"));
+}
+
+#[tokio::test]
+async fn http_upload_happy_and_spoof() {
+    let Some(db_url) = test_database_url() else {
+        return;
+    };
+    let Some((store, _bucket)) = test_minio_client() else {
+        return;
+    };
+    store.ensure_bucket().await.expect("bucket");
+
+    let ephemeral = EphemeralDb::create(&db_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrations");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    seed_uploader(
+        &pool,
+        org,
+        user,
+        "uploader@example.test",
+        "correct-password-1",
+    )
+    .await;
+
+    let runtime = RuntimeState::from_config(ServerConfig::test_with_endpoints(RuntimeEndpoints {
+        database_url: SecretString::new(&ephemeral.url),
+        qdrant_url: "http://127.0.0.1:1".into(),
+        minio_url: "http://127.0.0.1:9000".into(),
+    }))
+    .expect("runtime");
+    let auth = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+    let state_auth = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+    let state = AppState::from_parts_with_store(runtime, pool, Some(state_auth), Some(store))
+        .expect("state");
+    let app = router(state);
+
+    let login = auth
+        .login_password(
+            "uploader@example.test",
+            "correct-password-1",
+            &AuthRequestMeta {
+                request_id: "req-upload-test".into(),
+            },
+        )
+        .await
+        .expect("login");
+    let token = login.tokens.access_token.expose().to_string();
+
+    let pdf = std::fs::read(golden_dir().join("gold-004.pdf")).unwrap();
+    let body = multipart_body("report.pdf", &pdf);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/uploads")
+                .header("authorization", format!("Bearer {token}"))
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={BOUNDARY}"),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["disposition"], "accepted");
+    assert_eq!(json["canonicalFormat"], "pdf");
+    let key = json["objectKey"].as_str().unwrap();
+    assert!(!key.contains("report.pdf"));
+    assert!(key.starts_with("quarantine/"));
+
+    let spoof = std::fs::read(adversarial_dir().join("plain-text.pdf")).unwrap();
+    let body = multipart_body("plain-text.pdf", &spoof);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/uploads")
+                .header("authorization", format!("Bearer {token}"))
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={BOUNDARY}"),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["code"], "upload_rejected");
+    assert!(!bytes.windows(b"not a pdf".len()).any(|w| w == b"not a pdf"));
+
+    ephemeral.drop().await;
+}
+
+const BOUNDARY: &str = "----markhandUploadBoundary7MA4YWxk";
+
+fn multipart_body(filename: &str, content: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!("--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\nContent-Type: application/octet-stream\r\n\r\n").as_bytes(),
+    );
+    body.extend_from_slice(content);
+    body.extend_from_slice(format!("\r\n--{BOUNDARY}--\r\n").as_bytes());
+    body
+}
+
+#[test]
+fn upload_error_redacts_and_maps_status() {
+    let err = UploadError::rejected(ThreatClass::Oversize, ReasonCode::UploadTooLarge);
+    assert_eq!(err.status_code(), StatusCode::PAYLOAD_TOO_LARGE);
+    let debug = format!("{err:?}");
+    assert!(!debug.contains("passwd"));
+    assert_eq!(
+        hex::encode(Sha256::digest(b"hello")),
+        hex::encode(Sha256::digest(b"hello"))
+    );
+}

--- a/crates/server/tests/uploads.rs
+++ b/crates/server/tests/uploads.rs
@@ -626,6 +626,39 @@ async fn unparseable_compressed_span_rejects_closed() {
 }
 
 #[tokio::test]
+async fn declared_entry_count_rejects_before_name_allocation() {
+    let limits = LimitsConfig {
+        max_archive_entries: 4,
+        ..LimitsConfig::policy_defaults()
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("declared-too-many.docx");
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"PK\x05\x06");
+    bytes.extend_from_slice(&0_u16.to_le_bytes());
+    bytes.extend_from_slice(&0_u16.to_le_bytes());
+    bytes.extend_from_slice(&5_u16.to_le_bytes());
+    bytes.extend_from_slice(&5_u16.to_le_bytes());
+    bytes.extend_from_slice(&0_u32.to_le_bytes());
+    bytes.extend_from_slice(&0_u32.to_le_bytes());
+    bytes.extend_from_slice(&0_u16.to_le_bytes());
+    std::fs::write(&path, bytes).unwrap();
+
+    let base = CURRENT_ALLOCATED.load(Ordering::Relaxed);
+    PEAK_ALLOCATED.store(base, Ordering::Relaxed);
+    TRACK_ALLOCATIONS.store(true, Ordering::Relaxed);
+    let err = validate_zip_archive(&path, CanonicalFormat::Docx, &limits).unwrap_err();
+    TRACK_ALLOCATIONS.store(false, Ordering::Relaxed);
+    let peak_delta = PEAK_ALLOCATED.load(Ordering::Relaxed).saturating_sub(base);
+    assert_eq!(err.threat_class(), Some(ThreatClass::ArchiveBomb));
+    assert_eq!(err.reason_code(), ReasonCode::ArchiveEntryLimit);
+    assert!(
+        peak_delta < 8 * 1024 * 1024,
+        "declared entry count rejection allocated {peak_delta} bytes"
+    );
+}
+
+#[tokio::test]
 async fn entry_count_bomb_rejects() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("many.docx");

--- a/crates/server/tests/uploads.rs
+++ b/crates/server/tests/uploads.rs
@@ -32,11 +32,12 @@ use fileconv_server::services::upload::{
     UploadError,
 };
 use fileconv_server::state::RuntimeState;
-use fileconv_server::storage::keys::{parse_key_for_org, quarantine_key};
+use fileconv_server::storage::keys::{parse_key_for_org, quarantine_key, trusted_key};
 use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta, ObjectPutVerification};
 use futures::stream;
 use http_body_util::BodyExt;
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
 use tower::ServiceExt;
 use uuid::Uuid;
 use zip::write::SimpleFileOptions;
@@ -606,6 +607,25 @@ async fn forged_central_directory_size_rejects_during_inflation() {
 }
 
 #[tokio::test]
+async fn unparseable_compressed_span_rejects_closed() {
+    let limits = LimitsConfig::policy_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bad-span.docx");
+    write_docx_zip(&path, &[], CompressionMethod::Stored);
+    let mut bytes = std::fs::read(&path).unwrap();
+    let first_local = bytes
+        .windows(4)
+        .position(|window| window == b"PK\x03\x04")
+        .expect("local header");
+    bytes[first_local..first_local + 4].copy_from_slice(b"PX\x03\x04");
+    std::fs::write(&path, bytes).unwrap();
+
+    let err = validate_zip_archive(&path, CanonicalFormat::Docx, &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::MalformedOoxml));
+    assert_eq!(err.reason_code(), ReasonCode::MalformedArchive);
+}
+
+#[tokio::test]
 async fn entry_count_bomb_rejects() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("many.docx");
@@ -1022,6 +1042,76 @@ async fn verification_failed_upload_is_cleaned_by_generated_key() {
             | fileconv_server::storage::error::StorageError::Transport
     ));
     assert!(!client.object_exists(org, &key).await.expect("exists"));
+}
+
+#[tokio::test]
+async fn cancelled_stream_upload_finishes_verify_or_cleanup() {
+    let Some((client, _bucket)) = test_minio_client() else {
+        return;
+    };
+    client.ensure_bucket().await.expect("bucket");
+    let org = Uuid::new_v4();
+    let object_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let key = quarantine_key(org, object_id, Some("cancelled.txt")).unwrap();
+    let trusted_probe =
+        trusted_key(org, version_id, Uuid::new_v4(), Some("cancelled.txt")).unwrap();
+    let payload = b"cancelled upload still finishes verification and cleanup".to_vec();
+    let wrong_sha = hex::encode(Sha256::digest(b"not the uploaded payload"));
+    let meta = ObjectIdentityMeta {
+        org_id: org,
+        collection_id: None,
+        document_id: None,
+        version_id: None,
+        original_filename: Some("cancelled.txt".into()),
+        canonical_format: Some("txt".into()),
+        content_sha256: Some(wrong_sha.clone()),
+        content_length: Some(payload.len() as u64),
+        disposition: Some("accepted".into()),
+    };
+    let (mut writer, reader) = tokio::io::duplex(8);
+    {
+        let upload = client.put_object_stream(
+            org,
+            &key,
+            reader,
+            &meta,
+            "text/plain",
+            ObjectPutVerification {
+                expected_len: payload.len() as u64,
+                expected_sha256: &wrong_sha,
+            },
+        );
+        tokio::pin!(upload);
+        tokio::select! {
+            result = &mut upload => panic!("upload unexpectedly finished before cancellation: {result:?}"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(20)) => {}
+        }
+        writer
+            .write_all(&payload[..8])
+            .await
+            .expect("write first chunk");
+    }
+    writer
+        .write_all(&payload[8..])
+        .await
+        .expect("write remaining chunks");
+    writer.shutdown().await.expect("finish writer");
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            assert!(!client
+                .object_exists(org, &trusted_probe)
+                .await
+                .expect("trusted exists"));
+            if !client.object_exists(org, &key).await.expect("exists") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("owned upload task cleaned generated quarantine object");
 }
 
 #[tokio::test]

--- a/crates/server/tests/uploads.rs
+++ b/crates/server/tests/uploads.rs
@@ -30,7 +30,7 @@ use fileconv_server::services::upload::{
     UploadError,
 };
 use fileconv_server::state::RuntimeState;
-use fileconv_server::storage::keys::quarantine_key;
+use fileconv_server::storage::keys::{parse_key_for_org, quarantine_key};
 use fileconv_server::storage::minio::MinioClient;
 use futures::stream;
 use http_body_util::BodyExt;
@@ -39,6 +39,8 @@ use tower::ServiceExt;
 use uuid::Uuid;
 use zip::write::SimpleFileOptions;
 use zip::CompressionMethod;
+
+const DOCX_CONTENT_TYPES_XML: &[u8] = br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#;
 
 fn adversarial_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../bench/markhand_web/adversarial/files")
@@ -231,13 +233,89 @@ async fn stream_file(path: &Path) -> fileconv_server::services::upload::Streamed
     .expect("stream")
 }
 
+fn write_docx_zip(path: &Path, entries: &[(&str, &[u8])], compression: CompressionMethod) {
+    let file = std::fs::File::create(path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(compression);
+    zip.start_file("[Content_Types].xml", options).unwrap();
+    zip.write_all(DOCX_CONTENT_TYPES_XML).unwrap();
+    zip.start_file("word/document.xml", options).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><w:document></w:document>"#)
+        .unwrap();
+    for (name, data) in entries {
+        zip.start_file(*name, options).unwrap();
+        zip.write_all(data).unwrap();
+    }
+    zip.finish().unwrap();
+}
+
+fn write_manual_stored_zip(path: &Path, entries: &[(&str, &[u8])]) {
+    let mut bytes = Vec::new();
+    let mut central = Vec::new();
+    for (name, data) in entries {
+        let offset = bytes.len() as u32;
+        let crc = crc32fast::hash(data);
+        let name_bytes = name.as_bytes();
+        bytes.extend_from_slice(b"PK\x03\x04");
+        bytes.extend_from_slice(&20_u16.to_le_bytes());
+        bytes.extend_from_slice(&0_u16.to_le_bytes());
+        bytes.extend_from_slice(&0_u16.to_le_bytes());
+        bytes.extend_from_slice(&0_u16.to_le_bytes());
+        bytes.extend_from_slice(&0_u16.to_le_bytes());
+        bytes.extend_from_slice(&crc.to_le_bytes());
+        bytes.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(&0_u16.to_le_bytes());
+        bytes.extend_from_slice(name_bytes);
+        bytes.extend_from_slice(data);
+
+        central.extend_from_slice(b"PK\x01\x02");
+        central.extend_from_slice(&20_u16.to_le_bytes());
+        central.extend_from_slice(&20_u16.to_le_bytes());
+        central.extend_from_slice(&0_u16.to_le_bytes());
+        central.extend_from_slice(&0_u16.to_le_bytes());
+        central.extend_from_slice(&0_u16.to_le_bytes());
+        central.extend_from_slice(&0_u16.to_le_bytes());
+        central.extend_from_slice(&crc.to_le_bytes());
+        central.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        central.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        central.extend_from_slice(&(name_bytes.len() as u16).to_le_bytes());
+        central.extend_from_slice(&0_u16.to_le_bytes());
+        central.extend_from_slice(&0_u16.to_le_bytes());
+        central.extend_from_slice(&0_u16.to_le_bytes());
+        central.extend_from_slice(&0_u16.to_le_bytes());
+        central.extend_from_slice(&0_u32.to_le_bytes());
+        central.extend_from_slice(&offset.to_le_bytes());
+        central.extend_from_slice(name_bytes);
+    }
+    let central_offset = bytes.len() as u32;
+    let central_size = central.len() as u32;
+    bytes.extend_from_slice(&central);
+    bytes.extend_from_slice(b"PK\x05\x06");
+    bytes.extend_from_slice(&0_u16.to_le_bytes());
+    bytes.extend_from_slice(&0_u16.to_le_bytes());
+    bytes.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+    bytes.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+    bytes.extend_from_slice(&central_size.to_le_bytes());
+    bytes.extend_from_slice(&central_offset.to_le_bytes());
+    bytes.extend_from_slice(&0_u16.to_le_bytes());
+    std::fs::write(path, bytes).unwrap();
+}
+
 #[tokio::test]
 async fn spoof_pdf_and_html_pdf_reject() {
     let limits = LimitsConfig::policy_defaults();
     for name in ["plain-text.pdf", "actually-html.pdf"] {
         let path = adversarial_dir().join(name);
         let streamed = stream_file(&path).await;
-        let err = validate_streamed_bytes(&streamed, Some(name), &limits).unwrap_err();
+        let err = validate_streamed_bytes(
+            &streamed,
+            Some(name),
+            Some("application/octet-stream"),
+            &limits,
+        )
+        .unwrap_err();
         assert_eq!(err.threat_class(), Some(ThreatClass::ExtensionSpoof));
         assert_eq!(err.reason_code(), ReasonCode::ExtensionMagicMismatch);
     }
@@ -247,14 +325,26 @@ async fn spoof_pdf_and_html_pdf_reject() {
 async fn malformed_and_traversal_docx_reject() {
     let limits = LimitsConfig::policy_defaults();
     let malformed = stream_file(&adversarial_dir().join("malformed.docx")).await;
-    let err = validate_streamed_bytes(&malformed, Some("malformed.docx"), &limits).unwrap_err();
+    let err = validate_streamed_bytes(
+        &malformed,
+        Some("malformed.docx"),
+        Some("application/octet-stream"),
+        &limits,
+    )
+    .unwrap_err();
     assert!(matches!(
         err.threat_class(),
         Some(ThreatClass::MalformedOoxml)
     ));
 
     let traversal = stream_file(&adversarial_dir().join("traversal.docx")).await;
-    let err = validate_streamed_bytes(&traversal, Some("traversal.docx"), &limits).unwrap_err();
+    let err = validate_streamed_bytes(
+        &traversal,
+        Some("traversal.docx"),
+        Some("application/octet-stream"),
+        &limits,
+    )
+    .unwrap_err();
     assert_eq!(err.threat_class(), Some(ThreatClass::ArchiveTraversal));
 }
 
@@ -264,10 +354,155 @@ async fn zip_bomb_rejects_without_unbounded_decompress() {
     let streamed = stream_file(&adversarial_dir().join("compressed-bomb.docx")).await;
     // Memory bound: we only hold the small on-disk fixture + CD metadata.
     assert!(streamed.size_bytes < 64 * 1024);
-    let err =
-        validate_streamed_bytes(&streamed, Some("compressed-bomb.docx"), &limits).unwrap_err();
+    let err = validate_streamed_bytes(
+        &streamed,
+        Some("compressed-bomb.docx"),
+        Some("application/octet-stream"),
+        &limits,
+    )
+    .unwrap_err();
     assert_eq!(err.threat_class(), Some(ThreatClass::ArchiveBomb));
     assert_eq!(err.reason_code(), ReasonCode::ArchiveCompressionRatio);
+}
+
+#[tokio::test]
+async fn large_lazy_stream_keeps_memory_bounded() {
+    let limits = LimitsConfig::policy_defaults();
+    let before = current_rss_kib();
+    let chunks = (0..1024).map(|_| Ok::<_, std::io::Error>(Bytes::from(vec![b'a'; 64 * 1024])));
+    let streamed = stream_to_tempfile(stream::iter(chunks), &limits)
+        .await
+        .expect("stream large lazy body");
+    let after = current_rss_kib();
+    assert_eq!(streamed.size_bytes, 64 * 1024 * 1024);
+    assert!(streamed.head.len() <= 512);
+    if let (Some(before), Some(after)) = (before, after) {
+        assert!(
+            after.saturating_sub(before) < 32 * 1024,
+            "RSS grew from {before} KiB to {after} KiB"
+        );
+    }
+}
+
+fn current_rss_kib() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    status.lines().find_map(|line| {
+        let value = line.strip_prefix("VmRSS:")?.trim();
+        value.split_whitespace().next()?.parse().ok()
+    })
+}
+
+#[tokio::test]
+async fn hidden_nested_polyglot_duplicate_and_symlink_reject() {
+    let limits = LimitsConfig::policy_defaults();
+    let dir = tempfile::tempdir().unwrap();
+
+    let nested = dir.path().join("nested.docx");
+    write_docx_zip(
+        &nested,
+        &[("word/media/blob.bin", b"PK\x03\x04nested")],
+        CompressionMethod::Stored,
+    );
+    let err = validate_zip_archive(&nested, CanonicalFormat::Docx, &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::NestedArchive));
+
+    let polyglot = dir.path().join("polyglot.docx");
+    let file = std::fs::File::create(&polyglot).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    zip.start_file("[Content_Types].xml", options).unwrap();
+    zip.write_all(DOCX_CONTENT_TYPES_XML).unwrap();
+    zip.start_file("word/document.xml", options).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><w:document></w:document>"#)
+        .unwrap();
+    zip.start_file("ppt/presentation.xml", options).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><p:presentation></p:presentation>"#)
+        .unwrap();
+    zip.finish().unwrap();
+    let err = validate_zip_archive(&polyglot, CanonicalFormat::Docx, &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::MalformedOoxml));
+
+    let duplicate = dir.path().join("duplicate.docx");
+    write_manual_stored_zip(
+        &duplicate,
+        &[
+            ("[Content_Types].xml", DOCX_CONTENT_TYPES_XML),
+            (
+                "word/document.xml",
+                br#"<?xml version="1.0"?><w:document></w:document>"#,
+            ),
+            (
+                "word/document.xml",
+                br#"<?xml version="1.0"?><w:document></w:document>"#,
+            ),
+        ],
+    );
+    let err = validate_zip_archive(&duplicate, CanonicalFormat::Docx, &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::MalformedOoxml));
+
+    let symlink = dir.path().join("symlink.docx");
+    let file = std::fs::File::create(&symlink).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    zip.start_file("[Content_Types].xml", options).unwrap();
+    zip.write_all(DOCX_CONTENT_TYPES_XML).unwrap();
+    zip.start_file("word/document.xml", options).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><w:document></w:document>"#)
+        .unwrap();
+    let symlink_options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Stored)
+        .unix_permissions(0o120777);
+    zip.start_file("word/media/link", symlink_options).unwrap();
+    zip.write_all(b"target").unwrap();
+    zip.finish().unwrap();
+    let mut bytes = std::fs::read(&symlink).unwrap();
+    let mut pos = 0;
+    while let Some(offset) = bytes[pos..].windows(4).position(|w| w == b"PK\x01\x02") {
+        let start = pos + offset;
+        let name_len =
+            u16::from_le_bytes(bytes[start + 28..start + 30].try_into().unwrap()) as usize;
+        let name = &bytes[start + 46..start + 46 + name_len];
+        if name == b"word/media/link" {
+            bytes[start + 5] = 3;
+            bytes[start + 38..start + 42].copy_from_slice(&((0o120777_u32) << 16).to_le_bytes());
+            break;
+        }
+        pos = start + 4;
+    }
+    std::fs::write(&symlink, bytes).unwrap();
+    let err = validate_zip_archive(&symlink, CanonicalFormat::Docx, &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::ArchiveTraversal));
+}
+
+#[tokio::test]
+async fn forged_central_directory_size_rejects_during_inflation() {
+    let limits = LimitsConfig::policy_defaults();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("forged.docx");
+    let payload = [b'x'; 128];
+    write_docx_zip(
+        &path,
+        &[("word/media/payload.bin", payload.as_slice())],
+        CompressionMethod::Stored,
+    );
+    let mut bytes = std::fs::read(&path).unwrap();
+    let mut pos = 0;
+    while let Some(offset) = bytes[pos..].windows(4).position(|w| w == b"PK\x01\x02") {
+        let start = pos + offset;
+        let name_len =
+            u16::from_le_bytes(bytes[start + 28..start + 30].try_into().unwrap()) as usize;
+        let name = &bytes[start + 46..start + 46 + name_len];
+        if name == b"word/media/payload.bin" {
+            bytes[start + 24..start + 28].copy_from_slice(&1_u32.to_le_bytes());
+            break;
+        }
+        pos = start + 4;
+    }
+    std::fs::write(&path, bytes).unwrap();
+    let err = validate_zip_archive(&path, CanonicalFormat::Docx, &limits).unwrap_err();
+    assert!(matches!(
+        err.threat_class(),
+        Some(ThreatClass::MalformedOoxml) | Some(ThreatClass::ArchiveBomb)
+    ));
 }
 
 #[tokio::test]
@@ -278,8 +513,7 @@ async fn entry_count_bomb_rejects() {
     let mut zip = zip::ZipWriter::new(file);
     let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
     zip.start_file("[Content_Types].xml", options).unwrap();
-    zip.write_all(br#"<?xml version="1.0"?><Types></Types>"#)
-        .unwrap();
+    zip.write_all(DOCX_CONTENT_TYPES_XML).unwrap();
     zip.start_file("word/document.xml", options).unwrap();
     zip.write_all(br#"<?xml version="1.0"?><w:document></w:document>"#)
         .unwrap();
@@ -313,6 +547,56 @@ async fn oversize_stream_rejects_early() {
 }
 
 #[tokio::test]
+async fn mime_mismatch_and_malformed_audio_reject() {
+    let limits = LimitsConfig::policy_defaults();
+    let pdf = stream_to_tempfile(
+        stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from_static(
+            b"%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\nxref\n0 1\n0000000000 65535 f \ntrailer<</Root 1 0 R>>\nstartxref\n42\n%%EOF\n",
+        ))]),
+        &limits,
+    )
+    .await
+    .unwrap();
+    let err =
+        validate_streamed_bytes(&pdf, Some("ok.pdf"), Some("text/plain"), &limits).unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::MimeMismatch));
+
+    let bad_mp3 = stream_to_tempfile(
+        stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from_static(b"ID3bad"))]),
+        &limits,
+    )
+    .await
+    .unwrap();
+    let err = validate_streamed_bytes(&bad_mp3, Some("bad.mp3"), Some("audio/mpeg"), &limits)
+        .unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::ParserCorruption));
+
+    let mut wav = Vec::new();
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&36_u32.to_le_bytes());
+    wav.extend_from_slice(b"WAVEfmt ");
+    wav.extend_from_slice(&16_u32.to_le_bytes());
+    wav.extend_from_slice(&1_u16.to_le_bytes());
+    wav.extend_from_slice(&1_u16.to_le_bytes());
+    wav.extend_from_slice(&16_000_u32.to_le_bytes());
+    wav.extend_from_slice(&0_u32.to_le_bytes());
+    wav.extend_from_slice(&2_u16.to_le_bytes());
+    wav.extend_from_slice(&16_u16.to_le_bytes());
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&4_u32.to_le_bytes());
+    wav.extend_from_slice(&[0_u8; 4]);
+    let zero_rate = stream_to_tempfile(
+        stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(wav))]),
+        &limits,
+    )
+    .await
+    .unwrap();
+    let err = validate_streamed_bytes(&zero_rate, Some("zero.wav"), Some("audio/wav"), &limits)
+        .unwrap_err();
+    assert_eq!(err.threat_class(), Some(ThreatClass::ParserCorruption));
+}
+
+#[tokio::test]
 async fn truncated_stream_is_not_accepted() {
     let limits = LimitsConfig::policy_defaults();
     // Empty body after interruption-style empty stream → magic unrecognized / reject.
@@ -323,7 +607,13 @@ async fn truncated_stream_is_not_accepted() {
     .await
     .unwrap();
     assert_eq!(streamed.size_bytes, 0);
-    let err = validate_streamed_bytes(&streamed, Some("empty.pdf"), &limits).unwrap_err();
+    let err = validate_streamed_bytes(
+        &streamed,
+        Some("empty.pdf"),
+        Some("application/octet-stream"),
+        &limits,
+    )
+    .unwrap_err();
     assert!(matches!(
         err.threat_class(),
         Some(ThreatClass::UnsupportedFormat) | Some(ThreatClass::ExtensionSpoof)
@@ -334,14 +624,26 @@ async fn truncated_stream_is_not_accepted() {
 async fn corrupt_and_page_bomb_pdf_reject() {
     let limits = LimitsConfig::policy_defaults();
     let corrupt = stream_file(&adversarial_dir().join("corrupt.pdf")).await;
-    let err = validate_streamed_bytes(&corrupt, Some("corrupt.pdf"), &limits).unwrap_err();
+    let err = validate_streamed_bytes(
+        &corrupt,
+        Some("corrupt.pdf"),
+        Some("application/octet-stream"),
+        &limits,
+    )
+    .unwrap_err();
     assert!(matches!(
         err.threat_class(),
         Some(ThreatClass::ParserCorruption) | Some(ThreatClass::PdfPageBomb)
     ));
 
     let page_bomb = stream_file(&adversarial_dir().join("page-bomb.pdf")).await;
-    let err = validate_streamed_bytes(&page_bomb, Some("page-bomb.pdf"), &limits).unwrap_err();
+    let err = validate_streamed_bytes(
+        &page_bomb,
+        Some("page-bomb.pdf"),
+        Some("application/octet-stream"),
+        &limits,
+    )
+    .unwrap_err();
     assert_eq!(err.threat_class(), Some(ThreatClass::PdfPageBomb));
 }
 
@@ -349,15 +651,25 @@ async fn corrupt_and_page_bomb_pdf_reject() {
 async fn formula_csv_and_prompt_html_quarantine() {
     let limits = LimitsConfig::policy_defaults();
     let csv = stream_file(&adversarial_dir().join("formula.csv")).await;
-    let (format, disposition, threat, _) =
-        validate_streamed_bytes(&csv, Some("formula.csv"), &limits).unwrap();
+    let (format, disposition, threat, _) = validate_streamed_bytes(
+        &csv,
+        Some("formula.csv"),
+        Some("application/octet-stream"),
+        &limits,
+    )
+    .unwrap();
     assert_eq!(format, CanonicalFormat::Csv);
     assert_eq!(disposition, Disposition::Quarantined);
     assert_eq!(threat, Some(ThreatClass::CsvFormula));
 
     let html = stream_file(&adversarial_dir().join("prompt-injection.html")).await;
-    let (format, disposition, threat, _) =
-        validate_streamed_bytes(&html, Some("prompt-injection.html"), &limits).unwrap();
+    let (format, disposition, threat, _) = validate_streamed_bytes(
+        &html,
+        Some("prompt-injection.html"),
+        Some("application/octet-stream"),
+        &limits,
+    )
+    .unwrap();
     assert_eq!(format, CanonicalFormat::Html);
     assert_eq!(disposition, Disposition::Quarantined);
     assert_eq!(threat, Some(ThreatClass::PromptInjection));
@@ -374,8 +686,13 @@ async fn happy_path_small_fixtures_accepted() {
     ];
     for (name, expected) in cases {
         let streamed = stream_file(&golden_dir().join(name)).await;
-        let (format, disposition, _, _) =
-            validate_streamed_bytes(&streamed, Some(name), &limits).unwrap();
+        let (format, disposition, _, _) = validate_streamed_bytes(
+            &streamed,
+            Some(name),
+            Some("application/octet-stream"),
+            &limits,
+        )
+        .unwrap();
         assert_eq!(format, expected, "{name}");
         assert_eq!(disposition, Disposition::Accepted, "{name}");
         assert_disposition_is_typed(disposition);
@@ -431,7 +748,12 @@ async fn property_filename_and_magic_never_panic() {
             )
             .await
             .unwrap();
-            let result = validate_streamed_bytes(&streamed, Some(name), &limits);
+            let result = validate_streamed_bytes(
+                &streamed,
+                Some(name),
+                Some("application/octet-stream"),
+                &limits,
+            );
             match result {
                 Ok((_, disposition, _, _)) => assert_disposition_is_typed(disposition),
                 Err(error) => {
@@ -464,9 +786,16 @@ async fn happy_path_persists_to_quarantine_with_metadata() {
     let path = golden_dir().join("gold-004.pdf");
     let streamed = stream_file(&path).await;
     let expected_sha = streamed.sha256_hex.clone();
-    let outcome = validate_and_quarantine(&ctx, &client, &limits, streamed, Some("report.pdf"))
-        .await
-        .expect("accepted");
+    let outcome = validate_and_quarantine(
+        &ctx,
+        &client,
+        &limits,
+        streamed,
+        Some("report.pdf"),
+        Some("application/pdf"),
+    )
+    .await
+    .expect("accepted");
     assert_eq!(outcome.disposition, Disposition::Accepted);
     assert_eq!(outcome.canonical_format, CanonicalFormat::Pdf);
     assert_eq!(outcome.sha256_hex, expected_sha);
@@ -506,9 +835,16 @@ async fn rejected_upload_is_not_stored() {
     let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
     let limits = LimitsConfig::policy_defaults();
     let streamed = stream_file(&adversarial_dir().join("plain-text.pdf")).await;
-    let err = validate_and_quarantine(&ctx, &client, &limits, streamed, Some("plain-text.pdf"))
-        .await
-        .unwrap_err();
+    let err = validate_and_quarantine(
+        &ctx,
+        &client,
+        &limits,
+        streamed,
+        Some("plain-text.pdf"),
+        Some("application/pdf"),
+    )
+    .await
+    .unwrap_err();
     assert_eq!(err.threat_class(), Some(ThreatClass::ExtensionSpoof));
     // No object should have been created; a random key lookup stays NotFound-ish after auth.
     let probe = quarantine_key(org, Uuid::new_v4(), Some("plain-text.pdf")).unwrap();
@@ -524,6 +860,7 @@ async fn http_upload_happy_and_spoof() {
         return;
     };
     store.ensure_bucket().await.expect("bucket");
+    let store_for_assert = store.clone();
 
     let ephemeral = EphemeralDb::create(&db_url).await;
     apply_migrations(&ephemeral.url).await.expect("migrations");
@@ -597,10 +934,30 @@ async fn http_upload_happy_and_spoof() {
     let key = json["objectKey"].as_str().unwrap();
     assert!(!key.contains("report.pdf"));
     assert!(key.starts_with("quarantine/"));
+    let parsed_key = parse_key_for_org(key, org).expect("parse quarantine key");
+    let stored_meta = store_for_assert
+        .head_metadata(org, &parsed_key)
+        .await
+        .expect("head stored upload");
+    assert_eq!(
+        stored_meta.get("original-filename").map(String::as_str),
+        Some("report.pdf")
+    );
+    assert_eq!(
+        stored_meta.get("content-length-bytes"),
+        Some(&pdf.len().to_string())
+    );
+    let stored = store_for_assert
+        .get_object(org, &parsed_key)
+        .await
+        .expect("get stored upload");
+    assert_eq!(stored.len(), pdf.len());
+    assert_eq!(hex::encode(Sha256::digest(&stored)), json["sha256"]);
 
     let spoof = std::fs::read(adversarial_dir().join("plain-text.pdf")).unwrap();
     let body = multipart_body("plain-text.pdf", &spoof);
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -621,6 +978,72 @@ async fn http_upload_happy_and_spoof() {
     assert_eq!(json["code"], "upload_rejected");
     assert!(!bytes.windows(b"not a pdf".len()).any(|w| w == b"not a pdf"));
 
+    let truncated = multipart_body_without_close("late.pdf", &pdf);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/uploads")
+                .header("authorization", format!("Bearer {token}"))
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={BOUNDARY}"),
+                )
+                .body(Body::from(truncated))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_ne!(json["disposition"], "accepted");
+    assert!(json.get("objectKey").is_none());
+
+    let too_many_parts = many_part_body(10);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/uploads")
+                .header("authorization", format!("Bearer {token}"))
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={BOUNDARY}"),
+                )
+                .body(Body::from(too_many_parts))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(
+        json["details"]["reasonCode"],
+        ReasonCode::MultipartTooManyParts.as_str()
+    );
+
+    let huge_name = format!("{}.pdf", "a".repeat(9 * 1024));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/uploads")
+                .header("authorization", format!("Bearer {token}"))
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={BOUNDARY}"),
+                )
+                .body(Body::from(multipart_body(&huge_name, &pdf)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
     ephemeral.drop().await;
 }
 
@@ -633,6 +1056,29 @@ fn multipart_body(filename: &str, content: &[u8]) -> Vec<u8> {
     );
     body.extend_from_slice(content);
     body.extend_from_slice(format!("\r\n--{BOUNDARY}--\r\n").as_bytes());
+    body
+}
+
+fn multipart_body_without_close(filename: &str, content: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!("--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\nContent-Type: application/pdf\r\n\r\n").as_bytes(),
+    );
+    body.extend_from_slice(content);
+    body
+}
+
+fn many_part_body(parts: usize) -> Vec<u8> {
+    let mut body = Vec::new();
+    for i in 0..parts {
+        body.extend_from_slice(
+            format!(
+                "--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"field{i}\"\r\n\r\nx\r\n"
+            )
+            .as_bytes(),
+        );
+    }
+    body.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
     body
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-I01 — Streaming quarantine upload validation

Fail-closed multipart upload gate: content is streamed to the F06 **quarantine** namespace with bounded memory, validated (magic/extension/MIME agreement, OOXML/zip limits, structural sniff), and only persisted after the full request validates. Adversarial input is **rejected or safely quarantined** per the issue; deep format parsing is left to the converter stage.

### What it does
- **Streaming + hashing, bounded memory**: multipart streamed through fixed-size buffers with incremental SHA-256; no whole-file / whole-zip-entry / whole-decompressed-stream buffering; fixed-chunk MinIO PUT. Peak memory is O(fixed buffer), independent of upload size.
- **Canonical format**: derived from magic bytes; rejects when the client extension or concrete part MIME disagrees; ambiguous/polyglot OOXML and mixed-family (ODS+OOXML) containers rejected.
- **Zip / OOXML defense**: per-entry + aggregate uncompressed caps and compression ratio enforced **during inflation** (physical compressed spans, not declared sizes); entry-count cap enforced from the EOCD **before** central-directory allocation; rejects traversal/symlink/nested-archive (content-based)/duplicate names; XML parse buffer capped; ZIP64/unparseable headers fail closed.
- **Structural limits (fail closed)**: bounded PDF sniff (rejects truncated); real image dimensions; WAV RIFF/chunk bounds vs file length (rejects truncated); Symphonia probe for other audio.
- **Persist-after-validate**: whole multipart validated before any commit; no ignored field errors; nothing trusted persisted on interruption.
- **DoS controls**: per-route body limit (auth/other routes keep a small default), part-count/header caps, idle + upload timeouts, blocking work off the async executor, client-side S3 operation timeout.
- **TOCTOU-safe storage**: uploads the held file handle; verifies stored size + streamed SHA-256, deletes on mismatch; failure paths run key-authorized cleanup; cleanup is cancellation-safe and bounded (durable crash reconciliation deferred to I07).
- **Retention**: filename kept as object **metadata only**, never in the key; org-bound opaque quarantine keys (F06).

### Tests (live Postgres + Qdrant + MinIO)
25 upload tests + 9 F06 storage tests, incl. spoof/polyglot, zip bomb (high-ratio + forged CD + entry-count), traversal/symlink/nested, MIME mismatch, malformed/truncated audio, oversize, truncated/cancelled stream, verification-failed cleanup, bounded-memory (tracking allocator, lazy large stream), and quarantine metadata/hash/size verification.

### Review
Passed a strict security review gate over **5 rounds** (bounded memory, zip-bomb-during-inflation, MIME/struct fail-closed, persist-after-validate, DoS scoping, TOCTOU + cancellation-safe cleanup, entry-count DoS).

### Scope
Out of scope (safely quarantined; validated later by the converter): full PDF parser/page count, full OPC relationship/namespace validation, XLS-vs-OLE structural parsing, full non-WAV packet decode, live-service CI job (F02 integration-infra follow-up), durable pending-object crash reconciliation (I07).

Stacked on #220 (F06).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

