### PR TITLE
feat(server): P1B-I03 durable jobs, outbox and event log

### DIFF
--- a/crates/server/src/db/jobs.rs
+++ b/crates/server/src/db/jobs.rs
@@ -29,11 +29,53 @@ const EVENT_COLUMNS: &str = "id, org_id, sequence_no, event_type, payload_versio
     job_id, document_id, version_id, created_at";
 
 #[derive(Debug, Clone)]
+pub(crate) struct ValidatedJobPayload(JsonValue);
+
+#[derive(Debug, Clone)]
+pub(crate) struct ValidatedEventPayload(JsonValue);
+
+#[derive(Debug, Clone)]
+pub(crate) struct ValidatedCheckpointPayload(JsonValue);
+
+impl ValidatedJobPayload {
+    pub(crate) fn new(value: JsonValue) -> Result<Self, DbError> {
+        validate_id_only_payload(&value)?;
+        Ok(Self(value))
+    }
+
+    fn as_json(&self) -> &JsonValue {
+        &self.0
+    }
+}
+
+impl ValidatedEventPayload {
+    pub(crate) fn new(value: JsonValue) -> Result<Self, DbError> {
+        validate_id_only_payload(&value)?;
+        Ok(Self(value))
+    }
+
+    fn as_json(&self) -> &JsonValue {
+        &self.0
+    }
+}
+
+impl ValidatedCheckpointPayload {
+    pub(crate) fn new(value: JsonValue) -> Result<Self, DbError> {
+        validate_checkpoint_payload(&value)?;
+        Ok(Self(value))
+    }
+
+    fn as_json(&self) -> &JsonValue {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct NewJob<'a> {
     pub id: Uuid,
     pub job_type: JobType,
     pub payload_version: i32,
-    pub payload: &'a JsonValue,
+    pub payload: &'a ValidatedJobPayload,
     pub max_attempts: i32,
     pub idempotency_key: &'a str,
     pub document_id: Option<Uuid>,
@@ -41,7 +83,7 @@ pub struct NewJob<'a> {
     pub available_at: DateTime<Utc>,
     pub outbox_event_type: &'a str,
     pub outbox_payload_version: i32,
-    pub outbox_payload: &'a JsonValue,
+    pub outbox_payload: &'a ValidatedEventPayload,
     pub outbox_idempotency_key: &'a str,
 }
 
@@ -49,7 +91,7 @@ pub struct NewJob<'a> {
 pub struct NewOutboxEvent<'a> {
     pub event_type: &'a str,
     pub payload_version: i32,
-    pub payload: &'a JsonValue,
+    pub payload: &'a ValidatedEventPayload,
     pub idempotency_key: &'a str,
     pub job_id: Option<Uuid>,
 }
@@ -58,7 +100,7 @@ pub struct NewOutboxEvent<'a> {
 pub struct NewEventLogEntry<'a> {
     pub event_type: &'a str,
     pub payload_version: i32,
-    pub payload: &'a JsonValue,
+    pub payload: &'a ValidatedEventPayload,
     pub job_id: Option<Uuid>,
     pub document_id: Option<Uuid>,
     pub version_id: Option<Uuid>,
@@ -75,6 +117,7 @@ pub async fn insert_job_with_outbox(
     input: NewJob<'_>,
 ) -> Result<(Job, bool), DbError> {
     let job_type = input.job_type.as_str();
+    let payload = input.payload.as_json();
     let row = txn
         .query_opt(
             &format!(
@@ -91,7 +134,7 @@ pub async fn insert_job_with_outbox(
                 &ctx.org_id(),
                 &job_type,
                 &input.payload_version,
-                &input.payload,
+                &payload,
                 &input.max_attempts,
                 &input.idempotency_key,
                 &input.document_id,
@@ -149,24 +192,6 @@ pub async fn find_by_idempotency_key(
     row.map(|row| map_job(&row)).transpose()
 }
 
-pub async fn get_by_id(
-    txn: &Transaction<'_>,
-    ctx: &OrgContext,
-    job_id: Uuid,
-) -> Result<Option<Job>, DbError> {
-    let row = txn
-        .query_opt(
-            &format!(
-                "SELECT {JOB_COLUMNS}
-                 FROM jobs
-                 WHERE org_id = $1 AND id = $2"
-            ),
-            &[&ctx.org_id(), &job_id],
-        )
-        .await?;
-    row.map(|row| map_job(&row)).transpose()
-}
-
 pub async fn get_by_id_for_update(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
@@ -189,7 +214,7 @@ pub async fn get_by_id_for_update(
 pub async fn claim_pending(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
-    lease_owner: &str,
+    worker_id: &str,
     limit: i64,
     lease_ttl_secs: i64,
 ) -> Result<Vec<Job>, DbError> {
@@ -208,7 +233,7 @@ pub async fn claim_pending(
                  )
                  UPDATE jobs j
                  SET status = 'leased',
-                     lease_owner = $3,
+                     lease_owner = $3 || ':' || gen_random_uuid()::text,
                      lease_expires_at = clock_timestamp() + ($4::bigint * interval '1 second'),
                      heartbeat_at = clock_timestamp(),
                      started_at = COALESCE(started_at, clock_timestamp()),
@@ -218,7 +243,7 @@ pub async fn claim_pending(
                  WHERE j.org_id = $1 AND j.id = candidates.id
                  RETURNING {JOB_COLUMNS_J}"
             ),
-            &[&ctx.org_id(), &limit, &lease_owner, &lease_ttl_secs],
+            &[&ctx.org_id(), &limit, &worker_id, &lease_ttl_secs],
         )
         .await?;
     rows.iter().map(map_job).collect()
@@ -228,20 +253,28 @@ pub async fn heartbeat(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     job_id: Uuid,
-    lease_owner: &str,
+    lease_token: &str,
+    claimed_attempts: i32,
     lease_ttl_secs: i64,
 ) -> Result<bool, DbError> {
     let updated = txn
         .execute(
             "UPDATE jobs
              SET heartbeat_at = clock_timestamp(),
-                 lease_expires_at = clock_timestamp() + ($4::bigint * interval '1 second'),
+                 lease_expires_at = clock_timestamp() + ($5::bigint * interval '1 second'),
                  updated_at = clock_timestamp()
              WHERE org_id = $1
                AND id = $2
                AND lease_owner = $3
+               AND attempts = $4
                AND status = 'leased'",
-            &[&ctx.org_id(), &job_id, &lease_owner, &lease_ttl_secs],
+            &[
+                &ctx.org_id(),
+                &job_id,
+                &lease_token,
+                &claimed_attempts,
+                &lease_ttl_secs,
+            ],
         )
         .await?;
     Ok(updated == 1)
@@ -251,21 +284,30 @@ pub async fn save_checkpoint(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     job_id: Uuid,
-    lease_owner: &str,
-    checkpoint: &JsonValue,
+    lease_token: &str,
+    claimed_attempts: i32,
+    checkpoint: &ValidatedCheckpointPayload,
 ) -> Result<Option<Job>, DbError> {
+    let checkpoint = checkpoint.as_json();
     let row = txn
         .query_opt(
             &format!(
                 "UPDATE jobs
-                 SET checkpoint = $4, updated_at = clock_timestamp()
+                 SET checkpoint = $5, updated_at = clock_timestamp()
                  WHERE org_id = $1
                    AND id = $2
                    AND lease_owner = $3
+                   AND attempts = $4
                    AND status = 'leased'
                  RETURNING {JOB_COLUMNS}"
             ),
-            &[&ctx.org_id(), &job_id, &lease_owner, &checkpoint],
+            &[
+                &ctx.org_id(),
+                &job_id,
+                &lease_token,
+                &claimed_attempts,
+                &checkpoint,
+            ],
         )
         .await?;
     row.map(|row| map_job(&row)).transpose()
@@ -280,15 +322,26 @@ pub async fn reclaim_expired(
     let rows = txn
         .query(
             &format!(
-                "WITH expired AS (
+                "WITH locked AS (
                     SELECT id
                     FROM jobs
                     WHERE org_id = $1
                       AND status = 'leased'
-                      AND lease_expires_at < clock_timestamp()
                     ORDER BY lease_expires_at, id
                     FOR UPDATE SKIP LOCKED
                     LIMIT $2
+                 ),
+                 observed AS (
+                    SELECT clock_timestamp() AS now
+                 ),
+                 expired AS (
+                    SELECT j.id, observed.now
+                    FROM jobs j
+                    JOIN locked ON locked.id = j.id
+                    CROSS JOIN observed
+                    WHERE j.org_id = $1
+                      AND j.status = 'leased'
+                      AND j.lease_expires_at < observed.now
                  )
                  UPDATE jobs j
                  SET status = CASE
@@ -300,18 +353,18 @@ pub async fn reclaim_expired(
                      heartbeat_at = NULL,
                      available_at = CASE
                          WHEN j.attempts < j.max_attempts
-                             THEN clock_timestamp() + ($3::bigint * interval '1 second')
+                             THEN expired.now + ($3::bigint * interval '1 second')
                          ELSE j.available_at
                      END,
                      finished_at = CASE
                          WHEN j.attempts < j.max_attempts THEN NULL
-                         ELSE clock_timestamp()
+                         ELSE expired.now
                      END,
                      last_error = CASE
                          WHEN j.attempts < j.max_attempts THEN j.last_error
                          ELSE COALESCE(j.last_error, 'lease expired after max attempts')
                      END,
-                     updated_at = clock_timestamp()
+                     updated_at = expired.now
                  FROM expired
                  WHERE j.org_id = $1 AND j.id = expired.id
                  RETURNING {JOB_COLUMNS_J}"
@@ -326,7 +379,8 @@ pub async fn complete_owned(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     job_id: Uuid,
-    lease_owner: &str,
+    lease_token: &str,
+    claimed_attempts: i32,
 ) -> Result<Option<Job>, DbError> {
     let row = txn
         .query_opt(
@@ -341,10 +395,11 @@ pub async fn complete_owned(
                  WHERE org_id = $1
                    AND id = $2
                    AND lease_owner = $3
+                   AND attempts = $4
                    AND status = 'leased'
                  RETURNING {JOB_COLUMNS}"
             ),
-            &[&ctx.org_id(), &job_id, &lease_owner],
+            &[&ctx.org_id(), &job_id, &lease_token, &claimed_attempts],
         )
         .await?;
     row.map(|row| map_job(&row)).transpose()
@@ -354,7 +409,8 @@ pub async fn fail_owned(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     job_id: Uuid,
-    lease_owner: &str,
+    lease_token: &str,
+    claimed_attempts: i32,
     last_error: &str,
     backoff_secs: i64,
 ) -> Result<Option<Job>, DbError> {
@@ -371,25 +427,27 @@ pub async fn fail_owned(
                      heartbeat_at = NULL,
                      available_at = CASE
                          WHEN attempts < max_attempts
-                             THEN clock_timestamp() + ($5::bigint * interval '1 second')
+                             THEN clock_timestamp() + ($6::bigint * interval '1 second')
                          ELSE available_at
                      END,
                      finished_at = CASE
                          WHEN attempts < max_attempts THEN NULL
                          ELSE clock_timestamp()
                      END,
-                     last_error = $4,
+                     last_error = $5,
                      updated_at = clock_timestamp()
                  WHERE org_id = $1
                    AND id = $2
                    AND lease_owner = $3
+                   AND attempts = $4
                    AND status = 'leased'
                  RETURNING {JOB_COLUMNS}"
             ),
             &[
                 &ctx.org_id(),
                 &job_id,
-                &lease_owner,
+                &lease_token,
+                &claimed_attempts,
                 &last_error,
                 &backoff_secs,
             ],
@@ -429,6 +487,7 @@ pub async fn insert_outbox_event(
     ctx: &OrgContext,
     input: NewOutboxEvent<'_>,
 ) -> Result<OutboxEvent, DbError> {
+    let payload = input.payload.as_json();
     let row = txn
         .query_opt(
             &format!(
@@ -443,7 +502,7 @@ pub async fn insert_outbox_event(
                 &ctx.org_id(),
                 &input.event_type,
                 &input.payload_version,
-                &input.payload,
+                &payload,
                 &input.idempotency_key,
                 &input.job_id,
             ],
@@ -472,6 +531,7 @@ pub async fn append_event_log(
 ) -> Result<EventLogEntry, DbError> {
     lock_event_log_sequence(txn, ctx).await?;
     let sequence_no = next_event_sequence(txn, ctx).await?;
+    let payload = input.payload.as_json();
     let row = txn
         .query_one(
             &format!(
@@ -487,7 +547,7 @@ pub async fn append_event_log(
                 &sequence_no,
                 &input.event_type,
                 &input.payload_version,
-                &input.payload,
+                &payload,
                 &input.job_id,
                 &input.document_id,
                 &input.version_id,
@@ -517,6 +577,29 @@ pub async fn append_event_and_outbox(
     )
     .await?;
     Ok((entry, outbox))
+}
+
+pub async fn find_outbox_published_event(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    outbox_id: Uuid,
+) -> Result<Option<EventLogEntry>, DbError> {
+    let outbox_id = outbox_id.to_string();
+    let row = txn
+        .query_opt(
+            &format!(
+                "SELECT {EVENT_COLUMNS}
+                 FROM event_log
+                 WHERE org_id = $1
+                   AND event_type = 'outbox.published'
+                   AND payload->>'outbox_event_id' = $2
+                 ORDER BY sequence_no
+                 LIMIT 1"
+            ),
+            &[&ctx.org_id(), &outbox_id],
+        )
+        .await?;
+    row.map(|row| map_event_log_entry(&row)).transpose()
 }
 
 pub async fn claim_unpublished_outbox(
@@ -557,22 +640,6 @@ pub async fn mark_outbox_published(
         )
         .await?;
     row.map(|row| map_outbox_event(&row)).transpose()
-}
-
-pub async fn event_log_sequences(
-    txn: &Transaction<'_>,
-    ctx: &OrgContext,
-) -> Result<Vec<i64>, DbError> {
-    let rows = txn
-        .query(
-            "SELECT sequence_no
-             FROM event_log
-             WHERE org_id = $1
-             ORDER BY sequence_no",
-            &[&ctx.org_id()],
-        )
-        .await?;
-    Ok(rows.into_iter().map(|row| row.get(0)).collect())
 }
 
 async fn lock_event_log_sequence(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<(), DbError> {
@@ -652,4 +719,126 @@ pub(crate) fn map_event_log_entry(row: &Row) -> Result<EventLogEntry, DbError> {
         version_id: row.get("version_id"),
         created_at: row.get("created_at"),
     })
+}
+
+fn validate_id_only_payload(value: &JsonValue) -> Result<(), DbError> {
+    reject_forbidden_keys(value)?;
+    validate_id_only_value(value)
+}
+
+fn reject_forbidden_keys(value: &JsonValue) -> Result<(), DbError> {
+    match value {
+        JsonValue::Object(map) => {
+            for (key, nested) in map {
+                let normalized = key.to_ascii_lowercase();
+                if [
+                    "content", "secret", "token", "password", "markdown", "body", "text",
+                ]
+                .iter()
+                .any(|forbidden| normalized.contains(forbidden))
+                {
+                    return Err(DbError::Config(format!("forbidden payload field: {key}")));
+                }
+                reject_forbidden_keys(nested)?;
+            }
+        }
+        JsonValue::Array(values) => {
+            for nested in values {
+                reject_forbidden_keys(nested)?;
+            }
+        }
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {}
+    }
+    Ok(())
+}
+
+fn validate_id_only_value(value: &JsonValue) -> Result<(), DbError> {
+    match value {
+        JsonValue::Null => Ok(()),
+        JsonValue::String(value) => Uuid::parse_str(value)
+            .map(|_| ())
+            .map_err(|_| DbError::Config("payload strings must be UUIDs".into())),
+        JsonValue::Array(values) => {
+            for nested in values {
+                validate_id_only_value(nested)?;
+            }
+            Ok(())
+        }
+        JsonValue::Object(map) => {
+            for nested in map.values() {
+                validate_id_only_value(nested)?;
+            }
+            Ok(())
+        }
+        JsonValue::Bool(_) | JsonValue::Number(_) => Err(DbError::Config(
+            "job/event payloads may contain only UUID strings, arrays, objects, or null".into(),
+        )),
+    }
+}
+
+fn validate_checkpoint_payload(value: &JsonValue) -> Result<(), DbError> {
+    reject_forbidden_keys(value)?;
+    match value {
+        JsonValue::Object(map) => {
+            for (key, nested) in map {
+                match key.as_str() {
+                    "offset" => {
+                        if !(nested.is_null() || nested.as_u64().is_some()) {
+                            return Err(DbError::Config(
+                                "checkpoint offset must be an unsigned integer".into(),
+                            ));
+                        }
+                    }
+                    _ => validate_id_only_value(nested)?,
+                }
+            }
+            Ok(())
+        }
+        _ => Err(DbError::Config(
+            "checkpoint payload must be an object".into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validated_payloads_reject_nested_forbidden_fields() {
+        assert!(ValidatedJobPayload::new(json!({
+            "document_id": Uuid::new_v4(),
+            "nested": [{ "secret_token": Uuid::new_v4() }]
+        }))
+        .is_err());
+        assert!(ValidatedEventPayload::new(json!({
+            "outbox_event_id": Uuid::new_v4(),
+            "items": [{ "body": Uuid::new_v4() }]
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn repo_write_types_are_validated_newtypes_not_raw_json_values() {
+        let payload = ValidatedJobPayload::new(json!({ "document_id": Uuid::new_v4() }))
+            .expect("validated job payload");
+        let event = ValidatedEventPayload::new(json!({ "job_id": Uuid::new_v4() }))
+            .expect("validated event payload");
+        let _new_job = NewJob {
+            id: Uuid::new_v4(),
+            job_type: JobType::Convert,
+            payload_version: 1,
+            payload: &payload,
+            max_attempts: 1,
+            idempotency_key: "compile-time-typed",
+            document_id: None,
+            version_id: None,
+            available_at: Utc::now(),
+            outbox_event_type: "job.enqueued",
+            outbox_payload_version: 1,
+            outbox_payload: &event,
+            outbox_idempotency_key: "outbox-typed",
+        };
+    }
 }

--- a/crates/server/src/db/jobs.rs
+++ b/crates/server/src/db/jobs.rs
@@ -1,0 +1,655 @@
+//! Tenant-scoped durable job, outbox, and event-log repositories.
+//!
+//! Callers should run these functions inside [`crate::db::pool::with_org_txn`]
+//! so RLS `app.org_id` is set before any row is visible or mutable.
+
+use chrono::{DateTime, Utc};
+use serde_json::Value as JsonValue;
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{EventLogEntry, Job, JobStatus, JobType, OutboxEvent};
+
+const JOB_COLUMNS: &str = "id, org_id, job_type, status, payload_version, payload, attempts, \
+    max_attempts, lease_owner, lease_expires_at, heartbeat_at, checkpoint, idempotency_key, \
+    document_id, version_id, available_at, started_at, finished_at, last_error, created_at, \
+    updated_at";
+
+const JOB_COLUMNS_J: &str = "j.id, j.org_id, j.job_type, j.status, j.payload_version, j.payload, \
+    j.attempts, j.max_attempts, j.lease_owner, j.lease_expires_at, j.heartbeat_at, j.checkpoint, \
+    j.idempotency_key, j.document_id, j.version_id, j.available_at, j.started_at, j.finished_at, \
+    j.last_error, j.created_at, j.updated_at";
+
+const OUTBOX_COLUMNS: &str = "id, org_id, event_type, payload_version, payload, idempotency_key, \
+    job_id, published_at, created_at";
+
+const EVENT_COLUMNS: &str = "id, org_id, sequence_no, event_type, payload_version, payload, \
+    job_id, document_id, version_id, created_at";
+
+#[derive(Debug, Clone)]
+pub struct NewJob<'a> {
+    pub id: Uuid,
+    pub job_type: JobType,
+    pub payload_version: i32,
+    pub payload: &'a JsonValue,
+    pub max_attempts: i32,
+    pub idempotency_key: &'a str,
+    pub document_id: Option<Uuid>,
+    pub version_id: Option<Uuid>,
+    pub available_at: DateTime<Utc>,
+    pub outbox_event_type: &'a str,
+    pub outbox_payload_version: i32,
+    pub outbox_payload: &'a JsonValue,
+    pub outbox_idempotency_key: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewOutboxEvent<'a> {
+    pub event_type: &'a str,
+    pub payload_version: i32,
+    pub payload: &'a JsonValue,
+    pub idempotency_key: &'a str,
+    pub job_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewEventLogEntry<'a> {
+    pub event_type: &'a str,
+    pub payload_version: i32,
+    pub payload: &'a JsonValue,
+    pub job_id: Option<Uuid>,
+    pub document_id: Option<Uuid>,
+    pub version_id: Option<Uuid>,
+}
+
+pub async fn fresh_clock_timestamp(txn: &Transaction<'_>) -> Result<DateTime<Utc>, DbError> {
+    let row = txn.query_one("SELECT clock_timestamp()", &[]).await?;
+    Ok(row.get(0))
+}
+
+pub async fn insert_job_with_outbox(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewJob<'_>,
+) -> Result<(Job, bool), DbError> {
+    let job_type = input.job_type.as_str();
+    let row = txn
+        .query_opt(
+            &format!(
+                "INSERT INTO jobs (
+                    id, org_id, job_type, payload_version, payload, max_attempts,
+                    idempotency_key, document_id, version_id, available_at
+                 )
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                 ON CONFLICT (org_id, job_type, idempotency_key) DO NOTHING
+                 RETURNING {JOB_COLUMNS}"
+            ),
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &job_type,
+                &input.payload_version,
+                &input.payload,
+                &input.max_attempts,
+                &input.idempotency_key,
+                &input.document_id,
+                &input.version_id,
+                &input.available_at,
+            ],
+        )
+        .await?;
+
+    if let Some(row) = row {
+        let job = map_job(&row)?;
+        let outbox = insert_outbox_event(
+            txn,
+            ctx,
+            NewOutboxEvent {
+                event_type: input.outbox_event_type,
+                payload_version: input.outbox_payload_version,
+                payload: input.outbox_payload,
+                idempotency_key: input.outbox_idempotency_key,
+                job_id: Some(job.id),
+            },
+        )
+        .await?;
+        if outbox.job_id != Some(job.id) {
+            return Err(DbError::Config(
+                "outbox idempotency key conflicts with another job".into(),
+            ));
+        }
+        return Ok((job, true));
+    }
+
+    let existing = find_by_idempotency_key(txn, ctx, input.job_type, input.idempotency_key)
+        .await?
+        .ok_or(DbError::NotFound)?;
+    Ok((existing, false))
+}
+
+pub async fn find_by_idempotency_key(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_type: JobType,
+    idempotency_key: &str,
+) -> Result<Option<Job>, DbError> {
+    let job_type = job_type.as_str();
+    let row = txn
+        .query_opt(
+            &format!(
+                "SELECT {JOB_COLUMNS}
+                 FROM jobs
+                 WHERE org_id = $1 AND job_type = $2 AND idempotency_key = $3"
+            ),
+            &[&ctx.org_id(), &job_type, &idempotency_key],
+        )
+        .await?;
+    row.map(|row| map_job(&row)).transpose()
+}
+
+pub async fn get_by_id(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+) -> Result<Option<Job>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "SELECT {JOB_COLUMNS}
+                 FROM jobs
+                 WHERE org_id = $1 AND id = $2"
+            ),
+            &[&ctx.org_id(), &job_id],
+        )
+        .await?;
+    row.map(|row| map_job(&row)).transpose()
+}
+
+pub async fn get_by_id_for_update(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+) -> Result<Option<Job>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "SELECT {JOB_COLUMNS}
+                 FROM jobs
+                 WHERE org_id = $1 AND id = $2
+                 FOR UPDATE"
+            ),
+            &[&ctx.org_id(), &job_id],
+        )
+        .await?;
+    row.map(|row| map_job(&row)).transpose()
+}
+
+pub async fn claim_pending(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    lease_owner: &str,
+    limit: i64,
+    lease_ttl_secs: i64,
+) -> Result<Vec<Job>, DbError> {
+    let rows = txn
+        .query(
+            &format!(
+                "WITH candidates AS (
+                    SELECT id
+                    FROM jobs
+                    WHERE org_id = $1
+                      AND status = 'pending'
+                      AND available_at <= clock_timestamp()
+                    ORDER BY available_at, created_at, id
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT $2
+                 )
+                 UPDATE jobs j
+                 SET status = 'leased',
+                     lease_owner = $3,
+                     lease_expires_at = clock_timestamp() + ($4::bigint * interval '1 second'),
+                     heartbeat_at = clock_timestamp(),
+                     started_at = COALESCE(started_at, clock_timestamp()),
+                     attempts = attempts + 1,
+                     updated_at = clock_timestamp()
+                 FROM candidates
+                 WHERE j.org_id = $1 AND j.id = candidates.id
+                 RETURNING {JOB_COLUMNS_J}"
+            ),
+            &[&ctx.org_id(), &limit, &lease_owner, &lease_ttl_secs],
+        )
+        .await?;
+    rows.iter().map(map_job).collect()
+}
+
+pub async fn heartbeat(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_owner: &str,
+    lease_ttl_secs: i64,
+) -> Result<bool, DbError> {
+    let updated = txn
+        .execute(
+            "UPDATE jobs
+             SET heartbeat_at = clock_timestamp(),
+                 lease_expires_at = clock_timestamp() + ($4::bigint * interval '1 second'),
+                 updated_at = clock_timestamp()
+             WHERE org_id = $1
+               AND id = $2
+               AND lease_owner = $3
+               AND status = 'leased'",
+            &[&ctx.org_id(), &job_id, &lease_owner, &lease_ttl_secs],
+        )
+        .await?;
+    Ok(updated == 1)
+}
+
+pub async fn save_checkpoint(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_owner: &str,
+    checkpoint: &JsonValue,
+) -> Result<Option<Job>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "UPDATE jobs
+                 SET checkpoint = $4, updated_at = clock_timestamp()
+                 WHERE org_id = $1
+                   AND id = $2
+                   AND lease_owner = $3
+                   AND status = 'leased'
+                 RETURNING {JOB_COLUMNS}"
+            ),
+            &[&ctx.org_id(), &job_id, &lease_owner, &checkpoint],
+        )
+        .await?;
+    row.map(|row| map_job(&row)).transpose()
+}
+
+pub async fn reclaim_expired(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    limit: i64,
+    backoff_secs: i64,
+) -> Result<Vec<Job>, DbError> {
+    let rows = txn
+        .query(
+            &format!(
+                "WITH expired AS (
+                    SELECT id
+                    FROM jobs
+                    WHERE org_id = $1
+                      AND status = 'leased'
+                      AND lease_expires_at < clock_timestamp()
+                    ORDER BY lease_expires_at, id
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT $2
+                 )
+                 UPDATE jobs j
+                 SET status = CASE
+                         WHEN j.attempts < j.max_attempts THEN 'pending'
+                         ELSE 'dead_letter'
+                     END,
+                     lease_owner = NULL,
+                     lease_expires_at = NULL,
+                     heartbeat_at = NULL,
+                     available_at = CASE
+                         WHEN j.attempts < j.max_attempts
+                             THEN clock_timestamp() + ($3::bigint * interval '1 second')
+                         ELSE j.available_at
+                     END,
+                     finished_at = CASE
+                         WHEN j.attempts < j.max_attempts THEN NULL
+                         ELSE clock_timestamp()
+                     END,
+                     last_error = CASE
+                         WHEN j.attempts < j.max_attempts THEN j.last_error
+                         ELSE COALESCE(j.last_error, 'lease expired after max attempts')
+                     END,
+                     updated_at = clock_timestamp()
+                 FROM expired
+                 WHERE j.org_id = $1 AND j.id = expired.id
+                 RETURNING {JOB_COLUMNS_J}"
+            ),
+            &[&ctx.org_id(), &limit, &backoff_secs],
+        )
+        .await?;
+    rows.iter().map(map_job).collect()
+}
+
+pub async fn complete_owned(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_owner: &str,
+) -> Result<Option<Job>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "UPDATE jobs
+                 SET status = 'succeeded',
+                     lease_owner = NULL,
+                     lease_expires_at = NULL,
+                     heartbeat_at = NULL,
+                     finished_at = clock_timestamp(),
+                     updated_at = clock_timestamp()
+                 WHERE org_id = $1
+                   AND id = $2
+                   AND lease_owner = $3
+                   AND status = 'leased'
+                 RETURNING {JOB_COLUMNS}"
+            ),
+            &[&ctx.org_id(), &job_id, &lease_owner],
+        )
+        .await?;
+    row.map(|row| map_job(&row)).transpose()
+}
+
+pub async fn fail_owned(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_owner: &str,
+    last_error: &str,
+    backoff_secs: i64,
+) -> Result<Option<Job>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "UPDATE jobs
+                 SET status = CASE
+                         WHEN attempts < max_attempts THEN 'pending'
+                         ELSE 'dead_letter'
+                     END,
+                     lease_owner = NULL,
+                     lease_expires_at = NULL,
+                     heartbeat_at = NULL,
+                     available_at = CASE
+                         WHEN attempts < max_attempts
+                             THEN clock_timestamp() + ($5::bigint * interval '1 second')
+                         ELSE available_at
+                     END,
+                     finished_at = CASE
+                         WHEN attempts < max_attempts THEN NULL
+                         ELSE clock_timestamp()
+                     END,
+                     last_error = $4,
+                     updated_at = clock_timestamp()
+                 WHERE org_id = $1
+                   AND id = $2
+                   AND lease_owner = $3
+                   AND status = 'leased'
+                 RETURNING {JOB_COLUMNS}"
+            ),
+            &[
+                &ctx.org_id(),
+                &job_id,
+                &lease_owner,
+                &last_error,
+                &backoff_secs,
+            ],
+        )
+        .await?;
+    row.map(|row| map_job(&row)).transpose()
+}
+
+pub async fn cancel_job(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+) -> Result<Option<Job>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "UPDATE jobs
+                 SET status = 'cancelled',
+                     lease_owner = NULL,
+                     lease_expires_at = NULL,
+                     heartbeat_at = NULL,
+                     finished_at = clock_timestamp(),
+                     updated_at = clock_timestamp()
+                 WHERE org_id = $1
+                   AND id = $2
+                   AND status IN ('pending', 'leased')
+                 RETURNING {JOB_COLUMNS}"
+            ),
+            &[&ctx.org_id(), &job_id],
+        )
+        .await?;
+    row.map(|row| map_job(&row)).transpose()
+}
+
+pub async fn insert_outbox_event(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewOutboxEvent<'_>,
+) -> Result<OutboxEvent, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "INSERT INTO outbox_events (
+                    org_id, event_type, payload_version, payload, idempotency_key, job_id
+                 )
+                 VALUES ($1, $2, $3, $4, $5, $6)
+                 ON CONFLICT (org_id, event_type, idempotency_key) DO NOTHING
+                 RETURNING {OUTBOX_COLUMNS}"
+            ),
+            &[
+                &ctx.org_id(),
+                &input.event_type,
+                &input.payload_version,
+                &input.payload,
+                &input.idempotency_key,
+                &input.job_id,
+            ],
+        )
+        .await?;
+    if let Some(row) = row {
+        return map_outbox_event(&row);
+    }
+    let row = txn
+        .query_one(
+            &format!(
+                "SELECT {OUTBOX_COLUMNS}
+                 FROM outbox_events
+                 WHERE org_id = $1 AND event_type = $2 AND idempotency_key = $3"
+            ),
+            &[&ctx.org_id(), &input.event_type, &input.idempotency_key],
+        )
+        .await?;
+    map_outbox_event(&row)
+}
+
+pub async fn append_event_log(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewEventLogEntry<'_>,
+) -> Result<EventLogEntry, DbError> {
+    lock_event_log_sequence(txn, ctx).await?;
+    let sequence_no = next_event_sequence(txn, ctx).await?;
+    let row = txn
+        .query_one(
+            &format!(
+                "INSERT INTO event_log (
+                    org_id, sequence_no, event_type, payload_version, payload,
+                    job_id, document_id, version_id
+                 )
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                 RETURNING {EVENT_COLUMNS}"
+            ),
+            &[
+                &ctx.org_id(),
+                &sequence_no,
+                &input.event_type,
+                &input.payload_version,
+                &input.payload,
+                &input.job_id,
+                &input.document_id,
+                &input.version_id,
+            ],
+        )
+        .await?;
+    map_event_log_entry(&row)
+}
+
+pub async fn append_event_and_outbox(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    event: NewEventLogEntry<'_>,
+    outbox_idempotency_key: &str,
+) -> Result<(EventLogEntry, OutboxEvent), DbError> {
+    let entry = append_event_log(txn, ctx, event.clone()).await?;
+    let outbox = insert_outbox_event(
+        txn,
+        ctx,
+        NewOutboxEvent {
+            event_type: event.event_type,
+            payload_version: event.payload_version,
+            payload: event.payload,
+            idempotency_key: outbox_idempotency_key,
+            job_id: event.job_id,
+        },
+    )
+    .await?;
+    Ok((entry, outbox))
+}
+
+pub async fn claim_unpublished_outbox(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    limit: i64,
+) -> Result<Vec<OutboxEvent>, DbError> {
+    let rows = txn
+        .query(
+            &format!(
+                "SELECT {OUTBOX_COLUMNS}
+                 FROM outbox_events
+                 WHERE org_id = $1 AND published_at IS NULL
+                 ORDER BY created_at, id
+                 FOR UPDATE SKIP LOCKED
+                 LIMIT $2"
+            ),
+            &[&ctx.org_id(), &limit],
+        )
+        .await?;
+    rows.iter().map(map_outbox_event).collect()
+}
+
+pub async fn mark_outbox_published(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    outbox_id: Uuid,
+) -> Result<Option<OutboxEvent>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "UPDATE outbox_events
+                 SET published_at = clock_timestamp()
+                 WHERE org_id = $1 AND id = $2 AND published_at IS NULL
+                 RETURNING {OUTBOX_COLUMNS}"
+            ),
+            &[&ctx.org_id(), &outbox_id],
+        )
+        .await?;
+    row.map(|row| map_outbox_event(&row)).transpose()
+}
+
+pub async fn event_log_sequences(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+) -> Result<Vec<i64>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT sequence_no
+             FROM event_log
+             WHERE org_id = $1
+             ORDER BY sequence_no",
+            &[&ctx.org_id()],
+        )
+        .await?;
+    Ok(rows.into_iter().map(|row| row.get(0)).collect())
+}
+
+async fn lock_event_log_sequence(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<(), DbError> {
+    let org = ctx.org_id().to_string();
+    txn.execute(
+        "SELECT pg_advisory_xact_lock(hashtext('eventlog:' || $1))",
+        &[&org],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn next_event_sequence(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<i64, DbError> {
+    let row = txn
+        .query_one(
+            "SELECT COALESCE(MAX(sequence_no), 0)::bigint + 1
+             FROM event_log
+             WHERE org_id = $1",
+            &[&ctx.org_id()],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
+pub(crate) fn map_job(row: &Row) -> Result<Job, DbError> {
+    let job_type: String = row.get("job_type");
+    let status: String = row.get("status");
+    Ok(Job {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        job_type: JobType::parse(&job_type).map_err(DbError::Config)?,
+        status: JobStatus::parse(&status).map_err(DbError::Config)?,
+        payload_version: row.get("payload_version"),
+        payload: row.get("payload"),
+        attempts: row.get("attempts"),
+        max_attempts: row.get("max_attempts"),
+        lease_owner: row.get("lease_owner"),
+        lease_expires_at: row.get("lease_expires_at"),
+        heartbeat_at: row.get("heartbeat_at"),
+        checkpoint: row.get("checkpoint"),
+        idempotency_key: row.get("idempotency_key"),
+        document_id: row.get("document_id"),
+        version_id: row.get("version_id"),
+        available_at: row.get("available_at"),
+        started_at: row.get("started_at"),
+        finished_at: row.get("finished_at"),
+        last_error: row.get("last_error"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+pub(crate) fn map_outbox_event(row: &Row) -> Result<OutboxEvent, DbError> {
+    Ok(OutboxEvent {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        event_type: row.get("event_type"),
+        payload_version: row.get("payload_version"),
+        payload: row.get("payload"),
+        idempotency_key: row.get("idempotency_key"),
+        job_id: row.get("job_id"),
+        published_at: row.get("published_at"),
+        created_at: row.get("created_at"),
+    })
+}
+
+pub(crate) fn map_event_log_entry(row: &Row) -> Result<EventLogEntry, DbError> {
+    Ok(EventLogEntry {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        sequence_no: row.get("sequence_no"),
+        event_type: row.get("event_type"),
+        payload_version: row.get("payload_version"),
+        payload: row.get("payload"),
+        job_id: row.get("job_id"),
+        document_id: row.get("document_id"),
+        version_id: row.get("version_id"),
+        created_at: row.get("created_at"),
+    })
+}

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -4,7 +4,7 @@ pub mod chunks;
 pub mod collections;
 pub mod documents;
 pub mod error;
-pub mod jobs;
+pub(crate) mod jobs;
 pub mod models;
 pub mod orgs;
 pub mod pool;

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -4,6 +4,7 @@ pub mod chunks;
 pub mod collections;
 pub mod documents;
 pub mod error;
+pub mod jobs;
 pub mod models;
 pub mod orgs;
 pub mod pool;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -477,6 +477,29 @@ pub enum JobType {
     EmbeddingBatch,
 }
 
+impl JobType {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Convert => "convert",
+            Self::Index => "index",
+            Self::Delete => "delete",
+            Self::Reconcile => "reconcile",
+            Self::EmbeddingBatch => "embedding_batch",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "convert" => Ok(Self::Convert),
+            "index" => Ok(Self::Index),
+            "delete" => Ok(Self::Delete),
+            "reconcile" => Ok(Self::Reconcile),
+            "embedding_batch" => Ok(Self::EmbeddingBatch),
+            other => Err(format!("unknown job type: {other}")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum JobStatus {
@@ -487,6 +510,33 @@ pub enum JobStatus {
     Failed,
     Cancelled,
     DeadLetter,
+}
+
+impl JobStatus {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Leased => "leased",
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::DeadLetter => "dead_letter",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "pending" => Ok(Self::Pending),
+            "leased" => Ok(Self::Leased),
+            "running" => Ok(Self::Running),
+            "succeeded" => Ok(Self::Succeeded),
+            "failed" => Ok(Self::Failed),
+            "cancelled" => Ok(Self::Cancelled),
+            "dead_letter" => Ok(Self::DeadLetter),
+            other => Err(format!("unknown job status: {other}")),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/server/src/jobs/mod.rs
+++ b/crates/server/src/jobs/mod.rs
@@ -24,7 +24,11 @@ pub const CURRENT_JOB_PAYLOAD_VERSION: i32 = 2;
 pub const CURRENT_EVENT_PAYLOAD_VERSION: i32 = 2;
 
 const MAX_IDEMPOTENCY_KEY_LEN: usize = 160;
-const MAX_LEASE_IDENTIFIER_LEN: usize = 200;
+pub const MAX_WORKER_ID_LEN: usize = 128;
+const LEASE_TOKEN_SEPARATOR_LEN: usize = 1;
+const LEASE_TOKEN_UUID_LEN: usize = 36;
+pub const MAX_LEASE_TOKEN_LEN: usize =
+    MAX_WORKER_ID_LEN + LEASE_TOKEN_SEPARATOR_LEN + LEASE_TOKEN_UUID_LEN;
 const MAX_LAST_ERROR_LEN: usize = 2048;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -305,7 +309,7 @@ pub async fn claim(
     limit: u32,
     lease_ttl: Duration,
 ) -> Result<Vec<Job>, JobError> {
-    validate_lease_identifier(worker_id)?;
+    validate_worker_id(worker_id)?;
     let limit = checked_limit(limit)?;
     let lease_ttl_secs = checked_duration_secs(lease_ttl)?;
     pool::with_org_txn_typed(db_pool, ctx, {
@@ -714,10 +718,15 @@ fn validate_idempotency_key(key: &str) -> Result<(), JobError> {
     Ok(())
 }
 
+fn validate_worker_id(value: &str) -> Result<(), JobError> {
+    if value.is_empty() || value.len() > MAX_WORKER_ID_LEN || value.chars().any(char::is_control) {
+        return Err(JobError::InvalidLeaseOwner);
+    }
+    Ok(())
+}
+
 fn validate_lease_identifier(value: &str) -> Result<(), JobError> {
-    if value.is_empty()
-        || value.len() > MAX_LEASE_IDENTIFIER_LEN
-        || value.chars().any(char::is_control)
+    if value.is_empty() || value.len() > MAX_LEASE_TOKEN_LEN || value.chars().any(char::is_control)
     {
         return Err(JobError::InvalidLeaseOwner);
     }

--- a/crates/server/src/jobs/mod.rs
+++ b/crates/server/src/jobs/mod.rs
@@ -1,0 +1,778 @@
+//! Durable job service, payload contract, and outbox relay.
+//!
+//! Job, outbox, and event payloads are intentionally ID-only. Human content,
+//! filenames, object keys, raw errors, and secrets remain outside payload JSON.
+
+use std::time::Duration;
+
+use chrono::TimeDelta;
+use deadpool_postgres::Pool;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{EventLogEntry, Job, JobStatus, JobType, OutboxEvent};
+use crate::db::{jobs as repo, pool};
+
+pub const CURRENT_JOB_PAYLOAD_VERSION: i32 = 2;
+pub const CURRENT_EVENT_PAYLOAD_VERSION: i32 = 2;
+
+const MAX_IDEMPOTENCY_KEY_LEN: usize = 160;
+const MAX_LEASE_OWNER_LEN: usize = 128;
+const MAX_LAST_ERROR_LEN: usize = 2048;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct JobPayload {
+    pub document_id: Option<Uuid>,
+    pub version_id: Option<Uuid>,
+    pub collection_id: Option<Uuid>,
+    pub upload_id: Option<Uuid>,
+    pub batch_id: Option<Uuid>,
+}
+
+impl JobPayload {
+    pub fn to_json(&self) -> Result<JsonValue, JobError> {
+        let value = serde_json::to_value(self).map_err(|error| {
+            JobError::InvalidPayload(format!("job payload serialization failed: {error}"))
+        })?;
+        assert_id_only_payload(&value)?;
+        Ok(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
+struct JobPayloadV1 {
+    document_id: Option<Uuid>,
+    version_id: Option<Uuid>,
+}
+
+impl From<JobPayloadV1> for JobPayload {
+    fn from(value: JobPayloadV1) -> Self {
+        Self {
+            document_id: value.document_id,
+            version_id: value.version_id,
+            collection_id: None,
+            upload_id: None,
+            batch_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventPayload {
+    pub job_id: Option<Uuid>,
+    pub document_id: Option<Uuid>,
+    pub version_id: Option<Uuid>,
+    pub outbox_event_id: Option<Uuid>,
+}
+
+impl EventPayload {
+    fn for_job(job: &Job) -> Self {
+        Self {
+            job_id: Some(job.id),
+            document_id: job.document_id,
+            version_id: job.version_id,
+            outbox_event_id: None,
+        }
+    }
+
+    fn for_outbox(outbox: &OutboxEvent) -> Self {
+        Self {
+            job_id: outbox.job_id,
+            document_id: None,
+            version_id: None,
+            outbox_event_id: Some(outbox.id),
+        }
+    }
+
+    pub fn to_json(&self) -> Result<JsonValue, JobError> {
+        let value = serde_json::to_value(self).map_err(|error| {
+            JobError::InvalidPayload(format!("event payload serialization failed: {error}"))
+        })?;
+        assert_id_only_payload(&value)?;
+        Ok(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct CheckpointPayload {
+    pub cursor_id: Option<Uuid>,
+    pub completed_ids: Vec<Uuid>,
+    pub offset: Option<u64>,
+}
+
+impl CheckpointPayload {
+    pub fn to_json(&self) -> Result<JsonValue, JobError> {
+        let value = serde_json::to_value(self).map_err(|error| {
+            JobError::InvalidPayload(format!("checkpoint serialization failed: {error}"))
+        })?;
+        assert_checkpoint_payload(&value)?;
+        Ok(value)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EnqueueJob {
+    pub id: Uuid,
+    pub job_type: JobType,
+    pub payload: JobPayload,
+    pub idempotency_key: String,
+    pub max_attempts: u32,
+    pub available_after: Duration,
+}
+
+impl EnqueueJob {
+    pub fn new(job_type: JobType, payload: JobPayload, idempotency_key: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            job_type,
+            payload,
+            idempotency_key: idempotency_key.into(),
+            max_attempts: 5,
+            available_after: Duration::ZERO,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnqueueOutcome {
+    pub job: Job,
+    pub created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CancelOutcome {
+    Cancelled(Job),
+    AlreadyCancelled(Job),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutboxPublication {
+    pub outbox: OutboxEvent,
+    pub event: EventLogEntry,
+}
+
+#[derive(Debug, Error)]
+pub enum JobError {
+    #[error("job payload is invalid: {0}")]
+    InvalidPayload(String),
+    #[error("idempotency key is invalid")]
+    InvalidIdempotencyKey,
+    #[error("lease owner is invalid")]
+    InvalidLeaseOwner,
+    #[error("duration must be positive and fit in PostgreSQL seconds")]
+    InvalidDuration,
+    #[error("limit must be positive and fit in i64")]
+    InvalidLimit,
+    #[error("max attempts must be at least one and fit in i32")]
+    InvalidMaxAttempts,
+    #[error("job lease is not owned by this worker")]
+    LeaseLost,
+    #[error("job was not found")]
+    NotFound,
+    #[error("job in status {0:?} cannot be cancelled")]
+    CannotCancelTerminal(JobStatus),
+    #[error("database error")]
+    Database(#[from] DbError),
+}
+
+impl JobError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidPayload(_) => "job_invalid_payload",
+            Self::InvalidIdempotencyKey => "job_invalid_idempotency_key",
+            Self::InvalidLeaseOwner => "job_invalid_lease_owner",
+            Self::InvalidDuration => "job_invalid_duration",
+            Self::InvalidLimit => "job_invalid_limit",
+            Self::InvalidMaxAttempts => "job_invalid_max_attempts",
+            Self::LeaseLost => "job_lease_lost",
+            Self::NotFound => "job_not_found",
+            Self::CannotCancelTerminal(_) => "job_cannot_cancel_terminal",
+            Self::Database(_) => "job_database_error",
+        }
+    }
+}
+
+pub async fn enqueue(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    input: EnqueueJob,
+) -> Result<EnqueueOutcome, JobError> {
+    validate_idempotency_key(&input.idempotency_key)?;
+    let max_attempts = checked_max_attempts(input.max_attempts)?;
+    let available_after = checked_duration(input.available_after)?;
+    let payload_json = input.payload.to_json()?;
+    validate_job_payload_lineage(&input.payload)?;
+
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let observed_at = repo::fresh_clock_timestamp(txn).await?;
+                let available_at = observed_at
+                    .checked_add_signed(available_after)
+                    .ok_or(JobError::InvalidDuration)?;
+                let event_payload = EventPayload {
+                    job_id: Some(input.id),
+                    document_id: input.payload.document_id,
+                    version_id: input.payload.version_id,
+                    outbox_event_id: None,
+                }
+                .to_json()?;
+                let outbox_idempotency_key = format!("job.enqueued:{}", input.id);
+                let (job, created) = repo::insert_job_with_outbox(
+                    txn,
+                    &ctx,
+                    repo::NewJob {
+                        id: input.id,
+                        job_type: input.job_type,
+                        payload_version: CURRENT_JOB_PAYLOAD_VERSION,
+                        payload: &payload_json,
+                        max_attempts,
+                        idempotency_key: &input.idempotency_key,
+                        document_id: input.payload.document_id,
+                        version_id: input.payload.version_id,
+                        available_at,
+                        outbox_event_type: "job.enqueued",
+                        outbox_payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
+                        outbox_payload: &event_payload,
+                        outbox_idempotency_key: &outbox_idempotency_key,
+                    },
+                )
+                .await?;
+                Ok(EnqueueOutcome { job, created })
+            })
+        }
+    })
+    .await
+}
+
+pub async fn claim(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    lease_owner: &str,
+    limit: u32,
+    lease_ttl: Duration,
+) -> Result<Vec<Job>, JobError> {
+    validate_lease_owner(lease_owner)?;
+    let limit = checked_limit(limit)?;
+    let lease_ttl_secs = checked_duration_secs(lease_ttl)?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let lease_owner = lease_owner.to_string();
+        move |txn| {
+            Box::pin(async move {
+                repo::claim_pending(txn, &ctx, &lease_owner, limit, lease_ttl_secs)
+                    .await
+                    .map_err(Into::into)
+            })
+        }
+    })
+    .await
+}
+
+pub async fn heartbeat(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_owner: &str,
+    lease_ttl: Duration,
+) -> Result<bool, JobError> {
+    validate_lease_owner(lease_owner)?;
+    let lease_ttl_secs = checked_duration_secs(lease_ttl)?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let lease_owner = lease_owner.to_string();
+        move |txn| {
+            Box::pin(async move {
+                repo::heartbeat(txn, &ctx, job_id, &lease_owner, lease_ttl_secs)
+                    .await
+                    .map_err(Into::into)
+            })
+        }
+    })
+    .await
+}
+
+pub async fn checkpoint(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_owner: &str,
+    checkpoint: CheckpointPayload,
+) -> Result<Job, JobError> {
+    validate_lease_owner(lease_owner)?;
+    let checkpoint = checkpoint.to_json()?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let lease_owner = lease_owner.to_string();
+        move |txn| {
+            Box::pin(async move {
+                repo::save_checkpoint(txn, &ctx, job_id, &lease_owner, &checkpoint)
+                    .await?
+                    .ok_or(JobError::LeaseLost)
+            })
+        }
+    })
+    .await
+}
+
+pub async fn reclaim_expired(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    limit: u32,
+    backoff: Duration,
+) -> Result<Vec<Job>, JobError> {
+    let limit = checked_limit(limit)?;
+    let backoff_secs = checked_duration_secs(backoff)?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let jobs = repo::reclaim_expired(txn, &ctx, limit, backoff_secs).await?;
+                for job in &jobs {
+                    let event_type = match job.status {
+                        JobStatus::Pending => "job.reclaimed",
+                        JobStatus::DeadLetter => "job.dead_lettered",
+                        _ => {
+                            return Err(JobError::Database(DbError::Config(format!(
+                                "unexpected reclaim status: {:?}",
+                                job.status
+                            ))));
+                        }
+                    };
+                    let outbox_key = transition_key(job, event_type);
+                    write_job_event(txn, &ctx, job, event_type, &outbox_key).await?;
+                }
+                Ok(jobs)
+            })
+        }
+    })
+    .await
+}
+
+pub async fn complete(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_owner: &str,
+) -> Result<Job, JobError> {
+    validate_lease_owner(lease_owner)?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let lease_owner = lease_owner.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let job = repo::complete_owned(txn, &ctx, job_id, &lease_owner)
+                    .await?
+                    .ok_or(JobError::LeaseLost)?;
+                let outbox_key = transition_key(&job, "job.succeeded");
+                write_job_event(txn, &ctx, &job, "job.succeeded", &outbox_key).await?;
+                Ok(job)
+            })
+        }
+    })
+    .await
+}
+
+pub async fn fail(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_owner: &str,
+    last_error: &str,
+) -> Result<Job, JobError> {
+    validate_lease_owner(lease_owner)?;
+    let last_error = sanitize_last_error(last_error);
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let lease_owner = lease_owner.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let current = repo::get_by_id_for_update(txn, &ctx, job_id)
+                    .await?
+                    .filter(|job| {
+                        job.status == JobStatus::Leased
+                            && job.lease_owner.as_deref() == Some(lease_owner.as_str())
+                    })
+                    .ok_or(JobError::LeaseLost)?;
+                let backoff_secs = backoff_for_attempt(current.attempts)?;
+                let job =
+                    repo::fail_owned(txn, &ctx, job_id, &lease_owner, &last_error, backoff_secs)
+                        .await?
+                        .ok_or(JobError::LeaseLost)?;
+                let event_type = match job.status {
+                    JobStatus::Pending => "job.retry_scheduled",
+                    JobStatus::DeadLetter => "job.dead_lettered",
+                    _ => {
+                        return Err(JobError::Database(DbError::Config(format!(
+                            "unexpected failure status: {:?}",
+                            job.status
+                        ))));
+                    }
+                };
+                let outbox_key = transition_key(&job, event_type);
+                write_job_event(txn, &ctx, &job, event_type, &outbox_key).await?;
+                Ok(job)
+            })
+        }
+    })
+    .await
+}
+
+pub async fn cancel(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    job_id: Uuid,
+) -> Result<CancelOutcome, JobError> {
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let current = repo::get_by_id_for_update(txn, &ctx, job_id)
+                    .await?
+                    .ok_or(JobError::NotFound)?;
+                match current.status {
+                    JobStatus::Pending | JobStatus::Leased => {
+                        let job = repo::cancel_job(txn, &ctx, job_id)
+                            .await?
+                            .ok_or(JobError::NotFound)?;
+                        let outbox_key = transition_key(&job, "job.cancelled");
+                        write_job_event(txn, &ctx, &job, "job.cancelled", &outbox_key).await?;
+                        Ok(CancelOutcome::Cancelled(job))
+                    }
+                    JobStatus::Cancelled => Ok(CancelOutcome::AlreadyCancelled(current)),
+                    JobStatus::Succeeded
+                    | JobStatus::Failed
+                    | JobStatus::DeadLetter
+                    | JobStatus::Running => Err(JobError::CannotCancelTerminal(current.status)),
+                }
+            })
+        }
+    })
+    .await
+}
+
+pub async fn append_event(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    event_type: &str,
+    payload: EventPayload,
+) -> Result<EventLogEntry, JobError> {
+    validate_event_type(event_type)?;
+    let payload = payload.to_json()?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let event_type = event_type.to_string();
+        move |txn| {
+            Box::pin(async move {
+                repo::append_event_log(
+                    txn,
+                    &ctx,
+                    repo::NewEventLogEntry {
+                        event_type: &event_type,
+                        payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
+                        payload: &payload,
+                        job_id: None,
+                        document_id: None,
+                        version_id: None,
+                    },
+                )
+                .await
+                .map_err(Into::into)
+            })
+        }
+    })
+    .await
+}
+
+pub async fn relay_outbox(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    limit: u32,
+) -> Result<Vec<OutboxPublication>, JobError> {
+    let limit = checked_limit(limit)?;
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let outbox_events = repo::claim_unpublished_outbox(txn, &ctx, limit).await?;
+                let mut publications = Vec::with_capacity(outbox_events.len());
+                for outbox in outbox_events {
+                    let payload = EventPayload::for_outbox(&outbox).to_json()?;
+                    let event = repo::append_event_log(
+                        txn,
+                        &ctx,
+                        repo::NewEventLogEntry {
+                            event_type: "outbox.published",
+                            payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
+                            payload: &payload,
+                            job_id: outbox.job_id,
+                            document_id: None,
+                            version_id: None,
+                        },
+                    )
+                    .await?;
+                    let Some(outbox) = repo::mark_outbox_published(txn, &ctx, outbox.id).await?
+                    else {
+                        return Err(JobError::Database(DbError::Config(
+                            "claimed outbox event was already published".into(),
+                        )));
+                    };
+                    publications.push(OutboxPublication { outbox, event });
+                }
+                Ok(publications)
+            })
+        }
+    })
+    .await
+}
+
+pub fn decode_job_payload(version: i32, payload: JsonValue) -> Result<JobPayload, JobError> {
+    assert_id_only_payload(&payload)?;
+    match version {
+        1 => serde_json::from_value::<JobPayloadV1>(payload)
+            .map(Into::into)
+            .map_err(|error| JobError::InvalidPayload(format!("v1 decode failed: {error}"))),
+        2 => serde_json::from_value::<JobPayload>(payload)
+            .map_err(|error| JobError::InvalidPayload(format!("v2 decode failed: {error}"))),
+        other => Err(JobError::InvalidPayload(format!(
+            "unsupported payload version: {other}"
+        ))),
+    }
+}
+
+async fn write_job_event(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    job: &Job,
+    event_type: &str,
+    outbox_idempotency_key: &str,
+) -> Result<(), JobError> {
+    let payload = EventPayload::for_job(job).to_json()?;
+    repo::append_event_and_outbox(
+        txn,
+        ctx,
+        repo::NewEventLogEntry {
+            event_type,
+            payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
+            payload: &payload,
+            job_id: Some(job.id),
+            document_id: job.document_id,
+            version_id: job.version_id,
+        },
+        outbox_idempotency_key,
+    )
+    .await?;
+    Ok(())
+}
+
+fn validate_job_payload_lineage(payload: &JobPayload) -> Result<(), JobError> {
+    if payload.version_id.is_some() && payload.document_id.is_none() {
+        return Err(JobError::InvalidPayload(
+            "version_id requires document_id".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn assert_id_only_payload(value: &JsonValue) -> Result<(), JobError> {
+    assert_no_forbidden_keys(value)?;
+    assert_id_only_value(value)
+}
+
+fn assert_no_forbidden_keys(value: &JsonValue) -> Result<(), JobError> {
+    match value {
+        JsonValue::Object(map) => {
+            for (key, nested) in map {
+                let normalized = key.to_ascii_lowercase();
+                if [
+                    "content", "secret", "token", "password", "markdown", "body", "text",
+                ]
+                .iter()
+                .any(|forbidden| normalized.contains(forbidden))
+                {
+                    return Err(JobError::InvalidPayload(format!(
+                        "forbidden payload field: {key}"
+                    )));
+                }
+                assert_no_forbidden_keys(nested)?;
+            }
+        }
+        JsonValue::Array(values) => {
+            for nested in values {
+                assert_no_forbidden_keys(nested)?;
+            }
+        }
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {}
+    }
+    Ok(())
+}
+
+fn assert_id_only_value(value: &JsonValue) -> Result<(), JobError> {
+    match value {
+        JsonValue::Null => Ok(()),
+        JsonValue::String(value) => Uuid::parse_str(value)
+            .map(|_| ())
+            .map_err(|_| JobError::InvalidPayload("payload strings must be UUIDs".into())),
+        JsonValue::Array(values) => {
+            for nested in values {
+                assert_id_only_value(nested)?;
+            }
+            Ok(())
+        }
+        JsonValue::Object(map) => {
+            for nested in map.values() {
+                assert_id_only_value(nested)?;
+            }
+            Ok(())
+        }
+        JsonValue::Bool(_) | JsonValue::Number(_) => Err(JobError::InvalidPayload(
+            "job/event payloads may contain only UUID strings, arrays, objects, or null".into(),
+        )),
+    }
+}
+
+fn assert_checkpoint_payload(value: &JsonValue) -> Result<(), JobError> {
+    assert_no_forbidden_keys(value)?;
+    match value {
+        JsonValue::Object(map) => {
+            for (key, nested) in map {
+                match key.as_str() {
+                    "offset" => {
+                        if !(nested.is_null() || nested.as_u64().is_some()) {
+                            return Err(JobError::InvalidPayload(
+                                "checkpoint offset must be an unsigned integer".into(),
+                            ));
+                        }
+                    }
+                    _ => assert_id_only_value(nested)?,
+                }
+            }
+            Ok(())
+        }
+        _ => Err(JobError::InvalidPayload(
+            "checkpoint payload must be an object".into(),
+        )),
+    }
+}
+
+fn validate_idempotency_key(key: &str) -> Result<(), JobError> {
+    if key.is_empty() || key.len() > MAX_IDEMPOTENCY_KEY_LEN || key.chars().any(char::is_control) {
+        return Err(JobError::InvalidIdempotencyKey);
+    }
+    Ok(())
+}
+
+fn validate_lease_owner(owner: &str) -> Result<(), JobError> {
+    if owner.is_empty() || owner.len() > MAX_LEASE_OWNER_LEN || owner.chars().any(char::is_control)
+    {
+        return Err(JobError::InvalidLeaseOwner);
+    }
+    Ok(())
+}
+
+fn validate_event_type(event_type: &str) -> Result<(), JobError> {
+    if event_type.trim().is_empty() || event_type.chars().any(char::is_control) {
+        return Err(JobError::InvalidPayload("event_type is invalid".into()));
+    }
+    Ok(())
+}
+
+fn checked_max_attempts(max_attempts: u32) -> Result<i32, JobError> {
+    if max_attempts == 0 {
+        return Err(JobError::InvalidMaxAttempts);
+    }
+    i32::try_from(max_attempts).map_err(|_| JobError::InvalidMaxAttempts)
+}
+
+fn checked_limit(limit: u32) -> Result<i64, JobError> {
+    if limit == 0 {
+        return Err(JobError::InvalidLimit);
+    }
+    Ok(i64::from(limit))
+}
+
+fn checked_duration(duration: Duration) -> Result<TimeDelta, JobError> {
+    TimeDelta::from_std(duration).map_err(|_| JobError::InvalidDuration)
+}
+
+fn checked_duration_secs(duration: Duration) -> Result<i64, JobError> {
+    let secs = duration.as_secs();
+    if secs == 0 {
+        return Err(JobError::InvalidDuration);
+    }
+    i64::try_from(secs).map_err(|_| JobError::InvalidDuration)
+}
+
+fn backoff_for_attempt(attempts: i32) -> Result<i64, JobError> {
+    let attempts = u32::try_from(attempts.max(1)).map_err(|_| JobError::InvalidMaxAttempts)?;
+    let shift = attempts.saturating_sub(1).min(8);
+    Ok(1_i64 << shift)
+}
+
+fn sanitize_last_error(error: &str) -> String {
+    error
+        .chars()
+        .filter(|ch| !ch.is_control())
+        .take(MAX_LAST_ERROR_LEN)
+        .collect()
+}
+
+fn transition_key(job: &Job, event_type: &str) -> String {
+    format!("{event_type}:{}:{}", job.id, job.attempts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn older_job_payload_version_is_backward_readable() {
+        let document_id = Uuid::new_v4();
+        let payload = json!({ "document_id": document_id });
+        let decoded = decode_job_payload(1, payload).expect("decode v1 payload");
+        assert_eq!(decoded.document_id, Some(document_id));
+        assert_eq!(decoded.version_id, None);
+        assert_eq!(decoded.collection_id, None);
+    }
+
+    #[test]
+    fn payload_rejects_content_and_secret_fields() {
+        let content = json!({ "document_id": Uuid::new_v4(), "content": "hello" });
+        assert!(matches!(
+            decode_job_payload(2, content),
+            Err(JobError::InvalidPayload(_))
+        ));
+        let secret = json!({ "secret_token": Uuid::new_v4() });
+        assert!(matches!(
+            decode_job_payload(2, secret),
+            Err(JobError::InvalidPayload(_))
+        ));
+    }
+
+    #[test]
+    fn checkpoint_allows_progress_but_not_text() {
+        let checkpoint = CheckpointPayload {
+            cursor_id: Some(Uuid::new_v4()),
+            completed_ids: vec![Uuid::new_v4()],
+            offset: Some(42),
+        };
+        assert!(checkpoint.to_json().is_ok());
+        assert!(assert_checkpoint_payload(&json!({ "body": "not allowed" })).is_err());
+    }
+
+    #[test]
+    fn backoff_is_bounded_power_of_two() {
+        assert_eq!(backoff_for_attempt(1).unwrap(), 1);
+        assert_eq!(backoff_for_attempt(3).unwrap(), 4);
+        assert_eq!(backoff_for_attempt(99).unwrap(), 256);
+    }
+}

--- a/crates/server/src/jobs/mod.rs
+++ b/crates/server/src/jobs/mod.rs
@@ -3,6 +3,9 @@
 //! Job, outbox, and event payloads are intentionally ID-only. Human content,
 //! filenames, object keys, raw errors, and secrets remain outside payload JSON.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::TimeDelta;
@@ -21,7 +24,7 @@ pub const CURRENT_JOB_PAYLOAD_VERSION: i32 = 2;
 pub const CURRENT_EVENT_PAYLOAD_VERSION: i32 = 2;
 
 const MAX_IDEMPOTENCY_KEY_LEN: usize = 160;
-const MAX_LEASE_OWNER_LEN: usize = 128;
+const MAX_LEASE_IDENTIFIER_LEN: usize = 200;
 const MAX_LAST_ERROR_LEN: usize = 2048;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -39,7 +42,7 @@ impl JobPayload {
         let value = serde_json::to_value(self).map_err(|error| {
             JobError::InvalidPayload(format!("job payload serialization failed: {error}"))
         })?;
-        assert_id_only_payload(&value)?;
+        validate_job_payload_json(&value)?;
         Ok(value)
     }
 }
@@ -94,7 +97,7 @@ impl EventPayload {
         let value = serde_json::to_value(self).map_err(|error| {
             JobError::InvalidPayload(format!("event payload serialization failed: {error}"))
         })?;
-        assert_id_only_payload(&value)?;
+        validate_event_payload_json(&value)?;
         Ok(value)
     }
 }
@@ -112,7 +115,7 @@ impl CheckpointPayload {
         let value = serde_json::to_value(self).map_err(|error| {
             JobError::InvalidPayload(format!("checkpoint serialization failed: {error}"))
         })?;
-        assert_checkpoint_payload(&value)?;
+        validate_checkpoint_payload_json(&value)?;
         Ok(value)
     }
 }
@@ -156,6 +159,48 @@ pub enum CancelOutcome {
 pub struct OutboxPublication {
     pub outbox: OutboxEvent,
     pub event: EventLogEntry,
+}
+
+pub trait OutboxSink: Send + Sync {
+    fn publish<'a>(
+        &'a self,
+        txn: &'a tokio_postgres::Transaction<'_>,
+        ctx: &'a OrgContext,
+        event: &'a OutboxEvent,
+    ) -> Pin<Box<dyn Future<Output = Result<EventLogEntry, JobError>> + Send + 'a>>;
+}
+
+#[derive(Debug, Default)]
+pub struct EventLogOutboxSink;
+
+impl OutboxSink for EventLogOutboxSink {
+    fn publish<'a>(
+        &'a self,
+        txn: &'a tokio_postgres::Transaction<'_>,
+        ctx: &'a OrgContext,
+        event: &'a OutboxEvent,
+    ) -> Pin<Box<dyn Future<Output = Result<EventLogEntry, JobError>> + Send + 'a>> {
+        Box::pin(async move {
+            if let Some(existing) = repo::find_outbox_published_event(txn, ctx, event.id).await? {
+                return Ok(existing);
+            }
+            let payload = validated_event_payload(EventPayload::for_outbox(event))?;
+            repo::append_event_log(
+                txn,
+                ctx,
+                repo::NewEventLogEntry {
+                    event_type: "outbox.published",
+                    payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
+                    payload: &payload,
+                    job_id: event.job_id,
+                    document_id: None,
+                    version_id: None,
+                },
+            )
+            .await
+            .map_err(Into::into)
+        })
+    }
 }
 
 #[derive(Debug, Error)]
@@ -207,7 +252,7 @@ pub async fn enqueue(
     validate_idempotency_key(&input.idempotency_key)?;
     let max_attempts = checked_max_attempts(input.max_attempts)?;
     let available_after = checked_duration(input.available_after)?;
-    let payload_json = input.payload.to_json()?;
+    let payload = validated_job_payload(&input.payload)?;
     validate_job_payload_lineage(&input.payload)?;
 
     pool::with_org_txn_typed(db_pool, ctx, {
@@ -224,7 +269,7 @@ pub async fn enqueue(
                     version_id: input.payload.version_id,
                     outbox_event_id: None,
                 }
-                .to_json()?;
+                .to_validated()?;
                 let outbox_idempotency_key = format!("job.enqueued:{}", input.id);
                 let (job, created) = repo::insert_job_with_outbox(
                     txn,
@@ -233,7 +278,7 @@ pub async fn enqueue(
                         id: input.id,
                         job_type: input.job_type,
                         payload_version: CURRENT_JOB_PAYLOAD_VERSION,
-                        payload: &payload_json,
+                        payload: &payload,
                         max_attempts,
                         idempotency_key: &input.idempotency_key,
                         document_id: input.payload.document_id,
@@ -256,19 +301,19 @@ pub async fn enqueue(
 pub async fn claim(
     db_pool: &Pool,
     ctx: &OrgContext,
-    lease_owner: &str,
+    worker_id: &str,
     limit: u32,
     lease_ttl: Duration,
 ) -> Result<Vec<Job>, JobError> {
-    validate_lease_owner(lease_owner)?;
+    validate_lease_identifier(worker_id)?;
     let limit = checked_limit(limit)?;
     let lease_ttl_secs = checked_duration_secs(lease_ttl)?;
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
-        let lease_owner = lease_owner.to_string();
+        let worker_id = worker_id.to_string();
         move |txn| {
             Box::pin(async move {
-                repo::claim_pending(txn, &ctx, &lease_owner, limit, lease_ttl_secs)
+                repo::claim_pending(txn, &ctx, &worker_id, limit, lease_ttl_secs)
                     .await
                     .map_err(Into::into)
             })
@@ -281,19 +326,31 @@ pub async fn heartbeat(
     db_pool: &Pool,
     ctx: &OrgContext,
     job_id: Uuid,
-    lease_owner: &str,
+    lease_token: &str,
+    claimed_attempts: i32,
     lease_ttl: Duration,
-) -> Result<bool, JobError> {
-    validate_lease_owner(lease_owner)?;
+) -> Result<(), JobError> {
+    validate_lease_identifier(lease_token)?;
     let lease_ttl_secs = checked_duration_secs(lease_ttl)?;
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
-        let lease_owner = lease_owner.to_string();
+        let lease_token = lease_token.to_string();
         move |txn| {
             Box::pin(async move {
-                repo::heartbeat(txn, &ctx, job_id, &lease_owner, lease_ttl_secs)
-                    .await
-                    .map_err(Into::into)
+                if repo::heartbeat(
+                    txn,
+                    &ctx,
+                    job_id,
+                    &lease_token,
+                    claimed_attempts,
+                    lease_ttl_secs,
+                )
+                .await?
+                {
+                    Ok(())
+                } else {
+                    Err(JobError::LeaseLost)
+                }
             })
         }
     })
@@ -304,19 +361,27 @@ pub async fn checkpoint(
     db_pool: &Pool,
     ctx: &OrgContext,
     job_id: Uuid,
-    lease_owner: &str,
+    lease_token: &str,
+    claimed_attempts: i32,
     checkpoint: CheckpointPayload,
 ) -> Result<Job, JobError> {
-    validate_lease_owner(lease_owner)?;
-    let checkpoint = checkpoint.to_json()?;
+    validate_lease_identifier(lease_token)?;
+    let checkpoint = validated_checkpoint_payload(checkpoint)?;
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
-        let lease_owner = lease_owner.to_string();
+        let lease_token = lease_token.to_string();
         move |txn| {
             Box::pin(async move {
-                repo::save_checkpoint(txn, &ctx, job_id, &lease_owner, &checkpoint)
-                    .await?
-                    .ok_or(JobError::LeaseLost)
+                repo::save_checkpoint(
+                    txn,
+                    &ctx,
+                    job_id,
+                    &lease_token,
+                    claimed_attempts,
+                    &checkpoint,
+                )
+                .await?
+                .ok_or(JobError::LeaseLost)
             })
         }
     })
@@ -361,15 +426,16 @@ pub async fn complete(
     db_pool: &Pool,
     ctx: &OrgContext,
     job_id: Uuid,
-    lease_owner: &str,
+    lease_token: &str,
+    claimed_attempts: i32,
 ) -> Result<Job, JobError> {
-    validate_lease_owner(lease_owner)?;
+    validate_lease_identifier(lease_token)?;
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
-        let lease_owner = lease_owner.to_string();
+        let lease_token = lease_token.to_string();
         move |txn| {
             Box::pin(async move {
-                let job = repo::complete_owned(txn, &ctx, job_id, &lease_owner)
+                let job = repo::complete_owned(txn, &ctx, job_id, &lease_token, claimed_attempts)
                     .await?
                     .ok_or(JobError::LeaseLost)?;
                 let outbox_key = transition_key(&job, "job.succeeded");
@@ -385,28 +451,37 @@ pub async fn fail(
     db_pool: &Pool,
     ctx: &OrgContext,
     job_id: Uuid,
-    lease_owner: &str,
+    lease_token: &str,
+    claimed_attempts: i32,
     last_error: &str,
 ) -> Result<Job, JobError> {
-    validate_lease_owner(lease_owner)?;
+    validate_lease_identifier(lease_token)?;
     let last_error = sanitize_last_error(last_error);
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
-        let lease_owner = lease_owner.to_string();
+        let lease_token = lease_token.to_string();
         move |txn| {
             Box::pin(async move {
                 let current = repo::get_by_id_for_update(txn, &ctx, job_id)
                     .await?
                     .filter(|job| {
                         job.status == JobStatus::Leased
-                            && job.lease_owner.as_deref() == Some(lease_owner.as_str())
+                            && job.lease_owner.as_deref() == Some(lease_token.as_str())
+                            && job.attempts == claimed_attempts
                     })
                     .ok_or(JobError::LeaseLost)?;
                 let backoff_secs = backoff_for_attempt(current.attempts)?;
-                let job =
-                    repo::fail_owned(txn, &ctx, job_id, &lease_owner, &last_error, backoff_secs)
-                        .await?
-                        .ok_or(JobError::LeaseLost)?;
+                let job = repo::fail_owned(
+                    txn,
+                    &ctx,
+                    job_id,
+                    &lease_token,
+                    claimed_attempts,
+                    &last_error,
+                    backoff_secs,
+                )
+                .await?
+                .ok_or(JobError::LeaseLost)?;
                 let event_type = match job.status {
                     JobStatus::Pending => "job.retry_scheduled",
                     JobStatus::DeadLetter => "job.dead_lettered",
@@ -440,6 +515,10 @@ pub async fn cancel(
                     .ok_or(JobError::NotFound)?;
                 match current.status {
                     JobStatus::Pending | JobStatus::Leased => {
+                        // External/admin cancel is intentionally token-free: a user can
+                        // cancel pending/running work without knowing a worker lease.
+                        // Worker-side completion/failure/checkpoint remains fenced by
+                        // exact lease token, claimed attempts, and status='leased'.
                         let job = repo::cancel_job(txn, &ctx, job_id)
                             .await?
                             .ok_or(JobError::NotFound)?;
@@ -466,7 +545,7 @@ pub async fn append_event(
     payload: EventPayload,
 ) -> Result<EventLogEntry, JobError> {
     validate_event_type(event_type)?;
-    let payload = payload.to_json()?;
+    let payload = payload.to_validated()?;
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
         let event_type = event_type.to_string();
@@ -497,28 +576,29 @@ pub async fn relay_outbox(
     ctx: &OrgContext,
     limit: u32,
 ) -> Result<Vec<OutboxPublication>, JobError> {
+    let sink = Arc::new(EventLogOutboxSink);
+    relay_outbox_with_sink(db_pool, ctx, limit, &sink).await
+}
+
+pub async fn relay_outbox_with_sink<S>(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    limit: u32,
+    sink: &Arc<S>,
+) -> Result<Vec<OutboxPublication>, JobError>
+where
+    S: OutboxSink + ?Sized + 'static,
+{
     let limit = checked_limit(limit)?;
     pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
+        let sink = Arc::clone(sink);
         move |txn| {
             Box::pin(async move {
                 let outbox_events = repo::claim_unpublished_outbox(txn, &ctx, limit).await?;
                 let mut publications = Vec::with_capacity(outbox_events.len());
                 for outbox in outbox_events {
-                    let payload = EventPayload::for_outbox(&outbox).to_json()?;
-                    let event = repo::append_event_log(
-                        txn,
-                        &ctx,
-                        repo::NewEventLogEntry {
-                            event_type: "outbox.published",
-                            payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
-                            payload: &payload,
-                            job_id: outbox.job_id,
-                            document_id: None,
-                            version_id: None,
-                        },
-                    )
-                    .await?;
+                    let event = sink.publish(txn, &ctx, &outbox).await?;
                     let Some(outbox) = repo::mark_outbox_published(txn, &ctx, outbox.id).await?
                     else {
                         return Err(JobError::Database(DbError::Config(
@@ -535,7 +615,7 @@ pub async fn relay_outbox(
 }
 
 pub fn decode_job_payload(version: i32, payload: JsonValue) -> Result<JobPayload, JobError> {
-    assert_id_only_payload(&payload)?;
+    validate_job_payload_json(&payload)?;
     match version {
         1 => serde_json::from_value::<JobPayloadV1>(payload)
             .map(Into::into)
@@ -555,7 +635,7 @@ async fn write_job_event(
     event_type: &str,
     outbox_idempotency_key: &str,
 ) -> Result<(), JobError> {
-    let payload = EventPayload::for_job(job).to_json()?;
+    let payload = EventPayload::for_job(job).to_validated()?;
     repo::append_event_and_outbox(
         txn,
         ctx,
@@ -573,6 +653,51 @@ async fn write_job_event(
     Ok(())
 }
 
+impl EventPayload {
+    fn to_validated(&self) -> Result<repo::ValidatedEventPayload, JobError> {
+        let value = self.to_json()?;
+        repo::ValidatedEventPayload::new(value).map_err(payload_validation_error)
+    }
+}
+
+fn validated_job_payload(payload: &JobPayload) -> Result<repo::ValidatedJobPayload, JobError> {
+    let value = payload.to_json()?;
+    repo::ValidatedJobPayload::new(value).map_err(payload_validation_error)
+}
+
+fn validated_event_payload(payload: EventPayload) -> Result<repo::ValidatedEventPayload, JobError> {
+    payload.to_validated()
+}
+
+fn validated_checkpoint_payload(
+    checkpoint: CheckpointPayload,
+) -> Result<repo::ValidatedCheckpointPayload, JobError> {
+    let value = checkpoint.to_json()?;
+    repo::ValidatedCheckpointPayload::new(value).map_err(payload_validation_error)
+}
+
+fn validate_job_payload_json(value: &JsonValue) -> Result<(), JobError> {
+    repo::ValidatedJobPayload::new(value.clone())
+        .map(|_| ())
+        .map_err(payload_validation_error)
+}
+
+fn validate_event_payload_json(value: &JsonValue) -> Result<(), JobError> {
+    repo::ValidatedEventPayload::new(value.clone())
+        .map(|_| ())
+        .map_err(payload_validation_error)
+}
+
+fn validate_checkpoint_payload_json(value: &JsonValue) -> Result<(), JobError> {
+    repo::ValidatedCheckpointPayload::new(value.clone())
+        .map(|_| ())
+        .map_err(payload_validation_error)
+}
+
+fn payload_validation_error(error: DbError) -> JobError {
+    JobError::InvalidPayload(error.to_string())
+}
+
 fn validate_job_payload_lineage(payload: &JobPayload) -> Result<(), JobError> {
     if payload.version_id.is_some() && payload.document_id.is_none() {
         return Err(JobError::InvalidPayload(
@@ -582,87 +707,6 @@ fn validate_job_payload_lineage(payload: &JobPayload) -> Result<(), JobError> {
     Ok(())
 }
 
-fn assert_id_only_payload(value: &JsonValue) -> Result<(), JobError> {
-    assert_no_forbidden_keys(value)?;
-    assert_id_only_value(value)
-}
-
-fn assert_no_forbidden_keys(value: &JsonValue) -> Result<(), JobError> {
-    match value {
-        JsonValue::Object(map) => {
-            for (key, nested) in map {
-                let normalized = key.to_ascii_lowercase();
-                if [
-                    "content", "secret", "token", "password", "markdown", "body", "text",
-                ]
-                .iter()
-                .any(|forbidden| normalized.contains(forbidden))
-                {
-                    return Err(JobError::InvalidPayload(format!(
-                        "forbidden payload field: {key}"
-                    )));
-                }
-                assert_no_forbidden_keys(nested)?;
-            }
-        }
-        JsonValue::Array(values) => {
-            for nested in values {
-                assert_no_forbidden_keys(nested)?;
-            }
-        }
-        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {}
-    }
-    Ok(())
-}
-
-fn assert_id_only_value(value: &JsonValue) -> Result<(), JobError> {
-    match value {
-        JsonValue::Null => Ok(()),
-        JsonValue::String(value) => Uuid::parse_str(value)
-            .map(|_| ())
-            .map_err(|_| JobError::InvalidPayload("payload strings must be UUIDs".into())),
-        JsonValue::Array(values) => {
-            for nested in values {
-                assert_id_only_value(nested)?;
-            }
-            Ok(())
-        }
-        JsonValue::Object(map) => {
-            for nested in map.values() {
-                assert_id_only_value(nested)?;
-            }
-            Ok(())
-        }
-        JsonValue::Bool(_) | JsonValue::Number(_) => Err(JobError::InvalidPayload(
-            "job/event payloads may contain only UUID strings, arrays, objects, or null".into(),
-        )),
-    }
-}
-
-fn assert_checkpoint_payload(value: &JsonValue) -> Result<(), JobError> {
-    assert_no_forbidden_keys(value)?;
-    match value {
-        JsonValue::Object(map) => {
-            for (key, nested) in map {
-                match key.as_str() {
-                    "offset" => {
-                        if !(nested.is_null() || nested.as_u64().is_some()) {
-                            return Err(JobError::InvalidPayload(
-                                "checkpoint offset must be an unsigned integer".into(),
-                            ));
-                        }
-                    }
-                    _ => assert_id_only_value(nested)?,
-                }
-            }
-            Ok(())
-        }
-        _ => Err(JobError::InvalidPayload(
-            "checkpoint payload must be an object".into(),
-        )),
-    }
-}
-
 fn validate_idempotency_key(key: &str) -> Result<(), JobError> {
     if key.is_empty() || key.len() > MAX_IDEMPOTENCY_KEY_LEN || key.chars().any(char::is_control) {
         return Err(JobError::InvalidIdempotencyKey);
@@ -670,8 +714,10 @@ fn validate_idempotency_key(key: &str) -> Result<(), JobError> {
     Ok(())
 }
 
-fn validate_lease_owner(owner: &str) -> Result<(), JobError> {
-    if owner.is_empty() || owner.len() > MAX_LEASE_OWNER_LEN || owner.chars().any(char::is_control)
+fn validate_lease_identifier(value: &str) -> Result<(), JobError> {
+    if value.is_empty()
+        || value.len() > MAX_LEASE_IDENTIFIER_LEN
+        || value.chars().any(char::is_control)
     {
         return Err(JobError::InvalidLeaseOwner);
     }
@@ -766,7 +812,7 @@ mod tests {
             offset: Some(42),
         };
         assert!(checkpoint.to_json().is_ok());
-        assert!(assert_checkpoint_payload(&json!({ "body": "not allowed" })).is_err());
+        assert!(validate_checkpoint_payload_json(&json!({ "body": "not allowed" })).is_err());
     }
 
     #[test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,6 +7,7 @@ pub mod database;
 pub mod db;
 pub mod error;
 pub mod http;
+pub mod jobs;
 pub mod routes;
 pub mod services;
 pub mod state;

--- a/crates/server/tests/jobs.rs
+++ b/crates/server/tests/jobs.rs
@@ -1,0 +1,721 @@
+//! Live PostgreSQL tests for P1B-I03 durable jobs, outbox, and event log.
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` is unset. These tests use the
+//! non-superuser app role and production org-scoped transaction helper.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::error::DbError;
+use fileconv_server::db::jobs as db_jobs;
+use fileconv_server::db::models::{Job, JobStatus, JobType};
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::jobs::{
+    self, CancelOutcome, CheckpointPayload, EnqueueJob, EventPayload, JobError, JobPayload,
+    CURRENT_EVENT_PAYLOAD_VERSION, CURRENT_JOB_PAYLOAD_VERSION,
+};
+use serde_json::json;
+use tokio::sync::Barrier;
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("connect failed for {database_url}: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_jobs_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+async fn boot_pool(base_url: &str) -> (EphemeralDb, Pool) {
+    let ephemeral = EphemeralDb::create(base_url).await;
+    apply_migrations(&ephemeral.url)
+        .await
+        .expect("apply migrations");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    (ephemeral, pool)
+}
+
+fn ctx(org: Uuid, user: Uuid) -> OrgContext {
+    OrgContext::try_new(org, user, ["doc.upload"], []).expect("ctx")
+}
+
+async fn seed_org(pool: &Pool, org: Uuid, user: Uuid, slug: &str) -> OrgContext {
+    let context = ctx(org, user);
+    let slug = slug.to_string();
+    with_org_txn(pool, &context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &context, &slug, &slug).await?;
+                orgs::ensure_user(txn, &context, user, &format!("{slug}@example.test"), &slug)
+                    .await?;
+                orgs::ensure_membership(txn, &context).await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed org");
+    context
+}
+
+fn enqueue_spec(key: &str) -> EnqueueJob {
+    EnqueueJob::new(JobType::Convert, JobPayload::default(), key)
+}
+
+async fn enqueue_one(pool: &Pool, context: &OrgContext, key: &str) -> Job {
+    jobs::enqueue(pool, context, enqueue_spec(key))
+        .await
+        .expect("enqueue")
+        .job
+}
+
+async fn enqueue_with_attempts(
+    pool: &Pool,
+    context: &OrgContext,
+    key: &str,
+    max_attempts: u32,
+) -> Job {
+    let mut input = enqueue_spec(key);
+    input.max_attempts = max_attempts;
+    jobs::enqueue(pool, context, input)
+        .await
+        .expect("enqueue")
+        .job
+}
+
+async fn get_job(pool: &Pool, context: &OrgContext, job_id: Uuid) -> Job {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                db_jobs::get_by_id(txn, &context, job_id)
+                    .await?
+                    .ok_or(DbError::NotFound)
+            })
+        }
+    })
+    .await
+    .expect("get job")
+}
+
+async fn table_counts(pool: &Pool, context: &OrgContext) -> (i64, i64, i64) {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT
+                            (SELECT count(*)::bigint FROM jobs WHERE org_id = $1),
+                            (SELECT count(*)::bigint FROM outbox_events WHERE org_id = $1),
+                            (SELECT count(*)::bigint FROM event_log WHERE org_id = $1)",
+                        &[&context.org_id()],
+                    )
+                    .await?;
+                Ok((row.get(0), row.get(1), row.get(2)))
+            })
+        }
+    })
+    .await
+    .expect("table counts")
+}
+
+async fn force_expire(pool: &Pool, context: &OrgContext, job_id: Uuid) {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE jobs
+                     SET lease_expires_at = clock_timestamp() - interval '1 second'
+                     WHERE org_id = $1 AND id = $2",
+                    &[&context.org_id(), &job_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("force expire");
+}
+
+async fn force_available(pool: &Pool, context: &OrgContext, job_id: Uuid) {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE jobs
+                     SET available_at = clock_timestamp() - interval '1 second'
+                     WHERE org_id = $1 AND id = $2",
+                    &[&context.org_id(), &job_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("force available");
+}
+
+async fn unpublished_outbox_count(pool: &Pool, context: &OrgContext) -> i64 {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM outbox_events
+                         WHERE org_id = $1 AND published_at IS NULL",
+                        &[&context.org_id()],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("unpublished count")
+}
+
+#[tokio::test]
+async fn enqueue_and_outbox_are_atomic_and_rollback_together() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-atomic").await;
+
+    let outcome = jobs::enqueue(&pool, &context, enqueue_spec("atomic-ok"))
+        .await
+        .expect("enqueue");
+    assert!(outcome.created);
+    assert_eq!(table_counts(&pool, &context).await, (1, 1, 0));
+
+    let payload = JobPayload::default().to_json().expect("payload");
+    let event_payload = EventPayload {
+        job_id: Some(Uuid::new_v4()),
+        document_id: None,
+        version_id: None,
+        outbox_event_id: None,
+    }
+    .to_json()
+    .expect("event payload");
+    let forced: Result<(), DbError> = with_org_txn(&pool, &context, {
+        let context = context.clone();
+        move |txn| {
+            Box::pin(async move {
+                let now = db_jobs::fresh_clock_timestamp(txn).await?;
+                let job_id = Uuid::new_v4();
+                let outbox_key = format!("job.enqueued:{job_id}");
+                db_jobs::insert_job_with_outbox(
+                    txn,
+                    &context,
+                    db_jobs::NewJob {
+                        id: job_id,
+                        job_type: JobType::Convert,
+                        payload_version: CURRENT_JOB_PAYLOAD_VERSION,
+                        payload: &payload,
+                        max_attempts: 5,
+                        idempotency_key: "forced-rollback",
+                        document_id: None,
+                        version_id: None,
+                        available_at: now,
+                        outbox_event_type: "job.enqueued",
+                        outbox_payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
+                        outbox_payload: &event_payload,
+                        outbox_idempotency_key: &outbox_key,
+                    },
+                )
+                .await?;
+                Err(DbError::Config("forced rollback".into()))
+            })
+        }
+    })
+    .await;
+    assert!(forced.is_err());
+    assert_eq!(table_counts(&pool, &context).await, (1, 1, 0));
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn duplicate_enqueue_returns_existing_job_and_single_outbox() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-dup").await;
+
+    let first = jobs::enqueue(&pool, &context, enqueue_spec("dup-key"))
+        .await
+        .expect("first enqueue");
+    let second = jobs::enqueue(&pool, &context, enqueue_spec("dup-key"))
+        .await
+        .expect("duplicate enqueue");
+
+    assert!(first.created);
+    assert!(!second.created);
+    assert_eq!(first.job.id, second.job.id);
+    assert_eq!(table_counts(&pool, &context).await, (1, 1, 0));
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_claimers_do_not_double_claim_with_skip_locked() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-claim").await;
+    for index in 0..20 {
+        enqueue_one(&pool, &context, &format!("claim-{index}")).await;
+    }
+
+    let pool = Arc::new(pool);
+    let barrier = Arc::new(Barrier::new(8));
+    let mut handles = Vec::new();
+    for worker in 0..8 {
+        let pool = Arc::clone(&pool);
+        let context = context.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            jobs::claim(
+                &pool,
+                &context,
+                &format!("claimer-{worker}"),
+                4,
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("claim")
+            .into_iter()
+            .map(|job| job.id)
+            .collect::<Vec<_>>()
+        }));
+    }
+
+    let mut all_claimed = Vec::new();
+    for handle in handles {
+        all_claimed.extend(handle.await.expect("claimer task"));
+    }
+    let unique: HashSet<_> = all_claimed.iter().copied().collect();
+    assert_eq!(all_claimed.len(), unique.len(), "double-claimed job id");
+    assert_eq!(unique.len(), 20);
+
+    if let Ok(pool) = Arc::try_unwrap(pool) {
+        pool.close();
+    }
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn reclaim_expired_leases_preserves_live_heartbeat_and_dead_letters_exhausted() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-reclaim").await;
+
+    let reclaimable = enqueue_with_attempts(&pool, &context, "reclaimable", 3).await;
+    let exhausted = enqueue_with_attempts(&pool, &context, "exhausted", 1).await;
+    let live = enqueue_with_attempts(&pool, &context, "live", 3).await;
+    let claimed = jobs::claim(&pool, &context, "worker", 3, Duration::from_secs(60))
+        .await
+        .expect("claim");
+    assert_eq!(claimed.len(), 3);
+    force_expire(&pool, &context, reclaimable.id).await;
+    force_expire(&pool, &context, exhausted.id).await;
+    assert!(
+        jobs::heartbeat(&pool, &context, live.id, "worker", Duration::from_secs(60))
+            .await
+            .expect("heartbeat")
+    );
+
+    let reclaimed = jobs::reclaim_expired(&pool, &context, 10, Duration::from_secs(5))
+        .await
+        .expect("reclaim");
+    let reclaimed_ids: HashSet<_> = reclaimed.iter().map(|job| job.id).collect();
+    assert!(reclaimed_ids.contains(&reclaimable.id));
+    assert!(reclaimed_ids.contains(&exhausted.id));
+    assert!(!reclaimed_ids.contains(&live.id));
+
+    let reclaimable = get_job(&pool, &context, reclaimable.id).await;
+    let exhausted = get_job(&pool, &context, exhausted.id).await;
+    let live = get_job(&pool, &context, live.id).await;
+    assert_eq!(reclaimable.status, JobStatus::Pending);
+    assert_eq!(exhausted.status, JobStatus::DeadLetter);
+    assert_eq!(live.status, JobStatus::Leased);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn checkpoint_survives_kill_reclaim_and_resume_claim() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-checkpoint").await;
+    let job = enqueue_one(&pool, &context, "checkpoint").await;
+    jobs::claim(&pool, &context, "worker-a", 1, Duration::from_secs(60))
+        .await
+        .expect("claim");
+
+    let checkpoint = CheckpointPayload {
+        cursor_id: Some(Uuid::new_v4()),
+        completed_ids: vec![Uuid::new_v4(), Uuid::new_v4()],
+        offset: Some(7),
+    };
+    let checkpoint_json = checkpoint.to_json().expect("checkpoint json");
+    jobs::checkpoint(&pool, &context, job.id, "worker-a", checkpoint)
+        .await
+        .expect("checkpoint");
+    force_expire(&pool, &context, job.id).await;
+    jobs::reclaim_expired(&pool, &context, 10, Duration::from_secs(1))
+        .await
+        .expect("reclaim");
+    force_available(&pool, &context, job.id).await;
+    let resumed = jobs::claim(&pool, &context, "worker-b", 1, Duration::from_secs(60))
+        .await
+        .expect("resume claim");
+
+    assert_eq!(resumed.len(), 1);
+    assert_eq!(resumed[0].id, job.id);
+    assert_eq!(resumed[0].checkpoint, Some(checkpoint_json));
+    assert_eq!(resumed[0].attempts, 2);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn fail_retries_with_future_backoff_then_dead_letters_when_exhausted() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-retry").await;
+    let job = enqueue_with_attempts(&pool, &context, "retry", 2).await;
+    jobs::claim(&pool, &context, "worker", 1, Duration::from_secs(60))
+        .await
+        .expect("claim");
+
+    let retry = jobs::fail(&pool, &context, job.id, "worker", "transient")
+        .await
+        .expect("fail retry");
+    assert_eq!(retry.status, JobStatus::Pending);
+    assert!(retry.available_at > retry.updated_at);
+    assert_eq!(retry.last_error.as_deref(), Some("transient"));
+
+    force_available(&pool, &context, job.id).await;
+    jobs::claim(&pool, &context, "worker", 1, Duration::from_secs(60))
+        .await
+        .expect("claim retry");
+    let dead = jobs::fail(&pool, &context, job.id, "worker", "exhausted")
+        .await
+        .expect("fail dead");
+    assert_eq!(dead.status, JobStatus::DeadLetter);
+    assert!(dead.finished_at.is_some());
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn cancel_is_idempotent_and_owner_guards_in_flight_mutations() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-cancel").await;
+
+    let pending = enqueue_one(&pool, &context, "cancel-pending").await;
+    assert!(matches!(
+        jobs::cancel(&pool, &context, pending.id)
+            .await
+            .expect("cancel"),
+        CancelOutcome::Cancelled(_)
+    ));
+    assert!(matches!(
+        jobs::cancel(&pool, &context, pending.id)
+            .await
+            .expect("cancel again"),
+        CancelOutcome::AlreadyCancelled(_)
+    ));
+
+    let leased = enqueue_one(&pool, &context, "cancel-leased").await;
+    jobs::claim(&pool, &context, "owner", 1, Duration::from_secs(60))
+        .await
+        .expect("claim leased");
+    assert!(matches!(
+        jobs::cancel(&pool, &context, leased.id)
+            .await
+            .expect("cancel leased"),
+        CancelOutcome::Cancelled(_)
+    ));
+    assert!(
+        !jobs::heartbeat(&pool, &context, leased.id, "owner", Duration::from_secs(60))
+            .await
+            .expect("heartbeat lost")
+    );
+
+    let guarded = enqueue_one(&pool, &context, "owner-guard").await;
+    jobs::claim(&pool, &context, "owner-a", 1, Duration::from_secs(60))
+        .await
+        .expect("claim guarded");
+    assert!(matches!(
+        jobs::complete(&pool, &context, guarded.id, "owner-b").await,
+        Err(JobError::LeaseLost)
+    ));
+    assert!(matches!(
+        jobs::fail(&pool, &context, guarded.id, "owner-b", "nope").await,
+        Err(JobError::LeaseLost)
+    ));
+    jobs::complete(&pool, &context, guarded.id, "owner-a")
+        .await
+        .expect("complete owner");
+    assert!(matches!(
+        jobs::cancel(&pool, &context, guarded.id).await,
+        Err(JobError::CannotCancelTerminal(JobStatus::Succeeded))
+    ));
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_event_appends_are_per_org_gapless_and_unique() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-events").await;
+    let pool = Arc::new(pool);
+    let barrier = Arc::new(Barrier::new(32));
+    let mut handles = Vec::new();
+    for _ in 0..32 {
+        let pool = Arc::clone(&pool);
+        let context = context.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            jobs::append_event(
+                &pool,
+                &context,
+                "test.concurrent",
+                EventPayload {
+                    job_id: None,
+                    document_id: None,
+                    version_id: None,
+                    outbox_event_id: None,
+                },
+            )
+            .await
+            .expect("append event")
+        }));
+    }
+    for handle in handles {
+        handle.await.expect("event task");
+    }
+
+    let sequences = with_org_txn(&pool, &context, {
+        let context = context.clone();
+        move |txn| Box::pin(async move { db_jobs::event_log_sequences(txn, &context).await })
+    })
+    .await
+    .expect("sequences");
+    assert_eq!(sequences.len(), 32);
+    assert_eq!(sequences, (1_i64..=32).collect::<Vec<_>>());
+
+    if let Ok(pool) = Arc::try_unwrap(pool) {
+        pool.close();
+    }
+    ephemeral.drop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn outbox_relay_is_concurrent_safe_and_replay_idempotent() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-outbox").await;
+    for index in 0..20 {
+        enqueue_one(&pool, &context, &format!("outbox-{index}")).await;
+    }
+    assert_eq!(unpublished_outbox_count(&pool, &context).await, 20);
+
+    let pool = Arc::new(pool);
+    let barrier = Arc::new(Barrier::new(4));
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let pool = Arc::clone(&pool);
+        let context = context.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            jobs::relay_outbox(&pool, &context, 10)
+                .await
+                .expect("relay")
+        }));
+    }
+
+    let mut published = Vec::new();
+    for handle in handles {
+        published.extend(handle.await.expect("relay task"));
+    }
+    let unique: HashSet<_> = published
+        .iter()
+        .map(|publication| publication.outbox.id)
+        .collect();
+    assert_eq!(published.len(), unique.len());
+    assert_eq!(published.len(), 20);
+    assert_eq!(unpublished_outbox_count(&pool, &context).await, 0);
+    assert!(jobs::relay_outbox(&pool, &context, 10)
+        .await
+        .expect("replay")
+        .is_empty());
+
+    if let Ok(pool) = Arc::try_unwrap(pool) {
+        pool.close();
+    }
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn older_payload_deserializes_and_payloads_reject_content_or_secrets() {
+    let document_id = Uuid::new_v4();
+    let decoded = jobs::decode_job_payload(1, json!({ "document_id": document_id }))
+        .expect("decode older payload");
+    assert_eq!(decoded.document_id, Some(document_id));
+    assert_eq!(decoded.collection_id, None);
+
+    assert!(matches!(
+        jobs::decode_job_payload(2, json!({ "content": "raw markdown" })),
+        Err(JobError::InvalidPayload(_))
+    ));
+    assert!(matches!(
+        jobs::decode_job_payload(2, json!({ "secret": Uuid::new_v4() })),
+        Err(JobError::InvalidPayload(_))
+    ));
+}
+
+#[tokio::test]
+async fn org_isolation_prevents_cross_org_claim_see_and_mutate() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx_a = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-orga").await;
+    let ctx_b = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-orgb").await;
+    let job_a = enqueue_one(&pool, &ctx_a, "a").await;
+    let job_b = enqueue_one(&pool, &ctx_b, "b").await;
+
+    let claimed_b = jobs::claim(&pool, &ctx_b, "worker-b", 10, Duration::from_secs(60))
+        .await
+        .expect("claim b");
+    assert_eq!(
+        claimed_b.iter().map(|job| job.id).collect::<Vec<_>>(),
+        vec![job_b.id]
+    );
+    assert!(matches!(
+        jobs::complete(&pool, &ctx_b, job_a.id, "worker-b").await,
+        Err(JobError::LeaseLost)
+    ));
+
+    let claimed_a = jobs::claim(&pool, &ctx_a, "worker-a", 10, Duration::from_secs(60))
+        .await
+        .expect("claim a");
+    assert_eq!(
+        claimed_a.iter().map(|job| job.id).collect::<Vec<_>>(),
+        vec![job_a.id]
+    );
+    assert!(
+        !jobs::heartbeat(&pool, &ctx_b, job_a.id, "worker-a", Duration::from_secs(60))
+            .await
+            .expect("cross heartbeat")
+    );
+    jobs::complete(&pool, &ctx_a, job_a.id, "worker-a")
+        .await
+        .expect("complete a");
+
+    let (jobs_a, outbox_a, _) = table_counts(&pool, &ctx_a).await;
+    let (jobs_b, outbox_b, _) = table_counts(&pool, &ctx_b).await;
+    assert_eq!((jobs_a, jobs_b), (1, 1));
+    assert!(outbox_a >= 2);
+    assert_eq!(outbox_b, 1);
+
+    ephemeral.drop().await;
+}

--- a/crates/server/tests/jobs.rs
+++ b/crates/server/tests/jobs.rs
@@ -4,6 +4,9 @@
 //! non-superuser app role and production org-scoped transaction helper.
 
 use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,17 +14,16 @@ use deadpool_postgres::Pool;
 use fileconv_server::auth::context::OrgContext;
 use fileconv_server::database::apply_migrations;
 use fileconv_server::db::error::DbError;
-use fileconv_server::db::jobs as db_jobs;
 use fileconv_server::db::models::{Job, JobStatus, JobType};
 use fileconv_server::db::orgs;
 use fileconv_server::db::pool::{create_pool, with_org_txn};
 use fileconv_server::jobs::{
-    self, CancelOutcome, CheckpointPayload, EnqueueJob, EventPayload, JobError, JobPayload,
-    CURRENT_EVENT_PAYLOAD_VERSION, CURRENT_JOB_PAYLOAD_VERSION,
+    self, CancelOutcome, CheckpointPayload, EnqueueJob, EventLogOutboxSink, EventPayload, JobError,
+    JobPayload, OutboxSink, CURRENT_EVENT_PAYLOAD_VERSION, CURRENT_JOB_PAYLOAD_VERSION,
 };
 use serde_json::json;
 use tokio::sync::Barrier;
-use tokio_postgres::NoTls;
+use tokio_postgres::{NoTls, Row};
 use uuid::Uuid;
 
 fn test_database_url() -> Option<String> {
@@ -157,14 +159,57 @@ async fn get_job(pool: &Pool, context: &OrgContext, job_id: Uuid) -> Job {
         let context = context.clone();
         move |txn| {
             Box::pin(async move {
-                db_jobs::get_by_id(txn, &context, job_id)
+                let row = txn
+                    .query_opt(
+                        "SELECT id, org_id, job_type, status, payload_version, payload,
+                                attempts, max_attempts, lease_owner, lease_expires_at,
+                                heartbeat_at, checkpoint, idempotency_key, document_id,
+                                version_id, available_at, started_at, finished_at,
+                                last_error, created_at, updated_at
+                         FROM jobs
+                         WHERE org_id = $1 AND id = $2",
+                        &[&context.org_id(), &job_id],
+                    )
                     .await?
-                    .ok_or(DbError::NotFound)
+                    .ok_or(DbError::NotFound)?;
+                map_job(&row)
             })
         }
     })
     .await
     .expect("get job")
+}
+
+fn map_job(row: &Row) -> Result<Job, DbError> {
+    let job_type: String = row.get("job_type");
+    let status: String = row.get("status");
+    Ok(Job {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        job_type: JobType::parse(&job_type).map_err(DbError::Config)?,
+        status: JobStatus::parse(&status).map_err(DbError::Config)?,
+        payload_version: row.get("payload_version"),
+        payload: row.get("payload"),
+        attempts: row.get("attempts"),
+        max_attempts: row.get("max_attempts"),
+        lease_owner: row.get("lease_owner"),
+        lease_expires_at: row.get("lease_expires_at"),
+        heartbeat_at: row.get("heartbeat_at"),
+        checkpoint: row.get("checkpoint"),
+        idempotency_key: row.get("idempotency_key"),
+        document_id: row.get("document_id"),
+        version_id: row.get("version_id"),
+        available_at: row.get("available_at"),
+        started_at: row.get("started_at"),
+        finished_at: row.get("finished_at"),
+        last_error: row.get("last_error"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+fn lease_token(job: &Job) -> &str {
+    job.lease_owner.as_deref().expect("claimed job has token")
 }
 
 async fn table_counts(pool: &Pool, context: &OrgContext) -> (i64, i64, i64) {
@@ -250,6 +295,66 @@ async fn unpublished_outbox_count(pool: &Pool, context: &OrgContext) -> i64 {
     .expect("unpublished count")
 }
 
+async fn event_count(pool: &Pool, context: &OrgContext, event_type: &str) -> i64 {
+    with_org_txn(pool, context, {
+        let context = context.clone();
+        let event_type = event_type.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM event_log
+                         WHERE org_id = $1 AND event_type = $2",
+                        &[&context.org_id(), &event_type],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("event count")
+}
+
+struct FailingOnceSink {
+    failed: AtomicBool,
+    delegate: EventLogOutboxSink,
+}
+
+impl Default for FailingOnceSink {
+    fn default() -> Self {
+        Self {
+            failed: AtomicBool::new(false),
+            delegate: EventLogOutboxSink,
+        }
+    }
+}
+
+impl OutboxSink for FailingOnceSink {
+    fn publish<'a>(
+        &'a self,
+        txn: &'a tokio_postgres::Transaction<'_>,
+        ctx: &'a OrgContext,
+        event: &'a fileconv_server::db::models::OutboxEvent,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<fileconv_server::db::models::EventLogEntry, JobError>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            if !self.failed.swap(true, Ordering::SeqCst) {
+                return Err(JobError::Database(DbError::Config(
+                    "intentional sink failure".into(),
+                )));
+            }
+            self.delegate.publish(txn, ctx, event).await
+        })
+    }
+}
+
 #[tokio::test]
 async fn enqueue_and_outbox_are_atomic_and_rollback_together() {
     let Some(base_url) = test_database_url() else {
@@ -277,27 +382,41 @@ async fn enqueue_and_outbox_are_atomic_and_rollback_together() {
         let context = context.clone();
         move |txn| {
             Box::pin(async move {
-                let now = db_jobs::fresh_clock_timestamp(txn).await?;
+                let row = txn.query_one("SELECT clock_timestamp()", &[]).await?;
+                let now: chrono::DateTime<chrono::Utc> = row.get(0);
                 let job_id = Uuid::new_v4();
                 let outbox_key = format!("job.enqueued:{job_id}");
-                db_jobs::insert_job_with_outbox(
-                    txn,
-                    &context,
-                    db_jobs::NewJob {
-                        id: job_id,
-                        job_type: JobType::Convert,
-                        payload_version: CURRENT_JOB_PAYLOAD_VERSION,
-                        payload: &payload,
-                        max_attempts: 5,
-                        idempotency_key: "forced-rollback",
-                        document_id: None,
-                        version_id: None,
-                        available_at: now,
-                        outbox_event_type: "job.enqueued",
-                        outbox_payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
-                        outbox_payload: &event_payload,
-                        outbox_idempotency_key: &outbox_key,
-                    },
+                let job_type = JobType::Convert.as_str();
+                txn.execute(
+                    "INSERT INTO jobs (
+                        id, org_id, job_type, payload_version, payload, max_attempts,
+                        idempotency_key, document_id, version_id, available_at
+                     )
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, NULL, $8)",
+                    &[
+                        &job_id,
+                        &context.org_id(),
+                        &job_type,
+                        &CURRENT_JOB_PAYLOAD_VERSION,
+                        &payload,
+                        &5_i32,
+                        &"forced-rollback",
+                        &now,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO outbox_events (
+                        org_id, event_type, payload_version, payload, idempotency_key, job_id
+                     )
+                     VALUES ($1, 'job.enqueued', $2, $3, $4, $5)",
+                    &[
+                        &context.org_id(),
+                        &CURRENT_EVENT_PAYLOAD_VERSION,
+                        &event_payload,
+                        &outbox_key,
+                        &job_id,
+                    ],
                 )
                 .await?;
                 Err(DbError::Config("forced rollback".into()))
@@ -331,6 +450,44 @@ async fn duplicate_enqueue_returns_existing_job_and_single_outbox() {
     assert_eq!(first.job.id, second.job.id);
     assert_eq!(table_counts(&pool, &context).await, (1, 1, 0));
 
+    ephemeral.drop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_duplicate_enqueue_same_key_creates_one_job_and_one_outbox() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-dup-concurrent").await;
+    let pool = Arc::new(pool);
+    let barrier = Arc::new(Barrier::new(16));
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let pool = Arc::clone(&pool);
+        let context = context.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            jobs::enqueue(&pool, &context, enqueue_spec("dup-concurrent"))
+                .await
+                .expect("enqueue")
+                .job
+                .id
+        }));
+    }
+
+    let mut ids = Vec::new();
+    for handle in handles {
+        ids.push(handle.await.expect("enqueue task"));
+    }
+    let unique: HashSet<_> = ids.into_iter().collect();
+    assert_eq!(unique.len(), 1);
+    assert_eq!(table_counts(&pool, &context).await, (1, 1, 0));
+
+    if let Ok(pool) = Arc::try_unwrap(pool) {
+        pool.close();
+    }
     ephemeral.drop().await;
 }
 
@@ -398,13 +555,23 @@ async fn reclaim_expired_leases_preserves_live_heartbeat_and_dead_letters_exhaus
         .await
         .expect("claim");
     assert_eq!(claimed.len(), 3);
+    let live_claim = claimed
+        .iter()
+        .find(|claimed| claimed.id == live.id)
+        .expect("live claim")
+        .clone();
     force_expire(&pool, &context, reclaimable.id).await;
     force_expire(&pool, &context, exhausted.id).await;
-    assert!(
-        jobs::heartbeat(&pool, &context, live.id, "worker", Duration::from_secs(60))
-            .await
-            .expect("heartbeat")
-    );
+    jobs::heartbeat(
+        &pool,
+        &context,
+        live.id,
+        lease_token(&live_claim),
+        live_claim.attempts,
+        Duration::from_secs(60),
+    )
+    .await
+    .expect("heartbeat");
 
     let reclaimed = jobs::reclaim_expired(&pool, &context, 10, Duration::from_secs(5))
         .await
@@ -424,6 +591,137 @@ async fn reclaim_expired_leases_preserves_live_heartbeat_and_dead_letters_exhaus
     ephemeral.drop().await;
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn heartbeat_vs_reclaim_race_has_one_winner_and_no_lost_update() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-heartbeat-race").await;
+    let job = enqueue_with_attempts(&pool, &context, "heartbeat-race", 3).await;
+    let claim = jobs::claim(&pool, &context, "race-worker", 1, Duration::from_secs(60))
+        .await
+        .expect("claim")
+        .remove(0);
+    force_expire(&pool, &context, job.id).await;
+
+    let pool = Arc::new(pool);
+    let barrier = Arc::new(Barrier::new(2));
+    let heartbeat_pool = Arc::clone(&pool);
+    let heartbeat_ctx = context.clone();
+    let heartbeat_barrier = Arc::clone(&barrier);
+    let token = lease_token(&claim).to_string();
+    let attempts = claim.attempts;
+    let heartbeat = tokio::spawn(async move {
+        heartbeat_barrier.wait().await;
+        jobs::heartbeat(
+            &heartbeat_pool,
+            &heartbeat_ctx,
+            job.id,
+            &token,
+            attempts,
+            Duration::from_secs(60),
+        )
+        .await
+    });
+
+    let reclaim_pool = Arc::clone(&pool);
+    let reclaim_ctx = context.clone();
+    let reclaim_barrier = Arc::clone(&barrier);
+    let reclaim = tokio::spawn(async move {
+        reclaim_barrier.wait().await;
+        jobs::reclaim_expired(&reclaim_pool, &reclaim_ctx, 10, Duration::from_secs(1)).await
+    });
+
+    let heartbeat_result = heartbeat.await.expect("heartbeat task");
+    let reclaimed = reclaim.await.expect("reclaim task").expect("reclaim");
+    let stored = get_job(&pool, &context, job.id).await;
+    match heartbeat_result {
+        Ok(()) => {
+            assert!(reclaimed.is_empty());
+            assert_eq!(stored.status, JobStatus::Leased);
+            assert_eq!(stored.lease_owner.as_deref(), Some(lease_token(&claim)));
+        }
+        Err(JobError::LeaseLost) => {
+            assert_eq!(reclaimed.len(), 1);
+            assert_eq!(stored.status, JobStatus::Pending);
+            assert!(stored.lease_owner.is_none());
+        }
+        other => panic!("unexpected heartbeat result: {other:?}"),
+    }
+
+    if let Ok(pool) = Arc::try_unwrap(pool) {
+        pool.close();
+    }
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn stale_same_worker_reclaim_reclaim_token_cannot_mutate_new_lease() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-stale-token").await;
+    let job = enqueue_with_attempts(&pool, &context, "stale-token", 3).await;
+    let first = jobs::claim(&pool, &context, "same-worker", 1, Duration::from_secs(60))
+        .await
+        .expect("claim")
+        .remove(0);
+    let old_token = lease_token(&first).to_string();
+    let old_attempts = first.attempts;
+    force_expire(&pool, &context, job.id).await;
+    jobs::reclaim_expired(&pool, &context, 10, Duration::from_secs(1))
+        .await
+        .expect("reclaim");
+    force_available(&pool, &context, job.id).await;
+    let second = jobs::claim(&pool, &context, "same-worker", 1, Duration::from_secs(60))
+        .await
+        .expect("reclaim claim")
+        .remove(0);
+    assert_eq!(second.id, job.id);
+    assert_ne!(lease_token(&second), old_token);
+    assert_ne!(second.attempts, old_attempts);
+
+    assert!(matches!(
+        jobs::heartbeat(
+            &pool,
+            &context,
+            job.id,
+            &old_token,
+            old_attempts,
+            Duration::from_secs(60),
+        )
+        .await,
+        Err(JobError::LeaseLost)
+    ));
+    assert!(matches!(
+        jobs::checkpoint(
+            &pool,
+            &context,
+            job.id,
+            &old_token,
+            old_attempts,
+            CheckpointPayload::default(),
+        )
+        .await,
+        Err(JobError::LeaseLost)
+    ));
+    assert!(matches!(
+        jobs::complete(&pool, &context, job.id, &old_token, old_attempts).await,
+        Err(JobError::LeaseLost)
+    ));
+    assert!(matches!(
+        jobs::fail(&pool, &context, job.id, &old_token, old_attempts, "stale").await,
+        Err(JobError::LeaseLost)
+    ));
+    let stored = get_job(&pool, &context, job.id).await;
+    assert_eq!(stored.status, JobStatus::Leased);
+    assert_eq!(stored.lease_owner.as_deref(), Some(lease_token(&second)));
+
+    ephemeral.drop().await;
+}
+
 #[tokio::test]
 async fn checkpoint_survives_kill_reclaim_and_resume_claim() {
     let Some(base_url) = test_database_url() else {
@@ -432,9 +730,10 @@ async fn checkpoint_survives_kill_reclaim_and_resume_claim() {
     let (ephemeral, pool) = boot_pool(&base_url).await;
     let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-checkpoint").await;
     let job = enqueue_one(&pool, &context, "checkpoint").await;
-    jobs::claim(&pool, &context, "worker-a", 1, Duration::from_secs(60))
+    let claimed = jobs::claim(&pool, &context, "worker-a", 1, Duration::from_secs(60))
         .await
         .expect("claim");
+    let claim = claimed.first().expect("claimed job").clone();
 
     let checkpoint = CheckpointPayload {
         cursor_id: Some(Uuid::new_v4()),
@@ -442,9 +741,16 @@ async fn checkpoint_survives_kill_reclaim_and_resume_claim() {
         offset: Some(7),
     };
     let checkpoint_json = checkpoint.to_json().expect("checkpoint json");
-    jobs::checkpoint(&pool, &context, job.id, "worker-a", checkpoint)
-        .await
-        .expect("checkpoint");
+    jobs::checkpoint(
+        &pool,
+        &context,
+        job.id,
+        lease_token(&claim),
+        claim.attempts,
+        checkpoint,
+    )
+    .await
+    .expect("checkpoint");
     force_expire(&pool, &context, job.id).await;
     jobs::reclaim_expired(&pool, &context, 10, Duration::from_secs(1))
         .await
@@ -463,6 +769,46 @@ async fn checkpoint_survives_kill_reclaim_and_resume_claim() {
 }
 
 #[tokio::test]
+async fn non_owner_checkpoint_is_rejected_without_mutating_checkpoint() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "jobs-checkpoint-guard",
+    )
+    .await;
+    let job = enqueue_one(&pool, &context, "checkpoint-guard").await;
+    let claim = jobs::claim(&pool, &context, "owner", 1, Duration::from_secs(60))
+        .await
+        .expect("claim")
+        .remove(0);
+    assert!(matches!(
+        jobs::checkpoint(
+            &pool,
+            &context,
+            job.id,
+            "not-the-token",
+            claim.attempts,
+            CheckpointPayload {
+                cursor_id: Some(Uuid::new_v4()),
+                completed_ids: vec![],
+                offset: Some(1),
+            },
+        )
+        .await,
+        Err(JobError::LeaseLost)
+    ));
+    let stored = get_job(&pool, &context, job.id).await;
+    assert_eq!(stored.checkpoint, None);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
 async fn fail_retries_with_future_backoff_then_dead_letters_when_exhausted() {
     let Some(base_url) = test_database_url() else {
         return;
@@ -470,24 +816,40 @@ async fn fail_retries_with_future_backoff_then_dead_letters_when_exhausted() {
     let (ephemeral, pool) = boot_pool(&base_url).await;
     let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-retry").await;
     let job = enqueue_with_attempts(&pool, &context, "retry", 2).await;
-    jobs::claim(&pool, &context, "worker", 1, Duration::from_secs(60))
+    let claimed = jobs::claim(&pool, &context, "worker", 1, Duration::from_secs(60))
         .await
         .expect("claim");
+    let first_claim = claimed.first().expect("first claim").clone();
 
-    let retry = jobs::fail(&pool, &context, job.id, "worker", "transient")
-        .await
-        .expect("fail retry");
+    let retry = jobs::fail(
+        &pool,
+        &context,
+        job.id,
+        lease_token(&first_claim),
+        first_claim.attempts,
+        "transient",
+    )
+    .await
+    .expect("fail retry");
     assert_eq!(retry.status, JobStatus::Pending);
     assert!(retry.available_at > retry.updated_at);
     assert_eq!(retry.last_error.as_deref(), Some("transient"));
 
     force_available(&pool, &context, job.id).await;
-    jobs::claim(&pool, &context, "worker", 1, Duration::from_secs(60))
+    let claimed = jobs::claim(&pool, &context, "worker", 1, Duration::from_secs(60))
         .await
         .expect("claim retry");
-    let dead = jobs::fail(&pool, &context, job.id, "worker", "exhausted")
-        .await
-        .expect("fail dead");
+    let second_claim = claimed.first().expect("second claim").clone();
+    let dead = jobs::fail(
+        &pool,
+        &context,
+        job.id,
+        lease_token(&second_claim),
+        second_claim.attempts,
+        "exhausted",
+    )
+    .await
+    .expect("fail dead");
     assert_eq!(dead.status, JobStatus::DeadLetter);
     assert!(dead.finished_at.is_some());
 
@@ -517,36 +879,93 @@ async fn cancel_is_idempotent_and_owner_guards_in_flight_mutations() {
     ));
 
     let leased = enqueue_one(&pool, &context, "cancel-leased").await;
-    jobs::claim(&pool, &context, "owner", 1, Duration::from_secs(60))
+    let leased_claimed = jobs::claim(&pool, &context, "owner", 1, Duration::from_secs(60))
         .await
         .expect("claim leased");
+    let leased_claim = leased_claimed.first().expect("leased claim").clone();
     assert!(matches!(
         jobs::cancel(&pool, &context, leased.id)
             .await
             .expect("cancel leased"),
         CancelOutcome::Cancelled(_)
     ));
-    assert!(
-        !jobs::heartbeat(&pool, &context, leased.id, "owner", Duration::from_secs(60))
-            .await
-            .expect("heartbeat lost")
+    assert!(matches!(
+        jobs::heartbeat(
+            &pool,
+            &context,
+            leased.id,
+            lease_token(&leased_claim),
+            leased_claim.attempts,
+            Duration::from_secs(60),
+        )
+        .await,
+        Err(JobError::LeaseLost)
+    ));
+    assert!(matches!(
+        jobs::complete(
+            &pool,
+            &context,
+            leased.id,
+            lease_token(&leased_claim),
+            leased_claim.attempts,
+        )
+        .await,
+        Err(JobError::LeaseLost)
+    ));
+    assert!(matches!(
+        jobs::fail(
+            &pool,
+            &context,
+            leased.id,
+            lease_token(&leased_claim),
+            leased_claim.attempts,
+            "cancelled worker tried to fail",
+        )
+        .await,
+        Err(JobError::LeaseLost)
+    ));
+    assert_eq!(
+        get_job(&pool, &context, leased.id).await.status,
+        JobStatus::Cancelled
     );
 
     let guarded = enqueue_one(&pool, &context, "owner-guard").await;
-    jobs::claim(&pool, &context, "owner-a", 1, Duration::from_secs(60))
+    let guarded_claimed = jobs::claim(&pool, &context, "owner-a", 1, Duration::from_secs(60))
         .await
         .expect("claim guarded");
+    let guarded_claim = guarded_claimed.first().expect("guarded claim").clone();
     assert!(matches!(
-        jobs::complete(&pool, &context, guarded.id, "owner-b").await,
+        jobs::complete(
+            &pool,
+            &context,
+            guarded.id,
+            "owner-b",
+            guarded_claim.attempts
+        )
+        .await,
         Err(JobError::LeaseLost)
     ));
     assert!(matches!(
-        jobs::fail(&pool, &context, guarded.id, "owner-b", "nope").await,
+        jobs::fail(
+            &pool,
+            &context,
+            guarded.id,
+            "owner-b",
+            guarded_claim.attempts,
+            "nope"
+        )
+        .await,
         Err(JobError::LeaseLost)
     ));
-    jobs::complete(&pool, &context, guarded.id, "owner-a")
-        .await
-        .expect("complete owner");
+    jobs::complete(
+        &pool,
+        &context,
+        guarded.id,
+        lease_token(&guarded_claim),
+        guarded_claim.attempts,
+    )
+    .await
+    .expect("complete owner");
     assert!(matches!(
         jobs::cancel(&pool, &context, guarded.id).await,
         Err(JobError::CannotCancelTerminal(JobStatus::Succeeded))
@@ -592,7 +1011,20 @@ async fn concurrent_event_appends_are_per_org_gapless_and_unique() {
 
     let sequences = with_org_txn(&pool, &context, {
         let context = context.clone();
-        move |txn| Box::pin(async move { db_jobs::event_log_sequences(txn, &context).await })
+        move |txn| {
+            Box::pin(async move {
+                let rows = txn
+                    .query(
+                        "SELECT sequence_no
+                         FROM event_log
+                         WHERE org_id = $1
+                         ORDER BY sequence_no",
+                        &[&context.org_id()],
+                    )
+                    .await?;
+                Ok(rows.into_iter().map(|row| row.get(0)).collect::<Vec<i64>>())
+            })
+        }
     })
     .await
     .expect("sequences");
@@ -655,6 +1087,39 @@ async fn outbox_relay_is_concurrent_safe_and_replay_idempotent() {
 }
 
 #[tokio::test]
+async fn outbox_sink_failure_leaves_unpublished_and_retry_publishes_once() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(&pool, Uuid::new_v4(), Uuid::new_v4(), "jobs-outbox-failure").await;
+    enqueue_one(&pool, &context, "outbox-failure").await;
+    assert_eq!(unpublished_outbox_count(&pool, &context).await, 1);
+
+    let sink = Arc::new(FailingOnceSink::default());
+    assert!(matches!(
+        jobs::relay_outbox_with_sink(&pool, &context, 10, &sink).await,
+        Err(JobError::Database(_))
+    ));
+    assert_eq!(unpublished_outbox_count(&pool, &context).await, 1);
+    assert_eq!(event_count(&pool, &context, "outbox.published").await, 0);
+
+    let published = jobs::relay_outbox_with_sink(&pool, &context, 10, &sink)
+        .await
+        .expect("retry relay");
+    assert_eq!(published.len(), 1);
+    assert_eq!(unpublished_outbox_count(&pool, &context).await, 0);
+    assert_eq!(event_count(&pool, &context, "outbox.published").await, 1);
+    assert!(jobs::relay_outbox_with_sink(&pool, &context, 10, &sink)
+        .await
+        .expect("replay")
+        .is_empty());
+    assert_eq!(event_count(&pool, &context, "outbox.published").await, 1);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
 async fn older_payload_deserializes_and_payloads_reject_content_or_secrets() {
     let document_id = Uuid::new_v4();
     let decoded = jobs::decode_job_payload(1, json!({ "document_id": document_id }))
@@ -690,8 +1155,16 @@ async fn org_isolation_prevents_cross_org_claim_see_and_mutate() {
         claimed_b.iter().map(|job| job.id).collect::<Vec<_>>(),
         vec![job_b.id]
     );
+    let claim_b = claimed_b.first().expect("claim b").clone();
     assert!(matches!(
-        jobs::complete(&pool, &ctx_b, job_a.id, "worker-b").await,
+        jobs::complete(
+            &pool,
+            &ctx_b,
+            job_a.id,
+            lease_token(&claim_b),
+            claim_b.attempts
+        )
+        .await,
         Err(JobError::LeaseLost)
     ));
 
@@ -702,14 +1175,28 @@ async fn org_isolation_prevents_cross_org_claim_see_and_mutate() {
         claimed_a.iter().map(|job| job.id).collect::<Vec<_>>(),
         vec![job_a.id]
     );
-    assert!(
-        !jobs::heartbeat(&pool, &ctx_b, job_a.id, "worker-a", Duration::from_secs(60))
-            .await
-            .expect("cross heartbeat")
-    );
-    jobs::complete(&pool, &ctx_a, job_a.id, "worker-a")
-        .await
-        .expect("complete a");
+    let claim_a = claimed_a.first().expect("claim a").clone();
+    assert!(matches!(
+        jobs::heartbeat(
+            &pool,
+            &ctx_b,
+            job_a.id,
+            lease_token(&claim_a),
+            claim_a.attempts,
+            Duration::from_secs(60),
+        )
+        .await,
+        Err(JobError::LeaseLost)
+    ));
+    jobs::complete(
+        &pool,
+        &ctx_a,
+        job_a.id,
+        lease_token(&claim_a),
+        claim_a.attempts,
+    )
+    .await
+    .expect("complete a");
 
     let (jobs_a, outbox_a, _) = table_counts(&pool, &ctx_a).await;
     let (jobs_b, outbox_b, _) = table_counts(&pool, &ctx_b).await;

--- a/crates/server/tests/jobs.rs
+++ b/crates/server/tests/jobs.rs
@@ -20,6 +20,7 @@ use fileconv_server::db::pool::{create_pool, with_org_txn};
 use fileconv_server::jobs::{
     self, CancelOutcome, CheckpointPayload, EnqueueJob, EventLogOutboxSink, EventPayload, JobError,
     JobPayload, OutboxSink, CURRENT_EVENT_PAYLOAD_VERSION, CURRENT_JOB_PAYLOAD_VERSION,
+    MAX_LEASE_TOKEN_LEN, MAX_WORKER_ID_LEN,
 };
 use serde_json::json;
 use tokio::sync::Barrier;
@@ -764,6 +765,124 @@ async fn checkpoint_survives_kill_reclaim_and_resume_claim() {
     assert_eq!(resumed[0].id, job.id);
     assert_eq!(resumed[0].checkpoint, Some(checkpoint_json));
     assert_eq!(resumed[0].attempts, 2);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn max_length_worker_id_yields_usable_lease_tokens_for_all_worker_mutations() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "jobs-worker-boundary",
+    )
+    .await;
+    let worker_id = "w".repeat(MAX_WORKER_ID_LEN);
+
+    let heartbeat_job = enqueue_with_attempts(&pool, &context, "max-worker-heartbeat", 3).await;
+    let heartbeat_claim = jobs::claim(&pool, &context, &worker_id, 1, Duration::from_secs(60))
+        .await
+        .expect("claim heartbeat")
+        .remove(0);
+    let heartbeat_token = lease_token(&heartbeat_claim);
+    assert_eq!(heartbeat_token.len(), MAX_LEASE_TOKEN_LEN);
+    jobs::heartbeat(
+        &pool,
+        &context,
+        heartbeat_job.id,
+        heartbeat_token,
+        heartbeat_claim.attempts,
+        Duration::from_secs(60),
+    )
+    .await
+    .expect("heartbeat max token");
+
+    let checkpoint_job = enqueue_with_attempts(&pool, &context, "max-worker-checkpoint", 3).await;
+    let checkpoint_claim = jobs::claim(&pool, &context, &worker_id, 1, Duration::from_secs(60))
+        .await
+        .expect("claim checkpoint")
+        .remove(0);
+    let checkpoint = jobs::checkpoint(
+        &pool,
+        &context,
+        checkpoint_job.id,
+        lease_token(&checkpoint_claim),
+        checkpoint_claim.attempts,
+        CheckpointPayload {
+            cursor_id: Some(Uuid::new_v4()),
+            completed_ids: vec![Uuid::new_v4()],
+            offset: Some(1),
+        },
+    )
+    .await
+    .expect("checkpoint max token");
+    assert!(checkpoint.checkpoint.is_some());
+
+    let complete_job = enqueue_with_attempts(&pool, &context, "max-worker-complete", 3).await;
+    let complete_claim = jobs::claim(&pool, &context, &worker_id, 1, Duration::from_secs(60))
+        .await
+        .expect("claim complete")
+        .remove(0);
+    let completed = jobs::complete(
+        &pool,
+        &context,
+        complete_job.id,
+        lease_token(&complete_claim),
+        complete_claim.attempts,
+    )
+    .await
+    .expect("complete max token");
+    assert_eq!(completed.status, JobStatus::Succeeded);
+
+    let fail_job = enqueue_with_attempts(&pool, &context, "max-worker-fail", 3).await;
+    let fail_claim = jobs::claim(&pool, &context, &worker_id, 1, Duration::from_secs(60))
+        .await
+        .expect("claim fail")
+        .remove(0);
+    let failed = jobs::fail(
+        &pool,
+        &context,
+        fail_job.id,
+        lease_token(&fail_claim),
+        fail_claim.attempts,
+        "transient",
+    )
+    .await
+    .expect("fail max token");
+    assert_eq!(failed.status, JobStatus::Pending);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn over_limit_worker_id_is_rejected_before_claiming() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let context = seed_org(
+        &pool,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "jobs-worker-overlimit",
+    )
+    .await;
+    let job = enqueue_one(&pool, &context, "worker-overlimit").await;
+    let worker_id = "w".repeat(MAX_WORKER_ID_LEN + 1);
+
+    assert!(matches!(
+        jobs::claim(&pool, &context, &worker_id, 1, Duration::from_secs(60)).await,
+        Err(JobError::InvalidLeaseOwner)
+    ));
+    let stored = get_job(&pool, &context, job.id).await;
+    assert_eq!(stored.status, JobStatus::Pending);
+    assert_eq!(stored.attempts, 0);
+    assert!(stored.lease_owner.is_none());
 
     ephemeral.drop().await;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-I03 — Durable jobs, transactional outbox and sequenced event log

Postgres-only durable job system over the F03 `jobs` / `outbox_events` / `event_log` schema. No external queue.

### Design
- **Enqueue + outbox atomic**: job row and outbox event inserted in one `with_org_txn` transaction — commit never splits. Idempotent via `UNIQUE(org_id,job_type,idempotency_key)` (`ON CONFLICT DO NOTHING` → returns the existing job; duplicate enqueue harmless).
- **Claim**: `FOR UPDATE SKIP LOCKED` over `status='pending' AND available_at <= clock_timestamp()`, transitions to lease-bearing `status='leased'` (matches the partial reclaim index), sets owner/lease-expiry/heartbeat, `attempts += 1`. Concurrent claimers never double-claim.
- **Lease fencing**: `lease_owner = worker_id||':'||gen_random_uuid()` unique per claim; every in-flight mutation matches the full lease token + claimed `attempts` + `status='leased'`, so a stale/re-claimed worker is fenced out (`LeaseLost`). Claim-side and mutation-side length bounds derive from one shared constant.
- **Heartbeat / checkpoint**: owner-guarded; heartbeat extends the lease and reports lease loss; checkpoint (IDs/offset only) survives reclaim for resume.
- **Reclaim**: expired leases (`SKIP LOCKED`, partial index, `clock_timestamp()` captured after locking) → `pending`+backoff if attempts remain, else `dead_letter`; live heartbeat never reclaimed; checkpoint preserved.
- **Complete / fail / retry / cancel**: each transition atomic with its event; retry uses bounded exponential backoff, exhaustion → `dead_letter`; external/admin cancel (pending|leased → cancelled, idempotent; terminal rejected) is token-free by design, and worker mutations are fenced so a cancelled job can't be completed/failed.
- **Sequenced events**: per-org gapless `sequence_no` allocated under `pg_advisory_xact_lock(hashtext('eventlog:'||org_id))`.
- **Outbox relay**: `OutboxSink` trait + idempotent `EventLogOutboxSink`; the relay **delivers via the sink before** marking `published_at` (at-least-once, replay-safe), `SKIP LOCKED` so concurrent relays don't double-publish; a failed sink leaves the row unpublished for retry.
- **Versioned, safe payloads**: `payload_version` (v2, backward-reads v1); `db::jobs` is `pub(crate)` and write APIs take `Validated*Payload` newtypes (private inner) whose constructor recursively rejects content/secret/token/password/body/text fields — the repo cannot persist an unvalidated/secret payload.
- **Tenant isolation**: RLS + `org_id` predicate; cross-org cannot claim/see/mutate.

### Tests (live Postgres) — `tests/jobs.rs` (18)
Atomic enqueue (no split), duplicate-harmless (incl. concurrent), SKIP LOCKED no-double-claim, lease reclaim + heartbeat protection + checkpoint resume, retry/backoff → dead-letter, cancel + fencing, stale-token/non-owner rejection, worker-id/lease-token boundary round-trip, per-org gapless sequence under concurrency, outbox deliver-before-mark + publish-failure replay (publish-once), backward-readable payload, cross-org isolation. All prior suites green.

Reviewed over 3 strict rounds. Stacked on #222 (I02).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f786f-b237-7b8d-992f-08afce70f084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

