### PR TITLE
docs(backlog): mark completed Phase 1B issues done

### DIFF
--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -24,6 +24,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-F01 — Extend server skeleton với runtime POC
 
+- **Status:** done
 - **Plan:** Mở rộng `crates/server` API/worker skeleton từ F-02/F-07 với runtime
   dependencies, application state, graceful shutdown và các config fields đã được
   Phase 0 phê duyệt. Không tạo lại workspace/config conventions.
@@ -47,6 +48,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-F03 — Multi-org-ready schema và immutable migrations
 
+- **Status:** done
 - **Plan:** Migrations org/auth/RBAC/groups/collections, immutable versions/artifacts,
   atomic current-published pointer, parent/version/effective lineage, chunks/FTS,
   normalized claims, conflict/evidence lifecycle, jobs/outbox, quota/audit/index;
@@ -60,6 +62,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-F04 — OrgContext, repositories và state machine
 
+- **Status:** done
 - **Plan:** Tenant-scoped repos, transaction helpers, legal document transitions;
   transaction-local RLS context nếu chọn.
 - **Files:** `src/auth/context.rs`, `src/db/{orgs,collections,documents,chunks}.rs`,
@@ -71,6 +74,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-F05 — Password auth, rotating sessions và browser refresh transport
 
+- **Status:** done
 - **Plan:** Argon2; pinned JWT issuer/audience/alg/KID; short access; hashed rotating
   refresh family; provider interface; POC guards/audit; chốt transport theo auth ADR.
   Nếu dùng browser cookie: issue/rotate/clear `HttpOnly Secure SameSite`, CSRF token
@@ -86,6 +90,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-F06 — Fail-closed PG/Qdrant/MinIO adapters
 
+- **Status:** done
 - **Plan:** Pools, opaque key builder, quarantine/trusted namespace, deterministic
   points, versioned collection, mandatory org/collection filters, typed errors.
 - **Files:** `src/storage/{keys,minio,qdrant}.rs`, `src/db/pool.rs`,
@@ -99,6 +104,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-I01 — Streaming quarantine upload validation
 
+- **Status:** done
 - **Plan:** Multipart stream+hash; magic/extension canonical format; OOXML limits;
   PDF/audio limits; retention disposition.
 - **Files:** `routes/uploads.rs`, `services/upload/{stream,sniff,archive,limits}.rs`.
@@ -109,6 +115,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-I02 — Atomic quota admission
 
+- **Status:** done
 - **Plan:** Transactional reserve/finalize/refund, expiry, concurrent-job admission,
   quota headers/errors.
 - **Files:** `src/db/quota.rs`, `services/quota.rs`, quota middleware.
@@ -119,6 +126,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-I03 — Durable jobs, outbox và event log
 
+- **Status:** done
 - **Plan:** Versioned payload, transactional outbox, leased SKIP LOCKED claims,
   heartbeat/retry/checkpoint/cancel/dead-letter/idempotency/sequenced events.
 - **Files:** `src/jobs/**`, `src/db/jobs.rs`.
@@ -130,6 +138,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-I04 — Isolated converter worker
 
+- **Status:** done
 - **Plan:** Download quarantine; materialize server-derived canonical extension;
   process/cgroup limits and kill descendants; ephemeral cleanup/heartbeat/cancel.
 - **Files:** `src/workers/{convert,sandbox,limits}.rs`, worker image/config.
@@ -140,6 +149,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-I05 — Idempotent conversion promotion saga
 
+- **Status:** done
 - **Plan:** Checkpoint download/convert/stage/promote/DB/cleanup; immutable version;
   publish/current pointer riêng với draft/latest upload; index outbox;
   compensation/refund.
@@ -152,6 +162,7 @@ ghi trong issue đã `Done`.
 
 ### P1B-I06 — Chunk/embedding/index worker
 
+- **Status:** done
 - **Plan:** Core chunking + knowledge identity/signature chứa `version_id`; PG
   chunks/FTS; separate embedding batches; Qdrant payload version/effective/current;
   extract typed claim key/value/unit/scope; incremental conflict candidate outbox;

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "0d4c5505c172af62";
+    const ROADMAP_SOURCE_HASH = "611391ca6bda51a9";
     const phases = [
       {
         "id": "phase-f",
@@ -1122,7 +1122,7 @@
           [
             "P1B-F01",
             "Extend server skeleton với runtime POC",
-            "blocked"
+            "done"
           ],
           [
             "P1B-F02",
@@ -1132,52 +1132,52 @@
           [
             "P1B-F03",
             "Multi-org-ready schema và immutable migrations",
-            "blocked"
+            "done"
           ],
           [
             "P1B-F04",
             "OrgContext, repositories và state machine",
-            "blocked"
+            "done"
           ],
           [
             "P1B-F05",
             "Password auth, rotating sessions và browser refresh transport",
-            "blocked"
+            "done"
           ],
           [
             "P1B-F06",
             "Fail-closed PG/Qdrant/MinIO adapters",
-            "blocked"
+            "done"
           ],
           [
             "P1B-I01",
             "Streaming quarantine upload validation",
-            "blocked"
+            "done"
           ],
           [
             "P1B-I02",
             "Atomic quota admission",
-            "blocked"
+            "done"
           ],
           [
             "P1B-I03",
             "Durable jobs, outbox và event log",
-            "blocked"
+            "done"
           ],
           [
             "P1B-I04",
             "Isolated converter worker",
-            "blocked"
+            "done"
           ],
           [
             "P1B-I05",
             "Idempotent conversion promotion saga",
-            "blocked"
+            "done"
           ],
           [
             "P1B-I06",
             "Chunk/embedding/index worker",
-            "blocked"
+            "done"
           ],
           [
             "P1B-I07",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Update the Phase 1B backlog catalog so completed issues reflect reality (they were all still defaulting to `blocked`). Marks `status: done` for the finished issues and regenerates the roadmap artifact.

## Scope

- `plans/markhand-web/backlog/phase-1b/issues/README.md`: per-issue `**Status:** done` for **F01, F03, F04, F05, F06, I01, I02, I03, I04, I05, I06**. `F02` left `blocked` (its deployment scaffold is an explicit follow-up in the merged foundation PR #216 and issue #79 remains open); `I07` onward unchanged.
- `plans/markhand-web/roadmap.html`: regenerated by `scripts/build-roadmap.py`.

## Evidence

- [x] Tests: `python3 scripts/build-roadmap.py --check` (roadmap up to date), `make check-roadmap`, `python3 scripts/check-markhand-gates.py` (+ `--self-test`), `bash scripts/check-foundation-gate.sh --static-only` — all pass.
- [x] Manual/benchmark/migration evidence: docs-only; no code, no migration.

## Boundary and security review

- [x] Dependency boundary check passed (docs only).
- [x] Tenant/ACL impact reviewed: N/A.
- [x] Sensitive logging/secret/egress impact reviewed: N/A.
- [x] Security review trigger checked: N/A (no code).

## Follow-up

- GitHub issue open/closed + label sync (`scripts/sync-github-issues.py --update --sync-status`) still needs a write-capable token (the cloud agent `gh` is read-only); issues will otherwise auto-close as the stacked PR chain merges to `master`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

