### PR TITLE
feat(server): P1B-I06 chunk/embedding/index worker

### DIFF
--- a/crates/knowledge/src/embedding.rs
+++ b/crates/knowledge/src/embedding.rs
@@ -145,8 +145,8 @@ pub struct EmbeddingPlan {
     mode: &'static str,
     provider: String,
     model: String,
+    family: String,
     revision: String,
-    deployment: ProviderDeployment,
     expected_dimensions: Option<usize>,
     normalized: bool,
     runtime_path: String,
@@ -154,13 +154,15 @@ pub struct EmbeddingPlan {
 
 impl EmbeddingPlan {
     pub fn local_hash_v1() -> Self {
+        let deployment =
+            ProviderDeployment::from_base_url(None).expect("default deployment identity is valid");
+        let family = embedding_family("local", LOCAL_EMBEDDING_MODE, &deployment);
         Self {
             mode: LOCAL_EMBEDDING_MODE,
             provider: "local".into(),
             model: LOCAL_EMBEDDING_MODE.into(),
+            family,
             revision: "1".into(),
-            deployment: ProviderDeployment::from_base_url(None)
-                .expect("default deployment identity is valid"),
             expected_dimensions: Some(LOCAL_VECTOR_DIMENSIONS),
             normalized: true,
             runtime_path: RUNTIME_LOCAL_HASH.into(),
@@ -198,12 +200,13 @@ impl EmbeddingPlan {
                 "embedding runtime_path is unsupported",
             ));
         }
+        let family = embedding_family(&provider, &model, &deployment);
         Ok(Self {
             mode: PROVIDER_EMBEDDING_MODE,
             provider,
             model,
+            family,
             revision,
-            deployment,
             expected_dimensions,
             normalized: true,
             runtime_path,
@@ -231,6 +234,10 @@ impl EmbeddingPlan {
     }
 
     pub fn signature(&self, actual_dimensions: usize) -> Result<String> {
+        Ok(self.index_signature(actual_dimensions)?.digest())
+    }
+
+    pub fn index_signature(&self, actual_dimensions: usize) -> Result<IndexSignature<'_>> {
         if actual_dimensions == 0 {
             return Err(KnowledgeError::InvalidInput(
                 "embedding dimensions must be positive",
@@ -244,7 +251,7 @@ impl EmbeddingPlan {
                 });
             }
         }
-        Ok(self.signature_with_dimensions(actual_dimensions))
+        Ok(self.index_signature_unchecked(actual_dimensions))
     }
 
     /// Planning-only signature used before a provider reports its dimensions.
@@ -252,17 +259,14 @@ impl EmbeddingPlan {
     /// It must not be persisted as index metadata; once vectors arrive callers
     /// replace it with [`Self::signature`].
     pub fn provisional_signature(&self) -> String {
-        self.signature_with_dimensions(self.expected_dimensions.unwrap_or(0))
+        self.index_signature_unchecked(self.expected_dimensions.unwrap_or(0))
+            .digest()
     }
 
-    fn signature_with_dimensions(&self, dimensions: usize) -> String {
-        let family = format!(
-            "{}/{}/{}",
-            self.provider, self.model, self.deployment.digest
-        );
+    fn index_signature_unchecked(&self, dimensions: usize) -> IndexSignature<'_> {
         IndexSignature {
             runtime_path: &self.runtime_path,
-            embedding_family: &family,
+            embedding_family: &self.family,
             embedding_revision: &self.revision,
             dimensions,
             normalized: self.normalized,
@@ -270,8 +274,11 @@ impl EmbeddingPlan {
             body_text_version: BODY_TEXT_VERSION,
             query_normalization_version: QUERY_NORMALIZATION_VERSION,
         }
-        .digest()
     }
+}
+
+fn embedding_family(provider: &str, model: &str, deployment: &ProviderDeployment) -> String {
+    format!("{provider}/{model}/{}", deployment.digest)
 }
 
 pub fn validate_embedding_batch(
@@ -605,5 +612,17 @@ mod tests {
         assert!(!debug.contains("https://"));
         assert!(!debug.contains("secret"));
         assert!(!debug.contains("hidden"));
+    }
+
+    #[test]
+    fn plan_index_signature_matches_digest() {
+        let plan = EmbeddingPlan::local_hash_v1();
+        let signature = plan.index_signature(LOCAL_VECTOR_DIMENSIONS).unwrap();
+        assert_eq!(
+            signature.digest(),
+            plan.signature(LOCAL_VECTOR_DIMENSIONS).unwrap()
+        );
+        assert_eq!(signature.runtime_path, super::RUNTIME_LOCAL_HASH);
+        assert_eq!(signature.dimensions, LOCAL_VECTOR_DIMENSIONS);
     }
 }

--- a/crates/server/src/bin/worker.rs
+++ b/crates/server/src/bin/worker.rs
@@ -2,8 +2,11 @@ use std::time::Duration;
 
 use fileconv_server::auth::context::OrgContext;
 use fileconv_server::db::pool::create_pool;
-use fileconv_server::storage::MinioClient;
+use fileconv_server::jobs;
+use fileconv_server::services::indexing::IndexingOutboxSink;
+use fileconv_server::storage::{MinioClient, QdrantClient};
 use fileconv_server::workers::convert::{ConvertWorker, ConvertWorkerConfig};
+use fileconv_server::workers::index::{IndexWorker, IndexWorkerConfig, IndexWorkerRun};
 use fileconv_server::workers::limits::ResourceLimits;
 use fileconv_server::workers::sandbox::SandboxConfig;
 use uuid::Uuid;
@@ -57,12 +60,41 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
         .config()
         .storage_config()
         .map_err(|error| format!("invalid storage configuration: {error}"))?;
-    let storage = MinioClient::from_config(storage_config.minio())
-        .map_err(|error| format!("storage client failed: {}", error.code()))?;
     let worker_id = std::env::var("MARKHAND_WORKER_ID")
         .ok()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| format!("fileconv-worker-{}", std::process::id()));
+    let kind = std::env::var("MARKHAND_WORKER_KIND")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "convert".into());
+    match kind.as_str() {
+        "convert" => {
+            let storage = MinioClient::from_config(storage_config.minio())
+                .map_err(|error| format!("storage client failed: {}", error.code()))?;
+            run_convert_worker(state, pool, storage, worker_id, ctx).await
+        }
+        "index" => {
+            let storage = MinioClient::from_config(storage_config.minio())
+                .map_err(|error| format!("storage client failed: {}", error.code()))?;
+            let qdrant = QdrantClient::with_api_key(
+                storage_config.qdrant_url(),
+                storage_config.qdrant_api_key().cloned(),
+            )
+            .map_err(|error| format!("qdrant client failed: {}", error.code()))?;
+            run_index_worker(state, pool, storage, qdrant, worker_id, ctx).await
+        }
+        other => Err(format!("unknown MARKHAND_WORKER_KIND: {other}")),
+    }
+}
+
+async fn run_convert_worker(
+    state: fileconv_server::state::RuntimeState,
+    pool: deadpool_postgres::Pool,
+    storage: MinioClient,
+    worker_id: String,
+    ctx: OrgContext,
+) -> Result<(), String> {
     let mut config = ConvertWorkerConfig::new(worker_id, sandbox_config_from_env()?);
     config.lease_ttl = Duration::from_secs(state.config().limits().job_lease_seconds);
     if let Ok(value) = std::env::var("MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS") {
@@ -101,6 +133,65 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
                     Ok(outcome) => println!("fileconv-worker: {outcome:?}"),
                     Err(error) => {
                         eprintln!("fileconv-worker: convert worker error: {error}");
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_index_worker(
+    state: fileconv_server::state::RuntimeState,
+    pool: deadpool_postgres::Pool,
+    storage: MinioClient,
+    qdrant: QdrantClient,
+    worker_id: String,
+    ctx: OrgContext,
+) -> Result<(), String> {
+    let mut config = IndexWorkerConfig::new(worker_id);
+    config.lease_ttl = Duration::from_secs(state.config().limits().job_lease_seconds);
+    if let Ok(value) = std::env::var("MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS") {
+        config.heartbeat_interval = Duration::from_secs(value.parse().map_err(|_| {
+            "MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS must be an integer".to_string()
+        })?);
+    }
+    if let Ok(value) = std::env::var("MARKHAND_WORKER_MAX_JOB_SECS") {
+        config.max_job_duration = Duration::from_secs(
+            value
+                .parse()
+                .map_err(|_| "MARKHAND_WORKER_MAX_JOB_SECS must be an integer".to_string())?,
+        );
+    }
+    if let Ok(value) = std::env::var("MARKHAND_INDEX_EMBEDDING_BATCH_SIZE") {
+        config.embedding_batch_size = value
+            .parse()
+            .map_err(|_| "MARKHAND_INDEX_EMBEDDING_BATCH_SIZE must be an integer".to_string())?;
+    }
+    let approved_signature = state.config().index_signature().map(str::to_string);
+    let worker = IndexWorker::new(pool.clone(), storage, qdrant, config, approved_signature)
+        .map_err(|error| format!("index worker initialization failed: {error}"))?;
+    let sink = std::sync::Arc::new(IndexingOutboxSink::new());
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                println!("fileconv-worker: shutdown requested");
+                break;
+            }
+            result = async {
+                jobs::relay_outbox_with_sink(&pool, &ctx, 32, &sink)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                worker.run_once(&ctx).await.map_err(|error| error.to_string())
+            } => {
+                match result {
+                    Ok(IndexWorkerRun::NoJob) => {
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    }
+                    Ok(outcome) => println!("fileconv-worker: {outcome:?}"),
+                    Err(error) => {
+                        eprintln!("fileconv-worker: index worker error: {error}");
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
                 }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -733,6 +733,10 @@ impl ServerConfig {
         self.limits
     }
 
+    pub fn index_signature(&self) -> Option<&str> {
+        self.index_signature.as_deref()
+    }
+
     pub(crate) fn is_api_role(&self) -> bool {
         self.role == RuntimeRole::Api
     }

--- a/crates/server/src/db/chunks.rs
+++ b/crates/server/src/db/chunks.rs
@@ -61,6 +61,60 @@ pub async fn insert(
     map_chunk(&row)
 }
 
+/// Idempotently inserts a chunk row by canonical chunk identity.
+pub async fn insert_if_absent(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewChunk<'_>,
+) -> Result<Chunk, DbError> {
+    let heading_path: Vec<&str> = input.heading_path.iter().map(String::as_str).collect();
+    let row = txn
+        .query_one(
+            "WITH inserted AS (
+                INSERT INTO chunks (
+                    id, org_id, document_id, version_id, ordinal, heading_path, body,
+                    body_text_version, chunk_identity_sha256, index_metadata_id,
+                    index_signature
+                ) VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+                )
+                ON CONFLICT (chunk_identity_sha256) DO NOTHING
+                RETURNING id, org_id, document_id, version_id, ordinal, heading_path, body,
+                          body_text_version, chunk_identity_sha256, index_metadata_id,
+                          index_signature, page, slide, sheet, span_start, span_end,
+                          tsv::text AS tsv, created_at
+             )
+             SELECT id, org_id, document_id, version_id, ordinal, heading_path, body,
+                    body_text_version, chunk_identity_sha256, index_metadata_id,
+                    index_signature, page, slide, sheet, span_start, span_end,
+                    tsv, created_at
+             FROM inserted
+             UNION ALL
+             SELECT id, org_id, document_id, version_id, ordinal, heading_path, body,
+                    body_text_version, chunk_identity_sha256, index_metadata_id,
+                    index_signature, page, slide, sheet, span_start, span_end,
+                    tsv::text AS tsv, created_at
+             FROM chunks
+             WHERE org_id = $2 AND chunk_identity_sha256 = $9
+             LIMIT 1",
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &input.document_id,
+                &input.version_id,
+                &input.ordinal,
+                &heading_path,
+                &input.body,
+                &input.body_text_version,
+                &input.chunk_identity_sha256,
+                &input.index_metadata_id,
+                &input.index_signature,
+            ],
+        )
+        .await?;
+    map_chunk(&row)
+}
+
 /// Lists chunks for a document within the tenant.
 pub async fn list_by_document(
     txn: &Transaction<'_>,
@@ -88,6 +142,20 @@ pub async fn count(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<i64, DbErr
         .query_one(
             "SELECT count(*)::bigint FROM chunks WHERE org_id = $1",
             &[&ctx.org_id()],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
+pub async fn count_by_version(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    version_id: Uuid,
+) -> Result<i64, DbError> {
+    let row = txn
+        .query_one(
+            "SELECT count(*)::bigint FROM chunks WHERE org_id = $1 AND version_id = $2",
+            &[&ctx.org_id(), &version_id],
         )
         .await?;
     Ok(row.get(0))

--- a/crates/server/src/db/index_metadata.rs
+++ b/crates/server/src/db/index_metadata.rs
@@ -1,0 +1,165 @@
+//! Tenant-scoped index metadata generation repository.
+
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{EmbeddingRuntimePath, IndexMetadata};
+
+const INDEX_METADATA_COLUMNS: &str = "id, org_id, collection_id, index_signature_sha256, \
+    identity_version, chunking_version, body_text_version, query_normalization_version, \
+    embedding_family, embedding_revision, dimensions, normalized, runtime_path, generation, \
+    is_active, created_at";
+
+#[derive(Debug, Clone)]
+pub struct EnsureGeneration<'a> {
+    pub collection_id: Option<Uuid>,
+    pub signature_sha256: &'a str,
+    pub chunking_version: &'a str,
+    pub body_text_version: &'a str,
+    pub query_normalization_version: &'a str,
+    pub embedding_family: &'a str,
+    pub embedding_revision: &'a str,
+    pub dimensions: i32,
+    pub normalized: bool,
+    pub runtime_path: EmbeddingRuntimePath,
+}
+
+pub async fn find_active(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    collection_id: Option<Uuid>,
+) -> Result<Option<IndexMetadata>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "SELECT {INDEX_METADATA_COLUMNS}
+                 FROM index_metadata
+                 WHERE org_id = $1
+                   AND collection_id IS NOT DISTINCT FROM $2
+                   AND is_active"
+            ),
+            &[&ctx.org_id(), &collection_id],
+        )
+        .await?;
+    row.map(|row| map_index_metadata(&row)).transpose()
+}
+
+pub async fn ensure_active_generation(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: EnsureGeneration<'_>,
+) -> Result<IndexMetadata, DbError> {
+    lock_generation_scope(txn, ctx, input.collection_id).await?;
+    if let Some(active) = find_active_for_update(txn, ctx, input.collection_id).await? {
+        if active.index_signature_sha256 == input.signature_sha256 {
+            return Ok(active);
+        }
+        return Err(DbError::Config(
+            "index signature change requires an explicit reindex".into(),
+        ));
+    }
+
+    let runtime_path = input.runtime_path.as_str();
+    let row = txn
+        .query_opt(
+            &format!(
+                "WITH next_generation AS (
+                    SELECT COALESCE(MAX(generation), 0)::integer + 1 AS generation
+                    FROM index_metadata
+                    WHERE org_id = $1
+                      AND index_signature_sha256 = $3
+                 )
+                 INSERT INTO index_metadata (
+                    org_id, collection_id, index_signature_sha256, chunking_version,
+                    body_text_version, query_normalization_version, embedding_family,
+                    embedding_revision, dimensions, normalized, runtime_path, generation,
+                    is_active
+                 )
+                 SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+                        next_generation.generation, true
+                 FROM next_generation
+                 ON CONFLICT (org_id, index_signature_sha256, generation) DO NOTHING
+                 RETURNING {INDEX_METADATA_COLUMNS}"
+            ),
+            &[
+                &ctx.org_id(),
+                &input.collection_id,
+                &input.signature_sha256,
+                &input.chunking_version,
+                &input.body_text_version,
+                &input.query_normalization_version,
+                &input.embedding_family,
+                &input.embedding_revision,
+                &input.dimensions,
+                &input.normalized,
+                &runtime_path,
+            ],
+        )
+        .await?;
+    if let Some(row) = row {
+        return map_index_metadata(&row);
+    }
+    find_active(txn, ctx, input.collection_id)
+        .await?
+        .filter(|metadata| metadata.index_signature_sha256 == input.signature_sha256)
+        .ok_or(DbError::NotFound)
+}
+
+async fn find_active_for_update(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    collection_id: Option<Uuid>,
+) -> Result<Option<IndexMetadata>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "SELECT {INDEX_METADATA_COLUMNS}
+                 FROM index_metadata
+                 WHERE org_id = $1
+                   AND collection_id IS NOT DISTINCT FROM $2
+                   AND is_active
+                 FOR UPDATE"
+            ),
+            &[&ctx.org_id(), &collection_id],
+        )
+        .await?;
+    row.map(|row| map_index_metadata(&row)).transpose()
+}
+
+async fn lock_generation_scope(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    collection_id: Option<Uuid>,
+) -> Result<(), DbError> {
+    let collection = collection_id
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| "00000000-0000-0000-0000-000000000000".to_string());
+    let key = format!("index_metadata:{}:{collection}", ctx.org_id());
+    txn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", &[&key])
+        .await?;
+    Ok(())
+}
+
+fn map_index_metadata(row: &Row) -> Result<IndexMetadata, DbError> {
+    let runtime_path: String = row.get("runtime_path");
+    Ok(IndexMetadata {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        collection_id: row.get("collection_id"),
+        index_signature_sha256: row.get("index_signature_sha256"),
+        identity_version: row.get("identity_version"),
+        chunking_version: row.get("chunking_version"),
+        body_text_version: row.get("body_text_version"),
+        query_normalization_version: row.get("query_normalization_version"),
+        embedding_family: row.get("embedding_family"),
+        embedding_revision: row.get("embedding_revision"),
+        dimensions: row.get("dimensions"),
+        normalized: row.get("normalized"),
+        runtime_path: EmbeddingRuntimePath::parse(&runtime_path).map_err(DbError::Config)?,
+        generation: row.get("generation"),
+        is_active: row.get("is_active"),
+        created_at: row.get("created_at"),
+    })
+}

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -5,6 +5,7 @@ pub mod collections;
 pub mod document_versions;
 pub mod documents;
 pub mod error;
+pub mod index_metadata;
 pub(crate) mod jobs;
 pub mod models;
 pub mod orgs;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -740,6 +740,29 @@ pub enum EmbeddingRuntimePath {
     ProviderCloud,
 }
 
+impl EmbeddingRuntimePath {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LocalHash => "local-hash",
+            Self::LocalNeural => "local-neural",
+            Self::GlmCloudInterim => "glm-cloud-interim",
+            Self::VllmLocal => "vllm-local",
+            Self::ProviderCloud => "provider-cloud",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "local-hash" => Ok(Self::LocalHash),
+            "local-neural" => Ok(Self::LocalNeural),
+            "glm-cloud-interim" => Ok(Self::GlmCloudInterim),
+            "vllm-local" => Ok(Self::VllmLocal),
+            "provider-cloud" => Ok(Self::ProviderCloud),
+            other => Err(format!("unknown embedding runtime path: {other}")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IndexMetadata {
     pub id: Uuid,

--- a/crates/server/src/jobs/mod.rs
+++ b/crates/server/src/jobs/mod.rs
@@ -71,7 +71,8 @@ impl From<JobPayloadV1> for JobPayload {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct EventPayload {
     pub job_id: Option<Uuid>,
     pub document_id: Option<Uuid>,
@@ -271,53 +272,57 @@ pub async fn enqueue(
     ctx: &OrgContext,
     input: EnqueueJob,
 ) -> Result<EnqueueOutcome, JobError> {
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| Box::pin(async move { enqueue_within_txn(txn, &ctx, input).await })
+    })
+    .await
+}
+
+pub(crate) async fn enqueue_within_txn(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    input: EnqueueJob,
+) -> Result<EnqueueOutcome, JobError> {
     validate_idempotency_key(&input.idempotency_key)?;
     let max_attempts = checked_max_attempts(input.max_attempts)?;
     let available_after = checked_duration(input.available_after)?;
     let payload = validated_job_payload(&input.payload)?;
     validate_job_payload_lineage(&input.payload)?;
 
-    pool::with_org_txn_typed(db_pool, ctx, {
-        let ctx = ctx.clone();
-        move |txn| {
-            Box::pin(async move {
-                let observed_at = repo::fresh_clock_timestamp(txn).await?;
-                let available_at = observed_at
-                    .checked_add_signed(available_after)
-                    .ok_or(JobError::InvalidDuration)?;
-                let event_payload = EventPayload {
-                    job_id: Some(input.id),
-                    document_id: input.payload.document_id,
-                    version_id: input.payload.version_id,
-                    outbox_event_id: None,
-                }
-                .to_validated()?;
-                let outbox_idempotency_key = format!("job.enqueued:{}", input.id);
-                let (job, created) = repo::insert_job_with_outbox(
-                    txn,
-                    &ctx,
-                    repo::NewJob {
-                        id: input.id,
-                        job_type: input.job_type,
-                        payload_version: CURRENT_JOB_PAYLOAD_VERSION,
-                        payload: &payload,
-                        max_attempts,
-                        idempotency_key: &input.idempotency_key,
-                        document_id: input.payload.document_id,
-                        version_id: input.payload.version_id,
-                        available_at,
-                        outbox_event_type: "job.enqueued",
-                        outbox_payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
-                        outbox_payload: &event_payload,
-                        outbox_idempotency_key: &outbox_idempotency_key,
-                    },
-                )
-                .await?;
-                Ok(EnqueueOutcome { job, created })
-            })
-        }
-    })
-    .await
+    let observed_at = repo::fresh_clock_timestamp(txn).await?;
+    let available_at = observed_at
+        .checked_add_signed(available_after)
+        .ok_or(JobError::InvalidDuration)?;
+    let event_payload = EventPayload {
+        job_id: Some(input.id),
+        document_id: input.payload.document_id,
+        version_id: input.payload.version_id,
+        outbox_event_id: None,
+    }
+    .to_validated()?;
+    let outbox_idempotency_key = format!("job.enqueued:{}", input.id);
+    let (job, created) = repo::insert_job_with_outbox(
+        txn,
+        ctx,
+        repo::NewJob {
+            id: input.id,
+            job_type: input.job_type,
+            payload_version: CURRENT_JOB_PAYLOAD_VERSION,
+            payload: &payload,
+            max_attempts,
+            idempotency_key: &input.idempotency_key,
+            document_id: input.payload.document_id,
+            version_id: input.payload.version_id,
+            available_at,
+            outbox_event_type: "job.enqueued",
+            outbox_payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
+            outbox_payload: &event_payload,
+            outbox_idempotency_key: &outbox_idempotency_key,
+        },
+    )
+    .await?;
+    Ok(EnqueueOutcome { job, created })
 }
 
 pub async fn claim(
@@ -433,6 +438,21 @@ pub async fn checkpoint(
         }
     })
     .await
+}
+
+pub(crate) async fn checkpoint_within_txn(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_token: &str,
+    claimed_attempts: i32,
+    checkpoint: CheckpointPayload,
+) -> Result<Job, JobError> {
+    validate_lease_identifier(lease_token)?;
+    let checkpoint = validated_checkpoint_payload(checkpoint)?;
+    repo::save_checkpoint(txn, ctx, job_id, lease_token, claimed_attempts, &checkpoint)
+        .await?
+        .ok_or(JobError::LeaseLost)
 }
 
 pub async fn reclaim_expired(

--- a/crates/server/src/services/chunking.rs
+++ b/crates/server/src/services/chunking.rs
@@ -1,0 +1,70 @@
+//! Pure markdown chunk preparation for indexing.
+
+use fileconv_core::chunk::chunk_markdown;
+use fileconv_knowledge::identity::{chunk_identity, BODY_TEXT_VERSION};
+use uuid::Uuid;
+
+const CHUNK_MAX_CHARS: usize = 2000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedChunk {
+    pub ordinal: i32,
+    pub heading_path: Vec<String>,
+    pub heading_joined: String,
+    pub body: String,
+    pub chunk_identity: String,
+}
+
+pub fn prepare_chunks(document_id: Uuid, version_id: Uuid, markdown: &str) -> Vec<PreparedChunk> {
+    let document_id = document_id.to_string();
+    let version_id = version_id.to_string();
+    chunk_markdown(markdown, CHUNK_MAX_CHARS)
+        .into_iter()
+        .map(|chunk| {
+            let heading_path = if chunk.heading.is_empty() {
+                Vec::new()
+            } else {
+                chunk.heading.split(" > ").map(str::to_string).collect()
+            };
+            let ordinal = i32::try_from(chunk.index).expect("chunk index fits in i32");
+            let identity = chunk_identity(
+                &document_id,
+                &version_id,
+                chunk.index as u64,
+                &chunk.heading,
+                &chunk.text,
+                BODY_TEXT_VERSION,
+            );
+            PreparedChunk {
+                ordinal,
+                heading_path,
+                heading_joined: chunk.heading,
+                body: chunk.text,
+                chunk_identity: identity,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepare_chunks_splits_heading_path_and_identity_is_deterministic() {
+        let document_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let version_id = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+        let markdown = "# Chương I\n\nMở đầu.\n\n## Điều 1\n\nNội dung điều 1.";
+        let first = prepare_chunks(document_id, version_id, markdown);
+        let second = prepare_chunks(document_id, version_id, markdown);
+        assert_eq!(first, second);
+        assert_eq!(first[1].heading_joined, "Chương I > Điều 1");
+        assert_eq!(first[1].heading_path, vec!["Chương I", "Điều 1"]);
+        assert_eq!(first[1].chunk_identity.len(), 64);
+    }
+
+    #[test]
+    fn prepare_chunks_returns_empty_for_empty_markdown() {
+        assert!(prepare_chunks(Uuid::new_v4(), Uuid::new_v4(), " \n\t ").is_empty());
+    }
+}

--- a/crates/server/src/services/embedding.rs
+++ b/crates/server/src/services/embedding.rs
@@ -1,0 +1,61 @@
+//! Approved local embedding service for the index worker.
+
+use fileconv_knowledge::embedding::{
+    local_vector, validate_embedding_batch, EmbeddingPlan, LOCAL_VECTOR_DIMENSIONS,
+};
+use thiserror::Error;
+
+pub fn approved_plan() -> EmbeddingPlan {
+    EmbeddingPlan::local_hash_v1()
+}
+
+pub fn embed_bodies(bodies: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+    let vectors = bodies
+        .iter()
+        .map(|body| local_vector(body))
+        .collect::<Vec<_>>();
+    validate_embedding_batch(&vectors, bodies.len(), Some(LOCAL_VECTOR_DIMENSIONS))?;
+    if vectors
+        .iter()
+        .any(|vector| !is_l2_normalized(vector.values()))
+    {
+        return Err(EmbeddingError::NotNormalized);
+    }
+    Ok(vectors
+        .into_iter()
+        .map(|vector| vector.into_values())
+        .collect())
+}
+
+fn is_l2_normalized(values: &[f32]) -> bool {
+    let norm = values.iter().map(|value| value * value).sum::<f32>().sqrt();
+    norm.is_finite() && (norm - 1.0).abs() <= 0.001
+}
+
+#[derive(Debug, Error)]
+pub enum EmbeddingError {
+    #[error("embedding validation failed")]
+    Knowledge(#[from] fileconv_knowledge::KnowledgeError),
+    #[error("embedding vector is not L2-normalized")]
+    NotNormalized,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_embedding_is_deterministic_and_256_dimensional() {
+        let bodies = vec![
+            "đối soát giao dịch".to_string(),
+            "nội dung khác".to_string(),
+        ];
+        let first = embed_bodies(&bodies).unwrap();
+        let second = embed_bodies(&bodies).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 2);
+        assert!(first
+            .iter()
+            .all(|vector| vector.len() == LOCAL_VECTOR_DIMENSIONS));
+    }
+}

--- a/crates/server/src/services/indexing.rs
+++ b/crates/server/src/services/indexing.rs
@@ -1,0 +1,744 @@
+//! Index job bridge and indexing orchestration.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use deadpool_postgres::Pool;
+use fileconv_knowledge::embedding::LOCAL_VECTOR_DIMENSIONS;
+use fileconv_knowledge::identity::BODY_TEXT_VERSION;
+use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio::time::{interval_at, sleep_until, timeout, Instant as TokioInstant, MissedTickBehavior};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{
+    DocumentState, EmbeddingRuntimePath, EventLogEntry, Job, JobStatus, JobType, OutboxEvent,
+};
+use crate::db::pool::with_org_txn_typed;
+use crate::db::{chunks, document_versions, documents, index_metadata, jobs as repo};
+use crate::jobs::{
+    self, CheckpointPayload, EnqueueJob, EventPayload, JobError, JobPayload,
+    CURRENT_EVENT_PAYLOAD_VERSION,
+};
+use crate::services::chunking::{prepare_chunks, PreparedChunk};
+use crate::services::document_state;
+use crate::services::embedding::{self, EmbeddingError};
+use crate::storage::keys::{authorize_key_for_version, parse_key_for_org};
+use crate::storage::minio::MinioClient;
+use crate::storage::qdrant::{ChunkPointPayload, QdrantClient, UpsertPoint, VectorScope};
+use crate::storage::{ObjectNamespace, StorageError};
+
+#[derive(Debug, Default)]
+pub struct IndexingOutboxSink;
+
+impl IndexingOutboxSink {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl jobs::OutboxSink for IndexingOutboxSink {
+    fn publish<'a>(
+        &'a self,
+        txn: &'a tokio_postgres::Transaction<'_>,
+        ctx: &'a OrgContext,
+        event: &'a OutboxEvent,
+    ) -> Pin<Box<dyn Future<Output = Result<EventLogEntry, JobError>> + Send + 'a>> {
+        Box::pin(async move {
+            if event.event_type == "document.index_requested" {
+                let payload = serde_json::from_value::<EventPayload>(event.payload.clone())
+                    .map_err(|error| {
+                        JobError::InvalidPayload(format!("event decode failed: {error}"))
+                    })?;
+                let document_id = payload.document_id.ok_or_else(|| {
+                    JobError::InvalidPayload("index event missing document_id".into())
+                })?;
+                let version_id = payload.version_id.ok_or_else(|| {
+                    JobError::InvalidPayload("index event missing version_id".into())
+                })?;
+                let job_payload = JobPayload {
+                    document_id: Some(document_id),
+                    version_id: Some(version_id),
+                    ..JobPayload::default()
+                };
+                jobs::enqueue_within_txn(
+                    txn,
+                    ctx,
+                    EnqueueJob::new(JobType::Index, job_payload, format!("index:{version_id}")),
+                )
+                .await?;
+            }
+
+            append_outbox_published(txn, ctx, event).await
+        })
+    }
+}
+
+async fn append_outbox_published(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    event: &OutboxEvent,
+) -> Result<EventLogEntry, JobError> {
+    if let Some(existing) = repo::find_outbox_published_event(txn, ctx, event.id).await? {
+        return Ok(existing);
+    }
+    let payload = EventPayload {
+        job_id: event.job_id,
+        document_id: None,
+        version_id: None,
+        outbox_event_id: Some(event.id),
+    }
+    .to_json()?;
+    let payload = repo::ValidatedEventPayload::new(payload)
+        .map_err(|error| JobError::InvalidPayload(error.to_string()))?;
+    repo::append_event_log(
+        txn,
+        ctx,
+        repo::NewEventLogEntry {
+            event_type: "outbox.published",
+            payload_version: CURRENT_EVENT_PAYLOAD_VERSION,
+            payload: &payload,
+            job_id: event.job_id,
+            document_id: None,
+            version_id: None,
+        },
+    )
+    .await
+    .map_err(Into::into)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum IndexVersionOutcome {
+    Finalized { job_id: Uuid, chunks: usize },
+    CompleteOnly { chunks: usize },
+    AlreadyIndexed,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct IndexVersionInput<'a> {
+    pub job: &'a Job,
+    pub lease_token: &'a str,
+    pub attempts: i32,
+    pub lease_ttl: Duration,
+    pub heartbeat_interval: Duration,
+    pub embedding_batch_size: usize,
+    pub approved_signature: Option<&'a str>,
+    pub deadline: TokioInstant,
+}
+
+pub async fn index_version(
+    db_pool: &Pool,
+    storage: &MinioClient,
+    qdrant: &QdrantClient,
+    ctx: &OrgContext,
+    input: IndexVersionInput<'_>,
+) -> Result<IndexVersionOutcome, IndexingError> {
+    let payload = jobs::decode_job_payload(input.job.payload_version, input.job.payload.clone())?;
+    let document_id = payload.document_id.ok_or(IndexingError::InvalidPayload)?;
+    let version_id = payload.version_id.ok_or(IndexingError::InvalidPayload)?;
+    let (document, version, artifact) =
+        load_index_source(db_pool, ctx, document_id, version_id).await?;
+    let is_current = document.current_version_id == Some(version_id);
+    let is_effective = version.effective_to.is_none();
+
+    let trusted_key = parse_key_for_org(&artifact.object_key, ctx.org_id())?;
+    if trusted_key.namespace() != ObjectNamespace::Trusted {
+        return Err(IndexingError::MarkdownNotTrusted);
+    }
+    authorize_key_for_version(&trusted_key, version_id)
+        .map_err(|_| IndexingError::MarkdownKeyVersionMismatch)?;
+    let bytes = storage.get_object(ctx.org_id(), &trusted_key).await?;
+    let actual_sha256 = hex::encode(Sha256::digest(&bytes));
+    if actual_sha256 != artifact.content_sha256 {
+        return Err(IndexingError::MarkdownIntegrity);
+    }
+    let markdown = String::from_utf8(bytes.to_vec()).map_err(|_| IndexingError::MarkdownUtf8)?;
+    let prepared_chunks = prepare_chunks(document_id, version_id, &markdown);
+
+    let plan = embedding::approved_plan();
+    let signature = plan.index_signature(LOCAL_VECTOR_DIMENSIONS)?;
+    let signature_digest = signature.digest();
+    if let Some(approved) = input.approved_signature {
+        if approved != signature_digest {
+            return Err(IndexingError::SignatureMismatch);
+        }
+    }
+    let runtime_path =
+        EmbeddingRuntimePath::parse(signature.runtime_path).map_err(DbError::Config)?;
+    let dimensions = i32::try_from(signature.dimensions).map_err(|_| {
+        DbError::Config("embedding dimensions are out of range for database".into())
+    })?;
+    let metadata = ensure_generation(
+        db_pool,
+        ctx,
+        index_metadata::EnsureGeneration {
+            collection_id: Some(document.collection_id),
+            signature_sha256: &signature_digest,
+            chunking_version: signature.chunking_version,
+            body_text_version: signature.body_text_version,
+            query_normalization_version: signature.query_normalization_version,
+            embedding_family: signature.embedding_family,
+            embedding_revision: signature.embedding_revision,
+            dimensions,
+            normalized: signature.normalized,
+            runtime_path,
+        },
+    )
+    .await?;
+    heartbeat_once(db_pool, ctx, input).await?;
+
+    if is_current {
+        match document.state {
+            DocumentState::Indexed => return Ok(IndexVersionOutcome::AlreadyIndexed),
+            DocumentState::Converted => {
+                transition_current_to_indexing(db_pool, ctx, input, document_id, version_id)
+                    .await?;
+            }
+            DocumentState::Indexing => {}
+            other => return Err(IndexingError::UnexpectedDocumentState(other)),
+        }
+    }
+
+    let scope = VectorScope::new(ctx.org_id(), [document.collection_id]);
+    let collection_name = if prepared_chunks.is_empty() {
+        None
+    } else {
+        Some(qdrant.ensure_collection_for_signature(&signature).await?)
+    };
+    let mut offset = checkpoint_offset(input.job)?;
+    if offset > prepared_chunks.len() {
+        return Err(IndexingError::InvalidCheckpoint);
+    }
+    while offset < prepared_chunks.len() {
+        check_deadline(input.deadline)?;
+        let batch_end = offset
+            .saturating_add(input.embedding_batch_size)
+            .min(prepared_chunks.len());
+        let batch = &prepared_chunks[offset..batch_end];
+        let collection_name = collection_name
+            .as_ref()
+            .ok_or(IndexingError::MissingQdrantCollection)?;
+        heartbeat_while(db_pool, ctx, input, async {
+            let vectors = embed_batch(batch).await?;
+            let points = batch
+                .iter()
+                .zip(vectors)
+                .map(|(chunk, vector)| {
+                    Ok(UpsertPoint {
+                        chunk_identity: chunk.chunk_identity.clone(),
+                        vector,
+                        payload: ChunkPointPayload {
+                            org_id: ctx.org_id(),
+                            collection_id: document.collection_id,
+                            document_id,
+                            version_id,
+                            chunk_id: chunk.chunk_identity.clone(),
+                            ordinal: u64::try_from(chunk.ordinal)
+                                .map_err(|_| IndexingError::ChunkOrdinal)?,
+                            is_current,
+                            is_effective,
+                            index_generation: u32::try_from(metadata.generation)
+                                .map_err(|_| IndexingError::IndexGeneration)?,
+                        },
+                    })
+                })
+                .collect::<Result<Vec<_>, IndexingError>>()?;
+            // TODO(I07): superseded-version point flags need reconciliation when a
+            // newer version changes which version is current/effective.
+            // TODO(I07): retrieval must filter on committed PG version state and
+            // document indexed state, not solely on these Qdrant payload flags.
+            qdrant
+                .upsert_points(collection_name, &scope, &points)
+                .await?;
+            // TODO(I07): Qdrant is durable before the PG chunk/checkpoint commit;
+            // dead-lettered attempts may leave orphan vectors for reconcile/GC.
+            persist_chunk_batch(
+                db_pool,
+                ctx,
+                PersistBatchInput {
+                    claim: input,
+                    metadata_id: metadata.id,
+                    signature_digest: &signature_digest,
+                    document_id,
+                    version_id,
+                    batch,
+                    batch_end,
+                },
+            )
+            .await?;
+            Ok::<(), IndexingError>(())
+        })
+        .await?;
+        offset = batch_end;
+    }
+
+    if is_current {
+        let job = finalize_indexed(db_pool, ctx, input, document_id, version_id).await?;
+        Ok(IndexVersionOutcome::Finalized {
+            job_id: job.id,
+            chunks: prepared_chunks.len(),
+        })
+    } else {
+        Ok(IndexVersionOutcome::CompleteOnly {
+            chunks: prepared_chunks.len(),
+        })
+    }
+}
+
+async fn load_index_source(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<
+    (
+        crate::db::models::Document,
+        crate::db::models::DocumentVersion,
+        document_versions::ArtifactInsertOutcome,
+    ),
+    IndexingError,
+> {
+    with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                let version = document_versions::find_by_id(txn, &ctx, document_id, version_id)
+                    .await?
+                    .ok_or(DbError::NotFound)?;
+                let artifact = document_versions::find_markdown_artifact(txn, &ctx, version_id)
+                    .await?
+                    .ok_or(DbError::NotFound)?;
+                Ok::<_, IndexingError>((document, version, artifact))
+            })
+        }
+    })
+    .await
+}
+
+async fn ensure_generation(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    input: index_metadata::EnsureGeneration<'_>,
+) -> Result<crate::db::models::IndexMetadata, IndexingError> {
+    let owned = EnsureGenerationOwned::from(input);
+    with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                Ok::<_, IndexingError>(
+                    index_metadata::ensure_active_generation(txn, &ctx, owned.as_input()).await?,
+                )
+            })
+        }
+    })
+    .await
+}
+
+async fn transition_current_to_indexing(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    input: IndexVersionInput<'_>,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<(), IndexingError> {
+    let lease_token = input.lease_token.to_string();
+    let job_id = input.job.id;
+    let attempts = input.attempts;
+    with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                verify_claimed_job(txn, &ctx, job_id, &lease_token, attempts).await?;
+                let document = documents::get_by_id_for_update(txn, &ctx, document_id).await?;
+                if document.current_version_id != Some(version_id) {
+                    return Err(IndexingError::CurrentVersionChanged);
+                }
+                document_state::apply_transition(
+                    txn,
+                    &ctx,
+                    document_id,
+                    DocumentState::Converted,
+                    DocumentState::Indexing,
+                )
+                .await?;
+                Ok::<(), IndexingError>(())
+            })
+        }
+    })
+    .await
+}
+
+pub async fn finalize_indexed(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    input: IndexVersionInput<'_>,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<Job, IndexingError> {
+    let lease_token = input.lease_token.to_string();
+    let job_id = input.job.id;
+    let attempts = input.attempts;
+    with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                verify_claimed_job(txn, &ctx, job_id, &lease_token, attempts).await?;
+                let document = documents::get_by_id_for_update(txn, &ctx, document_id).await?;
+                if document.current_version_id != Some(version_id) {
+                    return Err(IndexingError::CurrentVersionChanged);
+                }
+                document_state::apply_transition(
+                    txn,
+                    &ctx,
+                    document_id,
+                    DocumentState::Indexing,
+                    DocumentState::Indexed,
+                )
+                .await?;
+                let completed = repo::complete_owned(txn, &ctx, job_id, &lease_token, attempts)
+                    .await?
+                    .ok_or(IndexingError::Job(JobError::LeaseLost))?;
+                write_job_succeeded_event(txn, &ctx, &completed).await?;
+                Ok::<_, IndexingError>(completed)
+            })
+        }
+    })
+    .await
+}
+
+async fn verify_claimed_job(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_token: &str,
+    attempts: i32,
+) -> Result<Job, IndexingError> {
+    repo::get_by_id_for_update(txn, ctx, job_id)
+        .await?
+        .filter(|job| {
+            job.status == JobStatus::Leased
+                && job.lease_owner.as_deref() == Some(lease_token)
+                && job.attempts == attempts
+        })
+        .ok_or(IndexingError::Job(JobError::LeaseLost))
+}
+
+async fn write_job_succeeded_event(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    job: &Job,
+) -> Result<(), IndexingError> {
+    let payload = validated_event_payload(EventPayload {
+        job_id: Some(job.id),
+        document_id: job.document_id,
+        version_id: job.version_id,
+        outbox_event_id: None,
+    })?;
+    repo::append_event_and_outbox(
+        txn,
+        ctx,
+        repo::NewEventLogEntry {
+            event_type: "job.succeeded",
+            payload_version: jobs::CURRENT_EVENT_PAYLOAD_VERSION,
+            payload: &payload,
+            job_id: Some(job.id),
+            document_id: job.document_id,
+            version_id: job.version_id,
+        },
+        &format!("job.succeeded:{}:{}", job.id, job.attempts),
+    )
+    .await?;
+    Ok(())
+}
+
+fn validated_event_payload(
+    payload: EventPayload,
+) -> Result<repo::ValidatedEventPayload, IndexingError> {
+    let value: JsonValue = payload.to_json().map_err(IndexingError::Job)?;
+    repo::ValidatedEventPayload::new(value)
+        .map_err(|error| IndexingError::Job(JobError::InvalidPayload(error.to_string())))
+}
+
+struct EnsureGenerationOwned {
+    collection_id: Option<Uuid>,
+    signature_sha256: String,
+    chunking_version: String,
+    body_text_version: String,
+    query_normalization_version: String,
+    embedding_family: String,
+    embedding_revision: String,
+    dimensions: i32,
+    normalized: bool,
+    runtime_path: EmbeddingRuntimePath,
+}
+
+impl From<index_metadata::EnsureGeneration<'_>> for EnsureGenerationOwned {
+    fn from(input: index_metadata::EnsureGeneration<'_>) -> Self {
+        Self {
+            collection_id: input.collection_id,
+            signature_sha256: input.signature_sha256.to_string(),
+            chunking_version: input.chunking_version.to_string(),
+            body_text_version: input.body_text_version.to_string(),
+            query_normalization_version: input.query_normalization_version.to_string(),
+            embedding_family: input.embedding_family.to_string(),
+            embedding_revision: input.embedding_revision.to_string(),
+            dimensions: input.dimensions,
+            normalized: input.normalized,
+            runtime_path: input.runtime_path,
+        }
+    }
+}
+
+impl EnsureGenerationOwned {
+    fn as_input(&self) -> index_metadata::EnsureGeneration<'_> {
+        index_metadata::EnsureGeneration {
+            collection_id: self.collection_id,
+            signature_sha256: &self.signature_sha256,
+            chunking_version: &self.chunking_version,
+            body_text_version: &self.body_text_version,
+            query_normalization_version: &self.query_normalization_version,
+            embedding_family: &self.embedding_family,
+            embedding_revision: &self.embedding_revision,
+            dimensions: self.dimensions,
+            normalized: self.normalized,
+            runtime_path: self.runtime_path,
+        }
+    }
+}
+
+async fn embed_batch(batch: &[PreparedChunk]) -> Result<Vec<Vec<f32>>, IndexingError> {
+    let bodies = batch
+        .iter()
+        .map(|chunk| chunk.body.clone())
+        .collect::<Vec<_>>();
+    tokio::task::spawn_blocking(move || embedding::embed_bodies(&bodies))
+        .await
+        .map_err(|_| IndexingError::EmbeddingJoin)?
+        .map_err(Into::into)
+}
+
+struct PersistBatchInput<'a> {
+    claim: IndexVersionInput<'a>,
+    metadata_id: Uuid,
+    signature_digest: &'a str,
+    document_id: Uuid,
+    version_id: Uuid,
+    batch: &'a [PreparedChunk],
+    batch_end: usize,
+}
+
+async fn persist_chunk_batch(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    input: PersistBatchInput<'_>,
+) -> Result<(), IndexingError> {
+    let batch = input.batch.to_vec();
+    let signature_digest = input.signature_digest.to_string();
+    let metadata_id = input.metadata_id;
+    let batch_end = u64::try_from(input.batch_end).map_err(|_| IndexingError::CheckpointOffset)?;
+    let lease_token = input.claim.lease_token.to_string();
+    let job_id = input.claim.job.id;
+    let attempts = input.claim.attempts;
+    let document_id = input.document_id;
+    let version_id = input.version_id;
+    with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                for chunk in &batch {
+                    chunks::insert_if_absent(
+                        txn,
+                        &ctx,
+                        chunks::NewChunk {
+                            id: Uuid::new_v4(),
+                            document_id,
+                            version_id,
+                            ordinal: chunk.ordinal,
+                            heading_path: &chunk.heading_path,
+                            body: &chunk.body,
+                            body_text_version: BODY_TEXT_VERSION,
+                            chunk_identity_sha256: &chunk.chunk_identity,
+                            index_metadata_id: metadata_id,
+                            index_signature: &signature_digest,
+                        },
+                    )
+                    .await?;
+                }
+                jobs::checkpoint_within_txn(
+                    txn,
+                    &ctx,
+                    job_id,
+                    &lease_token,
+                    attempts,
+                    CheckpointPayload {
+                        offset: Some(batch_end),
+                        ..CheckpointPayload::default()
+                    },
+                )
+                .await?;
+                Ok::<(), IndexingError>(())
+            })
+        }
+    })
+    .await
+}
+
+fn checkpoint_offset(job: &Job) -> Result<usize, IndexingError> {
+    let Some(value) = job.checkpoint.clone() else {
+        return Ok(0);
+    };
+    let checkpoint = serde_json::from_value::<CheckpointPayload>(value)
+        .map_err(|_| IndexingError::InvalidCheckpoint)?;
+    let offset = checkpoint.offset.unwrap_or(0);
+    usize::try_from(offset).map_err(|_| IndexingError::CheckpointOffset)
+}
+
+fn check_deadline(deadline: TokioInstant) -> Result<(), IndexingError> {
+    if TokioInstant::now() >= deadline {
+        Err(IndexingError::JobTimedOut)
+    } else {
+        Ok(())
+    }
+}
+
+async fn heartbeat_while<T, Fut>(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    input: IndexVersionInput<'_>,
+    future: Fut,
+) -> Result<T, IndexingError>
+where
+    Fut: Future<Output = Result<T, IndexingError>>,
+{
+    heartbeat_once(db_pool, ctx, input).await?;
+    tokio::pin!(future);
+    let mut heartbeat = heartbeat_interval(input.heartbeat_interval);
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut future => return result,
+            _ = sleep_until(input.deadline) => return Err(IndexingError::JobTimedOut),
+            _ = heartbeat.tick() => heartbeat_once(db_pool, ctx, input).await?,
+        }
+    }
+}
+
+async fn heartbeat_once(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    input: IndexVersionInput<'_>,
+) -> Result<(), IndexingError> {
+    match timeout(
+        heartbeat_call_timeout(input.lease_ttl, input.deadline),
+        jobs::heartbeat(
+            db_pool,
+            ctx,
+            input.job.id,
+            input.lease_token,
+            input.attempts,
+            input.lease_ttl,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(JobError::LeaseLost)) => Err(IndexingError::Job(JobError::LeaseLost)),
+        Ok(Err(error)) => Err(IndexingError::Job(error)),
+        Err(_) => Err(IndexingError::JobTimedOut),
+    }
+}
+
+fn heartbeat_interval(interval: Duration) -> tokio::time::Interval {
+    let mut heartbeat = interval_at(TokioInstant::now() + interval, interval);
+    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    heartbeat
+}
+
+fn heartbeat_call_timeout(lease_ttl: Duration, deadline: TokioInstant) -> Duration {
+    let mut lease_bound = lease_ttl / 3;
+    if lease_bound.is_zero() {
+        lease_bound = Duration::from_millis(1);
+    }
+    let remaining = deadline.saturating_duration_since(TokioInstant::now());
+    remaining.min(lease_bound)
+}
+
+#[derive(Debug, Error)]
+pub enum IndexingError {
+    #[error("database error")]
+    Db(#[from] DbError),
+    #[error("job error")]
+    Job(#[from] JobError),
+    #[error("storage error")]
+    Storage(#[from] StorageError),
+    #[error("knowledge error")]
+    Knowledge(#[from] fileconv_knowledge::KnowledgeError),
+    #[error("embedding error")]
+    Embedding(#[from] EmbeddingError),
+    #[error("embedding task failed")]
+    EmbeddingJoin,
+    #[error("index payload is missing document_id or version_id")]
+    InvalidPayload,
+    #[error("document is in unexpected state {0:?}")]
+    UnexpectedDocumentState(DocumentState),
+    #[error("markdown artifact key is not trusted")]
+    MarkdownNotTrusted,
+    #[error("markdown artifact key is bound to another version")]
+    MarkdownKeyVersionMismatch,
+    #[error("markdown artifact integrity check failed")]
+    MarkdownIntegrity,
+    #[error("markdown artifact is not utf-8")]
+    MarkdownUtf8,
+    #[error("configured index signature does not match approved local signature")]
+    SignatureMismatch,
+    #[error("index checkpoint is invalid")]
+    InvalidCheckpoint,
+    #[error("checkpoint offset is out of range")]
+    CheckpointOffset,
+    #[error("chunk ordinal is out of range")]
+    ChunkOrdinal,
+    #[error("index generation is out of range")]
+    IndexGeneration,
+    #[error("qdrant collection was not initialized")]
+    MissingQdrantCollection,
+    #[error("document current version changed while indexing")]
+    CurrentVersionChanged,
+    #[error("index job exceeded configured maximum duration")]
+    JobTimedOut,
+}
+
+impl IndexingError {
+    pub fn safe_job_error(&self) -> &'static str {
+        match self {
+            Self::Db(_) => "index database error",
+            Self::Job(_) => "index job error",
+            Self::Storage(_) => "index storage error",
+            Self::Knowledge(_) => "index knowledge error",
+            Self::Embedding(_) => "index embedding error",
+            Self::EmbeddingJoin => "index embedding join error",
+            Self::InvalidPayload => "index payload invalid",
+            Self::UnexpectedDocumentState(_) => "index document state invalid",
+            Self::MarkdownNotTrusted => "index markdown key invalid",
+            Self::MarkdownKeyVersionMismatch => "index markdown key version invalid",
+            Self::MarkdownIntegrity => "index markdown integrity failed",
+            Self::MarkdownUtf8 => "index markdown utf8 invalid",
+            Self::SignatureMismatch => "index signature mismatch",
+            Self::InvalidCheckpoint => "index checkpoint invalid",
+            Self::CheckpointOffset => "index checkpoint offset invalid",
+            Self::ChunkOrdinal => "index chunk ordinal invalid",
+            Self::IndexGeneration => "index generation invalid",
+            Self::MissingQdrantCollection => "index qdrant collection missing",
+            Self::CurrentVersionChanged => "index current version changed",
+            Self::JobTimedOut => "index job timed out",
+        }
+    }
+
+    pub fn is_retryable_job_failure(&self) -> bool {
+        !matches!(self, Self::Job(JobError::LeaseLost))
+    }
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -1,9 +1,12 @@
 //! Application services (use cases over repositories).
 
 pub mod artifacts;
+pub mod chunking;
 pub mod conversion;
 pub mod document_state;
+pub mod embedding;
 pub mod index_signature;
+pub mod indexing;
 pub mod promotion;
 pub mod quota;
 pub mod upload;

--- a/crates/server/src/workers/index.rs
+++ b/crates/server/src/workers/index.rs
@@ -1,0 +1,257 @@
+//! Durable index job worker.
+
+use std::time::Duration;
+
+use deadpool_postgres::Pool;
+use fileconv_knowledge::embedding::{EmbeddingPlan, LOCAL_VECTOR_DIMENSIONS};
+use thiserror::Error;
+use tokio::time::{timeout_at, Instant as TokioInstant};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::models::{Job, JobStatus, JobType};
+use crate::jobs::{self, JobError};
+use crate::services::indexing::{self, IndexVersionInput, IndexVersionOutcome, IndexingError};
+use crate::storage::minio::MinioClient;
+use crate::storage::qdrant::QdrantClient;
+
+const DEFAULT_CLAIM_LIMIT: u32 = 1;
+const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 5;
+const DEFAULT_MAX_JOB_DURATION_SECS: u64 = 300;
+const DEFAULT_EMBEDDING_BATCH_SIZE: usize = 64;
+const MAX_EMBEDDING_BATCH_SIZE: usize = 4096;
+
+#[derive(Debug, Clone)]
+pub struct IndexWorkerConfig {
+    pub worker_id: String,
+    pub lease_ttl: Duration,
+    pub heartbeat_interval: Duration,
+    pub max_job_duration: Duration,
+    pub embedding_batch_size: usize,
+}
+
+impl IndexWorkerConfig {
+    pub fn new(worker_id: impl Into<String>) -> Self {
+        Self {
+            worker_id: worker_id.into(),
+            lease_ttl: Duration::from_secs(60),
+            heartbeat_interval: Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL_SECS),
+            max_job_duration: Duration::from_secs(DEFAULT_MAX_JOB_DURATION_SECS),
+            embedding_batch_size: DEFAULT_EMBEDDING_BATCH_SIZE,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), IndexWorkerError> {
+        if self.heartbeat_interval.is_zero()
+            || self.lease_ttl.is_zero()
+            || self.heartbeat_interval > self.lease_ttl / 3
+        {
+            return Err(IndexWorkerError::InvalidHeartbeatConfig);
+        }
+        if self.max_job_duration.is_zero() {
+            return Err(IndexWorkerError::InvalidMaxJobDuration);
+        }
+        if self.embedding_batch_size == 0 || self.embedding_batch_size > MAX_EMBEDDING_BATCH_SIZE {
+            return Err(IndexWorkerError::InvalidBatchSize);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct IndexWorker {
+    db_pool: Pool,
+    storage: MinioClient,
+    qdrant: QdrantClient,
+    config: IndexWorkerConfig,
+    approved_signature: Option<String>,
+}
+
+impl IndexWorker {
+    pub fn new(
+        db_pool: Pool,
+        storage: MinioClient,
+        qdrant: QdrantClient,
+        config: IndexWorkerConfig,
+        approved_signature: Option<String>,
+    ) -> Result<Self, IndexWorkerError> {
+        config.validate()?;
+        if let Some(signature) = approved_signature.as_deref() {
+            let approved = EmbeddingPlan::local_hash_v1()
+                .index_signature(LOCAL_VECTOR_DIMENSIONS)
+                .map_err(IndexWorkerError::Knowledge)?
+                .digest();
+            if signature != approved {
+                return Err(IndexWorkerError::SignatureMismatch);
+            }
+        }
+        Ok(Self {
+            db_pool,
+            storage,
+            qdrant,
+            config,
+            approved_signature,
+        })
+    }
+
+    pub async fn run_once(&self, ctx: &OrgContext) -> Result<IndexWorkerRun, IndexWorkerError> {
+        let jobs = jobs::claim_type(
+            &self.db_pool,
+            ctx,
+            JobType::Index,
+            &self.config.worker_id,
+            DEFAULT_CLAIM_LIMIT,
+            self.config.lease_ttl,
+        )
+        .await?;
+        let Some(job) = jobs.into_iter().next() else {
+            return Ok(IndexWorkerRun::NoJob);
+        };
+        self.process_claimed_job(ctx, job).await
+    }
+
+    pub async fn process_claimed_job(
+        &self,
+        ctx: &OrgContext,
+        job: Job,
+    ) -> Result<IndexWorkerRun, IndexWorkerError> {
+        let lease_token = job
+            .lease_owner
+            .as_deref()
+            .ok_or(IndexWorkerError::MissingLease)?
+            .to_string();
+        let attempts = job.attempts;
+        let deadline = TokioInstant::now() + self.config.max_job_duration;
+        let input = IndexVersionInput {
+            job: &job,
+            lease_token: &lease_token,
+            attempts,
+            lease_ttl: self.config.lease_ttl,
+            heartbeat_interval: self.config.heartbeat_interval,
+            embedding_batch_size: self.config.embedding_batch_size,
+            approved_signature: self.approved_signature.as_deref(),
+            deadline,
+        };
+        let result = timeout_at(
+            deadline,
+            indexing::index_version(&self.db_pool, &self.storage, &self.qdrant, ctx, input),
+        )
+        .await;
+        match result {
+            Ok(Ok(IndexVersionOutcome::Finalized { job_id, chunks })) => {
+                Ok(IndexWorkerRun::Completed { job_id, chunks })
+            }
+            Ok(Ok(IndexVersionOutcome::CompleteOnly { chunks })) => {
+                match jobs::complete(&self.db_pool, ctx, job.id, &lease_token, attempts).await {
+                    Ok(completed) => Ok(IndexWorkerRun::Completed {
+                        job_id: completed.id,
+                        chunks,
+                    }),
+                    Err(JobError::LeaseLost) => Ok(IndexWorkerRun::LeaseLost { job_id: job.id }),
+                    Err(error) => Err(IndexWorkerError::Job(error)),
+                }
+            }
+            Ok(Ok(IndexVersionOutcome::AlreadyIndexed)) => {
+                match jobs::complete(&self.db_pool, ctx, job.id, &lease_token, attempts).await {
+                    Ok(completed) => Ok(IndexWorkerRun::Completed {
+                        job_id: completed.id,
+                        chunks: 0,
+                    }),
+                    Err(JobError::LeaseLost) => Ok(IndexWorkerRun::LeaseLost { job_id: job.id }),
+                    Err(error) => Err(IndexWorkerError::Job(error)),
+                }
+            }
+            Ok(Err(IndexingError::Job(JobError::LeaseLost))) => {
+                Ok(IndexWorkerRun::LeaseLost { job_id: job.id })
+            }
+            Ok(Err(error)) if error.is_retryable_job_failure() => {
+                self.fail_claimed(ctx, &job, &lease_token, attempts, error.safe_job_error())
+                    .await
+            }
+            Ok(Err(error)) => Err(IndexWorkerError::Indexing(error)),
+            Err(_) => {
+                self.fail_claimed(
+                    ctx,
+                    &job,
+                    &lease_token,
+                    attempts,
+                    IndexWorkerError::JobTimedOut.safe_job_error(),
+                )
+                .await
+            }
+        }
+    }
+
+    async fn fail_claimed(
+        &self,
+        ctx: &OrgContext,
+        job: &Job,
+        lease_token: &str,
+        attempts: i32,
+        last_error: &str,
+    ) -> Result<IndexWorkerRun, IndexWorkerError> {
+        match jobs::fail(
+            &self.db_pool,
+            ctx,
+            job.id,
+            lease_token,
+            attempts,
+            last_error,
+        )
+        .await
+        {
+            Ok(failed) => Ok(IndexWorkerRun::Failed {
+                job_id: failed.id,
+                terminal: failed.status == JobStatus::DeadLetter,
+            }),
+            Err(JobError::LeaseLost) => Ok(IndexWorkerRun::LeaseLost { job_id: job.id }),
+            Err(error) => Err(IndexWorkerError::Job(error)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexWorkerRun {
+    NoJob,
+    Completed { job_id: Uuid, chunks: usize },
+    Failed { job_id: Uuid, terminal: bool },
+    LeaseLost { job_id: Uuid },
+}
+
+#[derive(Debug, Error)]
+pub enum IndexWorkerError {
+    #[error("job error")]
+    Job(#[from] JobError),
+    #[error("indexing error")]
+    Indexing(#[from] IndexingError),
+    #[error("claimed job is missing a lease token")]
+    MissingLease,
+    #[error("worker heartbeat interval must be <= one third of lease ttl")]
+    InvalidHeartbeatConfig,
+    #[error("worker max job duration must be positive")]
+    InvalidMaxJobDuration,
+    #[error("embedding batch size must be between 1 and 4096")]
+    InvalidBatchSize,
+    #[error("configured index signature does not match approved local signature")]
+    SignatureMismatch,
+    #[error("knowledge error")]
+    Knowledge(fileconv_knowledge::KnowledgeError),
+    #[error("index job exceeded configured maximum duration")]
+    JobTimedOut,
+}
+
+impl IndexWorkerError {
+    pub fn safe_job_error(&self) -> &'static str {
+        match self {
+            Self::Job(_) => "index job error",
+            Self::Indexing(error) => error.safe_job_error(),
+            Self::MissingLease => "index missing lease",
+            Self::InvalidHeartbeatConfig => "index heartbeat config invalid",
+            Self::InvalidMaxJobDuration => "index max job duration invalid",
+            Self::InvalidBatchSize => "index batch size invalid",
+            Self::SignatureMismatch => "index signature mismatch",
+            Self::Knowledge(_) => "index knowledge error",
+            Self::JobTimedOut => "index job timed out",
+        }
+    }
+}

--- a/crates/server/src/workers/mod.rs
+++ b/crates/server/src/workers/mod.rs
@@ -1,5 +1,6 @@
 //! Background workers for Markhand Web.
 
 pub mod convert;
+pub mod index;
 pub mod limits;
 pub mod sandbox;

--- a/crates/server/tests/index_worker.rs
+++ b/crates/server/tests/index_worker.rs
@@ -1,0 +1,1004 @@
+//! Live tests for the durable index worker.
+//!
+//! These tests skip cleanly unless PostgreSQL, MinIO, and Qdrant test endpoints
+//! are provided in the environment.
+
+use bytes::Bytes;
+use deadpool_postgres::Pool;
+use fileconv_knowledge::embedding::LOCAL_VECTOR_DIMENSIONS;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::config::{MinioConfig, SecretString};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::collections::{self, NewCollection};
+use fileconv_server::db::documents::{self, NewDocument};
+use fileconv_server::db::models::{ArtifactKind, CollectionVisibility, DocumentState};
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::jobs::{self, EventPayload, CURRENT_EVENT_PAYLOAD_VERSION};
+use fileconv_server::services::chunking::prepare_chunks;
+use fileconv_server::services::embedding::{approved_plan, embed_bodies};
+use fileconv_server::services::indexing::IndexingOutboxSink;
+use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
+use fileconv_server::storage::qdrant::{
+    point_id_from_org_collection_and_chunk, ChunkPointPayload, QdrantClient, UpsertPoint,
+    VectorScope,
+};
+use fileconv_server::storage::trusted_key;
+use fileconv_server::workers::index::{IndexWorker, IndexWorkerConfig, IndexWorkerRun};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn test_minio_client() -> Option<MinioClient> {
+    let endpoint = match std::env::var("MARKHAND_TEST_MINIO_ENDPOINT") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ENDPOINT unset");
+            return None;
+        }
+    };
+    let access_key = std::env::var("MARKHAND_TEST_MINIO_ACCESS_KEY").ok()?;
+    let secret_key = std::env::var("MARKHAND_TEST_MINIO_SECRET_KEY").ok()?;
+    let region = std::env::var("MARKHAND_TEST_MINIO_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let bucket = format!("markhand-index-worker-{}", Uuid::new_v4().simple());
+    std::env::set_var("RUST_S3_SKIP_LOCATION_CONSTRAINT", "true");
+    let config = MinioConfig::new(
+        endpoint,
+        SecretString::new(access_key),
+        SecretString::new(secret_key),
+        bucket,
+        region,
+        true,
+    )
+    .expect("minio config");
+    Some(MinioClient::from_config(&config).expect("minio client"))
+}
+
+fn test_qdrant_client() -> Option<QdrantClient> {
+    let url = match std::env::var("MARKHAND_TEST_QDRANT_URL") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_QDRANT_URL unset");
+            return None;
+        }
+    };
+    let api_key = std::env::var("MARKHAND_TEST_QDRANT_API_KEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(SecretString::new);
+    Some(QdrantClient::with_api_key(url, api_key).expect("qdrant client"))
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_index_worker_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+struct LiveEnv {
+    db: EphemeralDb,
+    pool: Pool,
+    storage: MinioClient,
+    qdrant: QdrantClient,
+    ctx: OrgContext,
+}
+
+impl LiveEnv {
+    async fn boot() -> Option<Self> {
+        let base_url = test_database_url()?;
+        let storage = test_minio_client()?;
+        let qdrant = test_qdrant_client()?;
+        storage.ensure_bucket().await.expect("ensure bucket");
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("apply migrations");
+        let pool = create_pool(&db.url).expect("pool");
+        let ctx = OrgContext::try_new(Uuid::new_v4(), Uuid::new_v4(), ["doc.upload"], [])
+            .expect("org context");
+        Some(Self {
+            db,
+            pool,
+            storage,
+            qdrant,
+            ctx,
+        })
+    }
+
+    async fn drop(self) {
+        self.db.drop().await;
+    }
+}
+
+async fn seed_converted_document(
+    pool: &Pool,
+    storage: &MinioClient,
+    ctx: &OrgContext,
+    markdown: &str,
+) -> (Uuid, Uuid, Uuid) {
+    let collection_id = Uuid::new_v4();
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let artifact_id = Uuid::new_v4();
+    let outbox_key = format!("index-request:{version_id}");
+    let object_key =
+        trusted_key(ctx.org_id(), version_id, Uuid::new_v4(), None).expect("trusted key");
+    let object_key_string = object_key.as_str();
+    let sha256 = hex::encode(Sha256::digest(markdown.as_bytes()));
+    let markdown_len = markdown.len() as i64;
+    storage
+        .put_object(
+            ctx.org_id(),
+            &object_key,
+            Bytes::copy_from_slice(markdown.as_bytes()),
+            &ObjectIdentityMeta {
+                org_id: ctx.org_id(),
+                collection_id: Some(collection_id),
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                original_filename: None,
+                canonical_format: Some("md".into()),
+                content_sha256: Some(sha256.clone()),
+                content_length: Some(markdown.len() as u64),
+                disposition: Some("trusted".into()),
+            },
+            "text/markdown; charset=utf-8",
+        )
+        .await
+        .expect("put markdown");
+
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        let object_key_string = object_key_string.clone();
+        let sha256 = sha256.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &ctx, "index-worker-org", "Index Worker Org").await?;
+                orgs::ensure_user(
+                    txn,
+                    &ctx,
+                    ctx.user_id(),
+                    "index-worker@example.test",
+                    "Worker",
+                )
+                .await?;
+                orgs::ensure_membership(txn, &ctx).await?;
+                txn.execute(
+                    "INSERT INTO org_quotas (
+                        org_id, max_storage_bytes, max_documents,
+                        max_concurrent_jobs, max_monthly_tokens
+                     )
+                     VALUES ($1, 1000000000, 100000, 100, 1000000000)
+                     ON CONFLICT (org_id) DO NOTHING",
+                    &[&ctx.org_id()],
+                )
+                .await?;
+                let collection_name = format!("Index Worker Collection {collection_id}");
+                let collection_slug = format!("index-worker-{collection_id}");
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: collection_id,
+                        name: &collection_name,
+                        slug: &collection_slug,
+                        description: None,
+                        visibility: CollectionVisibility::Private,
+                    },
+                )
+                .await?;
+                documents::insert(
+                    txn,
+                    &ctx,
+                    NewDocument {
+                        id: document_id,
+                        collection_id,
+                        title: "Index Worker Doc",
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key, markdown_object_key,
+                        source_content_type, byte_size, created_by_user_id
+                     )
+                     VALUES ($1, $2, $3, 1, 'published', true, $4, $5, $5,
+                             'text/markdown', $6, $7)",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &sha256,
+                        &object_key_string,
+                        &markdown_len,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                let kind = ArtifactKind::Markdown.as_str();
+                txn.execute(
+                    "INSERT INTO derived_artifacts (
+                        id, org_id, document_id, version_id, artifact_kind,
+                        object_key, content_sha256, content_type, byte_size
+                     )
+                     VALUES ($1, $2, $3, $4, $5, $6, $7,
+                             'text/markdown; charset=utf-8', $8)",
+                    &[
+                        &artifact_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &version_id,
+                        &kind,
+                        &object_key_string,
+                        &sha256,
+                        &markdown_len,
+                    ],
+                )
+                .await?;
+                let converted = DocumentState::Converted.as_str();
+                txn.execute(
+                    "UPDATE documents
+                     SET state = $3, current_version_id = $4, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id, &converted, &version_id],
+                )
+                .await?;
+                let payload = EventPayload {
+                    job_id: None,
+                    document_id: Some(document_id),
+                    version_id: Some(version_id),
+                    outbox_event_id: None,
+                }
+                .to_json()
+                .expect("event payload");
+                txn.execute(
+                    "INSERT INTO outbox_events (
+                        org_id, event_type, payload_version, payload, idempotency_key
+                     )
+                     VALUES ($1, 'document.index_requested', $2, $3, $4)",
+                    &[
+                        &ctx.org_id(),
+                        &CURRENT_EVENT_PAYLOAD_VERSION,
+                        &payload,
+                        &outbox_key,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed converted document");
+    (document_id, version_id, collection_id)
+}
+
+async fn seed_promoted_current_version(
+    env: &LiveEnv,
+    document_id: Uuid,
+    collection_id: Uuid,
+    previous_version_id: Uuid,
+    markdown: &str,
+) -> Uuid {
+    let version_id = Uuid::new_v4();
+    let artifact_id = Uuid::new_v4();
+    let outbox_key = format!("index-request:{version_id}");
+    let object_key =
+        trusted_key(env.ctx.org_id(), version_id, Uuid::new_v4(), None).expect("trusted key");
+    let object_key_string = object_key.as_str();
+    let sha256 = hex::encode(Sha256::digest(markdown.as_bytes()));
+    let markdown_len = markdown.len() as i64;
+    env.storage
+        .put_object(
+            env.ctx.org_id(),
+            &object_key,
+            Bytes::copy_from_slice(markdown.as_bytes()),
+            &ObjectIdentityMeta {
+                org_id: env.ctx.org_id(),
+                collection_id: Some(collection_id),
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                original_filename: None,
+                canonical_format: Some("md".into()),
+                content_sha256: Some(sha256.clone()),
+                content_length: Some(markdown.len() as u64),
+                disposition: Some("trusted".into()),
+            },
+            "text/markdown; charset=utf-8",
+        )
+        .await
+        .expect("put promoted markdown");
+
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        let object_key_string = object_key_string.clone();
+        let sha256 = sha256.clone();
+        move |txn| {
+            Box::pin(async move {
+                let effective_to = txn
+                    .query_one("SELECT clock_timestamp()", &[])
+                    .await?
+                    .get::<_, chrono::DateTime<chrono::Utc>>(0);
+                txn.execute(
+                    "UPDATE document_versions
+                     SET is_current = false, effective_to = $4
+                     WHERE org_id = $1 AND document_id = $2 AND id = $3",
+                    &[
+                        &ctx.org_id(),
+                        &document_id,
+                        &previous_version_id,
+                        &effective_to,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key, markdown_object_key,
+                        source_content_type, byte_size, created_by_user_id
+                     )
+                     SELECT $1, $2, $3, COALESCE(MAX(version_number), 0)::integer + 1,
+                            'published', true, $4, $5, $5, 'text/markdown', $6, $7
+                     FROM document_versions
+                     WHERE org_id = $2 AND document_id = $3",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &sha256,
+                        &object_key_string,
+                        &markdown_len,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                let kind = ArtifactKind::Markdown.as_str();
+                txn.execute(
+                    "INSERT INTO derived_artifacts (
+                        id, org_id, document_id, version_id, artifact_kind,
+                        object_key, content_sha256, content_type, byte_size
+                     )
+                     VALUES ($1, $2, $3, $4, $5, $6, $7,
+                             'text/markdown; charset=utf-8', $8)",
+                    &[
+                        &artifact_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &version_id,
+                        &kind,
+                        &object_key_string,
+                        &sha256,
+                        &markdown_len,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE documents
+                     SET current_version_id = $3, state = 'converted', updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id, &version_id],
+                )
+                .await?;
+                let payload = EventPayload {
+                    job_id: None,
+                    document_id: Some(document_id),
+                    version_id: Some(version_id),
+                    outbox_event_id: None,
+                }
+                .to_json()
+                .expect("event payload");
+                txn.execute(
+                    "INSERT INTO outbox_events (
+                        org_id, event_type, payload_version, payload, idempotency_key
+                     )
+                     VALUES ($1, 'document.index_requested', $2, $3, $4)",
+                    &[
+                        &ctx.org_id(),
+                        &CURRENT_EVENT_PAYLOAD_VERSION,
+                        &payload,
+                        &outbox_key,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed promoted current version");
+    version_id
+}
+
+fn index_worker(
+    env: &LiveEnv,
+    approved_signature: Option<String>,
+) -> Result<IndexWorker, fileconv_server::workers::index::IndexWorkerError> {
+    let mut config = IndexWorkerConfig::new(format!("index-worker-{}", Uuid::new_v4()));
+    config.lease_ttl = Duration::from_secs(30);
+    config.heartbeat_interval = Duration::from_secs(5);
+    config.max_job_duration = Duration::from_secs(60);
+    config.embedding_batch_size = 2;
+    IndexWorker::new(
+        env.pool.clone(),
+        env.storage.clone(),
+        env.qdrant.clone(),
+        config,
+        approved_signature,
+    )
+}
+
+async fn relay(env: &LiveEnv) {
+    let sink = Arc::new(IndexingOutboxSink::new());
+    jobs::relay_outbox_with_sink(&env.pool, &env.ctx, 32, &sink)
+        .await
+        .expect("relay outbox");
+}
+
+async fn index_job_count(env: &LiveEnv) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM jobs
+                         WHERE org_id = $1 AND job_type = 'index'",
+                        &[&ctx.org_id()],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("index job count")
+}
+
+async fn chunk_count(env: &LiveEnv, version_id: Uuid) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                fileconv_server::db::chunks::count_by_version(txn, &ctx, version_id).await
+            })
+        }
+    })
+    .await
+    .expect("chunk count")
+}
+
+async fn document_state(env: &LiveEnv, document_id: Uuid) -> DocumentState {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| Box::pin(async move { documents::get_by_id(txn, &ctx, document_id).await })
+    })
+    .await
+    .expect("document")
+    .state
+}
+
+async fn active_signature(env: &LiveEnv, collection_id: Uuid) -> Option<String> {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                Ok(
+                    fileconv_server::db::index_metadata::find_active(
+                        txn,
+                        &ctx,
+                        Some(collection_id),
+                    )
+                    .await?
+                    .map(|metadata| metadata.index_signature_sha256),
+                )
+            })
+        }
+    })
+    .await
+    .expect("active signature")
+}
+
+async fn fetched_points(
+    env: &LiveEnv,
+    collection_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    markdown: &str,
+) -> Vec<(Uuid, ChunkPointPayload)> {
+    let chunks = prepare_chunks(document_id, version_id, markdown);
+    let plan = approved_plan();
+    let signature = plan.index_signature(LOCAL_VECTOR_DIMENSIONS).unwrap();
+    let collection_name = env
+        .qdrant
+        .ensure_collection_for_signature(&signature)
+        .await
+        .expect("ensure qdrant collection");
+    let ids = chunks
+        .iter()
+        .map(|chunk| {
+            point_id_from_org_collection_and_chunk(
+                env.ctx.org_id(),
+                collection_id,
+                &chunk.chunk_identity,
+            )
+            .expect("point id")
+        })
+        .collect::<Vec<_>>();
+    env.qdrant
+        .get_points(
+            &collection_name,
+            &VectorScope::new(env.ctx.org_id(), [collection_id]),
+            &ids,
+        )
+        .await
+        .expect("get points")
+}
+
+async fn reset_job_to_pending(env: &LiveEnv) {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE jobs
+                     SET status = 'pending', lease_owner = NULL, lease_expires_at = NULL,
+                         heartbeat_at = NULL, available_at = clock_timestamp(),
+                         finished_at = NULL, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND job_type = 'index'",
+                    &[&ctx.org_id()],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("reset job");
+}
+
+async fn reset_index_job_for_version(env: &LiveEnv, version_id: Uuid) {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE jobs
+                     SET status = 'pending', lease_owner = NULL, lease_expires_at = NULL,
+                         heartbeat_at = NULL, checkpoint = NULL, available_at = clock_timestamp(),
+                         finished_at = NULL, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND job_type = 'index' AND version_id = $2",
+                    &[&ctx.org_id(), &version_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("reset version job");
+}
+
+async fn insert_duplicate_index_outbox(env: &LiveEnv, document_id: Uuid, version_id: Uuid) {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let payload = EventPayload {
+                    job_id: None,
+                    document_id: Some(document_id),
+                    version_id: Some(version_id),
+                    outbox_event_id: None,
+                }
+                .to_json()
+                .expect("event payload");
+                let key = format!("index-request-duplicate:{version_id}");
+                txn.execute(
+                    "INSERT INTO outbox_events (
+                        org_id, event_type, payload_version, payload, idempotency_key
+                     )
+                     VALUES ($1, 'document.index_requested', $2, $3, $4)",
+                    &[
+                        &ctx.org_id(),
+                        &CURRENT_EVENT_PAYLOAD_VERSION,
+                        &payload,
+                        &key,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("duplicate outbox");
+}
+
+async fn seed_first_batch_and_checkpoint(
+    env: &LiveEnv,
+    collection_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    markdown: &str,
+) {
+    let chunks = prepare_chunks(document_id, version_id, markdown);
+    assert!(chunks.len() > 1);
+    let first = &chunks[0];
+    let plan = approved_plan();
+    let signature = plan.index_signature(LOCAL_VECTOR_DIMENSIONS).unwrap();
+    let signature_digest = signature.digest();
+    let collection_name = env
+        .qdrant
+        .ensure_collection_for_signature(&signature)
+        .await
+        .expect("ensure collection");
+    let vector = embed_bodies(std::slice::from_ref(&first.body))
+        .expect("embed")
+        .into_iter()
+        .next()
+        .expect("vector");
+    let metadata = with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        let signature_digest = signature_digest.clone();
+        let chunking_version = signature.chunking_version.to_string();
+        let body_text_version = signature.body_text_version.to_string();
+        let query_normalization_version = signature.query_normalization_version.to_string();
+        let embedding_family = signature.embedding_family.to_string();
+        let embedding_revision = signature.embedding_revision.to_string();
+        let normalized = signature.normalized;
+        move |txn| {
+            Box::pin(async move {
+                fileconv_server::db::index_metadata::ensure_active_generation(
+                    txn,
+                    &ctx,
+                    fileconv_server::db::index_metadata::EnsureGeneration {
+                        collection_id: Some(collection_id),
+                        signature_sha256: &signature_digest,
+                        chunking_version: &chunking_version,
+                        body_text_version: &body_text_version,
+                        query_normalization_version: &query_normalization_version,
+                        embedding_family: &embedding_family,
+                        embedding_revision: &embedding_revision,
+                        dimensions: LOCAL_VECTOR_DIMENSIONS as i32,
+                        normalized,
+                        runtime_path: fileconv_server::db::models::EmbeddingRuntimePath::LocalHash,
+                    },
+                )
+                .await
+            })
+        }
+    })
+    .await
+    .expect("ensure metadata");
+    env.qdrant
+        .upsert_points(
+            &collection_name,
+            &VectorScope::new(env.ctx.org_id(), [collection_id]),
+            &[UpsertPoint {
+                chunk_identity: first.chunk_identity.clone(),
+                vector,
+                payload: ChunkPointPayload {
+                    org_id: env.ctx.org_id(),
+                    collection_id,
+                    document_id,
+                    version_id,
+                    chunk_id: first.chunk_identity.clone(),
+                    ordinal: first.ordinal as u64,
+                    is_current: true,
+                    is_effective: true,
+                    index_generation: metadata.generation as u32,
+                },
+            }],
+        )
+        .await
+        .expect("upsert first point");
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        let first = first.clone();
+        let signature_digest = signature_digest.clone();
+        move |txn| {
+            Box::pin(async move {
+                fileconv_server::db::chunks::insert_if_absent(
+                    txn,
+                    &ctx,
+                    fileconv_server::db::chunks::NewChunk {
+                        id: Uuid::new_v4(),
+                        document_id,
+                        version_id,
+                        ordinal: first.ordinal,
+                        heading_path: &first.heading_path,
+                        body: &first.body,
+                        body_text_version: fileconv_knowledge::identity::BODY_TEXT_VERSION,
+                        chunk_identity_sha256: &first.chunk_identity,
+                        index_metadata_id: metadata.id,
+                        index_signature: &signature_digest,
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE documents
+                     SET state = 'indexing', updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id],
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE jobs
+                     SET checkpoint = $2
+                     WHERE org_id = $1 AND job_type = 'index'",
+                    &[&ctx.org_id(), &json!({ "offset": 1_u64 })],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed checkpoint");
+}
+
+fn sample_markdown() -> &'static str {
+    "# Chương I\n\nMở đầu.\n\n## Điều 1\n\nNội dung điều 1.\n\n## Điều 2\n\nNội dung điều 2.\n"
+}
+
+#[tokio::test]
+async fn live_index_worker_indexes_converted_document() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let markdown = sample_markdown();
+    let (document_id, version_id, collection_id) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown).await;
+    relay(&env).await;
+    assert_eq!(index_job_count(&env).await, 1);
+
+    let run = index_worker(&env, None)
+        .expect("worker")
+        .run_once(&env.ctx)
+        .await
+        .expect("run");
+    let IndexWorkerRun::Completed { chunks, .. } = run else {
+        panic!("unexpected run: {run:?}");
+    };
+    let expected = prepare_chunks(document_id, version_id, markdown);
+    assert_eq!(chunks, expected.len());
+    assert_eq!(
+        document_state(&env, document_id).await,
+        DocumentState::Indexed
+    );
+    assert_eq!(chunk_count(&env, version_id).await, expected.len() as i64);
+    let signature = approved_plan()
+        .index_signature(LOCAL_VECTOR_DIMENSIONS)
+        .unwrap()
+        .digest();
+    assert_eq!(active_signature(&env, collection_id).await, Some(signature));
+    let points = fetched_points(&env, collection_id, document_id, version_id, markdown).await;
+    assert_eq!(points.len(), expected.len());
+    for (_, payload) in points {
+        assert_eq!(payload.org_id, env.ctx.org_id());
+        assert_eq!(payload.collection_id, collection_id);
+        assert_eq!(payload.document_id, document_id);
+        assert_eq!(payload.version_id, version_id);
+        assert!(payload.is_current);
+        assert!(payload.is_effective);
+    }
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_index_worker_replay_is_idempotent() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let markdown = sample_markdown();
+    let (document_id, version_id, collection_id) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown).await;
+    relay(&env).await;
+    let worker = index_worker(&env, None).expect("worker");
+    assert!(matches!(
+        worker.run_once(&env.ctx).await.expect("first run"),
+        IndexWorkerRun::Completed { .. }
+    ));
+    let expected = prepare_chunks(document_id, version_id, markdown);
+    assert_eq!(chunk_count(&env, version_id).await, expected.len() as i64);
+    insert_duplicate_index_outbox(&env, document_id, version_id).await;
+    relay(&env).await;
+    assert_eq!(index_job_count(&env).await, 1);
+    reset_job_to_pending(&env).await;
+    assert!(matches!(
+        worker.run_once(&env.ctx).await.expect("replay"),
+        IndexWorkerRun::Completed { chunks: 0, .. }
+    ));
+    assert_eq!(chunk_count(&env, version_id).await, expected.len() as i64);
+    assert_eq!(
+        fetched_points(&env, collection_id, document_id, version_id, markdown)
+            .await
+            .len(),
+        expected.len()
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_index_worker_signature_mismatch_fails_closed() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let markdown = sample_markdown();
+    let (document_id, version_id, collection_id) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown).await;
+    relay(&env).await;
+    let bad_signature =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
+    assert!(index_worker(&env, Some(bad_signature)).is_err());
+    assert_eq!(chunk_count(&env, version_id).await, 0);
+    assert_eq!(
+        document_state(&env, document_id).await,
+        DocumentState::Converted
+    );
+    assert!(
+        fetched_points(&env, collection_id, document_id, version_id, markdown)
+            .await
+            .is_empty()
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_index_worker_stale_version_does_not_mark_current_indexed() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let markdown_a = sample_markdown();
+    let markdown_b = "# Chương II\n\nBản mới.\n\n## Điều 3\n\nNội dung điều 3.\n";
+    let (document_id, version_a, collection_id) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown_a).await;
+    relay(&env).await;
+    let worker = index_worker(&env, None).expect("worker");
+    assert!(matches!(
+        worker.run_once(&env.ctx).await.expect("index version a"),
+        IndexWorkerRun::Completed { .. }
+    ));
+    assert_eq!(
+        document_state(&env, document_id).await,
+        DocumentState::Indexed
+    );
+
+    let version_b =
+        seed_promoted_current_version(&env, document_id, collection_id, version_a, markdown_b)
+            .await;
+    reset_index_job_for_version(&env, version_a).await;
+    relay(&env).await;
+
+    let stale_run = worker.run_once(&env.ctx).await.expect("stale run");
+    assert!(matches!(
+        stale_run,
+        IndexWorkerRun::Completed { chunks, .. } if chunks == prepare_chunks(document_id, version_a, markdown_a).len()
+    ));
+    assert_eq!(
+        document_state(&env, document_id).await,
+        DocumentState::Converted
+    );
+    let points_a = fetched_points(&env, collection_id, document_id, version_a, markdown_a).await;
+    assert!(!points_a.is_empty());
+    assert!(points_a
+        .iter()
+        .all(|(_, payload)| !payload.is_current && !payload.is_effective));
+
+    let current_run = worker.run_once(&env.ctx).await.expect("current run");
+    assert!(matches!(
+        current_run,
+        IndexWorkerRun::Completed { chunks, .. } if chunks == prepare_chunks(document_id, version_b, markdown_b).len()
+    ));
+    assert_eq!(
+        document_state(&env, document_id).await,
+        DocumentState::Indexed
+    );
+    let points_b = fetched_points(&env, collection_id, document_id, version_b, markdown_b).await;
+    assert!(!points_b.is_empty());
+    assert!(points_b
+        .iter()
+        .all(|(_, payload)| payload.is_current && payload.is_effective));
+    assert_eq!(
+        chunk_count(&env, version_b).await,
+        prepare_chunks(document_id, version_b, markdown_b).len() as i64
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_index_worker_resumes_from_indexing_state() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let markdown = sample_markdown();
+    let (document_id, version_id, collection_id) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown).await;
+    relay(&env).await;
+    seed_first_batch_and_checkpoint(&env, collection_id, document_id, version_id, markdown).await;
+    let run = index_worker(&env, None)
+        .expect("worker")
+        .run_once(&env.ctx)
+        .await
+        .expect("run");
+    assert!(matches!(run, IndexWorkerRun::Completed { .. }));
+    let expected = prepare_chunks(document_id, version_id, markdown);
+    assert_eq!(chunk_count(&env, version_id).await, expected.len() as i64);
+    assert_eq!(
+        fetched_points(&env, collection_id, document_id, version_id, markdown)
+            .await
+            .len(),
+        expected.len()
+    );
+    assert_eq!(
+        document_state(&env, document_id).await,
+        DocumentState::Indexed
+    );
+    env.drop().await;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Implements **P1B-I06 (#89)** — the durable chunk/embedding/index worker. It consumes the `document.index_requested` outbox event emitted by the I05 promotion saga and turns a promoted, `converted` document version into PostgreSQL `chunks` (+ FTS tsvector) under an `index_metadata` generation and Qdrant vector points, driving the document lifecycle `converted → indexing → indexed`. Embeddings use the **approved local hash embedding only** (`local_hash_v1`, 256-dim, L2-normalized); user-selected/remote models are out of scope.

Stacked on `cursor/p1b-i05-promotion-saga-f084` (#225).

## Scope

- **Outbox → durable job bridge**: `IndexingOutboxSink` (`services/indexing.rs`) turns `document.index_requested` events into idempotent `JobType::Index` jobs (key `index:{version_id}`) inside the relay transaction. `jobs::enqueue` refactored into `enqueue_within_txn`; added `jobs::checkpoint_within_txn`.
- **`IndexWorker`** (`workers/index.rs`): claim/heartbeat/checkpoint/retry/dead-letter loop (no sandbox). Batched local embedding runs off the async executor (`spawn_blocking`), wrapped by a periodic heartbeat so the lease survives each batch; job duration is deadline-bounded.
- **Services**: `chunking.rs` (wraps the `fileconv-core` heading chunker, builds `heading_path` + canonical chunk identity), `embedding.rs` (approved local plan, rejects non‑normalized/degenerate vectors), `indexing.rs` (deterministic, idempotent `index_version` orchestration + fenced state transitions).
- **Repos/models**: `db/index_metadata.rs` (per‑`(org,signature)` generation registry, fail‑closed on signature change), `db/chunks::insert_if_absent` (idempotent by chunk identity), `EmbeddingRuntimePath::as_str/parse`, `config.index_signature()`.
- **Knowledge**: `EmbeddingPlan::index_signature()` returns the exact `IndexSignature` it hashes (single source of truth for the Qdrant generation digest); `signature()` unchanged.
- **Worker binary**: `MARKHAND_WORKER_KIND=index` runs the relay + index loop and validates `MARKHAND_INDEX_SIGNATURE` at startup; the default `convert` path is unchanged.

## Evidence

- [x] Tests:
  - Unit: `cargo test -p fileconv-server --lib` (73) and `cargo test -p fileconv-knowledge` green; new `chunking`/`embedding` unit tests.
  - Live integration (`tests/index_worker.rs`, self-skipping without env) run against real **PostgreSQL 5432 / Qdrant 6333 / MinIO 9000** — 5 passed: happy path, replay idempotency (no duplicate chunks/points, ≤1 index job), signature mismatch fails closed before publish, resume from `indexing`, and a multi-version test proving a stale (superseded) version's job cannot leave the current version unindexed.
  - Full server suite green live (191 tests, incl. 20 convert + all repo/quota/storage/uploads) — no regression from the `jobs` refactor.
- [x] Manual/benchmark/migration evidence: **no migration** (schema from `0006`/`0010` already present). CI‑parity preflight green: `make check-rust` (workspace clippy `-D warnings` + `Clippy legacy baseline has no new warnings`), `cargo fmt --all -- --check`, `cargo metadata --locked` (lockfile unchanged, no new deps), `check-dependency-policy.py`, `check-foundation-gate.sh --static-only`.

## Boundary and security review

- [x] Dependency boundary check passed (no new dependencies; architecture-boundaries clean).
- [x] Tenant/ACL impact reviewed: all DB access via `with_org_txn*` (RLS `app.org_id`, tables are `FORCE ROW LEVEL SECURITY`); Qdrant uses a non-empty `VectorScope` bound to the document's own `collection_id`; deterministic tenant-bound point IDs.
- [x] Sensitive logging/secret/egress impact reviewed: job/outbox/event payloads and checkpoints are ID-only (offset-only checkpoint); no markdown/body/secret in payloads, logs, or `Debug`; safe static job-error strings.
- [x] Security review trigger checked: two-round strict security review — **PASS** after hardening (fail‑closed preflight before state change, version‑fenced + lease‑fenced authoritative transitions, per‑`(org,signature)` generation numbering, signature startup validation, integrity + trusted-key-version checks, checkpoint bounds).

## Follow-up

- [ ] Docs/ADR/roadmap: n/a for this change.
- Deferred to **P1B-I07 (#90, tombstone/reconcile)** with explicit `TODO(I07)` markers: demoting a superseded version's Qdrant `is_current`/`is_effective` flags on version change; GC/reconcile of orphan vectors from an interrupted/dead-lettered index attempt; terminal `indexing → failed` compensation on permanent runtime failure. R01 retrieval must filter on committed PG version state + document `indexed`, not solely on Qdrant payload flags. A DB-level chunks immutability trigger is deferred to I07 so it can coexist with the tombstone/delete path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

