### PR TITLE
feat(server): P1B-I02 atomic quota admission

### DIFF
--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -15,6 +15,8 @@ const DEFAULT_MINIO_OPERATION_TIMEOUT_SECS: u64 = 30;
 const MAX_MINIO_OPERATION_TIMEOUT_SECS: u64 = 300;
 const DEFAULT_ACCESS_TOKEN_TTL_SECS: u64 = 900;
 const DEFAULT_REFRESH_TOKEN_TTL_SECS: u64 = 60 * 60 * 24 * 7;
+const DEFAULT_QUOTA_SWEEP_INTERVAL_SECS: u64 = 60;
+const DEFAULT_QUOTA_SWEEP_BATCH_SIZE: u32 = 500;
 const DEFAULT_ARGON2_MEMORY_KIB: u32 = 19_456;
 const DEFAULT_ARGON2_TIME_COST: u32 = 2;
 const DEFAULT_ARGON2_PARALLELISM: u32 = 1;
@@ -86,6 +88,7 @@ pub struct ServerConfig {
     auth: AuthConfig,
     limits: RuntimeLimits,
     upload: UploadConfig,
+    quota_sweep: QuotaSweepConfig,
     index_signature: Option<String>,
 }
 
@@ -130,6 +133,7 @@ impl fmt::Debug for ServerConfig {
             .field("auth", &self.auth)
             .field("limits", &self.limits)
             .field("upload", &self.upload)
+            .field("quota_sweep", &self.quota_sweep)
             .field("index_signature", &self.index_signature)
             .finish()
     }
@@ -345,6 +349,12 @@ pub struct RuntimeLimits {
     pub job_lease_seconds: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuotaSweepConfig {
+    pub interval_secs: u64,
+    pub batch_size: u32,
+}
+
 #[derive(Default, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ConfigFile {
@@ -382,6 +392,8 @@ struct ConfigFile {
     max_part_header_bytes: Option<u64>,
     upload_timeout_secs: Option<u64>,
     upload_idle_timeout_secs: Option<u64>,
+    quota_sweep_interval_secs: Option<u64>,
+    quota_sweep_batch_size: Option<u64>,
     index_signature: Option<String>,
 }
 
@@ -650,6 +662,22 @@ impl ServerConfig {
         let upload = UploadConfig {
             limits: upload_limits,
         };
+        let quota_sweep = QuotaSweepConfig {
+            interval_secs: numeric_value(
+                file,
+                env,
+                "MARKHAND_QUOTA_SWEEP_INTERVAL_SECS",
+                |value| value.quota_sweep_interval_secs,
+                DEFAULT_QUOTA_SWEEP_INTERVAL_SECS,
+            )?,
+            batch_size: u32_value(
+                file,
+                env,
+                "MARKHAND_QUOTA_SWEEP_BATCH_SIZE",
+                |value| value.quota_sweep_batch_size,
+                DEFAULT_QUOTA_SWEEP_BATCH_SIZE,
+            )?,
+        };
         let index_signature = optional_value(file, env, "MARKHAND_INDEX_SIGNATURE", |value| {
             value.index_signature.as_ref()
         });
@@ -671,6 +699,7 @@ impl ServerConfig {
             auth,
             limits,
             upload,
+            quota_sweep,
             index_signature,
         };
         config.validate()?;
@@ -693,6 +722,10 @@ impl ServerConfig {
     /// Upload intake limits (P0-09 policy defaults unless overridden).
     pub const fn upload(&self) -> &UploadConfig {
         &self.upload
+    }
+
+    pub const fn quota_sweep(&self) -> QuotaSweepConfig {
+        self.quota_sweep
     }
 
     /// Legacy runtime limits (max upload + job lease).
@@ -744,6 +777,10 @@ impl ServerConfig {
                 job_lease_seconds: DEFAULT_JOB_LEASE_SECONDS,
             },
             upload: UploadConfig::policy_defaults(),
+            quota_sweep: QuotaSweepConfig {
+                interval_secs: DEFAULT_QUOTA_SWEEP_INTERVAL_SECS,
+                batch_size: DEFAULT_QUOTA_SWEEP_BATCH_SIZE,
+            },
             index_signature: None,
         }
     }
@@ -910,6 +947,12 @@ impl ServerConfig {
             return Err(format!(
                 "MARKHAND_MINIO_OPERATION_TIMEOUT_SECS must be between 1 and {MAX_MINIO_OPERATION_TIMEOUT_SECS}"
             ));
+        }
+        if self.quota_sweep.interval_secs == 0 || self.quota_sweep.interval_secs > 86_400 {
+            return Err("MARKHAND_QUOTA_SWEEP_INTERVAL_SECS must be between 1 and 86400".into());
+        }
+        if self.quota_sweep.batch_size == 0 || self.quota_sweep.batch_size > 10_000 {
+            return Err("MARKHAND_QUOTA_SWEEP_BATCH_SIZE must be between 1 and 10000".into());
         }
         Ok(())
     }
@@ -1177,6 +1220,8 @@ mod tests {
             max_part_header_bytes: None,
             upload_timeout_secs: None,
             upload_idle_timeout_secs: None,
+            quota_sweep_interval_secs: None,
+            quota_sweep_batch_size: None,
             index_signature: None,
         };
         let env = BTreeMap::from([

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -7,3 +7,4 @@ pub mod error;
 pub mod models;
 pub mod orgs;
 pub mod pool;
+pub mod quota;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -571,6 +571,36 @@ pub enum ResourceKind {
     Tokens,
 }
 
+impl ResourceKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::StorageBytes => "storage_bytes",
+            Self::Documents => "documents",
+            Self::ConcurrentJobs => "concurrent_jobs",
+            Self::Tokens => "tokens",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "storage_bytes" => Ok(Self::StorageBytes),
+            "documents" => Ok(Self::Documents),
+            "concurrent_jobs" => Ok(Self::ConcurrentJobs),
+            "tokens" => Ok(Self::Tokens),
+            other => Err(format!("unknown resource kind: {other}")),
+        }
+    }
+
+    pub const fn counter_key(self) -> Option<&'static str> {
+        match self {
+            Self::StorageBytes => Some("storage_bytes"),
+            Self::Documents => Some("documents"),
+            Self::Tokens => Some("tokens"),
+            Self::ConcurrentJobs => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReservationStatus {
@@ -578,6 +608,27 @@ pub enum ReservationStatus {
     Finalized,
     Refunded,
     Expired,
+}
+
+impl ReservationStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Reserved => "reserved",
+            Self::Finalized => "finalized",
+            Self::Refunded => "refunded",
+            Self::Expired => "expired",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "reserved" => Ok(Self::Reserved),
+            "finalized" => Ok(Self::Finalized),
+            "refunded" => Ok(Self::Refunded),
+            "expired" => Ok(Self::Expired),
+            other => Err(format!("unknown reservation status: {other}")),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/server/src/db/pool.rs
+++ b/crates/server/src/db/pool.rs
@@ -13,6 +13,9 @@ use crate::db::error::DbError;
 /// Future returned by [`with_org_txn`] closures (boxed to satisfy HRTB + borrow).
 pub type OrgTxnFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, DbError>> + Send + 'a>>;
 
+/// Typed future returned by [`with_org_txn_typed`] closures.
+pub type OrgTxnTypedFuture<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>;
+
 /// Creates a deadpool-postgres pool with the default max size.
 pub fn create_pool(database_url: &str) -> Result<Pool, DbError> {
     create_pool_with_max_size(database_url, PoolConfig::default().max_size)
@@ -50,6 +53,34 @@ where
     match f(&txn).await {
         Ok(value) => {
             txn.commit().await?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = txn.rollback().await;
+            Err(error)
+        }
+    }
+}
+
+/// Runs `f` inside an org transaction while preserving service-specific errors.
+///
+/// This has the same RLS/session semantics as [`with_org_txn`]; it exists for
+/// service layers that need typed, non-database errors to trigger rollback.
+pub async fn with_org_txn_typed<T, F, E>(pool: &Pool, ctx: &OrgContext, f: F) -> Result<T, E>
+where
+    F: for<'c> FnOnce(&'c Transaction<'c>) -> OrgTxnTypedFuture<'c, T, E>,
+    E: From<DbError>,
+{
+    let mut client = pool.get().await.map_err(DbError::from).map_err(E::from)?;
+    let txn = client
+        .transaction()
+        .await
+        .map_err(DbError::from)
+        .map_err(E::from)?;
+    apply_org_context(&txn, ctx).await.map_err(E::from)?;
+    match f(&txn).await {
+        Ok(value) => {
+            txn.commit().await.map_err(DbError::from).map_err(E::from)?;
             Ok(value)
         }
         Err(error) => {

--- a/crates/server/src/db/quota.rs
+++ b/crates/server/src/db/quota.rs
@@ -1,0 +1,322 @@
+//! Tenant-scoped quota repositories.
+//!
+//! All functions require an [`OrgContext`] and are intended to run inside
+//! `pool::with_org_txn`, so RLS `app.org_id` is set before any quota row is
+//! read or mutated. Storage byte and document counters use a single all-time
+//! period (`1970-01-01` through `9999-12-31`) because their limits are
+//! cumulative. Token counters use the current UTC calendar month. Concurrent
+//! jobs are a live gauge derived only from active reservations and never write
+//! `usage_counters`.
+
+use chrono::{DateTime, Utc};
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{QuotaReservation, ReservationStatus, ResourceKind};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CounterPeriod {
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuotaUsage {
+    pub limit: i64,
+    pub committed: i64,
+    pub active_reserved: i64,
+}
+
+pub async fn lock_admission(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    kind: ResourceKind,
+) -> Result<(), DbError> {
+    let kind = kind.as_str();
+    let org = ctx.org_id().to_string();
+    txn.execute(
+        "SELECT pg_advisory_xact_lock(hashtext('quota:' || $1 || ':' || $2))",
+        &[&org, &kind],
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn quota_limit(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    kind: ResourceKind,
+) -> Result<i64, DbError> {
+    let column = match kind {
+        ResourceKind::StorageBytes => "max_storage_bytes",
+        ResourceKind::Documents => "max_documents::bigint",
+        ResourceKind::ConcurrentJobs => "max_concurrent_jobs::bigint",
+        ResourceKind::Tokens => "max_monthly_tokens",
+    };
+    let sql = format!("SELECT {column} FROM org_quotas WHERE org_id = $1");
+    let row = txn
+        .query_opt(&sql, &[&ctx.org_id()])
+        .await?
+        .ok_or(DbError::NotFound)?;
+    Ok(row.get(0))
+}
+
+pub async fn current_period(
+    txn: &Transaction<'_>,
+    kind: ResourceKind,
+) -> Result<CounterPeriod, DbError> {
+    let kind = kind.as_str();
+    let row = txn
+        .query_one(
+            "SELECT
+                CASE WHEN $1 = 'tokens'
+                    THEN date_trunc('month', now())
+                    ELSE timestamptz '1970-01-01 00:00:00+00'
+                END AS period_start,
+                CASE WHEN $1 = 'tokens'
+                    THEN date_trunc('month', now()) + interval '1 month'
+                    ELSE timestamptz '9999-12-31 00:00:00+00'
+                END AS period_end",
+            &[&kind],
+        )
+        .await?;
+    Ok(CounterPeriod {
+        start: row.get("period_start"),
+        end: row.get("period_end"),
+    })
+}
+
+pub async fn committed_usage(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    kind: ResourceKind,
+    period: CounterPeriod,
+) -> Result<i64, DbError> {
+    let Some(counter_key) = kind.counter_key() else {
+        return Ok(0);
+    };
+    let row = txn
+        .query_opt(
+            "SELECT value
+             FROM usage_counters
+             WHERE org_id = $1 AND counter_key = $2 AND period_start = $3",
+            &[&ctx.org_id(), &counter_key, &period.start],
+        )
+        .await?;
+    Ok(row.map_or(0, |row| row.get(0)))
+}
+
+pub async fn lock_committed_counter(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    kind: ResourceKind,
+    period: CounterPeriod,
+) -> Result<Option<i64>, DbError> {
+    let Some(counter_key) = kind.counter_key() else {
+        return Ok(None);
+    };
+    let row = txn
+        .query_opt(
+            "SELECT value
+             FROM usage_counters
+             WHERE org_id = $1 AND counter_key = $2 AND period_start = $3
+             FOR UPDATE",
+            &[&ctx.org_id(), &counter_key, &period.start],
+        )
+        .await?;
+    Ok(row.map(|row| row.get(0)))
+}
+
+pub async fn active_reserved(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    kind: ResourceKind,
+) -> Result<i64, DbError> {
+    let kind = kind.as_str();
+    let row = txn
+        .query_one(
+            "SELECT COALESCE(SUM(amount), 0)::bigint
+             FROM quota_reservations
+             WHERE org_id = $1
+               AND resource_kind = $2
+               AND status = 'reserved'
+               AND expires_at > now()",
+            &[&ctx.org_id(), &kind],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
+pub async fn usage(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    kind: ResourceKind,
+) -> Result<QuotaUsage, DbError> {
+    let period = current_period(txn, kind).await?;
+    Ok(QuotaUsage {
+        limit: quota_limit(txn, ctx, kind).await?,
+        committed: committed_usage(txn, ctx, kind, period).await?,
+        active_reserved: active_reserved(txn, ctx, kind).await?,
+    })
+}
+
+pub async fn find_by_key(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<Option<QuotaReservation>, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, reservation_key, resource_kind, amount, status,
+                    expires_at, job_id, created_at, settled_at
+             FROM quota_reservations
+             WHERE org_id = $1 AND reservation_key = $2",
+            &[&ctx.org_id(), &reservation_key],
+        )
+        .await?;
+    row.map(|row| map_reservation(&row)).transpose()
+}
+
+pub async fn insert_reserved(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+    kind: ResourceKind,
+    amount: i64,
+    ttl_secs: i64,
+    job_id: Option<Uuid>,
+) -> Result<Option<QuotaReservation>, DbError> {
+    let kind = kind.as_str();
+    let row = txn
+        .query_opt(
+            "INSERT INTO quota_reservations (
+                org_id, reservation_key, resource_kind, amount, expires_at, job_id
+             )
+             VALUES ($1, $2, $3, $4, now() + ($5::bigint * interval '1 second'), $6)
+             ON CONFLICT (org_id, reservation_key) DO NOTHING
+             RETURNING id, org_id, reservation_key, resource_kind, amount, status,
+                       expires_at, job_id, created_at, settled_at",
+            &[
+                &ctx.org_id(),
+                &reservation_key,
+                &kind,
+                &amount,
+                &ttl_secs,
+                &job_id,
+            ],
+        )
+        .await?;
+    row.map(|row| map_reservation(&row)).transpose()
+}
+
+pub async fn get_by_key_for_update(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<QuotaReservation, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, reservation_key, resource_kind, amount, status,
+                    expires_at, job_id, created_at, settled_at
+             FROM quota_reservations
+             WHERE org_id = $1 AND reservation_key = $2
+             FOR UPDATE",
+            &[&ctx.org_id(), &reservation_key],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_reservation(&row)
+}
+
+pub async fn set_status(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_id: Uuid,
+    status: ReservationStatus,
+) -> Result<QuotaReservation, DbError> {
+    let status = status.as_str();
+    let row = txn
+        .query_one(
+            "UPDATE quota_reservations
+             SET status = $3, settled_at = now()
+             WHERE org_id = $1 AND id = $2
+             RETURNING id, org_id, reservation_key, resource_kind, amount, status,
+                       expires_at, job_id, created_at, settled_at",
+            &[&ctx.org_id(), &reservation_id, &status],
+        )
+        .await?;
+    map_reservation(&row)
+}
+
+pub async fn upsert_counter_value(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    kind: ResourceKind,
+    period: CounterPeriod,
+    value: i64,
+) -> Result<(), DbError> {
+    let Some(counter_key) = kind.counter_key() else {
+        return Ok(());
+    };
+    txn.execute(
+        "INSERT INTO usage_counters (org_id, counter_key, period_start, period_end, value)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (org_id, counter_key, period_start)
+         DO UPDATE SET value = EXCLUDED.value,
+                       period_end = EXCLUDED.period_end,
+                       updated_at = now()",
+        &[
+            &ctx.org_id(),
+            &counter_key,
+            &period.start,
+            &period.end,
+            &value,
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn expire_reserved_batch(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    batch_size: i64,
+) -> Result<u64, DbError> {
+    let updated = txn
+        .execute(
+            "WITH expired AS (
+                SELECT id
+                FROM quota_reservations
+                WHERE org_id = $1 AND status = 'reserved' AND expires_at <= now()
+                ORDER BY expires_at, id
+                LIMIT $2
+                FOR UPDATE SKIP LOCKED
+             )
+             UPDATE quota_reservations qr
+             SET status = 'expired', settled_at = now()
+             FROM expired
+             WHERE qr.org_id = $1 AND qr.id = expired.id",
+            &[&ctx.org_id(), &batch_size],
+        )
+        .await?;
+    Ok(updated)
+}
+
+pub(crate) fn map_reservation(row: &Row) -> Result<QuotaReservation, DbError> {
+    let resource_kind: String = row.get("resource_kind");
+    let status: String = row.get("status");
+    Ok(QuotaReservation {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        reservation_key: row.get("reservation_key"),
+        resource_kind: ResourceKind::parse(&resource_kind).map_err(DbError::Config)?,
+        amount: row.get("amount"),
+        status: ReservationStatus::parse(&status).map_err(DbError::Config)?,
+        expires_at: row.get("expires_at"),
+        job_id: row.get("job_id"),
+        created_at: row.get("created_at"),
+        settled_at: row.get("settled_at"),
+    })
+}

--- a/crates/server/src/db/quota.rs
+++ b/crates/server/src/db/quota.rs
@@ -179,6 +179,49 @@ pub async fn find_by_key(
     row.map(|row| map_reservation(&row)).transpose()
 }
 
+pub async fn find_active_matching_by_key(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+    kind: ResourceKind,
+    amount: i64,
+) -> Result<Option<QuotaReservation>, DbError> {
+    let kind = kind.as_str();
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, reservation_key, resource_kind, amount, status,
+                    expires_at, job_id, created_at, settled_at
+             FROM quota_reservations
+             WHERE org_id = $1
+               AND reservation_key = $2
+               AND resource_kind = $3
+               AND amount = $4
+               AND status = 'reserved'
+               AND expires_at > now()",
+            &[&ctx.org_id(), &reservation_key, &kind, &amount],
+        )
+        .await?;
+    row.map(|row| map_reservation(&row)).transpose()
+}
+
+pub async fn kind_by_key(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<ResourceKind, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT resource_kind
+             FROM quota_reservations
+             WHERE org_id = $1 AND reservation_key = $2",
+            &[&ctx.org_id(), &reservation_key],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    let resource_kind: String = row.get(0);
+    ResourceKind::parse(&resource_kind).map_err(DbError::Config)
+}
+
 pub async fn insert_reserved(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
@@ -206,6 +249,69 @@ pub async fn insert_reserved(
                 &ttl_secs,
                 &job_id,
             ],
+        )
+        .await?;
+    row.map(|row| map_reservation(&row)).transpose()
+}
+
+pub async fn finalize_reserved_by_key(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<Option<QuotaReservation>, DbError> {
+    let row = txn
+        .query_opt(
+            "UPDATE quota_reservations
+             SET status = 'finalized', settled_at = now()
+             WHERE org_id = $1
+               AND reservation_key = $2
+               AND status = 'reserved'
+               AND expires_at > now()
+             RETURNING id, org_id, reservation_key, resource_kind, amount, status,
+                       expires_at, job_id, created_at, settled_at",
+            &[&ctx.org_id(), &reservation_key],
+        )
+        .await?;
+    row.map(|row| map_reservation(&row)).transpose()
+}
+
+pub async fn refund_reserved_by_key(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<Option<QuotaReservation>, DbError> {
+    let row = txn
+        .query_opt(
+            "UPDATE quota_reservations
+             SET status = 'refunded', settled_at = now()
+             WHERE org_id = $1
+               AND reservation_key = $2
+               AND status = 'reserved'
+               AND expires_at > now()
+             RETURNING id, org_id, reservation_key, resource_kind, amount, status,
+                       expires_at, job_id, created_at, settled_at",
+            &[&ctx.org_id(), &reservation_key],
+        )
+        .await?;
+    row.map(|row| map_reservation(&row)).transpose()
+}
+
+pub async fn expire_reserved_by_key_if_due(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<Option<QuotaReservation>, DbError> {
+    let row = txn
+        .query_opt(
+            "UPDATE quota_reservations
+             SET status = 'expired', settled_at = now()
+             WHERE org_id = $1
+               AND reservation_key = $2
+               AND status = 'reserved'
+               AND expires_at <= now()
+             RETURNING id, org_id, reservation_key, resource_kind, amount, status,
+                       expires_at, job_id, created_at, settled_at",
+            &[&ctx.org_id(), &reservation_key],
         )
         .await?;
     row.map(|row| map_reservation(&row)).transpose()
@@ -302,6 +408,12 @@ pub async fn expire_reserved_batch(
         )
         .await?;
     Ok(updated)
+}
+
+pub async fn list_org_ids_for_sweep(pool: &deadpool_postgres::Pool) -> Result<Vec<Uuid>, DbError> {
+    let client = pool.get().await?;
+    let rows = client.query("SELECT id FROM orgs ORDER BY id", &[]).await?;
+    Ok(rows.into_iter().map(|row| row.get(0)).collect())
 }
 
 pub(crate) fn map_reservation(row: &Row) -> Result<QuotaReservation, DbError> {

--- a/crates/server/src/db/quota.rs
+++ b/crates/server/src/db/quota.rs
@@ -29,6 +29,20 @@ pub struct QuotaUsage {
     pub active_reserved: i64,
 }
 
+pub struct ReservationInsert<'a> {
+    pub reservation_key: &'a str,
+    pub kind: ResourceKind,
+    pub amount: i64,
+    pub ttl_secs: i64,
+    pub job_id: Option<Uuid>,
+    pub observed_at: DateTime<Utc>,
+}
+
+pub async fn fresh_clock_timestamp(txn: &Transaction<'_>) -> Result<DateTime<Utc>, DbError> {
+    let row = txn.query_one("SELECT clock_timestamp()", &[]).await?;
+    Ok(row.get(0))
+}
+
 pub async fn lock_admission(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
@@ -66,20 +80,21 @@ pub async fn quota_limit(
 pub async fn current_period(
     txn: &Transaction<'_>,
     kind: ResourceKind,
+    observed_at: DateTime<Utc>,
 ) -> Result<CounterPeriod, DbError> {
     let kind = kind.as_str();
     let row = txn
         .query_one(
             "SELECT
                 CASE WHEN $1 = 'tokens'
-                    THEN date_trunc('month', now())
+                    THEN date_trunc('month', $2::timestamptz)
                     ELSE timestamptz '1970-01-01 00:00:00+00'
                 END AS period_start,
                 CASE WHEN $1 = 'tokens'
-                    THEN date_trunc('month', now()) + interval '1 month'
+                    THEN date_trunc('month', $2::timestamptz) + interval '1 month'
                     ELSE timestamptz '9999-12-31 00:00:00+00'
                 END AS period_end",
-            &[&kind],
+            &[&kind, &observed_at],
         )
         .await?;
     Ok(CounterPeriod {
@@ -133,6 +148,7 @@ pub async fn active_reserved(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     kind: ResourceKind,
+    observed_at: DateTime<Utc>,
 ) -> Result<i64, DbError> {
     let kind = kind.as_str();
     let row = txn
@@ -142,8 +158,8 @@ pub async fn active_reserved(
              WHERE org_id = $1
                AND resource_kind = $2
                AND status = 'reserved'
-               AND expires_at > now()",
-            &[&ctx.org_id(), &kind],
+               AND expires_at > $3",
+            &[&ctx.org_id(), &kind, &observed_at],
         )
         .await?;
     Ok(row.get(0))
@@ -153,12 +169,13 @@ pub async fn usage(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     kind: ResourceKind,
+    observed_at: DateTime<Utc>,
 ) -> Result<QuotaUsage, DbError> {
-    let period = current_period(txn, kind).await?;
+    let period = current_period(txn, kind, observed_at).await?;
     Ok(QuotaUsage {
         limit: quota_limit(txn, ctx, kind).await?,
         committed: committed_usage(txn, ctx, kind, period).await?,
-        active_reserved: active_reserved(txn, ctx, kind).await?,
+        active_reserved: active_reserved(txn, ctx, kind, observed_at).await?,
     })
 }
 
@@ -185,6 +202,8 @@ pub async fn find_active_matching_by_key(
     reservation_key: &str,
     kind: ResourceKind,
     amount: i64,
+    job_id: Option<Uuid>,
+    observed_at: DateTime<Utc>,
 ) -> Result<Option<QuotaReservation>, DbError> {
     let kind = kind.as_str();
     let row = txn
@@ -196,9 +215,17 @@ pub async fn find_active_matching_by_key(
                AND reservation_key = $2
                AND resource_kind = $3
                AND amount = $4
+               AND job_id IS NOT DISTINCT FROM $5
                AND status = 'reserved'
-               AND expires_at > now()",
-            &[&ctx.org_id(), &reservation_key, &kind, &amount],
+               AND expires_at > $6",
+            &[
+                &ctx.org_id(),
+                &reservation_key,
+                &kind,
+                &amount,
+                &job_id,
+                &observed_at,
+            ],
         )
         .await?;
     row.map(|row| map_reservation(&row)).transpose()
@@ -225,29 +252,26 @@ pub async fn kind_by_key(
 pub async fn insert_reserved(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
-    reservation_key: &str,
-    kind: ResourceKind,
-    amount: i64,
-    ttl_secs: i64,
-    job_id: Option<Uuid>,
+    spec: ReservationInsert<'_>,
 ) -> Result<Option<QuotaReservation>, DbError> {
-    let kind = kind.as_str();
+    let kind = spec.kind.as_str();
     let row = txn
         .query_opt(
             "INSERT INTO quota_reservations (
                 org_id, reservation_key, resource_kind, amount, expires_at, job_id
              )
-             VALUES ($1, $2, $3, $4, now() + ($5::bigint * interval '1 second'), $6)
+             VALUES ($1, $2, $3, $4, $7::timestamptz + ($5::bigint * interval '1 second'), $6)
              ON CONFLICT (org_id, reservation_key) DO NOTHING
              RETURNING id, org_id, reservation_key, resource_kind, amount, status,
                        expires_at, job_id, created_at, settled_at",
             &[
                 &ctx.org_id(),
-                &reservation_key,
+                &spec.reservation_key,
                 &kind,
-                &amount,
-                &ttl_secs,
-                &job_id,
+                &spec.amount,
+                &spec.ttl_secs,
+                &spec.job_id,
+                &spec.observed_at,
             ],
         )
         .await?;
@@ -258,18 +282,19 @@ pub async fn finalize_reserved_by_key(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     reservation_key: &str,
+    observed_at: DateTime<Utc>,
 ) -> Result<Option<QuotaReservation>, DbError> {
     let row = txn
         .query_opt(
             "UPDATE quota_reservations
-             SET status = 'finalized', settled_at = now()
+             SET status = 'finalized', settled_at = $3
              WHERE org_id = $1
                AND reservation_key = $2
                AND status = 'reserved'
-               AND expires_at > now()
+               AND expires_at > $3
              RETURNING id, org_id, reservation_key, resource_kind, amount, status,
                        expires_at, job_id, created_at, settled_at",
-            &[&ctx.org_id(), &reservation_key],
+            &[&ctx.org_id(), &reservation_key, &observed_at],
         )
         .await?;
     row.map(|row| map_reservation(&row)).transpose()
@@ -279,18 +304,19 @@ pub async fn refund_reserved_by_key(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     reservation_key: &str,
+    observed_at: DateTime<Utc>,
 ) -> Result<Option<QuotaReservation>, DbError> {
     let row = txn
         .query_opt(
             "UPDATE quota_reservations
-             SET status = 'refunded', settled_at = now()
+             SET status = 'refunded', settled_at = $3
              WHERE org_id = $1
                AND reservation_key = $2
                AND status = 'reserved'
-               AND expires_at > now()
+               AND expires_at > $3
              RETURNING id, org_id, reservation_key, resource_kind, amount, status,
                        expires_at, job_id, created_at, settled_at",
-            &[&ctx.org_id(), &reservation_key],
+            &[&ctx.org_id(), &reservation_key, &observed_at],
         )
         .await?;
     row.map(|row| map_reservation(&row)).transpose()
@@ -300,18 +326,19 @@ pub async fn expire_reserved_by_key_if_due(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     reservation_key: &str,
+    observed_at: DateTime<Utc>,
 ) -> Result<Option<QuotaReservation>, DbError> {
     let row = txn
         .query_opt(
             "UPDATE quota_reservations
-             SET status = 'expired', settled_at = now()
+             SET status = 'expired', settled_at = $3
              WHERE org_id = $1
                AND reservation_key = $2
                AND status = 'reserved'
-               AND expires_at <= now()
+               AND expires_at <= $3
              RETURNING id, org_id, reservation_key, resource_kind, amount, status,
                        expires_at, job_id, created_at, settled_at",
-            &[&ctx.org_id(), &reservation_key],
+            &[&ctx.org_id(), &reservation_key, &observed_at],
         )
         .await?;
     row.map(|row| map_reservation(&row)).transpose()
@@ -346,7 +373,7 @@ pub async fn set_status(
     let row = txn
         .query_one(
             "UPDATE quota_reservations
-             SET status = $3, settled_at = now()
+             SET status = $3, settled_at = clock_timestamp()
              WHERE org_id = $1 AND id = $2
              RETURNING id, org_id, reservation_key, resource_kind, amount, status,
                        expires_at, job_id, created_at, settled_at",
@@ -372,7 +399,7 @@ pub async fn upsert_counter_value(
          ON CONFLICT (org_id, counter_key, period_start)
          DO UPDATE SET value = EXCLUDED.value,
                        period_end = EXCLUDED.period_end,
-                       updated_at = now()",
+                       updated_at = clock_timestamp()",
         &[
             &ctx.org_id(),
             &counter_key,
@@ -389,22 +416,23 @@ pub async fn expire_reserved_batch(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     batch_size: i64,
+    observed_at: DateTime<Utc>,
 ) -> Result<u64, DbError> {
     let updated = txn
         .execute(
             "WITH expired AS (
                 SELECT id
                 FROM quota_reservations
-                WHERE org_id = $1 AND status = 'reserved' AND expires_at <= now()
+                WHERE org_id = $1 AND status = 'reserved' AND expires_at <= $3
                 ORDER BY expires_at, id
                 LIMIT $2
                 FOR UPDATE SKIP LOCKED
              )
              UPDATE quota_reservations qr
-             SET status = 'expired', settled_at = now()
+             SET status = 'expired', settled_at = $3
              FROM expired
              WHERE qr.org_id = $1 AND qr.id = expired.id",
-            &[&ctx.org_id(), &batch_size],
+            &[&ctx.org_id(), &batch_size, &observed_at],
         )
         .await?;
     Ok(updated)

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -16,9 +16,11 @@ use uuid::Uuid;
 use crate::api::ApiError;
 use crate::auth::jwt::JwtKeys;
 use crate::auth::provider::PasswordAuthProvider;
+use crate::config::QuotaSweepConfig;
 use crate::database;
 use crate::db::pool::create_pool;
 use crate::routes;
+use crate::services::quota;
 use crate::state::RuntimeState;
 
 const DEPENDENCY_TIMEOUT: Duration = Duration::from_secs(3);
@@ -66,6 +68,7 @@ impl AppState {
             ),
             Err(_) => None,
         };
+        start_quota_sweep(pool.clone(), runtime.config().quota_sweep());
         Ok(Self {
             runtime,
             http_client,
@@ -124,6 +127,31 @@ impl AppState {
     pub fn object_store(&self) -> Option<&crate::storage::MinioClient> {
         self.object_store.as_ref()
     }
+}
+
+fn start_quota_sweep(pool: Pool, config: QuotaSweepConfig) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(config.interval_secs));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            // Admission itself is time-correct (`expires_at > now()` in SQL). This
+            // bounded sweep is hygiene so expired reservations become terminal and
+            // operational gauges stop showing stale reserved rows.
+            match quota::sweep_expired_all_orgs(&pool, config.batch_size).await {
+                Ok(expired) if expired > 0 => {
+                    eprintln!("fileconv-server: quota expiry sweep marked {expired} reservations");
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    eprintln!(
+                        "fileconv-server: quota expiry sweep failed: {}",
+                        error.code()
+                    );
+                }
+            }
+        }
+    });
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -135,9 +135,10 @@ fn start_quota_sweep(pool: Pool, config: QuotaSweepConfig) {
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             interval.tick().await;
-            // Admission itself is time-correct (`expires_at > now()` in SQL). This
-            // bounded sweep is hygiene so expired reservations become terminal and
-            // operational gauges stop showing stale reserved rows.
+            // Admission itself is time-correct (it filters `expires_at` against a
+            // lock-scoped `clock_timestamp()` in SQL). This bounded sweep is hygiene
+            // so expired reservations become terminal and operational gauges stop
+            // showing stale reserved rows.
             match quota::sweep_expired_all_orgs(&pool, config.batch_size).await {
                 Ok(expired) if expired > 0 => {
                     eprintln!("fileconv-server: quota expiry sweep marked {expired} reservations");

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -18,9 +18,10 @@ use serde::Serialize;
 use crate::auth::middleware::AuthenticatedOrg;
 use crate::auth::permissions::require_permission;
 use crate::http::AppState;
+use crate::services::quota::{self, QuotaError, QuotaSnapshot};
 use crate::services::upload::{
-    stream_to_tempfile_with_idle_timeout, validate_and_quarantine, Disposition, LimitsConfig,
-    ReasonCode, StreamedUpload, ThreatClass, UploadError, UploadOutcome,
+    quota_reserve_hook, stream_to_tempfile_with_idle_timeout, validate_and_quarantine, Disposition,
+    LimitsConfig, ReasonCode, StreamedUpload, ThreatClass, UploadError, UploadOutcome,
 };
 
 pub fn router(max_upload_bytes: usize) -> Router<Arc<AppState>> {
@@ -55,7 +56,7 @@ async fn create_upload(
 ) -> Result<Response, UploadRouteError> {
     let request_id = auth.request_id.clone();
     require_permission(&auth.context, "doc.upload")
-        .map_err(|_| UploadRouteError(UploadError::PermissionDenied, request_id.clone()))?;
+        .map_err(|_| UploadRouteError::Upload(UploadError::PermissionDenied, request_id.clone()))?;
 
     let limits = state.runtime().config().upload().limits;
     let upload_timeout = Duration::from_secs(limits.upload_timeout_secs);
@@ -63,19 +64,29 @@ async fn create_upload(
     let pending = tokio::time::timeout(upload_timeout, read_multipart(multipart, limits))
         .await
         .map_err(|_| {
-            UploadRouteError(
+            UploadRouteError::Upload(
                 UploadError::MultipartInvalid {
                     reason: ReasonCode::MultipartTimeout,
                 },
                 request_id.clone(),
             )
         })?
-        .map_err(|error| UploadRouteError(error, request_id.clone()))?;
+        .map_err(|error| UploadRouteError::Upload(error, request_id.clone()))?;
 
-    let storage = state
-        .object_store()
-        .ok_or_else(|| UploadRouteError(UploadError::StorageUnavailable, request_id.clone()))?;
-    validate_and_quarantine(
+    let storage = state.object_store().ok_or_else(|| {
+        UploadRouteError::Upload(UploadError::StorageUnavailable, request_id.clone())
+    })?;
+    let reservation_key = upload_reservation_key(&auth, &request_id);
+    let quota = quota_reserve_hook(
+        state.pool(),
+        &auth.context,
+        &reservation_key,
+        pending.streamed.size_bytes,
+    )
+    .await
+    .map_err(|error| UploadRouteError::Quota(error, request_id.clone()))?;
+
+    let outcome = validate_and_quarantine(
         &auth.context,
         storage,
         &limits,
@@ -83,9 +94,23 @@ async fn create_upload(
         pending.declared_filename.as_deref(),
         pending.declared_content_type.as_deref(),
     )
-    .await
-    .map_err(|error| UploadRouteError(error, request_id.clone()))
-    .map(|outcome| success_response(outcome, &request_id))
+    .await;
+    match outcome {
+        Ok(outcome) => {
+            quota::finalize_upload(state.pool(), &auth.context, &reservation_key)
+                .await
+                .map_err(|error| UploadRouteError::Quota(error, request_id.clone()))?;
+            Ok(success_response(
+                outcome,
+                &request_id,
+                Some(quota.storage_headers()),
+            ))
+        }
+        Err(error) => {
+            let _ = quota::refund_upload(state.pool(), &auth.context, &reservation_key).await;
+            Err(UploadRouteError::Upload(error, request_id))
+        }
+    }
 }
 
 async fn read_multipart(
@@ -193,7 +218,11 @@ async fn drain_non_file_field(
     Ok(())
 }
 
-fn success_response(outcome: UploadOutcome, request_id: &str) -> Response {
+fn success_response(
+    outcome: UploadOutcome,
+    request_id: &str,
+    quota_snapshot: Option<QuotaSnapshot>,
+) -> Response {
     let status = match outcome.disposition {
         Disposition::Accepted | Disposition::Quarantined => StatusCode::CREATED,
         Disposition::Rejected => StatusCode::BAD_REQUEST,
@@ -214,13 +243,32 @@ fn success_response(outcome: UploadOutcome, request_id: &str) -> Response {
         original_filename: outcome.original_filename,
         request_id: request_id.to_string(),
     };
-    (status, Json(body)).into_response()
+    let mut response = (status, Json(body)).into_response();
+    if let Some(snapshot) = quota_snapshot {
+        quota::apply_quota_headers(response.headers_mut(), &snapshot);
+    }
+    response
 }
 
-struct UploadRouteError(UploadError, String);
+enum UploadRouteError {
+    Upload(UploadError, String),
+    Quota(QuotaError, String),
+}
 
 impl IntoResponse for UploadRouteError {
     fn into_response(self) -> Response {
-        self.0.into_response_with_request_id(&self.1)
+        match self {
+            Self::Upload(error, request_id) => error.into_response_with_request_id(&request_id),
+            Self::Quota(error, request_id) => error.into_response_with_request_id(&request_id),
+        }
     }
+}
+
+fn upload_reservation_key(auth: &AuthenticatedOrg, request_id: &str) -> String {
+    format!(
+        "{}.{}.{}",
+        auth.context.org_id(),
+        auth.context.user_id(),
+        request_id
+    )
 }

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -9,19 +9,22 @@ use std::time::Duration;
 use axum::extract::multipart::Field;
 use axum::extract::DefaultBodyLimit;
 use axum::extract::{Multipart, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use axum::{Json, Router};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
+use crate::api::ApiError;
 use crate::auth::middleware::AuthenticatedOrg;
 use crate::auth::permissions::require_permission;
 use crate::http::AppState;
 use crate::services::quota::{self, QuotaError, QuotaSnapshot};
 use crate::services::upload::{
-    quota_reserve_hook, stream_to_tempfile_with_idle_timeout, validate_and_quarantine, Disposition,
-    LimitsConfig, ReasonCode, StreamedUpload, ThreatClass, UploadError, UploadOutcome,
+    quota_reserve_hook, spawn_quota_settled_quarantine, stream_to_tempfile_with_idle_timeout,
+    Disposition, LimitsConfig, QuotaSettledUploadError, ReasonCode, StreamedUpload, ThreatClass,
+    UploadError, UploadOutcome,
 };
 
 pub fn router(max_upload_bytes: usize) -> Router<Arc<AppState>> {
@@ -52,6 +55,7 @@ struct UploadResponse {
 async fn create_upload(
     State(state): State<Arc<AppState>>,
     auth: AuthenticatedOrg,
+    headers: HeaderMap,
     multipart: Multipart,
 ) -> Result<Response, UploadRouteError> {
     let request_id = auth.request_id.clone();
@@ -76,8 +80,9 @@ async fn create_upload(
     let storage = state.object_store().ok_or_else(|| {
         UploadRouteError::Upload(UploadError::StorageUnavailable, request_id.clone())
     })?;
-    let reservation_key = upload_reservation_key(&auth, &request_id);
-    let quota = quota_reserve_hook(
+    let reservation_key = upload_reservation_key(&auth, &request_id, &headers)
+        .map_err(|message| UploadRouteError::Validation(message, request_id.clone()))?;
+    let reservation = quota_reserve_hook(
         state.pool(),
         &auth.context,
         &reservation_key,
@@ -85,31 +90,39 @@ async fn create_upload(
     )
     .await
     .map_err(|error| UploadRouteError::Quota(error, request_id.clone()))?;
+    if !reservation.storage.created || !reservation.document.created {
+        return Err(UploadRouteError::Quota(
+            QuotaError::ReservationConflict,
+            request_id,
+        ));
+    }
 
-    let outcome = validate_and_quarantine(
-        &auth.context,
-        storage,
-        &limits,
+    let handle = spawn_quota_settled_quarantine(
+        state.pool().clone(),
+        auth.context.clone(),
+        storage.clone(),
+        limits,
         pending.streamed,
-        pending.declared_filename.as_deref(),
-        pending.declared_content_type.as_deref(),
-    )
-    .await;
-    match outcome {
-        Ok(outcome) => {
-            quota::finalize_upload(state.pool(), &auth.context, &reservation_key)
-                .await
-                .map_err(|error| UploadRouteError::Quota(error, request_id.clone()))?;
-            Ok(success_response(
-                outcome,
-                &request_id,
-                Some(quota.storage_headers()),
-            ))
+        pending.declared_filename,
+        pending.declared_content_type,
+        reservation_key,
+    );
+    match handle.await {
+        Ok(Ok(success)) => Ok(success_response(
+            success.outcome,
+            &request_id,
+            Some(success.quota_snapshot),
+        )),
+        Ok(Err(QuotaSettledUploadError::Upload(error))) => {
+            Err(UploadRouteError::Upload(error, request_id.clone()))
         }
-        Err(error) => {
-            let _ = quota::refund_upload(state.pool(), &auth.context, &reservation_key).await;
-            Err(UploadRouteError::Upload(error, request_id))
+        Ok(Err(QuotaSettledUploadError::Quota(error))) => {
+            Err(UploadRouteError::Quota(error, request_id.clone()))
         }
+        Err(_) => Err(UploadRouteError::Upload(
+            UploadError::Internal,
+            request_id.clone(),
+        )),
     }
 }
 
@@ -253,6 +266,7 @@ fn success_response(
 enum UploadRouteError {
     Upload(UploadError, String),
     Quota(QuotaError, String),
+    Validation(String, String),
 }
 
 impl IntoResponse for UploadRouteError {
@@ -260,15 +274,51 @@ impl IntoResponse for UploadRouteError {
         match self {
             Self::Upload(error, request_id) => error.into_response_with_request_id(&request_id),
             Self::Quota(error, request_id) => error.into_response_with_request_id(&request_id),
+            Self::Validation(message, request_id) => (
+                StatusCode::BAD_REQUEST,
+                Json(ApiError {
+                    code: "validation_failed".into(),
+                    message,
+                    request_id,
+                    details: None,
+                }),
+            )
+                .into_response(),
         }
     }
 }
 
-fn upload_reservation_key(auth: &AuthenticatedOrg, request_id: &str) -> String {
-    format!(
-        "{}.{}.{}",
-        auth.context.org_id(),
-        auth.context.user_id(),
-        request_id
-    )
+fn upload_reservation_key(
+    auth: &AuthenticatedOrg,
+    request_id: &str,
+    headers: &HeaderMap,
+) -> Result<String, String> {
+    let operation = match headers.get("idempotency-key") {
+        Some(value) => {
+            let value = value
+                .to_str()
+                .map_err(|_| "Idempotency-Key must be visible ASCII".to_string())?;
+            validate_idempotency_key(value)?;
+            format!("client:{value}")
+        }
+        None => format!("request:{request_id}"),
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(auth.context.org_id().as_bytes());
+    hasher.update(auth.context.user_id().as_bytes());
+    hasher.update(operation.as_bytes());
+    Ok(format!("op.{}", hex::encode(hasher.finalize())))
+}
+
+fn validate_idempotency_key(value: &str) -> Result<(), String> {
+    if value.is_empty() || value.len() > 128 {
+        return Err("Idempotency-Key must be between 1 and 128 bytes".into());
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b':'))
+    {
+        return Err("Idempotency-Key contains unsupported characters".into());
+    }
+    Ok(())
 }

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -116,7 +116,7 @@ async fn create_upload(
         Ok(Err(QuotaSettledUploadError::Upload(error))) => {
             Err(UploadRouteError::Upload(error, request_id.clone()))
         }
-        Ok(Err(QuotaSettledUploadError::Quota(error))) => {
+        Ok(Err(QuotaSettledUploadError::Quota { error, .. })) => {
             Err(UploadRouteError::Quota(error, request_id.clone()))
         }
         Err(_) => Err(UploadRouteError::Upload(

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod document_state;
 pub mod index_signature;
+pub mod quota;
 pub mod upload;

--- a/crates/server/src/services/quota.rs
+++ b/crates/server/src/services/quota.rs
@@ -1,0 +1,554 @@
+//! Atomic quota admission, settlement, and HTTP error/header contract.
+//!
+//! Admission is serialized per `(org_id, resource_kind)` by
+//! `pg_advisory_xact_lock(hashtext('quota:' || org_id || ':' || resource_kind))`
+//! inside the F04 org transaction helper (`pool::with_org_txn_typed`, same RLS
+//! semantics as `with_org_txn`). The client never supplies committed counters
+//! or reservation amounts directly: route/services derive amounts from
+//! validated server-side facts such as measured upload bytes.
+
+use std::time::Duration;
+
+use axum::http::{header::RETRY_AFTER, HeaderName, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use chrono::Utc;
+use deadpool_postgres::Pool;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::api::ApiError;
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{QuotaReservation, ReservationStatus, ResourceKind};
+use crate::db::{pool, quota};
+
+pub const DEFAULT_RESERVATION_TTL: Duration = Duration::from_secs(15 * 60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QuotaSnapshot {
+    pub resource_kind: ResourceKind,
+    pub limit: i64,
+    pub committed: i64,
+    pub active_reserved: i64,
+    pub remaining: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuotaReservationOutcome {
+    pub reservation: QuotaReservation,
+    pub quota: QuotaSnapshot,
+    pub created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuotaDenial {
+    pub resource_kind: ResourceKind,
+    pub limit: i64,
+    pub committed: i64,
+    pub active_reserved: i64,
+    pub requested: i64,
+    pub remaining: i64,
+    pub retry_after_secs: Option<u64>,
+}
+
+#[derive(Debug, Error)]
+pub enum QuotaError {
+    #[error("quota is not configured for this organization")]
+    NotConfigured,
+    #[error("quota reservation key is invalid")]
+    InvalidReservationKey,
+    #[error("quota amount is invalid")]
+    InvalidAmount,
+    #[error("quota arithmetic overflow")]
+    ArithmeticOverflow,
+    #[error("quota exceeded")]
+    QuotaExceeded(QuotaDenial),
+    #[error("quota reservation not found")]
+    ReservationNotFound,
+    #[error("quota reservation resource mismatch")]
+    ReservationResourceMismatch,
+    #[error("quota reservation was refunded and cannot be finalized")]
+    RefundedCannotFinalize,
+    #[error("quota reservation expired and cannot be finalized")]
+    ExpiredCannotFinalize,
+    #[error("quota reservation was finalized and cannot be refunded")]
+    FinalizedCannotRefund,
+    #[error("database error")]
+    Database(DbError),
+}
+
+impl QuotaError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::NotConfigured => "quota_not_configured",
+            Self::InvalidReservationKey => "quota_invalid_key",
+            Self::InvalidAmount => "quota_invalid_amount",
+            Self::ArithmeticOverflow => "quota_arithmetic_overflow",
+            Self::QuotaExceeded(_) => "quota_exceeded",
+            Self::ReservationNotFound => "quota_reservation_not_found",
+            Self::ReservationResourceMismatch => "quota_reservation_resource_mismatch",
+            Self::RefundedCannotFinalize => "quota_refunded_cannot_finalize",
+            Self::ExpiredCannotFinalize => "quota_expired_cannot_finalize",
+            Self::FinalizedCannotRefund => "quota_finalized_cannot_refund",
+            Self::Database(_) => "quota_database_error",
+        }
+    }
+
+    pub const fn status_code(&self) -> StatusCode {
+        match self {
+            Self::QuotaExceeded(_) => StatusCode::TOO_MANY_REQUESTS,
+            Self::NotConfigured
+            | Self::InvalidReservationKey
+            | Self::InvalidAmount
+            | Self::ArithmeticOverflow
+            | Self::ReservationNotFound
+            | Self::ReservationResourceMismatch
+            | Self::RefundedCannotFinalize
+            | Self::ExpiredCannotFinalize
+            | Self::FinalizedCannotRefund
+            | Self::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    pub const fn user_message(&self) -> &'static str {
+        match self {
+            Self::QuotaExceeded(_) => "Quota exceeded",
+            Self::NotConfigured => "Quota is not configured",
+            _ => "Quota admission failed",
+        }
+    }
+}
+
+impl From<DbError> for QuotaError {
+    fn from(error: DbError) -> Self {
+        match error {
+            DbError::NotFound => Self::NotConfigured,
+            other => Self::Database(other),
+        }
+    }
+}
+
+impl IntoResponse for QuotaError {
+    fn into_response(self) -> Response {
+        self.into_response_with_request_id(&Uuid::new_v4().to_string())
+    }
+}
+
+impl QuotaError {
+    pub fn into_response_with_request_id(self, request_id: &str) -> Response {
+        let status = self.status_code();
+        let details = match &self {
+            Self::QuotaExceeded(denial) => Some(serde_json::json!({
+                "resourceKind": denial.resource_kind.as_str(),
+                "limit": denial.limit,
+                "used": denial.committed,
+                "activeReserved": denial.active_reserved,
+                "remaining": denial.remaining,
+                "requested": denial.requested,
+            })),
+            _ => None,
+        };
+        let mut response = (
+            status,
+            Json(ApiError {
+                code: self.code().into(),
+                message: self.user_message().into(),
+                request_id: request_id.to_string(),
+                details,
+            }),
+        )
+            .into_response();
+        if let Self::QuotaExceeded(denial) = &self {
+            apply_quota_headers(
+                response.headers_mut(),
+                &QuotaSnapshot {
+                    resource_kind: denial.resource_kind,
+                    limit: denial.limit,
+                    committed: denial.committed,
+                    active_reserved: denial.active_reserved,
+                    remaining: denial.remaining,
+                },
+            );
+            if let Some(seconds) = denial.retry_after_secs {
+                if let Ok(value) = HeaderValue::from_str(&seconds.to_string()) {
+                    response.headers_mut().insert(RETRY_AFTER, value);
+                }
+            }
+        }
+        response
+    }
+}
+
+pub fn apply_quota_headers(headers: &mut axum::http::HeaderMap, snapshot: &QuotaSnapshot) {
+    insert_header(headers, "x-quota-resource", snapshot.resource_kind.as_str());
+    insert_header(headers, "x-quota-limit", &snapshot.limit.to_string());
+    insert_header(headers, "x-quota-used", &snapshot.committed.to_string());
+    insert_header(
+        headers,
+        "x-quota-reserved",
+        &snapshot.active_reserved.to_string(),
+    );
+    insert_header(
+        headers,
+        "x-quota-remaining",
+        &snapshot.remaining.to_string(),
+    );
+}
+
+fn insert_header(headers: &mut axum::http::HeaderMap, name: &'static str, value: &str) {
+    if let Ok(value) = HeaderValue::from_str(value) {
+        headers.insert(HeaderName::from_static(name), value);
+    }
+}
+
+pub async fn reserve(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    reservation_key: &str,
+    resource_kind: ResourceKind,
+    amount: u64,
+    ttl: Duration,
+    job_id: Option<Uuid>,
+) -> Result<QuotaReservationOutcome, QuotaError> {
+    validate_reservation_key(reservation_key)?;
+    let amount = checked_amount(amount)?;
+    let ttl_secs = checked_ttl_secs(ttl)?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let reservation_key = reservation_key.to_string();
+        move |txn| {
+            Box::pin(async move {
+                quota::lock_admission(txn, &ctx, resource_kind).await?;
+                if let Some(existing) = quota::find_by_key(txn, &ctx, &reservation_key).await? {
+                    let snapshot = current_snapshot(txn, &ctx, resource_kind).await?;
+                    return Ok(QuotaReservationOutcome {
+                        reservation: existing,
+                        quota: snapshot,
+                        created: false,
+                    });
+                }
+
+                let usage = quota::usage(txn, &ctx, resource_kind).await?;
+                let remaining = remaining(usage.limit, usage.committed, usage.active_reserved)?;
+                if amount > remaining {
+                    return Err(QuotaError::QuotaExceeded(QuotaDenial {
+                        resource_kind,
+                        limit: usage.limit,
+                        committed: usage.committed,
+                        active_reserved: usage.active_reserved,
+                        requested: amount,
+                        remaining,
+                        retry_after_secs: retry_after_for(resource_kind),
+                    }));
+                }
+
+                let Some(inserted) = quota::insert_reserved(
+                    txn,
+                    &ctx,
+                    &reservation_key,
+                    resource_kind,
+                    amount,
+                    ttl_secs,
+                    job_id,
+                )
+                .await?
+                else {
+                    let existing = quota::find_by_key(txn, &ctx, &reservation_key)
+                        .await?
+                        .ok_or(QuotaError::ReservationNotFound)?;
+                    let snapshot = current_snapshot(txn, &ctx, resource_kind).await?;
+                    return Ok(QuotaReservationOutcome {
+                        reservation: existing,
+                        quota: snapshot,
+                        created: false,
+                    });
+                };
+
+                let active_reserved = usage
+                    .active_reserved
+                    .checked_add(amount)
+                    .ok_or(QuotaError::ArithmeticOverflow)?;
+                Ok(QuotaReservationOutcome {
+                    reservation: inserted,
+                    quota: QuotaSnapshot {
+                        resource_kind,
+                        limit: usage.limit,
+                        committed: usage.committed,
+                        active_reserved,
+                        remaining: remaining
+                            .checked_sub(amount)
+                            .ok_or(QuotaError::ArithmeticOverflow)?,
+                    },
+                    created: true,
+                })
+            })
+        }
+    })
+    .await
+}
+
+pub async fn finalize(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<QuotaReservation, QuotaError> {
+    validate_reservation_key(reservation_key)?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let reservation_key = reservation_key.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let reservation = quota::get_by_key_for_update(txn, &ctx, &reservation_key).await?;
+                quota::lock_admission(txn, &ctx, reservation.resource_kind).await?;
+                match reservation.status {
+                    ReservationStatus::Finalized => return Ok(reservation),
+                    ReservationStatus::Refunded => return Err(QuotaError::RefundedCannotFinalize),
+                    ReservationStatus::Expired => return Err(QuotaError::ExpiredCannotFinalize),
+                    ReservationStatus::Reserved => {}
+                }
+                if reservation.expires_at <= Utc::now() {
+                    quota::set_status(txn, &ctx, reservation.id, ReservationStatus::Expired)
+                        .await?;
+                    return Err(QuotaError::ExpiredCannotFinalize);
+                }
+
+                let finalized =
+                    quota::set_status(txn, &ctx, reservation.id, ReservationStatus::Finalized)
+                        .await?;
+                if finalized.resource_kind.counter_key().is_some() {
+                    let period = quota::current_period(txn, finalized.resource_kind).await?;
+                    let current =
+                        quota::lock_committed_counter(txn, &ctx, finalized.resource_kind, period)
+                            .await?
+                            .unwrap_or(0);
+                    let value = current
+                        .checked_add(finalized.amount)
+                        .ok_or(QuotaError::ArithmeticOverflow)?;
+                    quota::upsert_counter_value(txn, &ctx, finalized.resource_kind, period, value)
+                        .await?;
+                }
+                Ok(finalized)
+            })
+        }
+    })
+    .await
+}
+
+pub async fn refund(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<QuotaReservation, QuotaError> {
+    validate_reservation_key(reservation_key)?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let reservation_key = reservation_key.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let reservation = quota::get_by_key_for_update(txn, &ctx, &reservation_key).await?;
+                quota::lock_admission(txn, &ctx, reservation.resource_kind).await?;
+                match reservation.status {
+                    ReservationStatus::Refunded | ReservationStatus::Expired => {
+                        return Ok(reservation);
+                    }
+                    ReservationStatus::Finalized => return Err(QuotaError::FinalizedCannotRefund),
+                    ReservationStatus::Reserved => {}
+                }
+                if reservation.expires_at <= Utc::now() {
+                    return quota::set_status(
+                        txn,
+                        &ctx,
+                        reservation.id,
+                        ReservationStatus::Expired,
+                    )
+                    .await
+                    .map_err(Into::into);
+                }
+                quota::set_status(txn, &ctx, reservation.id, ReservationStatus::Refunded)
+                    .await
+                    .map_err(Into::into)
+            })
+        }
+    })
+    .await
+}
+
+pub async fn expire_reserved(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    batch_size: u32,
+) -> Result<u64, QuotaError> {
+    let batch_size = i64::from(batch_size.max(1));
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move { quota::expire_reserved_batch(txn, &ctx, batch_size).await })
+        }
+    })
+    .await
+    .map_err(Into::into)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UploadQuotaReservation {
+    pub storage: QuotaReservationOutcome,
+    pub document: Option<QuotaReservationOutcome>,
+}
+
+impl UploadQuotaReservation {
+    pub fn storage_headers(&self) -> QuotaSnapshot {
+        self.storage.quota
+    }
+}
+
+pub async fn reserve_upload(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    reservation_key: &str,
+    size_bytes: u64,
+    ttl: Duration,
+) -> Result<UploadQuotaReservation, QuotaError> {
+    let storage_key = format!("upload.storage.{reservation_key}");
+    let document_key = format!("upload.documents.{reservation_key}");
+    let storage = reserve(
+        db_pool,
+        ctx,
+        &storage_key,
+        ResourceKind::StorageBytes,
+        size_bytes,
+        ttl,
+        None,
+    )
+    .await?;
+    match reserve(
+        db_pool,
+        ctx,
+        &document_key,
+        ResourceKind::Documents,
+        1,
+        ttl,
+        None,
+    )
+    .await
+    {
+        Ok(document) => Ok(UploadQuotaReservation {
+            storage,
+            document: Some(document),
+        }),
+        Err(error) => {
+            let _ = refund(db_pool, ctx, &storage_key).await;
+            Err(error)
+        }
+    }
+}
+
+pub async fn finalize_upload(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<(), QuotaError> {
+    let storage_key = format!("upload.storage.{reservation_key}");
+    let document_key = format!("upload.documents.{reservation_key}");
+    finalize(db_pool, ctx, &document_key).await?;
+    finalize(db_pool, ctx, &storage_key).await?;
+    Ok(())
+}
+
+pub async fn refund_upload(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Result<(), QuotaError> {
+    let storage_key = format!("upload.storage.{reservation_key}");
+    let document_key = format!("upload.documents.{reservation_key}");
+    let document = refund(db_pool, ctx, &document_key).await;
+    let storage = refund(db_pool, ctx, &storage_key).await;
+    document?;
+    storage?;
+    Ok(())
+}
+
+async fn current_snapshot(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    resource_kind: ResourceKind,
+) -> Result<QuotaSnapshot, QuotaError> {
+    let usage = quota::usage(txn, ctx, resource_kind).await?;
+    Ok(QuotaSnapshot {
+        resource_kind,
+        limit: usage.limit,
+        committed: usage.committed,
+        active_reserved: usage.active_reserved,
+        remaining: remaining(usage.limit, usage.committed, usage.active_reserved)?,
+    })
+}
+
+fn remaining(limit: i64, committed: i64, active_reserved: i64) -> Result<i64, QuotaError> {
+    if limit < 0 || committed < 0 || active_reserved < 0 {
+        return Err(QuotaError::ArithmeticOverflow);
+    }
+    let used = committed
+        .checked_add(active_reserved)
+        .ok_or(QuotaError::ArithmeticOverflow)?;
+    if used >= limit {
+        Ok(0)
+    } else {
+        limit
+            .checked_sub(used)
+            .ok_or(QuotaError::ArithmeticOverflow)
+    }
+}
+
+fn checked_amount(amount: u64) -> Result<i64, QuotaError> {
+    if amount == 0 {
+        return Err(QuotaError::InvalidAmount);
+    }
+    i64::try_from(amount).map_err(|_| QuotaError::InvalidAmount)
+}
+
+fn checked_ttl_secs(ttl: Duration) -> Result<i64, QuotaError> {
+    let secs = ttl.as_secs();
+    if secs == 0 {
+        return Err(QuotaError::InvalidAmount);
+    }
+    i64::try_from(secs).map_err(|_| QuotaError::ArithmeticOverflow)
+}
+
+fn validate_reservation_key(key: &str) -> Result<(), QuotaError> {
+    if key.is_empty() || key.len() > 160 || key.chars().any(char::is_control) {
+        return Err(QuotaError::InvalidReservationKey);
+    }
+    Ok(())
+}
+
+const fn retry_after_for(kind: ResourceKind) -> Option<u64> {
+    match kind {
+        ResourceKind::ConcurrentJobs => Some(30),
+        ResourceKind::StorageBytes | ResourceKind::Documents | ResourceKind::Tokens => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checked_amount_rejects_zero_and_overflow() {
+        assert!(matches!(checked_amount(0), Err(QuotaError::InvalidAmount)));
+        assert!(matches!(
+            checked_amount(i64::MAX as u64 + 1),
+            Err(QuotaError::InvalidAmount)
+        ));
+    }
+
+    #[test]
+    fn remaining_is_checked_and_saturates_when_over_limit() {
+        assert_eq!(remaining(10, 3, 4).unwrap(), 3);
+        assert_eq!(remaining(10, 12, 0).unwrap(), 0);
+        assert!(matches!(
+            remaining(i64::MAX, i64::MAX, 1),
+            Err(QuotaError::ArithmeticOverflow)
+        ));
+    }
+}

--- a/crates/server/src/services/quota.rs
+++ b/crates/server/src/services/quota.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use axum::http::{header::RETRY_AFTER, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
+use chrono::{DateTime, Utc};
 use deadpool_postgres::Pool;
 use thiserror::Error;
 use uuid::Uuid;
@@ -277,6 +278,7 @@ pub async fn reserve(
         move |txn| {
             Box::pin(async move {
                 quota::lock_admission(txn, &ctx, resource_kind).await?;
+                let observed_at = quota::fresh_clock_timestamp(txn).await?;
                 if quota::find_by_key(txn, &ctx, &reservation_key)
                     .await?
                     .is_some()
@@ -287,12 +289,14 @@ pub async fn reserve(
                         &reservation_key,
                         resource_kind,
                         amount,
+                        job_id,
+                        observed_at,
                     )
                     .await?
                     else {
                         return Err(QuotaError::ReservationConflict);
                     };
-                    let snapshot = current_snapshot(txn, &ctx, resource_kind).await?;
+                    let snapshot = current_snapshot(txn, &ctx, resource_kind, observed_at).await?;
                     return Ok(QuotaReservationOutcome {
                         reservation: active,
                         quota: snapshot,
@@ -300,7 +304,7 @@ pub async fn reserve(
                     });
                 }
 
-                let usage = quota::usage(txn, &ctx, resource_kind)
+                let usage = quota::usage(txn, &ctx, resource_kind, observed_at)
                     .await
                     .map_err(map_quota_config_error)?;
                 let remaining = remaining(usage.limit, usage.committed, usage.active_reserved)?;
@@ -319,11 +323,14 @@ pub async fn reserve(
                 let Some(inserted) = quota::insert_reserved(
                     txn,
                     &ctx,
-                    &reservation_key,
-                    resource_kind,
-                    amount,
-                    ttl_secs,
-                    job_id,
+                    quota::ReservationInsert {
+                        reservation_key: &reservation_key,
+                        kind: resource_kind,
+                        amount,
+                        ttl_secs,
+                        job_id,
+                        observed_at,
+                    },
                 )
                 .await?
                 else {
@@ -336,12 +343,14 @@ pub async fn reserve(
                         &reservation_key,
                         resource_kind,
                         amount,
+                        job_id,
+                        observed_at,
                     )
                     .await?
                     else {
                         return Err(QuotaError::ReservationConflict);
                     };
-                    let snapshot = current_snapshot(txn, &ctx, resource_kind).await?;
+                    let snapshot = current_snapshot(txn, &ctx, resource_kind, observed_at).await?;
                     return Ok(QuotaReservationOutcome {
                         reservation: active,
                         quota: snapshot,
@@ -387,14 +396,18 @@ pub async fn finalize(
                     .await
                     .map_err(map_reservation_error)?;
                 quota::lock_admission(txn, &ctx, kind).await?;
+                let observed_at = quota::fresh_clock_timestamp(txn).await?;
                 if let Some(finalized) =
-                    quota::finalize_reserved_by_key(txn, &ctx, &reservation_key).await?
+                    quota::finalize_reserved_by_key(txn, &ctx, &reservation_key, observed_at)
+                        .await?
                 {
                     if finalized.resource_kind != kind {
                         return Err(QuotaError::ReservationResourceMismatch);
                     }
                     if finalized.resource_kind.counter_key().is_some() {
-                        let period = quota::current_period(txn, finalized.resource_kind).await?;
+                        let period =
+                            quota::current_period(txn, finalized.resource_kind, observed_at)
+                                .await?;
                         let current = quota::lock_committed_counter(
                             txn,
                             &ctx,
@@ -419,7 +432,8 @@ pub async fn finalize(
                 }
 
                 if let Some(expired) =
-                    quota::expire_reserved_by_key_if_due(txn, &ctx, &reservation_key).await?
+                    quota::expire_reserved_by_key_if_due(txn, &ctx, &reservation_key, observed_at)
+                        .await?
                 {
                     return Ok(QuotaSettlement::Expired(expired));
                 }
@@ -458,13 +472,15 @@ pub async fn refund(
                     .await
                     .map_err(map_reservation_error)?;
                 quota::lock_admission(txn, &ctx, kind).await?;
+                let observed_at = quota::fresh_clock_timestamp(txn).await?;
                 if let Some(refunded) =
-                    quota::refund_reserved_by_key(txn, &ctx, &reservation_key).await?
+                    quota::refund_reserved_by_key(txn, &ctx, &reservation_key, observed_at).await?
                 {
                     return Ok(QuotaSettlement::Refunded(refunded));
                 }
                 if let Some(expired) =
-                    quota::expire_reserved_by_key_if_due(txn, &ctx, &reservation_key).await?
+                    quota::expire_reserved_by_key_if_due(txn, &ctx, &reservation_key, observed_at)
+                        .await?
                 {
                     return Ok(QuotaSettlement::Expired(expired));
                 }
@@ -496,7 +512,10 @@ pub async fn expire_reserved(
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
         move |txn| {
-            Box::pin(async move { quota::expire_reserved_batch(txn, &ctx, batch_size).await })
+            Box::pin(async move {
+                let observed_at = quota::fresh_clock_timestamp(txn).await?;
+                quota::expire_reserved_batch(txn, &ctx, batch_size, observed_at).await
+            })
         }
     })
     .await
@@ -542,6 +561,7 @@ pub async fn reserve_upload(
                     &[ResourceKind::Documents, ResourceKind::StorageBytes],
                 )
                 .await?;
+                let observed_at = quota::fresh_clock_timestamp(txn).await?;
                 let document = reserve_spec_in_txn(
                     txn,
                     &ctx,
@@ -549,6 +569,7 @@ pub async fn reserve_upload(
                     ResourceKind::Documents,
                     1,
                     ttl_secs,
+                    observed_at,
                 )
                 .await?;
                 let storage = reserve_spec_in_txn(
@@ -558,6 +579,7 @@ pub async fn reserve_upload(
                     ResourceKind::StorageBytes,
                     storage_amount,
                     ttl_secs,
+                    observed_at,
                 )
                 .await?;
                 Ok(UploadQuotaReservation { storage, document })
@@ -587,18 +609,41 @@ pub async fn finalize_upload(
                     &[ResourceKind::Documents, ResourceKind::StorageBytes],
                 )
                 .await?;
-                let document_preview =
-                    preview_locked(txn, &ctx, &document_key, ResourceKind::Documents).await?;
-                let storage_preview =
-                    preview_locked(txn, &ctx, &storage_key, ResourceKind::StorageBytes).await?;
+                let observed_at = quota::fresh_clock_timestamp(txn).await?;
+                let document_preview = preview_locked(
+                    txn,
+                    &ctx,
+                    &document_key,
+                    ResourceKind::Documents,
+                    observed_at,
+                )
+                .await?;
+                let storage_preview = preview_locked(
+                    txn,
+                    &ctx,
+                    &storage_key,
+                    ResourceKind::StorageBytes,
+                    observed_at,
+                )
+                .await?;
                 let (document, storage) = match (&document_preview, &storage_preview) {
                     (QuotaSettlement::Reserved(_), QuotaSettlement::Reserved(_)) => {
-                        let document =
-                            finalize_locked(txn, &ctx, &document_key, ResourceKind::Documents)
-                                .await?;
-                        let storage =
-                            finalize_locked(txn, &ctx, &storage_key, ResourceKind::StorageBytes)
-                                .await?;
+                        let document = finalize_locked(
+                            txn,
+                            &ctx,
+                            &document_key,
+                            ResourceKind::Documents,
+                            observed_at,
+                        )
+                        .await?;
+                        let storage = finalize_locked(
+                            txn,
+                            &ctx,
+                            &storage_key,
+                            ResourceKind::StorageBytes,
+                            observed_at,
+                        )
+                        .await?;
                         (document, storage)
                     }
                     (
@@ -607,7 +652,8 @@ pub async fn finalize_upload(
                     ) => (document_preview, storage_preview),
                     _ => (document_preview, storage_preview),
                 };
-                let storage_quota = current_snapshot(txn, &ctx, ResourceKind::StorageBytes).await?;
+                let storage_quota =
+                    current_snapshot(txn, &ctx, ResourceKind::StorageBytes, observed_at).await?;
                 Ok::<UploadQuotaSettlement, QuotaError>(UploadQuotaSettlement {
                     storage,
                     document,
@@ -649,10 +695,23 @@ pub async fn refund_upload(
                     &[ResourceKind::Documents, ResourceKind::StorageBytes],
                 )
                 .await?;
-                let document_preview =
-                    preview_locked(txn, &ctx, &document_key, ResourceKind::Documents).await?;
-                let storage_preview =
-                    preview_locked(txn, &ctx, &storage_key, ResourceKind::StorageBytes).await?;
+                let observed_at = quota::fresh_clock_timestamp(txn).await?;
+                let document_preview = preview_locked(
+                    txn,
+                    &ctx,
+                    &document_key,
+                    ResourceKind::Documents,
+                    observed_at,
+                )
+                .await?;
+                let storage_preview = preview_locked(
+                    txn,
+                    &ctx,
+                    &storage_key,
+                    ResourceKind::StorageBytes,
+                    observed_at,
+                )
+                .await?;
                 let (document, storage) =
                     if matches!(&document_preview, QuotaSettlement::AlreadyFinalized(_))
                         || matches!(&storage_preview, QuotaSettlement::AlreadyFinalized(_))
@@ -661,19 +720,33 @@ pub async fn refund_upload(
                     } else {
                         let document = if matches!(&document_preview, QuotaSettlement::Reserved(_))
                         {
-                            refund_locked(txn, &ctx, &document_key, ResourceKind::Documents).await?
+                            refund_locked(
+                                txn,
+                                &ctx,
+                                &document_key,
+                                ResourceKind::Documents,
+                                observed_at,
+                            )
+                            .await?
                         } else {
                             document_preview
                         };
                         let storage = if matches!(&storage_preview, QuotaSettlement::Reserved(_)) {
-                            refund_locked(txn, &ctx, &storage_key, ResourceKind::StorageBytes)
-                                .await?
+                            refund_locked(
+                                txn,
+                                &ctx,
+                                &storage_key,
+                                ResourceKind::StorageBytes,
+                                observed_at,
+                            )
+                            .await?
                         } else {
                             storage_preview
                         };
                         (document, storage)
                     };
-                let storage_quota = current_snapshot(txn, &ctx, ResourceKind::StorageBytes).await?;
+                let storage_quota =
+                    current_snapshot(txn, &ctx, ResourceKind::StorageBytes, observed_at).await?;
                 Ok::<UploadQuotaSettlement, QuotaError>(UploadQuotaSettlement {
                     storage,
                     document,
@@ -716,6 +789,7 @@ async fn reserve_spec_in_txn(
     resource_kind: ResourceKind,
     amount: i64,
     ttl_secs: i64,
+    observed_at: DateTime<Utc>,
 ) -> Result<QuotaReservationOutcome, QuotaError> {
     validate_reservation_key(reservation_key)?;
     if amount <= 0 {
@@ -725,13 +799,20 @@ async fn reserve_spec_in_txn(
         .await?
         .is_some()
     {
-        let Some(active) =
-            quota::find_active_matching_by_key(txn, ctx, reservation_key, resource_kind, amount)
-                .await?
+        let Some(active) = quota::find_active_matching_by_key(
+            txn,
+            ctx,
+            reservation_key,
+            resource_kind,
+            amount,
+            None,
+            observed_at,
+        )
+        .await?
         else {
             return Err(QuotaError::ReservationConflict);
         };
-        let snapshot = current_snapshot(txn, ctx, resource_kind).await?;
+        let snapshot = current_snapshot(txn, ctx, resource_kind, observed_at).await?;
         return Ok(QuotaReservationOutcome {
             reservation: active,
             quota: snapshot,
@@ -739,7 +820,7 @@ async fn reserve_spec_in_txn(
         });
     }
 
-    let usage = quota::usage(txn, ctx, resource_kind)
+    let usage = quota::usage(txn, ctx, resource_kind, observed_at)
         .await
         .map_err(map_quota_config_error)?;
     let available = remaining(usage.limit, usage.committed, usage.active_reserved)?;
@@ -758,21 +839,31 @@ async fn reserve_spec_in_txn(
     let Some(inserted) = quota::insert_reserved(
         txn,
         ctx,
-        reservation_key,
-        resource_kind,
-        amount,
-        ttl_secs,
-        None,
+        quota::ReservationInsert {
+            reservation_key,
+            kind: resource_kind,
+            amount,
+            ttl_secs,
+            job_id: None,
+            observed_at,
+        },
     )
     .await?
     else {
-        let Some(active) =
-            quota::find_active_matching_by_key(txn, ctx, reservation_key, resource_kind, amount)
-                .await?
+        let Some(active) = quota::find_active_matching_by_key(
+            txn,
+            ctx,
+            reservation_key,
+            resource_kind,
+            amount,
+            None,
+            observed_at,
+        )
+        .await?
         else {
             return Err(QuotaError::ReservationConflict);
         };
-        let snapshot = current_snapshot(txn, ctx, resource_kind).await?;
+        let snapshot = current_snapshot(txn, ctx, resource_kind, observed_at).await?;
         return Ok(QuotaReservationOutcome {
             reservation: active,
             quota: snapshot,
@@ -804,6 +895,7 @@ async fn finalize_locked(
     ctx: &OrgContext,
     reservation_key: &str,
     expected_kind: ResourceKind,
+    observed_at: DateTime<Utc>,
 ) -> Result<QuotaSettlement, QuotaError> {
     let kind = quota::kind_by_key(txn, ctx, reservation_key)
         .await
@@ -811,11 +903,15 @@ async fn finalize_locked(
     if kind != expected_kind {
         return Err(QuotaError::ReservationResourceMismatch);
     }
-    if let Some(finalized) = quota::finalize_reserved_by_key(txn, ctx, reservation_key).await? {
-        add_committed_counter(txn, ctx, &finalized).await?;
+    if let Some(finalized) =
+        quota::finalize_reserved_by_key(txn, ctx, reservation_key, observed_at).await?
+    {
+        add_committed_counter(txn, ctx, &finalized, observed_at).await?;
         return Ok(QuotaSettlement::Finalized(finalized));
     }
-    if let Some(expired) = quota::expire_reserved_by_key_if_due(txn, ctx, reservation_key).await? {
+    if let Some(expired) =
+        quota::expire_reserved_by_key_if_due(txn, ctx, reservation_key, observed_at).await?
+    {
         return Ok(QuotaSettlement::Expired(expired));
     }
     let reservation = quota::get_by_key_for_update(txn, ctx, reservation_key)
@@ -834,6 +930,7 @@ async fn refund_locked(
     ctx: &OrgContext,
     reservation_key: &str,
     expected_kind: ResourceKind,
+    observed_at: DateTime<Utc>,
 ) -> Result<QuotaSettlement, QuotaError> {
     let kind = quota::kind_by_key(txn, ctx, reservation_key)
         .await
@@ -841,10 +938,14 @@ async fn refund_locked(
     if kind != expected_kind {
         return Err(QuotaError::ReservationResourceMismatch);
     }
-    if let Some(refunded) = quota::refund_reserved_by_key(txn, ctx, reservation_key).await? {
+    if let Some(refunded) =
+        quota::refund_reserved_by_key(txn, ctx, reservation_key, observed_at).await?
+    {
         return Ok(QuotaSettlement::Refunded(refunded));
     }
-    if let Some(expired) = quota::expire_reserved_by_key_if_due(txn, ctx, reservation_key).await? {
+    if let Some(expired) =
+        quota::expire_reserved_by_key_if_due(txn, ctx, reservation_key, observed_at).await?
+    {
         return Ok(QuotaSettlement::Expired(expired));
     }
     let reservation = quota::get_by_key_for_update(txn, ctx, reservation_key)
@@ -863,6 +964,7 @@ async fn preview_locked(
     ctx: &OrgContext,
     reservation_key: &str,
     expected_kind: ResourceKind,
+    observed_at: DateTime<Utc>,
 ) -> Result<QuotaSettlement, QuotaError> {
     let kind = quota::kind_by_key(txn, ctx, reservation_key)
         .await
@@ -870,7 +972,9 @@ async fn preview_locked(
     if kind != expected_kind {
         return Err(QuotaError::ReservationResourceMismatch);
     }
-    if let Some(expired) = quota::expire_reserved_by_key_if_due(txn, ctx, reservation_key).await? {
+    if let Some(expired) =
+        quota::expire_reserved_by_key_if_due(txn, ctx, reservation_key, observed_at).await?
+    {
         return Ok(QuotaSettlement::Expired(expired));
     }
     let reservation = quota::get_by_key_for_update(txn, ctx, reservation_key)
@@ -888,9 +992,10 @@ async fn add_committed_counter(
     txn: &tokio_postgres::Transaction<'_>,
     ctx: &OrgContext,
     reservation: &QuotaReservation,
+    observed_at: DateTime<Utc>,
 ) -> Result<(), QuotaError> {
     if reservation.resource_kind.counter_key().is_some() {
-        let period = quota::current_period(txn, reservation.resource_kind).await?;
+        let period = quota::current_period(txn, reservation.resource_kind, observed_at).await?;
         let current = quota::lock_committed_counter(txn, ctx, reservation.resource_kind, period)
             .await?
             .unwrap_or(0);
@@ -906,8 +1011,9 @@ async fn current_snapshot(
     txn: &tokio_postgres::Transaction<'_>,
     ctx: &OrgContext,
     resource_kind: ResourceKind,
+    observed_at: DateTime<Utc>,
 ) -> Result<QuotaSnapshot, QuotaError> {
-    let usage = quota::usage(txn, ctx, resource_kind)
+    let usage = quota::usage(txn, ctx, resource_kind, observed_at)
         .await
         .map_err(map_quota_config_error)?;
     Ok(QuotaSnapshot {

--- a/crates/server/src/services/quota.rs
+++ b/crates/server/src/services/quota.rs
@@ -12,7 +12,6 @@ use std::time::Duration;
 use axum::http::{header::RETRY_AFTER, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use chrono::Utc;
 use deadpool_postgres::Pool;
 use thiserror::Error;
 use uuid::Uuid;
@@ -42,6 +41,63 @@ pub struct QuotaReservationOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UploadQuotaReservation {
+    pub storage: QuotaReservationOutcome,
+    pub document: QuotaReservationOutcome,
+}
+
+impl UploadQuotaReservation {
+    pub fn storage_headers(&self) -> QuotaSnapshot {
+        self.storage.quota
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UploadQuotaSettlement {
+    pub storage: QuotaSettlement,
+    pub document: QuotaSettlement,
+    pub storage_quota: QuotaSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuotaSettlement {
+    Reserved(QuotaReservation),
+    Finalized(QuotaReservation),
+    AlreadyFinalized(QuotaReservation),
+    Refunded(QuotaReservation),
+    AlreadyRefunded(QuotaReservation),
+    Expired(QuotaReservation),
+    RefundedCannotFinalize(QuotaReservation),
+    FinalizedCannotRefund(QuotaReservation),
+}
+
+impl QuotaSettlement {
+    pub const fn reservation(&self) -> &QuotaReservation {
+        match self {
+            Self::Reserved(reservation)
+            | Self::Finalized(reservation)
+            | Self::AlreadyFinalized(reservation)
+            | Self::Refunded(reservation)
+            | Self::AlreadyRefunded(reservation)
+            | Self::Expired(reservation)
+            | Self::RefundedCannotFinalize(reservation)
+            | Self::FinalizedCannotRefund(reservation) => reservation,
+        }
+    }
+
+    pub const fn is_finalize_success(&self) -> bool {
+        matches!(self, Self::Finalized(_) | Self::AlreadyFinalized(_))
+    }
+
+    pub const fn is_refund_success(&self) -> bool {
+        matches!(
+            self,
+            Self::Refunded(_) | Self::AlreadyRefunded(_) | Self::Expired(_)
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QuotaDenial {
     pub resource_kind: ResourceKind,
     pub limit: i64,
@@ -68,6 +124,8 @@ pub enum QuotaError {
     ReservationNotFound,
     #[error("quota reservation resource mismatch")]
     ReservationResourceMismatch,
+    #[error("quota reservation key conflicts with a different or terminal reservation")]
+    ReservationConflict,
     #[error("quota reservation was refunded and cannot be finalized")]
     RefundedCannotFinalize,
     #[error("quota reservation expired and cannot be finalized")]
@@ -88,6 +146,7 @@ impl QuotaError {
             Self::QuotaExceeded(_) => "quota_exceeded",
             Self::ReservationNotFound => "quota_reservation_not_found",
             Self::ReservationResourceMismatch => "quota_reservation_resource_mismatch",
+            Self::ReservationConflict => "quota_reservation_conflict",
             Self::RefundedCannotFinalize => "quota_refunded_cannot_finalize",
             Self::ExpiredCannotFinalize => "quota_expired_cannot_finalize",
             Self::FinalizedCannotRefund => "quota_finalized_cannot_refund",
@@ -98,6 +157,7 @@ impl QuotaError {
     pub const fn status_code(&self) -> StatusCode {
         match self {
             Self::QuotaExceeded(_) => StatusCode::TOO_MANY_REQUESTS,
+            Self::ReservationConflict => StatusCode::CONFLICT,
             Self::NotConfigured
             | Self::InvalidReservationKey
             | Self::InvalidAmount
@@ -122,10 +182,7 @@ impl QuotaError {
 
 impl From<DbError> for QuotaError {
     fn from(error: DbError) -> Self {
-        match error {
-            DbError::NotFound => Self::NotConfigured,
-            other => Self::Database(other),
-        }
+        Self::Database(error)
     }
 }
 
@@ -220,16 +277,32 @@ pub async fn reserve(
         move |txn| {
             Box::pin(async move {
                 quota::lock_admission(txn, &ctx, resource_kind).await?;
-                if let Some(existing) = quota::find_by_key(txn, &ctx, &reservation_key).await? {
+                if quota::find_by_key(txn, &ctx, &reservation_key)
+                    .await?
+                    .is_some()
+                {
+                    let Some(active) = quota::find_active_matching_by_key(
+                        txn,
+                        &ctx,
+                        &reservation_key,
+                        resource_kind,
+                        amount,
+                    )
+                    .await?
+                    else {
+                        return Err(QuotaError::ReservationConflict);
+                    };
                     let snapshot = current_snapshot(txn, &ctx, resource_kind).await?;
                     return Ok(QuotaReservationOutcome {
-                        reservation: existing,
+                        reservation: active,
                         quota: snapshot,
                         created: false,
                     });
                 }
 
-                let usage = quota::usage(txn, &ctx, resource_kind).await?;
+                let usage = quota::usage(txn, &ctx, resource_kind)
+                    .await
+                    .map_err(map_quota_config_error)?;
                 let remaining = remaining(usage.limit, usage.committed, usage.active_reserved)?;
                 if amount > remaining {
                     return Err(QuotaError::QuotaExceeded(QuotaDenial {
@@ -254,12 +327,23 @@ pub async fn reserve(
                 )
                 .await?
                 else {
-                    let existing = quota::find_by_key(txn, &ctx, &reservation_key)
+                    quota::find_by_key(txn, &ctx, &reservation_key)
                         .await?
                         .ok_or(QuotaError::ReservationNotFound)?;
+                    let Some(active) = quota::find_active_matching_by_key(
+                        txn,
+                        &ctx,
+                        &reservation_key,
+                        resource_kind,
+                        amount,
+                    )
+                    .await?
+                    else {
+                        return Err(QuotaError::ReservationConflict);
+                    };
                     let snapshot = current_snapshot(txn, &ctx, resource_kind).await?;
                     return Ok(QuotaReservationOutcome {
-                        reservation: existing,
+                        reservation: active,
                         quota: snapshot,
                         created: false,
                     });
@@ -292,43 +376,67 @@ pub async fn finalize(
     db_pool: &Pool,
     ctx: &OrgContext,
     reservation_key: &str,
-) -> Result<QuotaReservation, QuotaError> {
+) -> Result<QuotaSettlement, QuotaError> {
     validate_reservation_key(reservation_key)?;
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
         let reservation_key = reservation_key.to_string();
         move |txn| {
             Box::pin(async move {
-                let reservation = quota::get_by_key_for_update(txn, &ctx, &reservation_key).await?;
-                quota::lock_admission(txn, &ctx, reservation.resource_kind).await?;
-                match reservation.status {
-                    ReservationStatus::Finalized => return Ok(reservation),
-                    ReservationStatus::Refunded => return Err(QuotaError::RefundedCannotFinalize),
-                    ReservationStatus::Expired => return Err(QuotaError::ExpiredCannotFinalize),
-                    ReservationStatus::Reserved => {}
-                }
-                if reservation.expires_at <= Utc::now() {
-                    quota::set_status(txn, &ctx, reservation.id, ReservationStatus::Expired)
+                let kind = quota::kind_by_key(txn, &ctx, &reservation_key)
+                    .await
+                    .map_err(map_reservation_error)?;
+                quota::lock_admission(txn, &ctx, kind).await?;
+                if let Some(finalized) =
+                    quota::finalize_reserved_by_key(txn, &ctx, &reservation_key).await?
+                {
+                    if finalized.resource_kind != kind {
+                        return Err(QuotaError::ReservationResourceMismatch);
+                    }
+                    if finalized.resource_kind.counter_key().is_some() {
+                        let period = quota::current_period(txn, finalized.resource_kind).await?;
+                        let current = quota::lock_committed_counter(
+                            txn,
+                            &ctx,
+                            finalized.resource_kind,
+                            period,
+                        )
+                        .await?
+                        .unwrap_or(0);
+                        let value = current
+                            .checked_add(finalized.amount)
+                            .ok_or(QuotaError::ArithmeticOverflow)?;
+                        quota::upsert_counter_value(
+                            txn,
+                            &ctx,
+                            finalized.resource_kind,
+                            period,
+                            value,
+                        )
                         .await?;
-                    return Err(QuotaError::ExpiredCannotFinalize);
+                    }
+                    return Ok(QuotaSettlement::Finalized(finalized));
                 }
 
-                let finalized =
-                    quota::set_status(txn, &ctx, reservation.id, ReservationStatus::Finalized)
-                        .await?;
-                if finalized.resource_kind.counter_key().is_some() {
-                    let period = quota::current_period(txn, finalized.resource_kind).await?;
-                    let current =
-                        quota::lock_committed_counter(txn, &ctx, finalized.resource_kind, period)
-                            .await?
-                            .unwrap_or(0);
-                    let value = current
-                        .checked_add(finalized.amount)
-                        .ok_or(QuotaError::ArithmeticOverflow)?;
-                    quota::upsert_counter_value(txn, &ctx, finalized.resource_kind, period, value)
-                        .await?;
+                if let Some(expired) =
+                    quota::expire_reserved_by_key_if_due(txn, &ctx, &reservation_key).await?
+                {
+                    return Ok(QuotaSettlement::Expired(expired));
                 }
-                Ok(finalized)
+
+                let reservation = quota::get_by_key_for_update(txn, &ctx, &reservation_key)
+                    .await
+                    .map_err(map_reservation_error)?;
+                match reservation.status {
+                    ReservationStatus::Finalized => {
+                        Ok(QuotaSettlement::AlreadyFinalized(reservation))
+                    }
+                    ReservationStatus::Refunded => {
+                        Ok(QuotaSettlement::RefundedCannotFinalize(reservation))
+                    }
+                    ReservationStatus::Expired => Ok(QuotaSettlement::Expired(reservation)),
+                    ReservationStatus::Reserved => Err(QuotaError::ReservationConflict),
+                }
             })
         }
     })
@@ -339,35 +447,40 @@ pub async fn refund(
     db_pool: &Pool,
     ctx: &OrgContext,
     reservation_key: &str,
-) -> Result<QuotaReservation, QuotaError> {
+) -> Result<QuotaSettlement, QuotaError> {
     validate_reservation_key(reservation_key)?;
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
         let reservation_key = reservation_key.to_string();
         move |txn| {
             Box::pin(async move {
-                let reservation = quota::get_by_key_for_update(txn, &ctx, &reservation_key).await?;
-                quota::lock_admission(txn, &ctx, reservation.resource_kind).await?;
+                let kind = quota::kind_by_key(txn, &ctx, &reservation_key)
+                    .await
+                    .map_err(map_reservation_error)?;
+                quota::lock_admission(txn, &ctx, kind).await?;
+                if let Some(refunded) =
+                    quota::refund_reserved_by_key(txn, &ctx, &reservation_key).await?
+                {
+                    return Ok(QuotaSettlement::Refunded(refunded));
+                }
+                if let Some(expired) =
+                    quota::expire_reserved_by_key_if_due(txn, &ctx, &reservation_key).await?
+                {
+                    return Ok(QuotaSettlement::Expired(expired));
+                }
+                let reservation = quota::get_by_key_for_update(txn, &ctx, &reservation_key)
+                    .await
+                    .map_err(map_reservation_error)?;
                 match reservation.status {
-                    ReservationStatus::Refunded | ReservationStatus::Expired => {
-                        return Ok(reservation);
+                    ReservationStatus::Refunded => {
+                        Ok(QuotaSettlement::AlreadyRefunded(reservation))
                     }
-                    ReservationStatus::Finalized => return Err(QuotaError::FinalizedCannotRefund),
-                    ReservationStatus::Reserved => {}
+                    ReservationStatus::Expired => Ok(QuotaSettlement::Expired(reservation)),
+                    ReservationStatus::Finalized => {
+                        Ok(QuotaSettlement::FinalizedCannotRefund(reservation))
+                    }
+                    ReservationStatus::Reserved => Err(QuotaError::ReservationConflict),
                 }
-                if reservation.expires_at <= Utc::now() {
-                    return quota::set_status(
-                        txn,
-                        &ctx,
-                        reservation.id,
-                        ReservationStatus::Expired,
-                    )
-                    .await
-                    .map_err(Into::into);
-                }
-                quota::set_status(txn, &ctx, reservation.id, ReservationStatus::Refunded)
-                    .await
-                    .map_err(Into::into)
             })
         }
     })
@@ -390,17 +503,20 @@ pub async fn expire_reserved(
     .map_err(Into::into)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UploadQuotaReservation {
-    pub storage: QuotaReservationOutcome,
-    pub document: Option<QuotaReservationOutcome>,
+pub async fn sweep_expired_all_orgs(db_pool: &Pool, batch_size: u32) -> Result<u64, QuotaError> {
+    let org_ids = quota::list_org_ids_for_sweep(db_pool).await?;
+    let mut expired = 0_u64;
+    for org_id in org_ids {
+        let ctx = OrgContext::try_new(org_id, SWEEP_USER_ID, [] as [&str; 0], [])
+            .map_err(|error| QuotaError::Database(DbError::Config(error.to_string())))?;
+        expired = expired
+            .checked_add(expire_reserved(db_pool, &ctx, batch_size).await?)
+            .ok_or(QuotaError::ArithmeticOverflow)?;
+    }
+    Ok(expired)
 }
 
-impl UploadQuotaReservation {
-    pub fn storage_headers(&self) -> QuotaSnapshot {
-        self.storage.quota
-    }
-}
+const SWEEP_USER_ID: Uuid = Uuid::from_u128(0x00000000000040008000000000000001);
 
 pub async fn reserve_upload(
     db_pool: &Pool,
@@ -409,63 +525,380 @@ pub async fn reserve_upload(
     size_bytes: u64,
     ttl: Duration,
 ) -> Result<UploadQuotaReservation, QuotaError> {
+    validate_reservation_key(reservation_key)?;
+    let storage_amount = checked_amount(size_bytes)?;
+    let ttl_secs = checked_ttl_secs(ttl)?;
     let storage_key = format!("upload.storage.{reservation_key}");
     let document_key = format!("upload.documents.{reservation_key}");
-    let storage = reserve(
-        db_pool,
-        ctx,
-        &storage_key,
-        ResourceKind::StorageBytes,
-        size_bytes,
-        ttl,
-        None,
-    )
-    .await?;
-    match reserve(
-        db_pool,
-        ctx,
-        &document_key,
-        ResourceKind::Documents,
-        1,
-        ttl,
-        None,
-    )
-    .await
-    {
-        Ok(document) => Ok(UploadQuotaReservation {
-            storage,
-            document: Some(document),
-        }),
-        Err(error) => {
-            let _ = refund(db_pool, ctx, &storage_key).await;
-            Err(error)
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let storage_key = storage_key.clone();
+        let document_key = document_key.clone();
+        move |txn| {
+            Box::pin(async move {
+                lock_resource_kinds(
+                    txn,
+                    &ctx,
+                    &[ResourceKind::Documents, ResourceKind::StorageBytes],
+                )
+                .await?;
+                let document = reserve_spec_in_txn(
+                    txn,
+                    &ctx,
+                    &document_key,
+                    ResourceKind::Documents,
+                    1,
+                    ttl_secs,
+                )
+                .await?;
+                let storage = reserve_spec_in_txn(
+                    txn,
+                    &ctx,
+                    &storage_key,
+                    ResourceKind::StorageBytes,
+                    storage_amount,
+                    ttl_secs,
+                )
+                .await?;
+                Ok(UploadQuotaReservation { storage, document })
+            })
         }
-    }
+    })
+    .await
 }
 
 pub async fn finalize_upload(
     db_pool: &Pool,
     ctx: &OrgContext,
     reservation_key: &str,
-) -> Result<(), QuotaError> {
+) -> Result<UploadQuotaSettlement, QuotaError> {
+    validate_reservation_key(reservation_key)?;
     let storage_key = format!("upload.storage.{reservation_key}");
     let document_key = format!("upload.documents.{reservation_key}");
-    finalize(db_pool, ctx, &document_key).await?;
-    finalize(db_pool, ctx, &storage_key).await?;
-    Ok(())
+    let settlement = pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let storage_key = storage_key.clone();
+        let document_key = document_key.clone();
+        move |txn| {
+            Box::pin(async move {
+                lock_resource_kinds(
+                    txn,
+                    &ctx,
+                    &[ResourceKind::Documents, ResourceKind::StorageBytes],
+                )
+                .await?;
+                let document_preview =
+                    preview_locked(txn, &ctx, &document_key, ResourceKind::Documents).await?;
+                let storage_preview =
+                    preview_locked(txn, &ctx, &storage_key, ResourceKind::StorageBytes).await?;
+                let (document, storage) = match (&document_preview, &storage_preview) {
+                    (QuotaSettlement::Reserved(_), QuotaSettlement::Reserved(_)) => {
+                        let document =
+                            finalize_locked(txn, &ctx, &document_key, ResourceKind::Documents)
+                                .await?;
+                        let storage =
+                            finalize_locked(txn, &ctx, &storage_key, ResourceKind::StorageBytes)
+                                .await?;
+                        (document, storage)
+                    }
+                    (
+                        QuotaSettlement::AlreadyFinalized(_),
+                        QuotaSettlement::AlreadyFinalized(_),
+                    ) => (document_preview, storage_preview),
+                    _ => (document_preview, storage_preview),
+                };
+                let storage_quota = current_snapshot(txn, &ctx, ResourceKind::StorageBytes).await?;
+                Ok::<UploadQuotaSettlement, QuotaError>(UploadQuotaSettlement {
+                    storage,
+                    document,
+                    storage_quota,
+                })
+            })
+        }
+    })
+    .await?;
+    if settlement.storage.is_finalize_success() && settlement.document.is_finalize_success() {
+        Ok(settlement)
+    } else {
+        Err(
+            finalize_settlement_error(&settlement.storage).unwrap_or_else(|| {
+                finalize_settlement_error(&settlement.document)
+                    .unwrap_or(QuotaError::ReservationConflict)
+            }),
+        )
+    }
 }
 
 pub async fn refund_upload(
     db_pool: &Pool,
     ctx: &OrgContext,
     reservation_key: &str,
-) -> Result<(), QuotaError> {
+) -> Result<UploadQuotaSettlement, QuotaError> {
+    validate_reservation_key(reservation_key)?;
     let storage_key = format!("upload.storage.{reservation_key}");
     let document_key = format!("upload.documents.{reservation_key}");
-    let document = refund(db_pool, ctx, &document_key).await;
-    let storage = refund(db_pool, ctx, &storage_key).await;
-    document?;
-    storage?;
+    let settlement = pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let storage_key = storage_key.clone();
+        let document_key = document_key.clone();
+        move |txn| {
+            Box::pin(async move {
+                lock_resource_kinds(
+                    txn,
+                    &ctx,
+                    &[ResourceKind::Documents, ResourceKind::StorageBytes],
+                )
+                .await?;
+                let document_preview =
+                    preview_locked(txn, &ctx, &document_key, ResourceKind::Documents).await?;
+                let storage_preview =
+                    preview_locked(txn, &ctx, &storage_key, ResourceKind::StorageBytes).await?;
+                let (document, storage) =
+                    if matches!(&document_preview, QuotaSettlement::AlreadyFinalized(_))
+                        || matches!(&storage_preview, QuotaSettlement::AlreadyFinalized(_))
+                    {
+                        (document_preview, storage_preview)
+                    } else {
+                        let document = if matches!(&document_preview, QuotaSettlement::Reserved(_))
+                        {
+                            refund_locked(txn, &ctx, &document_key, ResourceKind::Documents).await?
+                        } else {
+                            document_preview
+                        };
+                        let storage = if matches!(&storage_preview, QuotaSettlement::Reserved(_)) {
+                            refund_locked(txn, &ctx, &storage_key, ResourceKind::StorageBytes)
+                                .await?
+                        } else {
+                            storage_preview
+                        };
+                        (document, storage)
+                    };
+                let storage_quota = current_snapshot(txn, &ctx, ResourceKind::StorageBytes).await?;
+                Ok::<UploadQuotaSettlement, QuotaError>(UploadQuotaSettlement {
+                    storage,
+                    document,
+                    storage_quota,
+                })
+            })
+        }
+    })
+    .await?;
+    if settlement.storage.is_refund_success() && settlement.document.is_refund_success() {
+        Ok(settlement)
+    } else {
+        Err(
+            refund_settlement_error(&settlement.storage).unwrap_or_else(|| {
+                refund_settlement_error(&settlement.document)
+                    .unwrap_or(QuotaError::ReservationConflict)
+            }),
+        )
+    }
+}
+
+async fn lock_resource_kinds(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    kinds: &[ResourceKind],
+) -> Result<(), QuotaError> {
+    let mut ordered = kinds.to_vec();
+    ordered.sort_by_key(|kind| kind.as_str());
+    ordered.dedup_by_key(|kind| kind.as_str());
+    for kind in ordered {
+        quota::lock_admission(txn, ctx, kind).await?;
+    }
+    Ok(())
+}
+
+async fn reserve_spec_in_txn(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+    resource_kind: ResourceKind,
+    amount: i64,
+    ttl_secs: i64,
+) -> Result<QuotaReservationOutcome, QuotaError> {
+    validate_reservation_key(reservation_key)?;
+    if amount <= 0 {
+        return Err(QuotaError::InvalidAmount);
+    }
+    if quota::find_by_key(txn, ctx, reservation_key)
+        .await?
+        .is_some()
+    {
+        let Some(active) =
+            quota::find_active_matching_by_key(txn, ctx, reservation_key, resource_kind, amount)
+                .await?
+        else {
+            return Err(QuotaError::ReservationConflict);
+        };
+        let snapshot = current_snapshot(txn, ctx, resource_kind).await?;
+        return Ok(QuotaReservationOutcome {
+            reservation: active,
+            quota: snapshot,
+            created: false,
+        });
+    }
+
+    let usage = quota::usage(txn, ctx, resource_kind)
+        .await
+        .map_err(map_quota_config_error)?;
+    let available = remaining(usage.limit, usage.committed, usage.active_reserved)?;
+    if amount > available {
+        return Err(QuotaError::QuotaExceeded(QuotaDenial {
+            resource_kind,
+            limit: usage.limit,
+            committed: usage.committed,
+            active_reserved: usage.active_reserved,
+            requested: amount,
+            remaining: available,
+            retry_after_secs: retry_after_for(resource_kind),
+        }));
+    }
+
+    let Some(inserted) = quota::insert_reserved(
+        txn,
+        ctx,
+        reservation_key,
+        resource_kind,
+        amount,
+        ttl_secs,
+        None,
+    )
+    .await?
+    else {
+        let Some(active) =
+            quota::find_active_matching_by_key(txn, ctx, reservation_key, resource_kind, amount)
+                .await?
+        else {
+            return Err(QuotaError::ReservationConflict);
+        };
+        let snapshot = current_snapshot(txn, ctx, resource_kind).await?;
+        return Ok(QuotaReservationOutcome {
+            reservation: active,
+            quota: snapshot,
+            created: false,
+        });
+    };
+
+    let active_reserved = usage
+        .active_reserved
+        .checked_add(amount)
+        .ok_or(QuotaError::ArithmeticOverflow)?;
+    Ok(QuotaReservationOutcome {
+        reservation: inserted,
+        quota: QuotaSnapshot {
+            resource_kind,
+            limit: usage.limit,
+            committed: usage.committed,
+            active_reserved,
+            remaining: available
+                .checked_sub(amount)
+                .ok_or(QuotaError::ArithmeticOverflow)?,
+        },
+        created: true,
+    })
+}
+
+async fn finalize_locked(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+    expected_kind: ResourceKind,
+) -> Result<QuotaSettlement, QuotaError> {
+    let kind = quota::kind_by_key(txn, ctx, reservation_key)
+        .await
+        .map_err(map_reservation_error)?;
+    if kind != expected_kind {
+        return Err(QuotaError::ReservationResourceMismatch);
+    }
+    if let Some(finalized) = quota::finalize_reserved_by_key(txn, ctx, reservation_key).await? {
+        add_committed_counter(txn, ctx, &finalized).await?;
+        return Ok(QuotaSettlement::Finalized(finalized));
+    }
+    if let Some(expired) = quota::expire_reserved_by_key_if_due(txn, ctx, reservation_key).await? {
+        return Ok(QuotaSettlement::Expired(expired));
+    }
+    let reservation = quota::get_by_key_for_update(txn, ctx, reservation_key)
+        .await
+        .map_err(map_reservation_error)?;
+    match reservation.status {
+        ReservationStatus::Finalized => Ok(QuotaSettlement::AlreadyFinalized(reservation)),
+        ReservationStatus::Refunded => Ok(QuotaSettlement::RefundedCannotFinalize(reservation)),
+        ReservationStatus::Expired => Ok(QuotaSettlement::Expired(reservation)),
+        ReservationStatus::Reserved => Err(QuotaError::ReservationConflict),
+    }
+}
+
+async fn refund_locked(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+    expected_kind: ResourceKind,
+) -> Result<QuotaSettlement, QuotaError> {
+    let kind = quota::kind_by_key(txn, ctx, reservation_key)
+        .await
+        .map_err(map_reservation_error)?;
+    if kind != expected_kind {
+        return Err(QuotaError::ReservationResourceMismatch);
+    }
+    if let Some(refunded) = quota::refund_reserved_by_key(txn, ctx, reservation_key).await? {
+        return Ok(QuotaSettlement::Refunded(refunded));
+    }
+    if let Some(expired) = quota::expire_reserved_by_key_if_due(txn, ctx, reservation_key).await? {
+        return Ok(QuotaSettlement::Expired(expired));
+    }
+    let reservation = quota::get_by_key_for_update(txn, ctx, reservation_key)
+        .await
+        .map_err(map_reservation_error)?;
+    match reservation.status {
+        ReservationStatus::Refunded => Ok(QuotaSettlement::AlreadyRefunded(reservation)),
+        ReservationStatus::Expired => Ok(QuotaSettlement::Expired(reservation)),
+        ReservationStatus::Finalized => Ok(QuotaSettlement::FinalizedCannotRefund(reservation)),
+        ReservationStatus::Reserved => Err(QuotaError::ReservationConflict),
+    }
+}
+
+async fn preview_locked(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+    expected_kind: ResourceKind,
+) -> Result<QuotaSettlement, QuotaError> {
+    let kind = quota::kind_by_key(txn, ctx, reservation_key)
+        .await
+        .map_err(map_reservation_error)?;
+    if kind != expected_kind {
+        return Err(QuotaError::ReservationResourceMismatch);
+    }
+    if let Some(expired) = quota::expire_reserved_by_key_if_due(txn, ctx, reservation_key).await? {
+        return Ok(QuotaSettlement::Expired(expired));
+    }
+    let reservation = quota::get_by_key_for_update(txn, ctx, reservation_key)
+        .await
+        .map_err(map_reservation_error)?;
+    match reservation.status {
+        ReservationStatus::Reserved => Ok(QuotaSettlement::Reserved(reservation)),
+        ReservationStatus::Finalized => Ok(QuotaSettlement::AlreadyFinalized(reservation)),
+        ReservationStatus::Refunded => Ok(QuotaSettlement::AlreadyRefunded(reservation)),
+        ReservationStatus::Expired => Ok(QuotaSettlement::Expired(reservation)),
+    }
+}
+
+async fn add_committed_counter(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    reservation: &QuotaReservation,
+) -> Result<(), QuotaError> {
+    if reservation.resource_kind.counter_key().is_some() {
+        let period = quota::current_period(txn, reservation.resource_kind).await?;
+        let current = quota::lock_committed_counter(txn, ctx, reservation.resource_kind, period)
+            .await?
+            .unwrap_or(0);
+        let value = current
+            .checked_add(reservation.amount)
+            .ok_or(QuotaError::ArithmeticOverflow)?;
+        quota::upsert_counter_value(txn, ctx, reservation.resource_kind, period, value).await?;
+    }
     Ok(())
 }
 
@@ -474,7 +907,9 @@ async fn current_snapshot(
     ctx: &OrgContext,
     resource_kind: ResourceKind,
 ) -> Result<QuotaSnapshot, QuotaError> {
-    let usage = quota::usage(txn, ctx, resource_kind).await?;
+    let usage = quota::usage(txn, ctx, resource_kind)
+        .await
+        .map_err(map_quota_config_error)?;
     Ok(QuotaSnapshot {
         resource_kind,
         limit: usage.limit,
@@ -482,6 +917,45 @@ async fn current_snapshot(
         active_reserved: usage.active_reserved,
         remaining: remaining(usage.limit, usage.committed, usage.active_reserved)?,
     })
+}
+
+fn finalize_settlement_error(settlement: &QuotaSettlement) -> Option<QuotaError> {
+    match settlement {
+        QuotaSettlement::Finalized(_) | QuotaSettlement::AlreadyFinalized(_) => None,
+        QuotaSettlement::Reserved(_) => None,
+        QuotaSettlement::Expired(_) => Some(QuotaError::ExpiredCannotFinalize),
+        QuotaSettlement::Refunded(_)
+        | QuotaSettlement::AlreadyRefunded(_)
+        | QuotaSettlement::RefundedCannotFinalize(_) => Some(QuotaError::RefundedCannotFinalize),
+        QuotaSettlement::FinalizedCannotRefund(_) => Some(QuotaError::ReservationConflict),
+    }
+}
+
+fn refund_settlement_error(settlement: &QuotaSettlement) -> Option<QuotaError> {
+    match settlement {
+        QuotaSettlement::Refunded(_)
+        | QuotaSettlement::AlreadyRefunded(_)
+        | QuotaSettlement::Expired(_) => None,
+        QuotaSettlement::Reserved(_) => None,
+        QuotaSettlement::Finalized(_)
+        | QuotaSettlement::AlreadyFinalized(_)
+        | QuotaSettlement::FinalizedCannotRefund(_) => Some(QuotaError::FinalizedCannotRefund),
+        QuotaSettlement::RefundedCannotFinalize(_) => Some(QuotaError::ReservationConflict),
+    }
+}
+
+fn map_quota_config_error(error: DbError) -> QuotaError {
+    match error {
+        DbError::NotFound => QuotaError::NotConfigured,
+        other => QuotaError::Database(other),
+    }
+}
+
+fn map_reservation_error(error: DbError) -> QuotaError {
+    match error {
+        DbError::NotFound => QuotaError::ReservationNotFound,
+        other => QuotaError::Database(other),
+    }
 }
 
 fn remaining(limit: i64, committed: i64, active_reserved: i64) -> Result<i64, QuotaError> {

--- a/crates/server/src/services/upload/mod.rs
+++ b/crates/server/src/services/upload/mod.rs
@@ -33,7 +33,9 @@ use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
 use crate::auth::permissions::{require_permission, ResolveError};
-use crate::services::quota::{self, QuotaError, UploadQuotaReservation, DEFAULT_RESERVATION_TTL};
+use crate::services::quota::{
+    self, QuotaError, QuotaSnapshot, UploadQuotaReservation, DEFAULT_RESERVATION_TTL,
+};
 use crate::storage::keys::quarantine_key;
 use crate::storage::minio::{MinioClient, ObjectIdentityMeta, ObjectPutVerification};
 use crate::storage::ObjectKey;
@@ -91,6 +93,72 @@ pub async fn quota_reserve_hook(
     bytes: u64,
 ) -> Result<UploadQuotaReservation, QuotaError> {
     quota::reserve_upload(pool, org, reservation_key, bytes, DEFAULT_RESERVATION_TTL).await
+}
+
+#[derive(Debug)]
+pub struct QuotaSettledUpload {
+    pub outcome: UploadOutcome,
+    pub quota_snapshot: QuotaSnapshot,
+}
+
+#[derive(Debug)]
+pub enum QuotaSettledUploadError {
+    Upload(UploadError),
+    Quota(QuotaError),
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_quota_settled_quarantine(
+    pool: deadpool_postgres::Pool,
+    org: OrgContext,
+    storage: MinioClient,
+    limits: LimitsConfig,
+    streamed: StreamedUpload,
+    declared_filename: Option<String>,
+    declared_content_type: Option<String>,
+    reservation_key: String,
+) -> tokio::task::JoinHandle<Result<QuotaSettledUpload, QuotaSettledUploadError>> {
+    tokio::spawn(async move {
+        let outcome = validate_and_quarantine(
+            &org,
+            &storage,
+            &limits,
+            streamed,
+            declared_filename.as_deref(),
+            declared_content_type.as_deref(),
+        )
+        .await;
+        match outcome {
+            Ok(outcome) => match quota::finalize_upload(&pool, &org, &reservation_key).await {
+                Ok(settlement) => Ok(QuotaSettledUpload {
+                    outcome,
+                    quota_snapshot: settlement.storage_quota,
+                }),
+                Err(error) => {
+                    if let Err(cleanup_error) = storage
+                        .cleanup_generated_object(org.org_id(), &outcome.object_key)
+                        .await
+                    {
+                        eprintln!(
+                            "fileconv-server: quota finalize failed and upload cleanup failed: {}",
+                            cleanup_error.code()
+                        );
+                    }
+                    Err(QuotaSettledUploadError::Quota(error))
+                }
+            },
+            Err(error) => {
+                if let Err(refund_error) = quota::refund_upload(&pool, &org, &reservation_key).await
+                {
+                    eprintln!(
+                        "fileconv-server: quota refund after upload failure failed: {}",
+                        refund_error.code()
+                    );
+                }
+                Err(QuotaSettledUploadError::Upload(error))
+            }
+        }
+    })
 }
 
 /// Validate a fully-received tempfile and optionally persist to quarantine storage.

--- a/crates/server/src/services/upload/mod.rs
+++ b/crates/server/src/services/upload/mod.rs
@@ -1,7 +1,10 @@
 //! Quarantine upload intake (P1B-I01): auth → stream → hash → allowlist → disposition.
 //!
-//! Quota reservation is intentionally not implemented here (P1B-I02). Callers must
-//! invoke [`quota_reserve_hook`] which currently logs a TODO and returns Ok.
+//! Upload routes must call [`quota_reserve_hook`] after streaming has produced a
+//! server-measured byte count, then finalize the returned reservation only after
+//! object-store persistence succeeds. Failures after reservation must refund; if
+//! a process crashes, the reservation TTL releases admission and the expiry sweep
+//! marks it terminal.
 
 mod archive;
 mod error;
@@ -30,6 +33,7 @@ use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
 use crate::auth::permissions::{require_permission, ResolveError};
+use crate::services::quota::{self, QuotaError, UploadQuotaReservation, DEFAULT_RESERVATION_TTL};
 use crate::storage::keys::quarantine_key;
 use crate::storage::minio::{MinioClient, ObjectIdentityMeta, ObjectPutVerification};
 use crate::storage::ObjectKey;
@@ -75,14 +79,18 @@ pub struct UploadOutcome {
     pub original_filename: Option<String>,
 }
 
-/// Integration hook for P1B-I02 quota reservation (not implemented).
+/// Integration hook for P1B-I02 quota reservation.
 ///
-/// Callers must invoke this before streaming bytes. Today it is a no-op success
-/// so intake remains fail-open on quota until I02 lands — the hook exists so the
-/// call site is unambiguous.
-pub fn quota_reserve_hook(_org: &OrgContext, _idempotency_key: &str, _bytes: Option<u64>) {
-    // TODO(P1B-I02): atomically reserve tenant quota with an idempotency key
-    // before accepting upload bytes; release on rejection/timeout.
+/// The amount comes from `StreamedUpload::size_bytes`, not from a request field.
+/// One upload reserves storage bytes and one document slot under server-derived
+/// child keys. `reservation_key` must be server-minted by the caller.
+pub async fn quota_reserve_hook(
+    pool: &deadpool_postgres::Pool,
+    org: &OrgContext,
+    reservation_key: &str,
+    bytes: u64,
+) -> Result<UploadQuotaReservation, QuotaError> {
+    quota::reserve_upload(pool, org, reservation_key, bytes, DEFAULT_RESERVATION_TTL).await
 }
 
 /// Validate a fully-received tempfile and optionally persist to quarantine storage.
@@ -98,9 +106,6 @@ pub async fn validate_and_quarantine(
         ResolveError::PermissionDenied => UploadError::PermissionDenied,
         _ => UploadError::Internal,
     })?;
-
-    // TODO(P1B-I02): pass expected size into quota_reserve_hook once implemented.
-    quota_reserve_hook(org, "upload", Some(streamed.size_bytes));
 
     let mut validation_file = streamed.rewinded_file_clone()?;
     let head = streamed.head.clone();

--- a/crates/server/src/services/upload/mod.rs
+++ b/crates/server/src/services/upload/mod.rs
@@ -104,7 +104,10 @@ pub struct QuotaSettledUpload {
 #[derive(Debug)]
 pub enum QuotaSettledUploadError {
     Upload(UploadError),
-    Quota(QuotaError),
+    Quota {
+        error: QuotaError,
+        outcome: Box<UploadOutcome>,
+    },
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -135,16 +138,37 @@ pub fn spawn_quota_settled_quarantine(
                     quota_snapshot: settlement.storage_quota,
                 }),
                 Err(error) => {
+                    // In-process settlement guarantee: after storage succeeds but quota
+                    // finalize fails, release quota before deleting the untrusted
+                    // quarantine object. If either best-effort cleanup step fails, the
+                    // reservation TTL/sweep prevents permanent over-limit state and the
+                    // quarantine object remains eligible for later GC.
+                    // TODO(I03/I07): durable finalize/cleanup reconciliation on crash / double-failure.
+                    if let Err(refund_error) =
+                        quota::refund_upload(&pool, &org, &reservation_key).await
+                    {
+                        eprintln!(
+                            "fileconv-server: quota refund after finalize failure failed; \
+                             reservation_key={} code={}",
+                            reservation_key,
+                            refund_error.code()
+                        );
+                    }
                     if let Err(cleanup_error) = storage
                         .cleanup_generated_object(org.org_id(), &outcome.object_key)
                         .await
                     {
                         eprintln!(
-                            "fileconv-server: quota finalize failed and upload cleanup failed: {}",
+                            "fileconv-server: quota finalize failed and upload cleanup failed; \
+                             reservation_key={} code={}",
+                            reservation_key,
                             cleanup_error.code()
                         );
                     }
-                    Err(QuotaSettledUploadError::Quota(error))
+                    Err(QuotaSettledUploadError::Quota {
+                        error,
+                        outcome: Box::new(outcome),
+                    })
                 }
             },
             Err(error) => {

--- a/crates/server/tests/quota.rs
+++ b/crates/server/tests/quota.rs
@@ -1,0 +1,735 @@
+//! Live PostgreSQL tests for P1B-I02 atomic quota admission.
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` is unset. These tests use the
+//! non-superuser app role and the same tenant transaction helper as production.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::models::{ReservationStatus, ResourceKind};
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::services::quota::{
+    self, apply_quota_headers, QuotaDenial, QuotaError, QuotaSnapshot,
+};
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("connect failed for {database_url}: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_quota_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+async fn boot_pool(base_url: &str) -> (EphemeralDb, Pool) {
+    let ephemeral = EphemeralDb::create(base_url).await;
+    apply_migrations(&ephemeral.url)
+        .await
+        .expect("apply migrations");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    (ephemeral, pool)
+}
+
+fn ctx(org: Uuid, user: Uuid) -> OrgContext {
+    OrgContext::try_new(org, user, ["doc.upload"], []).expect("ctx")
+}
+
+#[derive(Debug, Clone, Copy)]
+struct QuotaFixture {
+    storage: i64,
+    documents: i32,
+    concurrent: i32,
+    tokens: i64,
+}
+
+async fn seed_org_with_quota(
+    pool: &Pool,
+    org: Uuid,
+    user: Uuid,
+    slug: &str,
+    quota: QuotaFixture,
+) -> OrgContext {
+    let context = ctx(org, user);
+    let slug = slug.to_string();
+    with_org_txn(pool, &context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &context, &slug, &slug).await?;
+                orgs::ensure_user(txn, &context, user, &format!("{slug}@example.test"), &slug)
+                    .await?;
+                orgs::ensure_membership(txn, &context).await?;
+                txn.execute(
+                    "INSERT INTO org_quotas (
+                        org_id, max_storage_bytes, max_documents,
+                        max_concurrent_jobs, max_monthly_tokens
+                     )
+                     VALUES ($1, $2, $3, $4, $5)",
+                    &[
+                        &org,
+                        &quota.storage,
+                        &quota.documents,
+                        &quota.concurrent,
+                        &quota.tokens,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed org quota");
+    context
+}
+
+async fn active_reserved(pool: &Pool, context: &OrgContext, kind: ResourceKind) -> i64 {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                let kind = kind.as_str();
+                let row = txn
+                    .query_one(
+                        "SELECT COALESCE(SUM(amount), 0)::bigint
+                         FROM quota_reservations
+                         WHERE org_id = $1 AND resource_kind = $2
+                           AND status = 'reserved' AND expires_at > now()",
+                        &[&context.org_id(), &kind],
+                    )
+                    .await?;
+                Ok(row.get::<_, i64>(0))
+            })
+        }
+    })
+    .await
+    .expect("active reserved")
+}
+
+async fn counter_value(pool: &Pool, context: &OrgContext, key: &str) -> i64 {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        let key = key.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT COALESCE(SUM(value), 0)::bigint
+                         FROM usage_counters
+                         WHERE org_id = $1 AND counter_key = $2",
+                        &[&context.org_id(), &key],
+                    )
+                    .await?;
+                Ok(row.get::<_, i64>(0))
+            })
+        }
+    })
+    .await
+    .expect("counter value")
+}
+
+async fn reservation_count(pool: &Pool, context: &OrgContext, key: &str) -> i64 {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        let key = key.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM quota_reservations
+                         WHERE org_id = $1 AND reservation_key = $2",
+                        &[&context.org_id(), &key],
+                    )
+                    .await?;
+                Ok(row.get::<_, i64>(0))
+            })
+        }
+    })
+    .await
+    .expect("reservation count")
+}
+
+async fn force_expire(pool: &Pool, context: &OrgContext, key: &str) {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        let key = key.to_string();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE quota_reservations
+                     SET expires_at = now() - interval '1 second'
+                     WHERE org_id = $1 AND reservation_key = $2",
+                    &[&context.org_id(), &key],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("force expire");
+}
+
+#[tokio::test]
+async fn concurrent_reserve_does_not_over_reserve() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let pool = Arc::new(pool);
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-concurrent",
+        QuotaFixture {
+            storage: 5,
+            documents: 100,
+            concurrent: 10,
+            tokens: 100,
+        },
+    )
+    .await;
+
+    let attempts = 16;
+    let mut tasks = Vec::new();
+    for idx in 0..attempts {
+        let pool = Arc::clone(&pool);
+        let context = context.clone();
+        tasks.push(tokio::spawn(async move {
+            quota::reserve(
+                &pool,
+                &context,
+                &format!("concurrent-{idx}"),
+                ResourceKind::StorageBytes,
+                1,
+                Duration::from_secs(60),
+                None,
+            )
+            .await
+        }));
+    }
+
+    let mut succeeded = 0;
+    let mut denied = 0;
+    for task in tasks {
+        match task.await.expect("join") {
+            Ok(_) => succeeded += 1,
+            Err(QuotaError::QuotaExceeded(_)) => denied += 1,
+            Err(error) => panic!("unexpected quota error: {error:?}"),
+        }
+    }
+    assert_eq!(succeeded, 5);
+    assert_eq!(denied, attempts - 5);
+    assert_eq!(
+        active_reserved(&pool, &context, ResourceKind::StorageBytes).await,
+        5
+    );
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn terminal_settlement_is_idempotent_and_typed() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-settle",
+        QuotaFixture {
+            storage: 100,
+            documents: 10,
+            concurrent: 1,
+            tokens: 100,
+        },
+    )
+    .await;
+
+    quota::reserve(
+        &pool,
+        &context,
+        "finalize-once",
+        ResourceKind::StorageBytes,
+        7,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+    quota::finalize(&pool, &context, "finalize-once")
+        .await
+        .unwrap();
+    quota::finalize(&pool, &context, "finalize-once")
+        .await
+        .unwrap();
+    assert_eq!(counter_value(&pool, &context, "storage_bytes").await, 7);
+    assert!(matches!(
+        quota::refund(&pool, &context, "finalize-once").await,
+        Err(QuotaError::FinalizedCannotRefund)
+    ));
+
+    quota::reserve(
+        &pool,
+        &context,
+        "refund-once",
+        ResourceKind::StorageBytes,
+        5,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+    quota::refund(&pool, &context, "refund-once").await.unwrap();
+    quota::refund(&pool, &context, "refund-once").await.unwrap();
+    assert_eq!(
+        active_reserved(&pool, &context, ResourceKind::StorageBytes).await,
+        0
+    );
+    assert!(matches!(
+        quota::finalize(&pool, &context, "refund-once").await,
+        Err(QuotaError::RefundedCannotFinalize)
+    ));
+
+    quota::reserve(
+        &pool,
+        &context,
+        "expire-once",
+        ResourceKind::StorageBytes,
+        5,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+    force_expire(&pool, &context, "expire-once").await;
+    assert_eq!(
+        quota::expire_reserved(&pool, &context, 10).await.unwrap(),
+        1
+    );
+    assert!(matches!(
+        quota::finalize(&pool, &context, "expire-once").await,
+        Err(QuotaError::ExpiredCannotFinalize)
+    ));
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn idempotency_key_retries_create_one_reservation() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let pool = Arc::new(pool);
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-idem",
+        QuotaFixture {
+            storage: 10,
+            documents: 10,
+            concurrent: 10,
+            tokens: 10,
+        },
+    )
+    .await;
+
+    let first = quota::reserve(
+        &pool,
+        &context,
+        "same-key",
+        ResourceKind::StorageBytes,
+        1,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+    let second = quota::reserve(
+        &pool,
+        &context,
+        "same-key",
+        ResourceKind::StorageBytes,
+        1,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(first.created);
+    assert!(!second.created);
+    assert_eq!(first.reservation.id, second.reservation.id);
+
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let pool = Arc::clone(&pool);
+        let context = context.clone();
+        tasks.push(tokio::spawn(async move {
+            quota::reserve(
+                &pool,
+                &context,
+                "same-key-concurrent",
+                ResourceKind::StorageBytes,
+                1,
+                Duration::from_secs(60),
+                None,
+            )
+            .await
+            .expect("same-key reserve")
+            .reservation
+            .id
+        }));
+    }
+    let mut ids = Vec::new();
+    for task in tasks {
+        ids.push(task.await.expect("join"));
+    }
+    assert!(ids.iter().all(|id| *id == ids[0]));
+    assert_eq!(
+        reservation_count(&pool, &context, "same-key-concurrent").await,
+        1
+    );
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn expired_crash_reservation_does_not_block_and_sweeps() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-crash",
+        QuotaFixture {
+            storage: 1,
+            documents: 10,
+            concurrent: 10,
+            tokens: 10,
+        },
+    )
+    .await;
+
+    quota::reserve(
+        &pool,
+        &context,
+        "crashed",
+        ResourceKind::StorageBytes,
+        1,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+    force_expire(&pool, &context, "crashed").await;
+    quota::reserve(
+        &pool,
+        &context,
+        "replacement",
+        ResourceKind::StorageBytes,
+        1,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .expect("expired reservation must not block");
+    assert_eq!(
+        quota::expire_reserved(&pool, &context, 10).await.unwrap(),
+        1
+    );
+
+    with_org_txn(&pool, &context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                let status: String = txn
+                    .query_one(
+                        "SELECT status FROM quota_reservations
+                         WHERE org_id = $1 AND reservation_key = 'crashed'",
+                        &[&context.org_id()],
+                    )
+                    .await?
+                    .get(0);
+                assert_eq!(status, ReservationStatus::Expired.as_str());
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn overflow_paths_reject_without_wrap_or_panic() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-overflow",
+        QuotaFixture {
+            storage: i64::MAX,
+            documents: 10,
+            concurrent: 10,
+            tokens: 10,
+        },
+    )
+    .await;
+
+    assert!(matches!(
+        quota::reserve(
+            &pool,
+            &context,
+            "too-large",
+            ResourceKind::StorageBytes,
+            i64::MAX as u64 + 1,
+            Duration::from_secs(60),
+            None,
+        )
+        .await,
+        Err(QuotaError::InvalidAmount)
+    ));
+
+    with_org_txn(&pool, &context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO usage_counters (
+                        org_id, counter_key, period_start, period_end, value
+                     )
+                     VALUES (
+                        $1, 'storage_bytes',
+                        timestamptz '1970-01-01 00:00:00+00',
+                        timestamptz '9999-12-31 00:00:00+00',
+                        $2
+                     )",
+                    &[&context.org_id(), &i64::MAX],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO quota_reservations (
+                        org_id, reservation_key, resource_kind, amount, expires_at
+                     )
+                     VALUES ($1, 'overflow-finalize', 'storage_bytes', 1, now() + interval '1 hour')",
+                    &[&context.org_id()],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+    assert!(matches!(
+        quota::finalize(&pool, &context, "overflow-finalize").await,
+        Err(QuotaError::ArithmeticOverflow)
+    ));
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn quota_rows_are_org_scoped_by_predicate_and_rls() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let org_a = Uuid::new_v4();
+    let org_b = Uuid::new_v4();
+    let ctx_a = seed_org_with_quota(
+        &pool,
+        org_a,
+        Uuid::new_v4(),
+        "quota-iso-a",
+        QuotaFixture {
+            storage: 10,
+            documents: 10,
+            concurrent: 10,
+            tokens: 10,
+        },
+    )
+    .await;
+    let ctx_b = seed_org_with_quota(
+        &pool,
+        org_b,
+        Uuid::new_v4(),
+        "quota-iso-b",
+        QuotaFixture {
+            storage: 10,
+            documents: 10,
+            concurrent: 10,
+            tokens: 10,
+        },
+    )
+    .await;
+
+    quota::reserve(
+        &pool,
+        &ctx_a,
+        "shared-name",
+        ResourceKind::StorageBytes,
+        3,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+    quota::reserve(
+        &pool,
+        &ctx_b,
+        "shared-name",
+        ResourceKind::StorageBytes,
+        4,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+    quota::finalize(&pool, &ctx_b, "shared-name").await.unwrap();
+
+    assert_eq!(
+        active_reserved(&pool, &ctx_a, ResourceKind::StorageBytes).await,
+        3
+    );
+    assert_eq!(counter_value(&pool, &ctx_a, "storage_bytes").await, 0);
+    assert_eq!(counter_value(&pool, &ctx_b, "storage_bytes").await, 4);
+
+    with_org_txn(&pool, &ctx_a, move |txn| {
+        Box::pin(async move {
+            let leaked: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM quota_reservations WHERE org_id = $1",
+                    &[&org_b],
+                )
+                .await?
+                .get(0);
+            assert_eq!(leaked, 0, "RLS must hide org B quota rows from org A");
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    ephemeral.drop().await;
+}
+
+#[test]
+fn quota_error_and_success_headers_are_resource_scoped() {
+    let denial = QuotaError::QuotaExceeded(QuotaDenial {
+        resource_kind: ResourceKind::ConcurrentJobs,
+        limit: 2,
+        committed: 0,
+        active_reserved: 2,
+        requested: 1,
+        remaining: 0,
+        retry_after_secs: Some(30),
+    });
+    let response = denial.into_response();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        response.headers().get("x-quota-resource").unwrap(),
+        "concurrent_jobs"
+    );
+    assert_eq!(response.headers().get("x-quota-limit").unwrap(), "2");
+    assert_eq!(response.headers().get("x-quota-remaining").unwrap(), "0");
+    assert_eq!(response.headers().get("retry-after").unwrap(), "30");
+
+    let mut headers = axum::http::HeaderMap::new();
+    apply_quota_headers(
+        &mut headers,
+        &QuotaSnapshot {
+            resource_kind: ResourceKind::StorageBytes,
+            limit: 10,
+            committed: 3,
+            active_reserved: 2,
+            remaining: 5,
+        },
+    );
+    assert_eq!(headers.get("x-quota-resource").unwrap(), "storage_bytes");
+    assert_eq!(headers.get("x-quota-used").unwrap(), "3");
+    assert_eq!(headers.get("x-quota-reserved").unwrap(), "2");
+}

--- a/crates/server/tests/quota.rs
+++ b/crates/server/tests/quota.rs
@@ -14,9 +14,11 @@ use fileconv_server::database::apply_migrations;
 use fileconv_server::db::models::{ReservationStatus, ResourceKind};
 use fileconv_server::db::orgs;
 use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::db::quota as db_quota;
 use fileconv_server::services::quota::{
     self, apply_quota_headers, QuotaDenial, QuotaError, QuotaSettlement, QuotaSnapshot,
 };
+use tokio::sync::oneshot;
 use tokio_postgres::NoTls;
 use uuid::Uuid;
 
@@ -163,7 +165,7 @@ async fn active_reserved(pool: &Pool, context: &OrgContext, kind: ResourceKind) 
                         "SELECT COALESCE(SUM(amount), 0)::bigint
                          FROM quota_reservations
                          WHERE org_id = $1 AND resource_kind = $2
-                           AND status = 'reserved' AND expires_at > now()",
+                           AND status = 'reserved' AND expires_at > clock_timestamp()",
                         &[&context.org_id(), &kind],
                     )
                     .await?;
@@ -547,6 +549,63 @@ async fn mismatched_and_terminal_key_reuse_is_rejected() {
         Err(QuotaError::ReservationConflict)
     ));
 
+    let job_a = Uuid::new_v4();
+    let job_b = Uuid::new_v4();
+    with_org_txn(&pool, &context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                for (job_id, key) in [(job_a, "job-a"), (job_b, "job-b")] {
+                    txn.execute(
+                        "INSERT INTO jobs (id, org_id, job_type, idempotency_key)
+                         VALUES ($1, $2, 'convert', $3)",
+                        &[&job_id, &context.org_id(), &key],
+                    )
+                    .await?;
+                }
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+    let first_job = quota::reserve(
+        &pool,
+        &context,
+        "job-key-conflict",
+        ResourceKind::ConcurrentJobs,
+        1,
+        Duration::from_secs(60),
+        Some(job_a),
+    )
+    .await
+    .unwrap();
+    let retry_job = quota::reserve(
+        &pool,
+        &context,
+        "job-key-conflict",
+        ResourceKind::ConcurrentJobs,
+        1,
+        Duration::from_secs(60),
+        Some(job_a),
+    )
+    .await
+    .unwrap();
+    assert_eq!(first_job.reservation.id, retry_job.reservation.id);
+    let job_conflict = quota::reserve(
+        &pool,
+        &context,
+        "job-key-conflict",
+        ResourceKind::ConcurrentJobs,
+        1,
+        Duration::from_secs(60),
+        Some(job_b),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(job_conflict, QuotaError::ReservationConflict));
+    assert_eq!(job_conflict.status_code(), StatusCode::CONFLICT);
+
     ephemeral.drop().await;
 }
 
@@ -783,6 +842,115 @@ async fn expired_crash_reservation_does_not_block_and_sweeps() {
     })
     .await
     .unwrap();
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn finalize_waiting_on_quota_lock_uses_fresh_post_lock_clock() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-stale-clock",
+        QuotaFixture {
+            storage: 10,
+            documents: 10,
+            concurrent: 10,
+            tokens: 10,
+        },
+    )
+    .await;
+
+    quota::reserve(
+        &pool,
+        &context,
+        "expires-while-waiting",
+        ResourceKind::StorageBytes,
+        1,
+        Duration::from_secs(2),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let (locked_tx, locked_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let holder_pool = pool.clone();
+    let holder_ctx = context.clone();
+    let holder = tokio::spawn(async move {
+        let txn_ctx = holder_ctx.clone();
+        with_org_txn(&holder_pool, &holder_ctx, move |txn| {
+            Box::pin(async move {
+                db_quota::lock_admission(txn, &txn_ctx, ResourceKind::StorageBytes).await?;
+                let _ = locked_tx.send(());
+                let _ = release_rx.await;
+                Ok(())
+            })
+        })
+        .await
+    });
+    locked_rx.await.expect("holder acquired quota lock");
+
+    let (started_tx, started_rx) = oneshot::channel();
+    let finalize_pool = pool.clone();
+    let finalize_ctx = context.clone();
+    let finalize = tokio::spawn(async move {
+        let txn_ctx = finalize_ctx.clone();
+        with_org_txn(&finalize_pool, &finalize_ctx, move |txn| {
+            Box::pin(async move {
+                let _ = started_tx.send(());
+                db_quota::lock_admission(txn, &txn_ctx, ResourceKind::StorageBytes).await?;
+                let observed_at = db_quota::fresh_clock_timestamp(txn).await?;
+                let finalized = db_quota::finalize_reserved_by_key(
+                    txn,
+                    &txn_ctx,
+                    "expires-while-waiting",
+                    observed_at,
+                )
+                .await?;
+                let expired = db_quota::expire_reserved_by_key_if_due(
+                    txn,
+                    &txn_ctx,
+                    "expires-while-waiting",
+                    observed_at,
+                )
+                .await?;
+                Ok((finalized, expired))
+            })
+        })
+        .await
+    });
+    started_rx.await.expect("finalize transaction started");
+    tokio::time::sleep(Duration::from_millis(2_200)).await;
+    release_tx.send(()).expect("release holder");
+    holder.await.expect("holder join").expect("holder txn");
+
+    let (finalized, expired) = finalize
+        .await
+        .expect("finalize join")
+        .expect("finalize txn");
+    assert!(finalized.is_none(), "expired reservation must not finalize");
+    assert_eq!(
+        expired.expect("reservation expired after lock wait").status,
+        ReservationStatus::Expired
+    );
+    assert_eq!(counter_value(&pool, &context, "storage_bytes").await, 0);
+    quota::reserve(
+        &pool,
+        &context,
+        "replacement-after-wait",
+        ResourceKind::StorageBytes,
+        10,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .expect("expired reservation releases quota capacity");
 
     ephemeral.drop().await;
 }

--- a/crates/server/tests/quota.rs
+++ b/crates/server/tests/quota.rs
@@ -15,7 +15,7 @@ use fileconv_server::db::models::{ReservationStatus, ResourceKind};
 use fileconv_server::db::orgs;
 use fileconv_server::db::pool::{create_pool, with_org_txn};
 use fileconv_server::services::quota::{
-    self, apply_quota_headers, QuotaDenial, QuotaError, QuotaSnapshot,
+    self, apply_quota_headers, QuotaDenial, QuotaError, QuotaSettlement, QuotaSnapshot,
 };
 use tokio_postgres::NoTls;
 use uuid::Uuid;
@@ -330,16 +330,24 @@ async fn terminal_settlement_is_idempotent_and_typed() {
     )
     .await
     .unwrap();
-    quota::finalize(&pool, &context, "finalize-once")
-        .await
-        .unwrap();
-    quota::finalize(&pool, &context, "finalize-once")
-        .await
-        .unwrap();
+    assert!(matches!(
+        quota::finalize(&pool, &context, "finalize-once")
+            .await
+            .unwrap(),
+        QuotaSettlement::Finalized(_)
+    ));
+    assert!(matches!(
+        quota::finalize(&pool, &context, "finalize-once")
+            .await
+            .unwrap(),
+        QuotaSettlement::AlreadyFinalized(_)
+    ));
     assert_eq!(counter_value(&pool, &context, "storage_bytes").await, 7);
     assert!(matches!(
-        quota::refund(&pool, &context, "finalize-once").await,
-        Err(QuotaError::FinalizedCannotRefund)
+        quota::refund(&pool, &context, "finalize-once")
+            .await
+            .unwrap(),
+        QuotaSettlement::FinalizedCannotRefund(_)
     ));
 
     quota::reserve(
@@ -353,15 +361,23 @@ async fn terminal_settlement_is_idempotent_and_typed() {
     )
     .await
     .unwrap();
-    quota::refund(&pool, &context, "refund-once").await.unwrap();
-    quota::refund(&pool, &context, "refund-once").await.unwrap();
+    assert!(matches!(
+        quota::refund(&pool, &context, "refund-once").await.unwrap(),
+        QuotaSettlement::Refunded(_)
+    ));
+    assert!(matches!(
+        quota::refund(&pool, &context, "refund-once").await.unwrap(),
+        QuotaSettlement::AlreadyRefunded(_)
+    ));
     assert_eq!(
         active_reserved(&pool, &context, ResourceKind::StorageBytes).await,
         0
     );
     assert!(matches!(
-        quota::finalize(&pool, &context, "refund-once").await,
-        Err(QuotaError::RefundedCannotFinalize)
+        quota::finalize(&pool, &context, "refund-once")
+            .await
+            .unwrap(),
+        QuotaSettlement::RefundedCannotFinalize(_)
     ));
 
     quota::reserve(
@@ -381,8 +397,10 @@ async fn terminal_settlement_is_idempotent_and_typed() {
         1
     );
     assert!(matches!(
-        quota::finalize(&pool, &context, "expire-once").await,
-        Err(QuotaError::ExpiredCannotFinalize)
+        quota::finalize(&pool, &context, "expire-once")
+            .await
+            .unwrap(),
+        QuotaSettlement::Expired(_)
     ));
 
     ephemeral.drop().await;
@@ -463,6 +481,236 @@ async fn idempotency_key_retries_create_one_reservation() {
     assert_eq!(
         reservation_count(&pool, &context, "same-key-concurrent").await,
         1
+    );
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn mismatched_and_terminal_key_reuse_is_rejected() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-conflict",
+        QuotaFixture {
+            storage: 10,
+            documents: 10,
+            concurrent: 10,
+            tokens: 10,
+        },
+    )
+    .await;
+
+    quota::reserve(
+        &pool,
+        &context,
+        "reuse-conflict",
+        ResourceKind::StorageBytes,
+        2,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        quota::reserve(
+            &pool,
+            &context,
+            "reuse-conflict",
+            ResourceKind::StorageBytes,
+            3,
+            Duration::from_secs(60),
+            None,
+        )
+        .await,
+        Err(QuotaError::ReservationConflict)
+    ));
+    quota::refund(&pool, &context, "reuse-conflict")
+        .await
+        .unwrap();
+    assert!(matches!(
+        quota::reserve(
+            &pool,
+            &context,
+            "reuse-conflict",
+            ResourceKind::StorageBytes,
+            2,
+            Duration::from_secs(60),
+            None,
+        )
+        .await,
+        Err(QuotaError::ReservationConflict)
+    ));
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn concurrent_finalize_and_refund_do_not_double_apply() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let pool = Arc::new(pool);
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-race",
+        QuotaFixture {
+            storage: 10,
+            documents: 10,
+            concurrent: 10,
+            tokens: 10,
+        },
+    )
+    .await;
+    quota::reserve(
+        &pool,
+        &context,
+        "settle-race",
+        ResourceKind::StorageBytes,
+        4,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let fin_pool = Arc::clone(&pool);
+    let fin_ctx = context.clone();
+    let finalize =
+        tokio::spawn(async move { quota::finalize(&fin_pool, &fin_ctx, "settle-race").await });
+    let refund_pool = Arc::clone(&pool);
+    let refund_ctx = context.clone();
+    let refund =
+        tokio::spawn(async move { quota::refund(&refund_pool, &refund_ctx, "settle-race").await });
+
+    let finalize = finalize.await.unwrap();
+    let refund = refund.await.unwrap();
+    let finalized = matches!(
+        &finalize,
+        Ok(QuotaSettlement::Finalized(_) | QuotaSettlement::AlreadyFinalized(_))
+    ) || matches!(&refund, Ok(QuotaSettlement::FinalizedCannotRefund(_)));
+    let refunded = matches!(
+        &refund,
+        Ok(QuotaSettlement::Refunded(_) | QuotaSettlement::AlreadyRefunded(_))
+    ) || matches!(&finalize, Ok(QuotaSettlement::RefundedCannotFinalize(_)));
+    assert_ne!(finalized, refunded, "exactly one terminal direction wins");
+    assert!(
+        counter_value(&pool, &context, "storage_bytes").await == 0
+            || counter_value(&pool, &context, "storage_bytes").await == 4
+    );
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn upload_two_resource_settlement_is_atomic() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-upload-atomic",
+        QuotaFixture {
+            storage: 100,
+            documents: 10,
+            concurrent: 10,
+            tokens: 10,
+        },
+    )
+    .await;
+
+    quota::reserve_upload(&pool, &context, "upload-atomic", 9, Duration::from_secs(60))
+        .await
+        .unwrap();
+    // Force one member of the two-resource operation to be non-finalizable. The
+    // finalize transaction must not partially increment the other counter.
+    quota::refund(&pool, &context, "upload.documents.upload-atomic")
+        .await
+        .unwrap();
+    assert!(matches!(
+        quota::finalize_upload(&pool, &context, "upload-atomic").await,
+        Err(QuotaError::RefundedCannotFinalize)
+    ));
+    assert_eq!(counter_value(&pool, &context, "storage_bytes").await, 0);
+    assert_eq!(counter_value(&pool, &context, "documents").await, 0);
+    assert_eq!(
+        active_reserved(&pool, &context, ResourceKind::StorageBytes).await,
+        9
+    );
+
+    quota::refund_upload(&pool, &context, "upload-atomic")
+        .await
+        .unwrap();
+    assert_eq!(
+        active_reserved(&pool, &context, ResourceKind::StorageBytes).await,
+        0
+    );
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn concurrent_jobs_admission_respects_limit() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let pool = Arc::new(pool);
+    let context = seed_org_with_quota(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "quota-jobs",
+        QuotaFixture {
+            storage: 100,
+            documents: 10,
+            concurrent: 2,
+            tokens: 10,
+        },
+    )
+    .await;
+    let mut tasks = Vec::new();
+    for idx in 0..6 {
+        let pool = Arc::clone(&pool);
+        let context = context.clone();
+        tasks.push(tokio::spawn(async move {
+            quota::reserve(
+                &pool,
+                &context,
+                &format!("job-{idx}"),
+                ResourceKind::ConcurrentJobs,
+                1,
+                Duration::from_secs(60),
+                None,
+            )
+            .await
+        }));
+    }
+    let mut ok = 0;
+    let mut denied = 0;
+    for task in tasks {
+        match task.await.unwrap() {
+            Ok(_) => ok += 1,
+            Err(QuotaError::QuotaExceeded(_)) => denied += 1,
+            Err(error) => panic!("unexpected error: {error:?}"),
+        }
+    }
+    assert_eq!(ok, 2);
+    assert_eq!(denied, 4);
+    assert_eq!(
+        active_reserved(&pool, &context, ResourceKind::ConcurrentJobs).await,
+        2
     );
 
     ephemeral.drop().await;

--- a/crates/server/tests/uploads.rs
+++ b/crates/server/tests/uploads.rs
@@ -241,6 +241,16 @@ async fn seed_uploader(pool: &Pool, org: Uuid, user: Uuid, email: &str, password
                 orgs::ensure_user(txn, &owned, user, &email, "Uploader").await?;
                 orgs::ensure_membership(txn, &owned).await?;
                 txn.execute(
+                    "INSERT INTO org_quotas (
+                        org_id, max_storage_bytes, max_documents,
+                        max_concurrent_jobs, max_monthly_tokens
+                     )
+                     VALUES ($1, 1073741824, 1000, 10, 1000000)
+                     ON CONFLICT (org_id) DO NOTHING",
+                    &[&org],
+                )
+                .await?;
+                txn.execute(
                     "INSERT INTO permissions (id, code, description)
                      VALUES ($1, 'doc.upload', 'Upload')
                      ON CONFLICT (code) DO NOTHING",
@@ -951,8 +961,28 @@ async fn property_filename_and_magic_never_panic() {
 
 #[tokio::test]
 async fn quota_hook_is_callable() {
-    let org = OrgContext::try_new(Uuid::new_v4(), Uuid::new_v4(), ["doc.upload"], []).unwrap();
-    quota_reserve_hook(&org, "test-idem", Some(12));
+    let Some(db_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&db_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrations");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    seed_uploader(
+        &pool,
+        org,
+        user,
+        "quota-hook@example.test",
+        "correct-password-1",
+    )
+    .await;
+    let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
+    let reservation = quota_reserve_hook(&pool, &ctx, "test-idem", 12)
+        .await
+        .expect("reserve quota");
+    assert_eq!(reservation.storage.reservation.amount, 12);
+    ephemeral.drop().await;
 }
 
 #[tokio::test]

--- a/crates/server/tests/uploads.rs
+++ b/crates/server/tests/uploads.rs
@@ -25,11 +25,12 @@ use fileconv_server::database::apply_migrations;
 use fileconv_server::db::orgs;
 use fileconv_server::db::pool::{create_pool, with_org_txn};
 use fileconv_server::http::{router, AppState};
+use fileconv_server::services::quota as quota_service;
 use fileconv_server::services::upload::{
     assert_disposition_is_typed, detect_magic, quota_reserve_hook, reject_dangerous_entry_name,
-    resolve_canonical_format, stream_to_tempfile, validate_and_quarantine, validate_streamed_bytes,
-    validate_zip_archive, CanonicalFormat, Disposition, LimitsConfig, ReasonCode, ThreatClass,
-    UploadError,
+    resolve_canonical_format, spawn_quota_settled_quarantine, stream_to_tempfile,
+    validate_and_quarantine, validate_streamed_bytes, validate_zip_archive, CanonicalFormat,
+    Disposition, LimitsConfig, QuotaSettledUploadError, ReasonCode, ThreatClass, UploadError,
 };
 use fileconv_server::state::RuntimeState;
 use fileconv_server::storage::keys::{parse_key_for_org, quarantine_key, trusted_key};
@@ -1037,6 +1038,82 @@ async fn quota_hook_is_callable() {
         .await
         .expect("reserve quota");
     assert_eq!(reservation.storage.reservation.amount, 12);
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn finalize_failure_refunds_quota_and_deletes_quarantine_object() {
+    let Some(db_url) = test_database_url() else {
+        return;
+    };
+    let Some((client, _bucket)) = test_minio_client() else {
+        return;
+    };
+    client.ensure_bucket().await.expect("bucket");
+
+    let ephemeral = EphemeralDb::create(&db_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrations");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    seed_uploader(
+        &pool,
+        org,
+        user,
+        "finalize-cleanup@example.test",
+        "correct-password-1",
+    )
+    .await;
+    let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
+    let reservation_key = "finalize-cleanup";
+    let streamed = stream_file(&golden_dir().join("gold-004.pdf")).await;
+    quota_reserve_hook(&pool, &ctx, reservation_key, streamed.size_bytes)
+        .await
+        .expect("reserve quota");
+    quota_service::refund(&pool, &ctx, &format!("upload.documents.{reservation_key}"))
+        .await
+        .expect("force document reservation non-finalizable");
+
+    let handle = spawn_quota_settled_quarantine(
+        pool.clone(),
+        ctx.clone(),
+        client.clone(),
+        LimitsConfig::policy_defaults(),
+        streamed,
+        Some("report.pdf".into()),
+        Some("application/pdf".into()),
+        reservation_key.into(),
+    );
+    let err = handle
+        .await
+        .expect("upload task join")
+        .expect_err("finalize should fail");
+    let outcome = match err {
+        QuotaSettledUploadError::Quota { error, outcome } => {
+            assert!(matches!(
+                error,
+                quota_service::QuotaError::RefundedCannotFinalize
+            ));
+            outcome
+        }
+        other => panic!("unexpected upload task result: {other:?}"),
+    };
+
+    assert!(!client
+        .object_exists(org, &outcome.object_key)
+        .await
+        .expect("object exists"));
+    assert_eq!(
+        quota_reservation_status(&pool, &ctx, "upload.storage.finalize-cleanup").await,
+        Some("refunded".into())
+    );
+    assert_eq!(
+        quota_reservation_status(&pool, &ctx, "upload.documents.finalize-cleanup").await,
+        Some("refunded".into())
+    );
+    assert_eq!(quota_counter_value(&pool, &ctx, "storage_bytes").await, 0);
+    assert_eq!(quota_counter_value(&pool, &ctx, "documents").await, 0);
+
     ephemeral.drop().await;
 }
 

--- a/crates/server/tests/uploads.rs
+++ b/crates/server/tests/uploads.rs
@@ -306,6 +306,61 @@ async fn stream_file(path: &Path) -> fileconv_server::services::upload::Streamed
     .expect("stream")
 }
 
+fn upload_operation_key(org: Uuid, user: Uuid, idempotency_key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(org.as_bytes());
+    hasher.update(user.as_bytes());
+    hasher.update(format!("client:{idempotency_key}").as_bytes());
+    format!("op.{}", hex::encode(hasher.finalize()))
+}
+
+async fn quota_reservation_status(
+    pool: &Pool,
+    ctx: &OrgContext,
+    reservation_key: &str,
+) -> Option<String> {
+    let reservation_key = reservation_key.to_string();
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_opt(
+                        "SELECT status FROM quota_reservations
+                         WHERE org_id = $1 AND reservation_key = $2",
+                        &[&ctx.org_id(), &reservation_key],
+                    )
+                    .await?;
+                Ok(row.map(|row| row.get::<_, String>(0)))
+            })
+        }
+    })
+    .await
+    .expect("quota status")
+}
+
+async fn quota_counter_value(pool: &Pool, ctx: &OrgContext, counter_key: &str) -> i64 {
+    let counter_key = counter_key.to_string();
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT COALESCE(SUM(value), 0)::bigint
+                         FROM usage_counters
+                         WHERE org_id = $1 AND counter_key = $2",
+                        &[&ctx.org_id(), &counter_key],
+                    )
+                    .await?;
+                Ok(row.get::<_, i64>(0))
+            })
+        }
+    })
+    .await
+    .expect("quota counter")
+}
+
 fn write_docx_zip(path: &Path, entries: &[(&str, &[u8])], compression: CompressionMethod) {
     let file = std::fs::File::create(path).unwrap();
     let mut zip = zip::ZipWriter::new(file);
@@ -1257,6 +1312,7 @@ async fn http_upload_happy_and_spoof() {
                 .method("POST")
                 .uri("/api/v1/uploads")
                 .header("authorization", format!("Bearer {token}"))
+                .header("idempotency-key", "http-upload-retry-key")
                 .header(
                     "content-type",
                     format!("multipart/form-data; boundary={BOUNDARY}"),
@@ -1293,6 +1349,25 @@ async fn http_upload_happy_and_spoof() {
         .expect("get stored upload");
     assert_eq!(stored.len(), pdf.len());
     assert_eq!(hex::encode(Sha256::digest(&stored)), json["sha256"]);
+
+    let retry = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/uploads")
+                .header("authorization", format!("Bearer {token}"))
+                .header("idempotency-key", "http-upload-retry-key")
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={BOUNDARY}"),
+                )
+                .body(Body::from(multipart_body("report.pdf", &pdf)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(retry.status(), StatusCode::CONFLICT);
 
     let spoof = std::fs::read(adversarial_dir().join("plain-text.pdf")).unwrap();
     let body = multipart_body("plain-text.pdf", &spoof);
@@ -1383,6 +1458,122 @@ async fn http_upload_happy_and_spoof() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn cancelled_http_upload_settles_quota_consistently() {
+    let Some(db_url) = test_database_url() else {
+        return;
+    };
+    let Some((store, _bucket)) = test_minio_client() else {
+        return;
+    };
+    store.ensure_bucket().await.expect("bucket");
+
+    let ephemeral = EphemeralDb::create(&db_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrations");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    seed_uploader(
+        &pool,
+        org,
+        user,
+        "cancel-quota@example.test",
+        "correct-password-1",
+    )
+    .await;
+    let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
+
+    let runtime = RuntimeState::from_config(ServerConfig::test_with_endpoints(RuntimeEndpoints {
+        database_url: SecretString::new(&ephemeral.url),
+        qdrant_url: "http://127.0.0.1:1".into(),
+        minio_url: "http://127.0.0.1:9000".into(),
+    }))
+    .expect("runtime");
+    let auth = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+    let state_auth = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+    let state =
+        AppState::from_parts_with_store(runtime, pool.clone(), Some(state_auth), Some(store))
+            .expect("state");
+    let app = router(state);
+    let login = auth
+        .login_password(
+            "cancel-quota@example.test",
+            "correct-password-1",
+            &AuthRequestMeta {
+                request_id: "req-cancel-quota".into(),
+            },
+        )
+        .await
+        .expect("login");
+    let token = login.tokens.access_token.expose().to_string();
+
+    let idempotency_key = "cancel-quota-key-1";
+    let operation_key = upload_operation_key(org, user, idempotency_key);
+    let storage_reservation_key = format!("upload.storage.{operation_key}");
+    let payload = vec![b'a'; 8 * 1024 * 1024];
+    let expected_len = payload.len() as i64;
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/uploads")
+        .header("authorization", format!("Bearer {token}"))
+        .header("idempotency-key", idempotency_key)
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={BOUNDARY}"),
+        )
+        .body(Body::from(multipart_body("cancelled.txt", &payload)))
+        .unwrap();
+    let handle = tokio::spawn(app.oneshot(request));
+
+    let mut saw_reservation = false;
+    for _ in 0..100 {
+        if quota_reservation_status(&pool, &ctx, &storage_reservation_key)
+            .await
+            .is_some()
+        {
+            saw_reservation = true;
+            break;
+        }
+        if handle.is_finished() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    assert!(saw_reservation, "request should reach quota reservation");
+    handle.abort();
+    let _ = handle.await;
+
+    let mut terminal = None;
+    for _ in 0..200 {
+        let status = quota_reservation_status(&pool, &ctx, &storage_reservation_key).await;
+        if matches!(
+            status.as_deref(),
+            Some("finalized" | "refunded" | "expired")
+        ) {
+            terminal = status;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    let terminal = terminal.expect("quota reservation reaches terminal state");
+    let storage_counter = quota_counter_value(&pool, &ctx, "storage_bytes").await;
+    match terminal.as_str() {
+        "finalized" => assert_eq!(storage_counter, expected_len),
+        "refunded" | "expired" => assert_eq!(storage_counter, 0),
+        other => panic!("unexpected terminal status {other}"),
+    }
 
     ephemeral.drop().await;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-I02 — Atomic quota admission

Transactional, tenant-scoped quota reserve / finalize / refund with expiry and concurrent-job admission over the F03 `org_quotas` / `usage_counters` / `quota_reservations` schema. Checked arithmetic; the client can never mutate counters.

### Design
- **No over-reservation under concurrency**: admission runs inside `with_org_txn` (RLS `app.org_id`) and takes `pg_advisory_xact_lock(hashtext('quota:'||org_id||':'||resource_kind))` first, serializing admission per (org, resource_kind). `available = limit − committed_usage − active_reserved`, where active = `status='reserved' AND expires_at > now()`.
- **committed_usage**: cumulative kinds (`storage_bytes`, `documents`) use an all-time counter period; `tokens` uses the current UTC month; `concurrent_jobs` has no counter — the live gauge is the active reservations.
- **Idempotency / crash**: `reservation_key` unique per org → retries return the existing reservation; a crashed caller's `reserved` row stops counting once `expires_at` passes and is swept to `expired`.
- **Terminal settlement**: every reservation resolves to `finalized` (counter += amount exactly once, UPSERT), `refunded`, or `expired`; finalize/refund are idempotent and reject illegal transitions (typed errors). TTL guarantees release even without a settle call.
- **Checked arithmetic**: rejects zero, `u64 > i64::MAX`, and add overflow on both admission and counter increment.
- **Middleware/headers**: quota denial → `429 Too Many Requests` (+ `Retry-After` for `concurrent_jobs`), with `X-Quota-Resource/Limit/Used/Reserved/Remaining`.
- **Client cannot modify counters**: only server services mutate reservations/counters; the upload amount is the server-measured `StreamedUpload::size_bytes`, not client input.

### I01 wiring
Upload intake reserves `storage_bytes` + `documents` (server-minted idempotency key), finalizes both on success, refunds both on validation/storage failure; crash paths released by TTL + sweep.

### Tests (live Postgres)
`tests/quota.rs` (7): concurrent admission never over-reserves (real advisory-lock contention), terminal settlement (finalize/refund/expire, idempotent), idempotency/retry, crash-expiry, i64 overflow rejection, org isolation. Plus updated upload tests (25) with seeded quotas; F06 storage (9) still green.

Stacked on #221 (I01).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

