### PR TITLE
feat(server): P1B-I07 tombstone delete and reconcile

### DIFF
--- a/crates/server/src/bin/worker.rs
+++ b/crates/server/src/bin/worker.rs
@@ -3,11 +3,16 @@ use std::time::Duration;
 use fileconv_server::auth::context::OrgContext;
 use fileconv_server::db::pool::create_pool;
 use fileconv_server::jobs;
-use fileconv_server::services::indexing::IndexingOutboxSink;
+use fileconv_server::services::indexing::OutboxJobSink;
+use fileconv_server::services::reconciliation::ReconcileMode;
 use fileconv_server::storage::{MinioClient, QdrantClient};
 use fileconv_server::workers::convert::{ConvertWorker, ConvertWorkerConfig};
+use fileconv_server::workers::delete::{DeleteWorker, DeleteWorkerConfig, DeleteWorkerRun};
 use fileconv_server::workers::index::{IndexWorker, IndexWorkerConfig, IndexWorkerRun};
 use fileconv_server::workers::limits::ResourceLimits;
+use fileconv_server::workers::reconcile::{
+    ReconcileWorker, ReconcileWorkerConfig, ReconcileWorkerRun,
+};
 use fileconv_server::workers::sandbox::SandboxConfig;
 use uuid::Uuid;
 
@@ -83,6 +88,26 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
             )
             .map_err(|error| format!("qdrant client failed: {}", error.code()))?;
             run_index_worker(state, pool, storage, qdrant, worker_id, ctx).await
+        }
+        "delete" => {
+            let storage = MinioClient::from_config(storage_config.minio())
+                .map_err(|error| format!("storage client failed: {}", error.code()))?;
+            let qdrant = QdrantClient::with_api_key(
+                storage_config.qdrant_url(),
+                storage_config.qdrant_api_key().cloned(),
+            )
+            .map_err(|error| format!("qdrant client failed: {}", error.code()))?;
+            run_delete_worker(state, pool, storage, qdrant, worker_id, ctx).await
+        }
+        "reconcile" => {
+            let storage = MinioClient::from_config(storage_config.minio())
+                .map_err(|error| format!("storage client failed: {}", error.code()))?;
+            let qdrant = QdrantClient::with_api_key(
+                storage_config.qdrant_url(),
+                storage_config.qdrant_api_key().cloned(),
+            )
+            .map_err(|error| format!("qdrant client failed: {}", error.code()))?;
+            run_reconcile_worker(state, pool, storage, qdrant, worker_id, ctx).await
         }
         other => Err(format!("unknown MARKHAND_WORKER_KIND: {other}")),
     }
@@ -172,7 +197,7 @@ async fn run_index_worker(
     let approved_signature = state.config().index_signature().map(str::to_string);
     let worker = IndexWorker::new(pool.clone(), storage, qdrant, config, approved_signature)
         .map_err(|error| format!("index worker initialization failed: {error}"))?;
-    let sink = std::sync::Arc::new(IndexingOutboxSink::new());
+    let sink = std::sync::Arc::new(OutboxJobSink::new());
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
@@ -192,6 +217,115 @@ async fn run_index_worker(
                     Ok(outcome) => println!("fileconv-worker: {outcome:?}"),
                     Err(error) => {
                         eprintln!("fileconv-worker: index worker error: {error}");
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_delete_worker(
+    state: fileconv_server::state::RuntimeState,
+    pool: deadpool_postgres::Pool,
+    storage: MinioClient,
+    qdrant: QdrantClient,
+    worker_id: String,
+    ctx: OrgContext,
+) -> Result<(), String> {
+    let mut config = DeleteWorkerConfig::new(worker_id);
+    config.lease_ttl = Duration::from_secs(state.config().limits().job_lease_seconds);
+    if let Ok(value) = std::env::var("MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS") {
+        config.heartbeat_interval = Duration::from_secs(value.parse().map_err(|_| {
+            "MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS must be an integer".to_string()
+        })?);
+    }
+    if let Ok(value) = std::env::var("MARKHAND_WORKER_MAX_JOB_SECS") {
+        config.max_job_duration = Duration::from_secs(
+            value
+                .parse()
+                .map_err(|_| "MARKHAND_WORKER_MAX_JOB_SECS must be an integer".to_string())?,
+        );
+    }
+    let worker = DeleteWorker::new(pool.clone(), storage, qdrant, config)
+        .map_err(|error| format!("delete worker initialization failed: {error}"))?;
+    let sink = std::sync::Arc::new(OutboxJobSink::new());
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                println!("fileconv-worker: shutdown requested");
+                break;
+            }
+            result = async {
+                jobs::relay_outbox_with_sink(&pool, &ctx, 32, &sink)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                worker.run_once(&ctx).await.map_err(|error| error.to_string())
+            } => {
+                match result {
+                    Ok(DeleteWorkerRun::NoJob) => {
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    }
+                    Ok(outcome) => println!("fileconv-worker: {outcome:?}"),
+                    Err(error) => {
+                        eprintln!("fileconv-worker: delete worker error: {error}");
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_reconcile_worker(
+    state: fileconv_server::state::RuntimeState,
+    pool: deadpool_postgres::Pool,
+    storage: MinioClient,
+    qdrant: QdrantClient,
+    worker_id: String,
+    ctx: OrgContext,
+) -> Result<(), String> {
+    let mut config = ReconcileWorkerConfig::new(worker_id);
+    config.lease_ttl = Duration::from_secs(state.config().limits().job_lease_seconds);
+    if let Ok(value) = std::env::var("MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS") {
+        config.heartbeat_interval = Duration::from_secs(value.parse().map_err(|_| {
+            "MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS must be an integer".to_string()
+        })?);
+    }
+    if let Ok(value) = std::env::var("MARKHAND_WORKER_MAX_JOB_SECS") {
+        config.max_job_duration = Duration::from_secs(
+            value
+                .parse()
+                .map_err(|_| "MARKHAND_WORKER_MAX_JOB_SECS must be an integer".to_string())?,
+        );
+    }
+    if let Ok(value) = std::env::var("MARKHAND_RECONCILE_MODE") {
+        config.mode = ReconcileMode::parse(value.trim()).map_err(|error| error.to_string())?;
+    }
+    let worker = ReconcileWorker::new(pool.clone(), storage, qdrant, config)
+        .map_err(|error| format!("reconcile worker initialization failed: {error}"))?;
+    let sink = std::sync::Arc::new(OutboxJobSink::new());
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                println!("fileconv-worker: shutdown requested");
+                break;
+            }
+            result = async {
+                jobs::relay_outbox_with_sink(&pool, &ctx, 32, &sink)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                worker.run_once(&ctx).await.map_err(|error| error.to_string())
+            } => {
+                match result {
+                    Ok(ReconcileWorkerRun::NoJob) => {
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    }
+                    Ok(outcome) => println!("fileconv-worker: {outcome:?}"),
+                    Err(error) => {
+                        eprintln!("fileconv-worker: reconcile worker error: {error}");
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
                 }

--- a/crates/server/src/db/chunks.rs
+++ b/crates/server/src/db/chunks.rs
@@ -136,6 +136,39 @@ pub async fn list_by_document(
     rows.iter().map(map_chunk).collect()
 }
 
+/// Lists distinct index signature digests that may contain vector points for a document.
+pub async fn distinct_index_signatures_by_document(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<Vec<String>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT DISTINCT index_signature
+             FROM chunks
+             WHERE org_id = $1 AND document_id = $2
+             ORDER BY index_signature",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?;
+    Ok(rows.iter().map(|row| row.get("index_signature")).collect())
+}
+
+/// Deletes retrieval chunks for a document. Immutable versions/artifacts are retained.
+pub async fn delete_by_document(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<u64, DbError> {
+    let deleted = txn
+        .execute(
+            "DELETE FROM chunks WHERE org_id = $1 AND document_id = $2",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?;
+    Ok(deleted)
+}
+
 /// Counts chunks visible under the tenant (cross-org denial evidence).
 pub async fn count(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<i64, DbError> {
     let row = txn

--- a/crates/server/src/db/document_versions.rs
+++ b/crates/server/src/db/document_versions.rs
@@ -238,6 +238,84 @@ pub async fn find_markdown_artifact(
     .transpose()
 }
 
+/// Lists distinct object keys recorded for every version/artifact of a document.
+///
+/// These rows are immutable inventory; purge deletes only the objects they name.
+pub async fn list_object_keys_by_document(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<Vec<String>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT key
+             FROM (
+                SELECT original_object_key AS key
+                FROM document_versions
+                WHERE org_id = $1 AND document_id = $2
+                UNION
+                SELECT markdown_object_key AS key
+                FROM document_versions
+                WHERE org_id = $1 AND document_id = $2 AND markdown_object_key IS NOT NULL
+                UNION
+                SELECT object_key AS key
+                FROM derived_artifacts
+                WHERE org_id = $1 AND document_id = $2
+             ) keys
+             WHERE key IS NOT NULL
+             ORDER BY key",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?;
+    Ok(rows.iter().map(|row| row.get("key")).collect())
+}
+
+pub async fn object_key_is_referenced(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    object_key: &str,
+) -> Result<bool, DbError> {
+    let row = txn
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM document_versions
+                WHERE org_id = $1
+                  AND (
+                    original_object_key = $2
+                    OR markdown_object_key = $2
+                  )
+                UNION ALL
+                SELECT 1
+                FROM derived_artifacts
+                WHERE org_id = $1 AND object_key = $2
+             )",
+            &[&ctx.org_id(), &object_key],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
+pub async fn list_by_document(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<Vec<DocumentVersion>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT id, org_id, document_id, version_number, parent_version_id,
+                    publication_state, is_current, content_sha256, original_object_key,
+                    markdown_object_key, source_filename, source_content_type, byte_size,
+                    effective_from, effective_to, change_summary, created_by_user_id, created_at
+             FROM document_versions
+             WHERE org_id = $1 AND document_id = $2
+             ORDER BY version_number, id",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?;
+    rows.iter().map(map_version).collect()
+}
+
 pub async fn promote_current_if_needed(
     txn: &Transaction<'_>,
     ctx: &OrgContext,

--- a/crates/server/src/db/documents.rs
+++ b/crates/server/src/db/documents.rs
@@ -151,6 +151,27 @@ pub(crate) async fn cas_state(
     update_state_cas(txn, ctx, document_id, expected_state, new_state).await
 }
 
+/// Sets `deleted_at` exactly once for tombstoned documents.
+pub async fn mark_deleted_at(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<Document, DbError> {
+    let row = txn
+        .query_opt(
+            "UPDATE documents
+             SET deleted_at = COALESCE(deleted_at, clock_timestamp()),
+                 updated_at = clock_timestamp()
+             WHERE org_id = $1 AND id = $2
+             RETURNING id, org_id, collection_id, title, state, current_version_id,
+                       created_by_user_id, created_at, updated_at, deleted_at",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_document(&row)
+}
+
 /// Counts documents for the tenant (used by cross-org denial tests).
 pub async fn count(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<i64, DbError> {
     let row = txn

--- a/crates/server/src/db/index_metadata.rs
+++ b/crates/server/src/db/index_metadata.rs
@@ -107,6 +107,27 @@ pub async fn ensure_active_generation(
         .ok_or(DbError::NotFound)
 }
 
+/// Lists all known signature digests for a collection, including inactive generations.
+pub async fn list_signatures_by_collection(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    collection_id: Uuid,
+) -> Result<Vec<String>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT DISTINCT index_signature_sha256
+             FROM index_metadata
+             WHERE org_id = $1 AND collection_id = $2
+             ORDER BY index_signature_sha256",
+            &[&ctx.org_id(), &collection_id],
+        )
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|row| row.get("index_signature_sha256"))
+        .collect())
+}
+
 async fn find_active_for_update(
     txn: &Transaction<'_>,
     ctx: &OrgContext,

--- a/crates/server/src/db/jobs.rs
+++ b/crates/server/src/db/jobs.rs
@@ -422,6 +422,75 @@ pub async fn reclaim_expired(
     rows.iter().map(map_job).collect()
 }
 
+pub async fn list_dead_letter_of_type(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_type: JobType,
+    after_id: Option<Uuid>,
+    limit: i64,
+) -> Result<Vec<Job>, DbError> {
+    let job_type = job_type.as_str();
+    let rows = txn
+        .query(
+            &format!(
+                "SELECT {JOB_COLUMNS}
+                 FROM jobs
+                 WHERE org_id = $1 AND job_type = $2 AND status = 'dead_letter'
+                   AND ($3::uuid IS NULL OR id > $3)
+                 ORDER BY id
+                 LIMIT $4"
+            ),
+            &[&ctx.org_id(), &job_type, &after_id, &limit],
+        )
+        .await?;
+    rows.iter().map(map_job).collect()
+}
+
+pub async fn has_active_writer_job(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<bool, DbError> {
+    let row = txn
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM jobs
+                WHERE org_id = $1
+                  AND document_id = $2
+                  AND job_type IN ('index', 'embedding_batch')
+                  AND status IN ('pending', 'leased', 'running')
+             )",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
+pub async fn cancel_active_writer_jobs(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<u64, DbError> {
+    let cancelled = txn
+        .execute(
+            "UPDATE jobs
+             SET status = 'cancelled',
+                 lease_owner = NULL,
+                 lease_expires_at = NULL,
+                 heartbeat_at = NULL,
+                 finished_at = clock_timestamp(),
+                 updated_at = clock_timestamp()
+             WHERE org_id = $1
+               AND document_id = $2
+               AND job_type IN ('index', 'embedding_batch')
+               AND status IN ('pending', 'leased', 'running')",
+            &[&ctx.org_id(), &document_id],
+        )
+        .await?;
+    Ok(cancelled)
+}
+
 pub async fn complete_owned(
     txn: &Transaction<'_>,
     ctx: &OrgContext,

--- a/crates/server/src/jobs/mod.rs
+++ b/crates/server/src/jobs/mod.rs
@@ -13,6 +13,7 @@ use deadpool_postgres::Pool;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
+use tokio::time::{interval_at, sleep_until, timeout, Instant as TokioInstant, MissedTickBehavior};
 use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
@@ -191,6 +192,71 @@ pub trait OutboxSink: Send + Sync {
         ctx: &'a OrgContext,
         event: &'a OutboxEvent,
     ) -> Pin<Box<dyn Future<Output = Result<EventLogEntry, JobError>> + Send + 'a>>;
+}
+
+#[derive(Clone, Copy)]
+pub struct HeartbeatClaim<'a> {
+    pub db_pool: &'a Pool,
+    pub ctx: &'a OrgContext,
+    pub job_id: Uuid,
+    pub lease_token: &'a str,
+    pub attempts: i32,
+    pub lease_ttl: Duration,
+    pub heartbeat_interval: Duration,
+    pub deadline: TokioInstant,
+}
+
+#[derive(Debug, Error)]
+pub enum HeartbeatError {
+    #[error("job error")]
+    Job(#[from] JobError),
+    #[error("job exceeded configured maximum duration")]
+    TimedOut,
+}
+
+pub async fn heartbeat_once_claimed(claim: HeartbeatClaim<'_>) -> Result<(), HeartbeatError> {
+    match timeout(
+        heartbeat_call_timeout(claim.lease_ttl, claim.deadline),
+        heartbeat(
+            claim.db_pool,
+            claim.ctx,
+            claim.job_id,
+            claim.lease_token,
+            claim.attempts,
+            claim.lease_ttl,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(HeartbeatError::Job(error)),
+        Err(_) => Err(HeartbeatError::TimedOut),
+    }
+}
+
+pub async fn heartbeat_while_claimed<T, E, Fut>(
+    claim: HeartbeatClaim<'_>,
+    future: Fut,
+) -> Result<T, E>
+where
+    Fut: Future<Output = Result<T, E>>,
+    E: From<HeartbeatError>,
+{
+    heartbeat_once_claimed(claim).await.map_err(E::from)?;
+    tokio::pin!(future);
+    let mut heartbeat = interval_at(
+        TokioInstant::now() + claim.heartbeat_interval,
+        claim.heartbeat_interval,
+    );
+    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut future => return result,
+            _ = sleep_until(claim.deadline) => return Err(E::from(HeartbeatError::TimedOut)),
+            _ = heartbeat.tick() => heartbeat_once_claimed(claim).await.map_err(E::from)?,
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -868,6 +934,15 @@ fn checked_duration_secs(duration: Duration) -> Result<i64, JobError> {
         return Err(JobError::InvalidDuration);
     }
     i64::try_from(secs).map_err(|_| JobError::InvalidDuration)
+}
+
+fn heartbeat_call_timeout(lease_ttl: Duration, deadline: TokioInstant) -> Duration {
+    let mut lease_bound = lease_ttl / 3;
+    if lease_bound.is_zero() {
+        lease_bound = Duration::from_millis(1);
+    }
+    let remaining = deadline.saturating_duration_since(TokioInstant::now());
+    remaining.min(lease_bound)
 }
 
 fn backoff_for_attempt(attempts: i32) -> Result<i64, JobError> {

--- a/crates/server/src/services/deletion.rs
+++ b/crates/server/src/services/deletion.rs
@@ -1,0 +1,514 @@
+//! Tombstone request and purge orchestration.
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use deadpool_postgres::Pool;
+use serde_json::{json, Value as JsonValue};
+use thiserror::Error;
+use tokio::time::Instant as TokioInstant;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::auth::session::{write_audit, AuditEvent};
+use crate::db::error::DbError;
+use crate::db::models::{Document, DocumentState, Job, JobStatus};
+use crate::db::pool::with_org_txn_typed;
+use crate::db::{chunks, document_versions, documents, index_metadata, jobs as repo};
+use crate::jobs::{
+    self, CheckpointPayload, EventPayload, HeartbeatClaim, HeartbeatError, JobError,
+};
+use crate::services::document_state;
+use crate::services::index_signature::collection_name_for_digest;
+use crate::storage::keys::parse_key_for_org;
+use crate::storage::minio::MinioClient;
+use crate::storage::qdrant::{QdrantClient, VectorScope};
+use crate::storage::StorageError;
+
+const PURGE_STEP_QDRANT: u64 = 1;
+const PURGE_STEP_MINIO: u64 = 2;
+const PURGE_STEP_CHUNKS: u64 = 3;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeleteRequestOutcome {
+    Requested(Document),
+    AlreadyRequested(Document),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PurgeDocumentInput<'a> {
+    pub job: &'a Job,
+    pub lease_token: &'a str,
+    pub attempts: i32,
+    pub lease_ttl: Duration,
+    pub heartbeat_interval: Duration,
+    pub deadline: TokioInstant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PurgeDocumentOutcome {
+    Purged { job_id: Uuid, deleted_chunks: u64 },
+    AlreadyPurged { job_id: Uuid },
+}
+
+struct PurgePlan {
+    document: Document,
+    signatures: Vec<String>,
+    object_keys: Vec<String>,
+}
+
+pub async fn request_delete(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<DeleteRequestOutcome, DeletionError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let document = documents::get_by_id_for_update(txn, &ctx, document_id).await?;
+                match document.state {
+                    DocumentState::Tombstoned | DocumentState::Purged => {
+                        Ok(DeleteRequestOutcome::AlreadyRequested(document))
+                    }
+                    DocumentState::Indexed => {
+                        // POC limitation: deletion is currently defined after successful indexing.
+                        // Tombstone holds the document row lock, then best-effort cancels any
+                        // pending/leased writer jobs. The chunk-persist path also locks this row
+                        // before writing, so a racing writer serializes behind the tombstone and
+                        // completes without resurrecting chunks.
+                        let cancelled_writers =
+                            repo::cancel_active_writer_jobs(txn, &ctx, document_id).await?;
+                        document_state::apply_transition(
+                            txn,
+                            &ctx,
+                            document_id,
+                            DocumentState::Indexed,
+                            DocumentState::Tombstoned,
+                        )
+                        .await?;
+                        let tombstoned = documents::mark_deleted_at(txn, &ctx, document_id).await?;
+                        let payload = validated_event_payload(EventPayload {
+                            job_id: None,
+                            document_id: Some(document_id),
+                            version_id: tombstoned.current_version_id,
+                            outbox_event_id: None,
+                        })?;
+                        repo::insert_outbox_event(
+                            txn,
+                            &ctx,
+                            repo::NewOutboxEvent {
+                                event_type: "document.delete_requested",
+                                payload_version: jobs::CURRENT_EVENT_PAYLOAD_VERSION,
+                                payload: &payload,
+                                idempotency_key: &format!(
+                                    "document.delete_requested.{document_id}"
+                                ),
+                                job_id: None,
+                            },
+                        )
+                        .await?;
+                        let resource_id = document_id.to_string();
+                        let request_id = format!("delete-{document_id}");
+                        write_audit(
+                            txn,
+                            AuditEvent {
+                                org_id: ctx.org_id(),
+                                actor_user_id: Some(ctx.user_id()),
+                                action: "document.tombstone",
+                                resource_type: "document",
+                                resource_id: Some(&resource_id),
+                                outcome: "success",
+                                request_id: &request_id,
+                                metadata: json!({
+                                    "document_id": document_id,
+                                    "version_id": tombstoned.current_version_id,
+                                    "cancelled_writer_jobs": cancelled_writers,
+                                }),
+                            },
+                        )
+                        .await?;
+                        Ok(DeleteRequestOutcome::Requested(tombstoned))
+                    }
+                    other => Err(DeletionError::UnexpectedState(other)),
+                }
+            })
+        }
+    })
+    .await
+}
+
+pub async fn purge_document(
+    pool: &Pool,
+    storage: &MinioClient,
+    qdrant: &QdrantClient,
+    ctx: &OrgContext,
+    input: PurgeDocumentInput<'_>,
+) -> Result<PurgeDocumentOutcome, DeletionError> {
+    let payload = jobs::decode_job_payload(input.job.payload_version, input.job.payload.clone())?;
+    let document_id = payload.document_id.ok_or(DeletionError::InvalidPayload)?;
+    let plan = load_purge_plan(pool, ctx, document_id).await?;
+    if plan.document.state == DocumentState::Purged {
+        let completed =
+            jobs::complete(pool, ctx, input.job.id, input.lease_token, input.attempts).await?;
+        return Ok(PurgeDocumentOutcome::AlreadyPurged {
+            job_id: completed.id,
+        });
+    }
+    if plan.document.state != DocumentState::Tombstoned {
+        return Err(DeletionError::UnexpectedState(plan.document.state));
+    }
+
+    let mut offset = checkpoint_offset(input.job)?;
+    if offset > PURGE_STEP_CHUNKS {
+        return Err(DeletionError::InvalidCheckpoint);
+    }
+    if offset < PURGE_STEP_QDRANT {
+        check_deadline(input.deadline)?;
+        heartbeat_while(
+            pool,
+            ctx,
+            input,
+            delete_qdrant_points(qdrant, ctx, &plan, document_id),
+        )
+        .await?;
+        save_checkpoint(pool, ctx, input, PURGE_STEP_QDRANT).await?;
+        offset = PURGE_STEP_QDRANT;
+    }
+    if offset < PURGE_STEP_MINIO {
+        check_deadline(input.deadline)?;
+        heartbeat_while(
+            pool,
+            ctx,
+            input,
+            delete_minio_objects(storage, ctx, &plan.object_keys),
+        )
+        .await?;
+        save_checkpoint(pool, ctx, input, PURGE_STEP_MINIO).await?;
+        offset = PURGE_STEP_MINIO;
+    }
+    let deleted_chunks = if offset < PURGE_STEP_CHUNKS {
+        check_deadline(input.deadline)?;
+        let deleted =
+            heartbeat_while(pool, ctx, input, delete_chunks(pool, ctx, document_id)).await?;
+        save_checkpoint(pool, ctx, input, PURGE_STEP_CHUNKS).await?;
+        deleted
+    } else {
+        0
+    };
+
+    check_deadline(input.deadline)?;
+    heartbeat_while(
+        pool,
+        ctx,
+        input,
+        delete_qdrant_points(qdrant, ctx, &plan, document_id),
+    )
+    .await?;
+    let completed = finalize_purged(pool, ctx, input, document_id, deleted_chunks).await?;
+    Ok(PurgeDocumentOutcome::Purged {
+        job_id: completed.id,
+        deleted_chunks,
+    })
+}
+
+async fn load_purge_plan(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<PurgePlan, DeletionError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                let mut signatures = BTreeSet::new();
+                for signature in
+                    chunks::distinct_index_signatures_by_document(txn, &ctx, document_id).await?
+                {
+                    signatures.insert(signature);
+                }
+                for signature in
+                    index_metadata::list_signatures_by_collection(txn, &ctx, document.collection_id)
+                        .await?
+                {
+                    signatures.insert(signature);
+                }
+                let object_keys =
+                    document_versions::list_object_keys_by_document(txn, &ctx, document_id).await?;
+                Ok(PurgePlan {
+                    document,
+                    signatures: signatures.into_iter().collect(),
+                    object_keys,
+                })
+            })
+        }
+    })
+    .await
+}
+
+async fn delete_qdrant_points(
+    qdrant: &QdrantClient,
+    ctx: &OrgContext,
+    plan: &PurgePlan,
+    document_id: Uuid,
+) -> Result<(), DeletionError> {
+    let scope = VectorScope::new(ctx.org_id(), [plan.document.collection_id]);
+    let filter = [json!({
+        "key": "document_id",
+        "match": { "value": document_id.to_string() }
+    })];
+    for digest in &plan.signatures {
+        let collection = collection_name_for_digest(digest)?;
+        qdrant.delete_by_scope(&collection, &scope, &filter).await?;
+    }
+    Ok(())
+}
+
+async fn delete_minio_objects(
+    storage: &MinioClient,
+    ctx: &OrgContext,
+    object_keys: &[String],
+) -> Result<(), DeletionError> {
+    for raw_key in object_keys {
+        let key = parse_key_for_org(raw_key, ctx.org_id())?;
+        match storage.delete_object(ctx.org_id(), &key).await {
+            Ok(()) | Err(StorageError::NotFound) => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+async fn delete_chunks(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<u64, DeletionError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move { Ok(chunks::delete_by_document(txn, &ctx, document_id).await?) })
+        }
+    })
+    .await
+}
+
+async fn finalize_purged(
+    pool: &Pool,
+    ctx: &OrgContext,
+    input: PurgeDocumentInput<'_>,
+    document_id: Uuid,
+    deleted_chunks: u64,
+) -> Result<Job, DeletionError> {
+    let lease_token = input.lease_token.to_string();
+    let job_id = input.job.id;
+    let attempts = input.attempts;
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                verify_claimed_job(txn, &ctx, job_id, &lease_token, attempts).await?;
+                document_state::apply_transition(
+                    txn,
+                    &ctx,
+                    document_id,
+                    DocumentState::Tombstoned,
+                    DocumentState::Purged,
+                )
+                .await?;
+                let completed = repo::complete_owned(txn, &ctx, job_id, &lease_token, attempts)
+                    .await?
+                    .ok_or(DeletionError::Job(JobError::LeaseLost))?;
+                write_job_succeeded_event(txn, &ctx, &completed).await?;
+                let resource_id = document_id.to_string();
+                let request_id = format!("purge-{job_id}");
+                write_audit(
+                    txn,
+                    AuditEvent {
+                        org_id: ctx.org_id(),
+                        actor_user_id: Some(ctx.user_id()),
+                        action: "document.purge",
+                        resource_type: "document",
+                        resource_id: Some(&resource_id),
+                        outcome: "success",
+                        request_id: &request_id,
+                        metadata: json!({
+                            "document_id": document_id,
+                            "job_id": job_id,
+                            "deleted_chunks": deleted_chunks,
+                        }),
+                    },
+                )
+                .await?;
+                Ok(completed)
+            })
+        }
+    })
+    .await
+}
+
+async fn verify_claimed_job(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_token: &str,
+    attempts: i32,
+) -> Result<Job, DeletionError> {
+    repo::get_by_id_for_update(txn, ctx, job_id)
+        .await?
+        .filter(|job| {
+            job.status == JobStatus::Leased
+                && job.lease_owner.as_deref() == Some(lease_token)
+                && job.attempts == attempts
+        })
+        .ok_or(DeletionError::Job(JobError::LeaseLost))
+}
+
+async fn write_job_succeeded_event(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    job: &Job,
+) -> Result<(), DeletionError> {
+    let payload = validated_event_payload(EventPayload {
+        job_id: Some(job.id),
+        document_id: job.document_id,
+        version_id: job.version_id,
+        outbox_event_id: None,
+    })?;
+    repo::append_event_and_outbox(
+        txn,
+        ctx,
+        repo::NewEventLogEntry {
+            event_type: "job.succeeded",
+            payload_version: jobs::CURRENT_EVENT_PAYLOAD_VERSION,
+            payload: &payload,
+            job_id: Some(job.id),
+            document_id: job.document_id,
+            version_id: job.version_id,
+        },
+        &format!("job.succeeded:{}:{}", job.id, job.attempts),
+    )
+    .await?;
+    Ok(())
+}
+
+fn validated_event_payload(
+    payload: EventPayload,
+) -> Result<repo::ValidatedEventPayload, DeletionError> {
+    let value: JsonValue = payload.to_json().map_err(DeletionError::Job)?;
+    repo::ValidatedEventPayload::new(value)
+        .map_err(|error| DeletionError::Job(JobError::InvalidPayload(error.to_string())))
+}
+
+fn checkpoint_offset(job: &Job) -> Result<u64, DeletionError> {
+    let Some(value) = job.checkpoint.clone() else {
+        return Ok(0);
+    };
+    let checkpoint = serde_json::from_value::<CheckpointPayload>(value)
+        .map_err(|_| DeletionError::InvalidCheckpoint)?;
+    Ok(checkpoint.offset.unwrap_or(0))
+}
+
+async fn save_checkpoint(
+    pool: &Pool,
+    ctx: &OrgContext,
+    input: PurgeDocumentInput<'_>,
+    offset: u64,
+) -> Result<(), DeletionError> {
+    jobs::checkpoint(
+        pool,
+        ctx,
+        input.job.id,
+        input.lease_token,
+        input.attempts,
+        CheckpointPayload {
+            offset: Some(offset),
+            ..CheckpointPayload::default()
+        },
+    )
+    .await?;
+    Ok(())
+}
+
+async fn heartbeat_while<T, Fut>(
+    pool: &Pool,
+    ctx: &OrgContext,
+    input: PurgeDocumentInput<'_>,
+    future: Fut,
+) -> Result<T, DeletionError>
+where
+    Fut: std::future::Future<Output = Result<T, DeletionError>>,
+{
+    jobs::heartbeat_while_claimed(heartbeat_claim(pool, ctx, input), future).await
+}
+
+fn check_deadline(deadline: TokioInstant) -> Result<(), DeletionError> {
+    if TokioInstant::now() >= deadline {
+        Err(DeletionError::JobTimedOut)
+    } else {
+        Ok(())
+    }
+}
+
+fn heartbeat_claim<'a>(
+    pool: &'a Pool,
+    ctx: &'a OrgContext,
+    input: PurgeDocumentInput<'a>,
+) -> HeartbeatClaim<'a> {
+    HeartbeatClaim {
+        db_pool: pool,
+        ctx,
+        job_id: input.job.id,
+        lease_token: input.lease_token,
+        attempts: input.attempts,
+        lease_ttl: input.lease_ttl,
+        heartbeat_interval: input.heartbeat_interval,
+        deadline: input.deadline,
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DeletionError {
+    #[error("database error")]
+    Db(#[from] DbError),
+    #[error("job error")]
+    Job(#[from] JobError),
+    #[error("storage error")]
+    Storage(#[from] StorageError),
+    #[error("delete payload is missing document_id")]
+    InvalidPayload,
+    #[error("delete checkpoint is invalid")]
+    InvalidCheckpoint,
+    #[error("document is in unexpected state {0:?}")]
+    UnexpectedState(DocumentState),
+    #[error("delete job exceeded configured maximum duration")]
+    JobTimedOut,
+}
+
+impl From<HeartbeatError> for DeletionError {
+    fn from(value: HeartbeatError) -> Self {
+        match value {
+            HeartbeatError::Job(error) => Self::Job(error),
+            HeartbeatError::TimedOut => Self::JobTimedOut,
+        }
+    }
+}
+
+impl DeletionError {
+    pub fn safe_job_error(&self) -> &'static str {
+        match self {
+            Self::Db(_) => "delete database error",
+            Self::Job(_) => "delete job error",
+            Self::Storage(_) => "delete storage error",
+            Self::InvalidPayload => "delete payload invalid",
+            Self::InvalidCheckpoint => "delete checkpoint invalid",
+            Self::UnexpectedState(_) => "delete document state invalid",
+            Self::JobTimedOut => "delete job timed out",
+        }
+    }
+
+    pub fn is_retryable_job_failure(&self) -> bool {
+        !matches!(self, Self::Job(JobError::LeaseLost))
+    }
+}

--- a/crates/server/src/services/indexing.rs
+++ b/crates/server/src/services/indexing.rs
@@ -7,10 +7,10 @@ use std::time::Duration;
 use deadpool_postgres::Pool;
 use fileconv_knowledge::embedding::LOCAL_VECTOR_DIMENSIONS;
 use fileconv_knowledge::identity::BODY_TEXT_VERSION;
-use serde_json::Value as JsonValue;
+use serde_json::{json, Value as JsonValue};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
-use tokio::time::{interval_at, sleep_until, timeout, Instant as TokioInstant, MissedTickBehavior};
+use tokio::time::Instant as TokioInstant;
 use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
@@ -21,27 +21,32 @@ use crate::db::models::{
 use crate::db::pool::with_org_txn_typed;
 use crate::db::{chunks, document_versions, documents, index_metadata, jobs as repo};
 use crate::jobs::{
-    self, CheckpointPayload, EnqueueJob, EventPayload, JobError, JobPayload,
-    CURRENT_EVENT_PAYLOAD_VERSION,
+    self, CheckpointPayload, EnqueueJob, EventPayload, HeartbeatClaim, HeartbeatError, JobError,
+    JobPayload, CURRENT_EVENT_PAYLOAD_VERSION,
 };
 use crate::services::chunking::{prepare_chunks, PreparedChunk};
 use crate::services::document_state;
 use crate::services::embedding::{self, EmbeddingError};
+use crate::services::index_signature::CollectionName;
+use crate::services::reconciliation;
 use crate::storage::keys::{authorize_key_for_version, parse_key_for_org};
 use crate::storage::minio::MinioClient;
-use crate::storage::qdrant::{ChunkPointPayload, QdrantClient, UpsertPoint, VectorScope};
+use crate::storage::qdrant::{
+    point_id_from_org_collection_and_chunk, ChunkPointPayload, QdrantClient, UpsertPoint,
+    VectorScope,
+};
 use crate::storage::{ObjectNamespace, StorageError};
 
 #[derive(Debug, Default)]
-pub struct IndexingOutboxSink;
+pub struct OutboxJobSink;
 
-impl IndexingOutboxSink {
+impl OutboxJobSink {
     pub fn new() -> Self {
         Self
     }
 }
 
-impl jobs::OutboxSink for IndexingOutboxSink {
+impl jobs::OutboxSink for OutboxJobSink {
     fn publish<'a>(
         &'a self,
         txn: &'a tokio_postgres::Transaction<'_>,
@@ -49,28 +54,54 @@ impl jobs::OutboxSink for IndexingOutboxSink {
         event: &'a OutboxEvent,
     ) -> Pin<Box<dyn Future<Output = Result<EventLogEntry, JobError>> + Send + 'a>> {
         Box::pin(async move {
-            if event.event_type == "document.index_requested" {
-                let payload = serde_json::from_value::<EventPayload>(event.payload.clone())
-                    .map_err(|error| {
-                        JobError::InvalidPayload(format!("event decode failed: {error}"))
+            match event.event_type.as_str() {
+                "document.index_requested" => {
+                    let payload = serde_json::from_value::<EventPayload>(event.payload.clone())
+                        .map_err(|error| {
+                            JobError::InvalidPayload(format!("event decode failed: {error}"))
+                        })?;
+                    let document_id = payload.document_id.ok_or_else(|| {
+                        JobError::InvalidPayload("index event missing document_id".into())
                     })?;
-                let document_id = payload.document_id.ok_or_else(|| {
-                    JobError::InvalidPayload("index event missing document_id".into())
-                })?;
-                let version_id = payload.version_id.ok_or_else(|| {
-                    JobError::InvalidPayload("index event missing version_id".into())
-                })?;
-                let job_payload = JobPayload {
-                    document_id: Some(document_id),
-                    version_id: Some(version_id),
-                    ..JobPayload::default()
-                };
-                jobs::enqueue_within_txn(
-                    txn,
-                    ctx,
-                    EnqueueJob::new(JobType::Index, job_payload, format!("index:{version_id}")),
-                )
-                .await?;
+                    let version_id = payload.version_id.ok_or_else(|| {
+                        JobError::InvalidPayload("index event missing version_id".into())
+                    })?;
+                    let job_payload = JobPayload {
+                        document_id: Some(document_id),
+                        version_id: Some(version_id),
+                        ..JobPayload::default()
+                    };
+                    jobs::enqueue_within_txn(
+                        txn,
+                        ctx,
+                        EnqueueJob::new(JobType::Index, job_payload, format!("index:{version_id}")),
+                    )
+                    .await?;
+                }
+                "document.delete_requested" => {
+                    let payload = serde_json::from_value::<EventPayload>(event.payload.clone())
+                        .map_err(|error| {
+                            JobError::InvalidPayload(format!("event decode failed: {error}"))
+                        })?;
+                    let document_id = payload.document_id.ok_or_else(|| {
+                        JobError::InvalidPayload("delete event missing document_id".into())
+                    })?;
+                    let job_payload = JobPayload {
+                        document_id: Some(document_id),
+                        ..JobPayload::default()
+                    };
+                    jobs::enqueue_within_txn(
+                        txn,
+                        ctx,
+                        EnqueueJob::new(
+                            JobType::Delete,
+                            job_payload,
+                            format!("delete:{document_id}"),
+                        ),
+                    )
+                    .await?;
+                }
+                _ => {}
             }
 
             append_outbox_published(txn, ctx, event).await
@@ -116,6 +147,7 @@ pub enum IndexVersionOutcome {
     Finalized { job_id: Uuid, chunks: usize },
     CompleteOnly { chunks: usize },
     AlreadyIndexed,
+    Aborted,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -142,6 +174,12 @@ pub async fn index_version(
     let version_id = payload.version_id.ok_or(IndexingError::InvalidPayload)?;
     let (document, version, artifact) =
         load_index_source(db_pool, ctx, document_id, version_id).await?;
+    if matches!(
+        document.state,
+        DocumentState::Tombstoned | DocumentState::Purged
+    ) {
+        return Ok(IndexVersionOutcome::Aborted);
+    }
     let is_current = document.current_version_id == Some(version_id);
     let is_effective = version.effective_to.is_none();
 
@@ -247,16 +285,24 @@ pub async fn index_version(
                     })
                 })
                 .collect::<Result<Vec<_>, IndexingError>>()?;
-            // TODO(I07): superseded-version point flags need reconciliation when a
-            // newer version changes which version is current/effective.
-            // TODO(I07): retrieval must filter on committed PG version state and
-            // document indexed state, not solely on these Qdrant payload flags.
+            let point_ids = batch
+                .iter()
+                .map(|chunk| {
+                    point_id_from_org_collection_and_chunk(
+                        ctx.org_id(),
+                        document.collection_id,
+                        &chunk.chunk_identity,
+                    )
+                })
+                .collect::<Result<Vec<_>, StorageError>>()?;
+            // Reconciliation repairs stale/orphan vector flags; retrieval should still
+            // filter on committed PG version/document state in a future hardening pass.
             qdrant
                 .upsert_points(collection_name, &scope, &points)
                 .await?;
-            // TODO(I07): Qdrant is durable before the PG chunk/checkpoint commit;
-            // dead-lettered attempts may leave orphan vectors for reconcile/GC.
-            persist_chunk_batch(
+            // Qdrant is durable before the PG chunk/checkpoint commit; I07 reconcile
+            // treats any dead-letter leftovers as PG-authoritative orphan vectors.
+            let persist_result = persist_chunk_batch(
                 db_pool,
                 ctx,
                 PersistBatchInput {
@@ -269,7 +315,35 @@ pub async fn index_version(
                     batch_end,
                 },
             )
-            .await?;
+            .await;
+            if let Err(error) = persist_result {
+                if should_compensate_batch_points(db_pool, ctx, document_id, &error).await {
+                    match compensate_batch_points(
+                        qdrant,
+                        collection_name,
+                        &scope,
+                        document_id,
+                        &point_ids,
+                    )
+                    .await
+                    {
+                        Ok(()) => {}
+                        Err(_) => {
+                            eprintln!("fileconv-server: index vector compensation failed");
+                            enqueue_compensation_reconcile(
+                                db_pool,
+                                ctx,
+                                document_id,
+                                input.job.id,
+                                input.attempts,
+                                offset,
+                            )
+                            .await;
+                        }
+                    }
+                }
+                return Err(error);
+            }
             Ok::<(), IndexingError>(())
         })
         .await?;
@@ -355,6 +429,12 @@ async fn transition_current_to_indexing(
             Box::pin(async move {
                 verify_claimed_job(txn, &ctx, job_id, &lease_token, attempts).await?;
                 let document = documents::get_by_id_for_update(txn, &ctx, document_id).await?;
+                if matches!(
+                    document.state,
+                    DocumentState::Tombstoned | DocumentState::Purged
+                ) {
+                    return Err(IndexingError::DocumentDeleted);
+                }
                 if document.current_version_id != Some(version_id) {
                     return Err(IndexingError::CurrentVersionChanged);
                 }
@@ -391,6 +471,12 @@ pub async fn finalize_indexed(
                 let document = documents::get_by_id_for_update(txn, &ctx, document_id).await?;
                 if document.current_version_id != Some(version_id) {
                     return Err(IndexingError::CurrentVersionChanged);
+                }
+                if matches!(
+                    document.state,
+                    DocumentState::Tombstoned | DocumentState::Purged
+                ) {
+                    return Err(IndexingError::DocumentDeleted);
                 }
                 document_state::apply_transition(
                     txn,
@@ -522,6 +608,75 @@ async fn embed_batch(batch: &[PreparedChunk]) -> Result<Vec<Vec<f32>>, IndexingE
         .map_err(Into::into)
 }
 
+async fn should_compensate_batch_points(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    error: &IndexingError,
+) -> bool {
+    match error {
+        IndexingError::DocumentDeleted => true,
+        IndexingError::Job(JobError::LeaseLost) => document_is_deleted(db_pool, ctx, document_id)
+            .await
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+pub async fn enqueue_compensation_reconcile(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    job_id: Uuid,
+    attempts: i32,
+    batch_start: usize,
+) {
+    let reason = format!("{job_id}:{attempts}:{batch_start}");
+    if reconciliation::enqueue_reconcile(db_pool, ctx, document_id, &reason)
+        .await
+        .is_err()
+    {
+        eprintln!("fileconv-server: incident reconcile enqueue failed");
+    }
+}
+
+async fn document_is_deleted(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<bool, IndexingError> {
+    with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                Ok::<_, IndexingError>(matches!(
+                    document.state,
+                    DocumentState::Tombstoned | DocumentState::Purged
+                ))
+            })
+        }
+    })
+    .await
+}
+
+pub async fn compensate_batch_points(
+    qdrant: &QdrantClient,
+    collection_name: &CollectionName,
+    scope: &VectorScope,
+    document_id: Uuid,
+    point_ids: &[Uuid],
+) -> Result<(), IndexingError> {
+    let document_filter = [json!({
+        "key": "document_id",
+        "match": { "value": document_id.to_string() }
+    })];
+    qdrant
+        .delete_points_by_ids(collection_name, scope, &document_filter, point_ids)
+        .await?;
+    Ok(())
+}
+
 struct PersistBatchInput<'a> {
     claim: IndexVersionInput<'a>,
     metadata_id: Uuid,
@@ -550,6 +705,14 @@ async fn persist_chunk_batch(
         let ctx = ctx.clone();
         move |txn| {
             Box::pin(async move {
+                verify_claimed_job(txn, &ctx, job_id, &lease_token, attempts).await?;
+                let document = documents::get_by_id_for_update(txn, &ctx, document_id).await?;
+                if matches!(
+                    document.state,
+                    DocumentState::Tombstoned | DocumentState::Purged
+                ) {
+                    return Err(IndexingError::DocumentDeleted);
+                }
                 for chunk in &batch {
                     chunks::insert_if_absent(
                         txn,
@@ -615,17 +778,7 @@ async fn heartbeat_while<T, Fut>(
 where
     Fut: Future<Output = Result<T, IndexingError>>,
 {
-    heartbeat_once(db_pool, ctx, input).await?;
-    tokio::pin!(future);
-    let mut heartbeat = heartbeat_interval(input.heartbeat_interval);
-    loop {
-        tokio::select! {
-            biased;
-            result = &mut future => return result,
-            _ = sleep_until(input.deadline) => return Err(IndexingError::JobTimedOut),
-            _ = heartbeat.tick() => heartbeat_once(db_pool, ctx, input).await?,
-        }
-    }
+    jobs::heartbeat_while_claimed(heartbeat_claim(db_pool, ctx, input), future).await
 }
 
 async fn heartbeat_once(
@@ -633,39 +786,26 @@ async fn heartbeat_once(
     ctx: &OrgContext,
     input: IndexVersionInput<'_>,
 ) -> Result<(), IndexingError> {
-    match timeout(
-        heartbeat_call_timeout(input.lease_ttl, input.deadline),
-        jobs::heartbeat(
-            db_pool,
-            ctx,
-            input.job.id,
-            input.lease_token,
-            input.attempts,
-            input.lease_ttl,
-        ),
-    )
-    .await
-    {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(JobError::LeaseLost)) => Err(IndexingError::Job(JobError::LeaseLost)),
-        Ok(Err(error)) => Err(IndexingError::Job(error)),
-        Err(_) => Err(IndexingError::JobTimedOut),
-    }
+    jobs::heartbeat_once_claimed(heartbeat_claim(db_pool, ctx, input))
+        .await
+        .map_err(Into::into)
 }
 
-fn heartbeat_interval(interval: Duration) -> tokio::time::Interval {
-    let mut heartbeat = interval_at(TokioInstant::now() + interval, interval);
-    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    heartbeat
-}
-
-fn heartbeat_call_timeout(lease_ttl: Duration, deadline: TokioInstant) -> Duration {
-    let mut lease_bound = lease_ttl / 3;
-    if lease_bound.is_zero() {
-        lease_bound = Duration::from_millis(1);
+fn heartbeat_claim<'a>(
+    db_pool: &'a Pool,
+    ctx: &'a OrgContext,
+    input: IndexVersionInput<'a>,
+) -> HeartbeatClaim<'a> {
+    HeartbeatClaim {
+        db_pool,
+        ctx,
+        job_id: input.job.id,
+        lease_token: input.lease_token,
+        attempts: input.attempts,
+        lease_ttl: input.lease_ttl,
+        heartbeat_interval: input.heartbeat_interval,
+        deadline: input.deadline,
     }
-    let remaining = deadline.saturating_duration_since(TokioInstant::now());
-    remaining.min(lease_bound)
 }
 
 #[derive(Debug, Error)]
@@ -708,8 +848,19 @@ pub enum IndexingError {
     MissingQdrantCollection,
     #[error("document current version changed while indexing")]
     CurrentVersionChanged,
+    #[error("document was tombstoned or purged while indexing")]
+    DocumentDeleted,
     #[error("index job exceeded configured maximum duration")]
     JobTimedOut,
+}
+
+impl From<HeartbeatError> for IndexingError {
+    fn from(value: HeartbeatError) -> Self {
+        match value {
+            HeartbeatError::Job(error) => Self::Job(error),
+            HeartbeatError::TimedOut => Self::JobTimedOut,
+        }
+    }
 }
 
 impl IndexingError {
@@ -734,6 +885,7 @@ impl IndexingError {
             Self::IndexGeneration => "index generation invalid",
             Self::MissingQdrantCollection => "index qdrant collection missing",
             Self::CurrentVersionChanged => "index current version changed",
+            Self::DocumentDeleted => "index document deleted",
             Self::JobTimedOut => "index job timed out",
         }
     }

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -3,10 +3,12 @@
 pub mod artifacts;
 pub mod chunking;
 pub mod conversion;
+pub mod deletion;
 pub mod document_state;
 pub mod embedding;
 pub mod index_signature;
 pub mod indexing;
 pub mod promotion;
 pub mod quota;
+pub mod reconciliation;
 pub mod upload;

--- a/crates/server/src/services/reconciliation.rs
+++ b/crates/server/src/services/reconciliation.rs
@@ -1,0 +1,662 @@
+//! PostgreSQL-authoritative drift detection and safe destructive repair.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use deadpool_postgres::Pool;
+use serde_json::json;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::auth::session::{write_audit, AuditEvent};
+use crate::db::error::DbError;
+use crate::db::models::{Chunk, Document, DocumentState, DocumentVersion, JobType};
+use crate::db::pool::with_org_txn_typed;
+use crate::db::{chunks, document_versions, documents, index_metadata, jobs as repo};
+use crate::jobs::{self, CheckpointPayload, EnqueueJob, EnqueueOutcome, JobError, JobPayload};
+use crate::services::index_signature::collection_name_for_digest;
+use crate::storage::keys::parse_key_for_org;
+use crate::storage::minio::MinioClient;
+use crate::storage::qdrant::{
+    point_id_from_org_collection_and_chunk, ChunkPointPayload, QdrantClient, VectorScope,
+};
+use crate::storage::StorageError;
+
+const DEAD_LETTER_PAGE_LIMIT: i64 = 500;
+const QDRANT_SCROLL_PAGE_LIMIT: usize = 1024;
+const QDRANT_SCROLL_TOTAL_LIMIT: usize = 100_000;
+const POINT_DELETE_BATCH: usize = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReconcileMode {
+    DryRun,
+    Repair,
+}
+
+impl ReconcileMode {
+    pub fn parse(value: &str) -> Result<Self, ReconciliationError> {
+        match value {
+            "dry-run" | "dry_run" | "dryrun" => Ok(Self::DryRun),
+            "repair" => Ok(Self::Repair),
+            _ => Err(ReconciliationError::InvalidMode),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileRepairCounts {
+    pub orphan_vectors: usize,
+    pub stale_vectors: usize,
+    pub staged_objects: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileReport {
+    pub missing_vectors: usize,
+    pub orphan_vectors: usize,
+    pub stale_vectors: usize,
+    pub in_flight_vectors: usize,
+    pub missing_objects: usize,
+    pub repaired: ReconcileRepairCounts,
+}
+
+struct DocumentInventory {
+    document: Document,
+    versions: Vec<DocumentVersion>,
+    chunks: Vec<Chunk>,
+    object_keys: Vec<String>,
+    signatures: Vec<String>,
+    active_writer_job: bool,
+}
+
+#[derive(Debug, Clone)]
+struct VectorCandidate {
+    signature: String,
+    point_id: Uuid,
+    payload: ChunkPointPayload,
+}
+
+pub async fn enqueue_reconcile(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    reason: &str,
+) -> Result<EnqueueOutcome, JobError> {
+    jobs::enqueue(
+        pool,
+        ctx,
+        EnqueueJob::new(
+            JobType::Reconcile,
+            JobPayload {
+                document_id: Some(document_id),
+                ..JobPayload::default()
+            },
+            format!("reconcile:{document_id}:{reason}"),
+        ),
+    )
+    .await
+}
+
+pub async fn reconcile_document(
+    pool: &Pool,
+    storage: &MinioClient,
+    qdrant: &QdrantClient,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    mode: ReconcileMode,
+) -> Result<ReconcileReport, ReconciliationError> {
+    let inventory = load_inventory(pool, ctx, document_id).await?;
+    let scope = VectorScope::new(ctx.org_id(), [inventory.document.collection_id]);
+    let points_by_signature =
+        scroll_document_points(qdrant, &scope, &inventory.signatures, document_id).await?;
+    let mut report = ReconcileReport::default();
+
+    if matches!(
+        inventory.document.state,
+        DocumentState::Tombstoned | DocumentState::Purged
+    ) {
+        let candidates = all_point_candidates(
+            &points_by_signature,
+            ctx.org_id(),
+            inventory.document.collection_id,
+            document_id,
+        )?;
+        report.orphan_vectors = candidates.len();
+        if mode == ReconcileMode::Repair && report.orphan_vectors > 0 {
+            report.repaired.orphan_vectors = report.orphan_vectors;
+            // Audit the planned destructive repair BEFORE deleting so a crash
+            // between the vector delete and the audit can never leave an
+            // unaudited deletion (audit_log.outcome is limited to success/deny/error).
+            write_repair_audit(pool, ctx, document_id, &report, "success").await?;
+            delete_exact_point_candidates(qdrant, &scope, document_id, &candidates).await?;
+        }
+        return Ok(report);
+    }
+
+    let chunk_ids = inventory
+        .chunks
+        .iter()
+        .map(|chunk| chunk.chunk_identity_sha256.clone())
+        .collect::<BTreeSet<_>>();
+    let versions = inventory
+        .versions
+        .iter()
+        .map(|version| (version.id, version))
+        .collect::<BTreeMap<_, _>>();
+    let mut orphan_candidates = Vec::new();
+    let mut stale_candidates = Vec::new();
+
+    for (signature, points) in &points_by_signature {
+        for (point_id, payload) in points {
+            if !point_candidate_matches(
+                payload,
+                ctx.org_id(),
+                inventory.document.collection_id,
+                document_id,
+            ) {
+                continue;
+            }
+            if !chunk_ids.contains(&payload.chunk_id) {
+                if inventory.document.state == DocumentState::Indexed
+                    && !inventory.active_writer_job
+                {
+                    report.orphan_vectors += 1;
+                    orphan_candidates.push(VectorCandidate {
+                        signature: signature.clone(),
+                        point_id: *point_id,
+                        payload: payload.clone(),
+                    });
+                } else {
+                    report.in_flight_vectors += 1;
+                }
+                continue;
+            }
+            let stale_current = payload.is_current
+                && Some(payload.version_id) != inventory.document.current_version_id;
+            let stale_effective = payload.is_effective
+                && versions
+                    .get(&payload.version_id)
+                    .is_some_and(|version| version.effective_to.is_some());
+            if stale_current || stale_effective {
+                report.stale_vectors += 1;
+                stale_candidates.push(VectorCandidate {
+                    signature: signature.clone(),
+                    point_id: *point_id,
+                    payload: payload.clone(),
+                });
+            }
+        }
+    }
+
+    report.missing_vectors = count_missing_vectors(
+        qdrant,
+        &scope,
+        inventory.document.collection_id,
+        &inventory.chunks,
+    )
+    .await?;
+    report.missing_objects = count_missing_objects(storage, ctx, &inventory.object_keys).await?;
+
+    if mode == ReconcileMode::Repair {
+        let can_repair_indexed = inventory.document.state == DocumentState::Indexed
+            && !active_writer_job(pool, ctx, document_id).await?;
+        if can_repair_indexed {
+            let repair_count = orphan_candidates.len() + stale_candidates.len();
+            if repair_count > 0 {
+                report.repaired.orphan_vectors = orphan_candidates.len();
+                report.repaired.stale_vectors = stale_candidates.len();
+                // Durable audit before the destructive delete (see note above).
+                write_repair_audit(pool, ctx, document_id, &report, "success").await?;
+                delete_exact_point_candidates(qdrant, &scope, document_id, &orphan_candidates)
+                    .await?;
+                delete_exact_point_candidates(qdrant, &scope, document_id, &stale_candidates)
+                    .await?;
+            }
+        } else {
+            report.in_flight_vectors += orphan_candidates.len();
+        }
+    }
+
+    Ok(report)
+}
+
+pub async fn reconcile_dead_letter_jobs(
+    pool: &Pool,
+    storage: &MinioClient,
+    ctx: &OrgContext,
+    mode: ReconcileMode,
+) -> Result<ReconcileReport, ReconciliationError> {
+    let mut report = ReconcileReport::default();
+    let mut after_id = None;
+    loop {
+        let jobs = list_dead_letter_convert_page(pool, ctx, after_id).await?;
+        if jobs.is_empty() {
+            break;
+        }
+        after_id = jobs.last().map(|job| job.id);
+        if mode == ReconcileMode::Repair {
+            for job in &jobs {
+                let Some(checkpoint) = job.checkpoint.clone() else {
+                    continue;
+                };
+                let checkpoint = serde_json::from_value::<CheckpointPayload>(checkpoint)
+                    .map_err(|_| ReconciliationError::InvalidCheckpoint)?;
+                for raw_key in checkpoint.staged_object_keys {
+                    if object_key_is_referenced(pool, ctx, &raw_key).await? {
+                        continue;
+                    }
+                    let key = parse_key_for_org(&raw_key, ctx.org_id())?;
+                    if storage.object_exists(ctx.org_id(), &key).await? {
+                        storage.cleanup_generated_object(ctx.org_id(), &key).await?;
+                        report.repaired.staged_objects += 1;
+                    }
+                }
+            }
+        }
+        if jobs.len() < DEAD_LETTER_PAGE_LIMIT as usize {
+            break;
+        }
+    }
+    if mode == ReconcileMode::Repair && report.repaired.staged_objects > 0 {
+        write_dead_letter_audit(pool, ctx, report.repaired.staged_objects).await?;
+    }
+    Ok(report)
+}
+
+async fn list_dead_letter_convert_page(
+    pool: &Pool,
+    ctx: &OrgContext,
+    after_id: Option<Uuid>,
+) -> Result<Vec<crate::db::models::Job>, ReconciliationError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                Ok::<_, ReconciliationError>(
+                    repo::list_dead_letter_of_type(
+                        txn,
+                        &ctx,
+                        JobType::Convert,
+                        after_id,
+                        DEAD_LETTER_PAGE_LIMIT,
+                    )
+                    .await?,
+                )
+            })
+        }
+    })
+    .await
+}
+
+async fn load_inventory(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<DocumentInventory, ReconciliationError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                let versions = document_versions::list_by_document(txn, &ctx, document_id).await?;
+                let chunks = chunks::list_by_document(txn, &ctx, document_id).await?;
+                let object_keys =
+                    document_versions::list_object_keys_by_document(txn, &ctx, document_id).await?;
+                let active_writer_job = repo::has_active_writer_job(txn, &ctx, document_id).await?;
+                let mut signatures = BTreeSet::new();
+                for signature in
+                    chunks::distinct_index_signatures_by_document(txn, &ctx, document_id).await?
+                {
+                    signatures.insert(signature);
+                }
+                for signature in
+                    index_metadata::list_signatures_by_collection(txn, &ctx, document.collection_id)
+                        .await?
+                {
+                    signatures.insert(signature);
+                }
+                Ok(DocumentInventory {
+                    document,
+                    versions,
+                    chunks,
+                    object_keys,
+                    signatures: signatures.into_iter().collect(),
+                    active_writer_job,
+                })
+            })
+        }
+    })
+    .await
+}
+
+async fn scroll_document_points(
+    qdrant: &QdrantClient,
+    scope: &VectorScope,
+    signatures: &[String],
+    document_id: Uuid,
+) -> Result<BTreeMap<String, Vec<(Uuid, ChunkPointPayload)>>, ReconciliationError> {
+    let filter = [json!({
+        "key": "document_id",
+        "match": { "value": document_id.to_string() }
+    })];
+    let mut out = BTreeMap::new();
+    let mut total_points = 0usize;
+    for digest in signatures {
+        let collection = collection_name_for_digest(digest)?;
+        let mut points = Vec::new();
+        let mut offset = None;
+        loop {
+            let page = qdrant
+                .scroll_points_page(
+                    &collection,
+                    scope,
+                    &filter,
+                    QDRANT_SCROLL_PAGE_LIMIT,
+                    offset,
+                )
+                .await?;
+            total_points = total_points.saturating_add(page.points.len());
+            points.extend(page.points);
+            if total_points > QDRANT_SCROLL_TOTAL_LIMIT {
+                return Err(ReconciliationError::ScrollLimitExceeded);
+            }
+            let Some(next) = page.next_page_offset else {
+                break;
+            };
+            offset = Some(next);
+        }
+        out.insert(digest.clone(), points);
+    }
+    Ok(out)
+}
+
+async fn delete_exact_point_candidates(
+    qdrant: &QdrantClient,
+    scope: &VectorScope,
+    document_id: Uuid,
+    candidates: &[VectorCandidate],
+) -> Result<(), ReconciliationError> {
+    let collection_id = single_collection_id(scope)?;
+    let mut by_signature: BTreeMap<String, Vec<&VectorCandidate>> = BTreeMap::new();
+    for candidate in candidates {
+        if !point_candidate_matches(&candidate.payload, scope.org_id, collection_id, document_id) {
+            continue;
+        }
+        by_signature
+            .entry(candidate.signature.clone())
+            .or_default()
+            .push(candidate);
+    }
+    for (digest, candidates) in by_signature {
+        let collection = collection_name_for_digest(&digest)?;
+        let document_filter = [json!({
+            "key": "document_id",
+            "match": { "value": document_id.to_string() }
+        })];
+        for batch in candidates.chunks(POINT_DELETE_BATCH) {
+            let ids = batch
+                .iter()
+                .map(|candidate| candidate.point_id)
+                .collect::<Vec<_>>();
+            qdrant
+                .delete_points_by_ids(&collection, scope, &document_filter, &ids)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+fn single_collection_id(scope: &VectorScope) -> Result<Uuid, ReconciliationError> {
+    if scope.collection_ids.len() != 1 {
+        return Err(ReconciliationError::Storage(StorageError::MissingScope));
+    }
+    scope
+        .collection_ids
+        .iter()
+        .next()
+        .copied()
+        .ok_or(ReconciliationError::Storage(StorageError::MissingScope))
+}
+
+fn all_point_candidates(
+    points_by_signature: &BTreeMap<String, Vec<(Uuid, ChunkPointPayload)>>,
+    org_id: Uuid,
+    collection_id: Uuid,
+    document_id: Uuid,
+) -> Result<Vec<VectorCandidate>, ReconciliationError> {
+    let mut candidates = Vec::new();
+    for (signature, points) in points_by_signature {
+        for (point_id, payload) in points {
+            if point_candidate_matches(payload, org_id, collection_id, document_id) {
+                candidates.push(VectorCandidate {
+                    signature: signature.clone(),
+                    point_id: *point_id,
+                    payload: payload.clone(),
+                });
+            }
+        }
+    }
+    Ok(candidates)
+}
+
+fn point_candidate_matches(
+    payload: &ChunkPointPayload,
+    org_id: Uuid,
+    collection_id: Uuid,
+    document_id: Uuid,
+) -> bool {
+    payload.org_id == org_id
+        && payload.collection_id == collection_id
+        && payload.document_id == document_id
+}
+
+async fn active_writer_job(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Result<bool, ReconciliationError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                Ok::<_, ReconciliationError>(
+                    repo::has_active_writer_job(txn, &ctx, document_id).await?,
+                )
+            })
+        }
+    })
+    .await
+}
+
+async fn object_key_is_referenced(
+    pool: &Pool,
+    ctx: &OrgContext,
+    object_key: &str,
+) -> Result<bool, ReconciliationError> {
+    let object_key = object_key.to_string();
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                Ok::<_, ReconciliationError>(
+                    document_versions::object_key_is_referenced(txn, &ctx, &object_key).await?,
+                )
+            })
+        }
+    })
+    .await
+}
+
+async fn count_missing_vectors(
+    qdrant: &QdrantClient,
+    scope: &VectorScope,
+    collection_id: Uuid,
+    chunks: &[Chunk],
+) -> Result<usize, ReconciliationError> {
+    let mut by_signature: BTreeMap<String, Vec<&Chunk>> = BTreeMap::new();
+    for chunk in chunks {
+        by_signature
+            .entry(chunk.index_signature.clone())
+            .or_default()
+            .push(chunk);
+    }
+    let mut missing = 0;
+    for (digest, chunks) in by_signature {
+        let collection = collection_name_for_digest(&digest)?;
+        let ids = chunks
+            .iter()
+            .map(|chunk| {
+                point_id_from_org_collection_and_chunk(
+                    scope.org_id,
+                    collection_id,
+                    &chunk.chunk_identity_sha256,
+                )
+            })
+            .collect::<Result<Vec<_>, StorageError>>()?;
+        let found = qdrant.get_points(&collection, scope, &ids).await?;
+        let found_ids = found.into_iter().map(|(id, _)| id).collect::<BTreeSet<_>>();
+        missing += ids.iter().filter(|id| !found_ids.contains(id)).count();
+    }
+    Ok(missing)
+}
+
+async fn count_missing_objects(
+    storage: &MinioClient,
+    ctx: &OrgContext,
+    object_keys: &[String],
+) -> Result<usize, ReconciliationError> {
+    let mut missing = 0;
+    for raw_key in object_keys {
+        let key = parse_key_for_org(raw_key, ctx.org_id())?;
+        if !storage.object_exists(ctx.org_id(), &key).await? {
+            missing += 1;
+        }
+    }
+    Ok(missing)
+}
+
+async fn write_repair_audit(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    report: &ReconcileReport,
+    outcome: &'static str,
+) -> Result<(), ReconciliationError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        let repaired = report.repaired.clone();
+        move |txn| {
+            Box::pin(async move {
+                let resource_id = document_id.to_string();
+                let request_id = format!("reconcile-{document_id}");
+                write_audit(
+                    txn,
+                    AuditEvent {
+                        org_id: ctx.org_id(),
+                        actor_user_id: Some(ctx.user_id()),
+                        action: "reconcile.repair",
+                        resource_type: "document",
+                        resource_id: Some(&resource_id),
+                        outcome,
+                        request_id: &request_id,
+                        metadata: json!({
+                            "document_id": document_id,
+                            "orphan_vectors": repaired.orphan_vectors,
+                            "stale_vectors": repaired.stale_vectors,
+                        }),
+                    },
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+}
+
+async fn write_dead_letter_audit(
+    pool: &Pool,
+    ctx: &OrgContext,
+    staged_objects: usize,
+) -> Result<(), ReconciliationError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                write_audit(
+                    txn,
+                    AuditEvent {
+                        org_id: ctx.org_id(),
+                        actor_user_id: Some(ctx.user_id()),
+                        action: "reconcile.repair",
+                        resource_type: "jobs",
+                        resource_id: None,
+                        outcome: "success",
+                        request_id: "reconcile-gc",
+                        metadata: json!({
+                            "dead_letter_staged_objects": staged_objects,
+                            "quota_marker_cleanup": "todo_i02_expiry_sweep",
+                        }),
+                    },
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+}
+
+#[derive(Debug, Error)]
+pub enum ReconciliationError {
+    #[error("database error")]
+    Db(#[from] DbError),
+    #[error("job error")]
+    Job(#[from] JobError),
+    #[error("storage error")]
+    Storage(#[from] StorageError),
+    #[error("reconcile mode is invalid")]
+    InvalidMode,
+    #[error("reconcile checkpoint is invalid")]
+    InvalidCheckpoint,
+    #[error("reconcile qdrant scroll limit exceeded")]
+    ScrollLimitExceeded,
+}
+
+impl ReconciliationError {
+    pub fn safe_job_error(&self) -> &'static str {
+        match self {
+            Self::Db(_) => "reconcile database error",
+            Self::Job(_) => "reconcile job error",
+            Self::Storage(_) => "reconcile storage error",
+            Self::InvalidMode => "reconcile mode invalid",
+            Self::InvalidCheckpoint => "reconcile checkpoint invalid",
+            Self::ScrollLimitExceeded => "reconcile scroll limit exceeded",
+        }
+    }
+
+    pub fn is_retryable_job_failure(&self) -> bool {
+        !matches!(self, Self::Job(JobError::LeaseLost))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_reconcile_modes() {
+        assert_eq!(
+            ReconcileMode::parse("dry-run").unwrap(),
+            ReconcileMode::DryRun
+        );
+        assert_eq!(
+            ReconcileMode::parse("repair").unwrap(),
+            ReconcileMode::Repair
+        );
+        assert!(matches!(
+            ReconcileMode::parse("delete"),
+            Err(ReconciliationError::InvalidMode)
+        ));
+    }
+}

--- a/crates/server/src/storage/minio.rs
+++ b/crates/server/src/storage/minio.rs
@@ -301,8 +301,8 @@ impl MinioClient {
             return Err(StorageError::ConfigInvalid);
         }
         let generated_key = request.key.clone();
-        // TODO(I07): persist pending generated keys in the durable outbox/GC so crash
-        // recovery can reconcile objects beyond this live bounded task.
+        // I07 reconciles checkpointed dead-letter staging keys; uncheckpointed crash
+        // windows still need a future durable generated-object intent.
         let path = generated_key.as_str();
         let mut headers = identity_headers(&request.meta, &request.content_type)?;
         headers.insert(

--- a/crates/server/src/storage/qdrant.rs
+++ b/crates/server/src/storage/qdrant.rs
@@ -28,6 +28,7 @@ use crate::storage::error::StorageError;
 use crate::storage::url_safety::normalize_service_url;
 
 const POINT_ID_DOMAIN: &[u8] = b"markhand-qdrant-point-v2";
+const SCROLL_PAGE_LIMIT: usize = 1024;
 
 /// Mandatory tenant + authorized-collection scope for every vector operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -141,6 +142,12 @@ pub struct SearchHit {
     pub point_id: Uuid,
     pub score: f32,
     pub payload: ChunkPointPayload,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScrolledPoints {
+    pub points: Vec<(Uuid, ChunkPointPayload)>,
+    pub next_page_offset: Option<Value>,
 }
 
 /// Fail-closed Qdrant client using the HTTP REST API (no gRPC dependency).
@@ -450,10 +457,117 @@ impl QdrantClient {
             .send()
             .await
             .map_err(|_| StorageError::Transport)?;
+        if response.status().as_u16() == 404 {
+            return Ok(());
+        }
         if !response.status().is_success() {
             return Err(StorageError::Backend);
         }
         Ok(())
+    }
+
+    /// Delete exact point ids, fenced by mandatory org + authorized collection filters.
+    pub async fn delete_points_by_ids(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        extra_must: &[Value],
+        ids: &[Uuid],
+    ) -> Result<(), StorageError> {
+        scope.validate()?;
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let mut must = mandatory_filter_must(scope);
+        must.extend(extra_must.iter().cloned());
+        let ids: Vec<Value> = ids.iter().map(|id| Value::String(id.to_string())).collect();
+        must.push(json!({ "has_id": ids }));
+        let url = format!(
+            "{}/collections/{}/points/delete?wait=true",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let response = self
+            .authed(self.http.post(&url))
+            .json(&json!({ "filter": { "must": must } }))
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if response.status().as_u16() == 404 {
+            return Ok(());
+        }
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        Ok(())
+    }
+
+    /// Scroll scoped points with mandatory org + authorized collection filters.
+    pub async fn scroll_points(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        extra_must: &[Value],
+        limit: usize,
+    ) -> Result<Vec<(Uuid, ChunkPointPayload)>, StorageError> {
+        self.scroll_points_page(collection_name, scope, extra_must, limit, None)
+            .await
+            .map(|page| page.points)
+    }
+
+    pub async fn scroll_points_page(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        extra_must: &[Value],
+        limit: usize,
+        offset: Option<Value>,
+    ) -> Result<ScrolledPoints, StorageError> {
+        scope.validate()?;
+        if limit == 0 || limit > SCROLL_PAGE_LIMIT {
+            return Err(StorageError::PreconditionFailed);
+        }
+        let mut must = mandatory_filter_must(scope);
+        must.extend(extra_must.iter().cloned());
+        let url = format!(
+            "{}/collections/{}/points/scroll",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let mut request = json!({
+            "filter": { "must": must },
+            "limit": limit,
+            "with_payload": true,
+            "with_vector": false,
+        });
+        if let Some(cursor) = offset {
+            request["offset"] = cursor;
+        }
+        let response = self
+            .authed(self.http.post(&url))
+            .json(&request)
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if response.status().as_u16() == 404 {
+            return Ok(ScrolledPoints {
+                points: Vec::new(),
+                next_page_offset: None,
+            });
+        }
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        let body: Value = response.json().await.map_err(|_| StorageError::Backend)?;
+        let points = parse_scrolled_points(scope, &body)?;
+        let next_page_offset = match body.pointer("/result/next_page_offset").cloned() {
+            Some(Value::Null) | None => None,
+            Some(value) => Some(value),
+        };
+        Ok(ScrolledPoints {
+            points,
+            next_page_offset,
+        })
     }
 
     /// Fetch points by id using a **server-side** org + collection + has_id filter.
@@ -489,27 +603,14 @@ impl QdrantClient {
             .send()
             .await
             .map_err(|_| StorageError::Transport)?;
+        if response.status().as_u16() == 404 {
+            return Ok(Vec::new());
+        }
         if !response.status().is_success() {
             return Err(StorageError::Backend);
         }
         let body: Value = response.json().await.map_err(|_| StorageError::Backend)?;
-        let points = body
-            .pointer("/result/points")
-            .and_then(Value::as_array)
-            .ok_or(StorageError::Backend)?;
-        let mut out = Vec::new();
-        for point in points {
-            let id = parse_point_id(point.get("id").ok_or(StorageError::Backend)?)?;
-            let payload =
-                ChunkPointPayload::from_json(point.get("payload").ok_or(StorageError::Backend)?)?;
-            if payload.org_id != scope.org_id
-                || !scope.collection_ids.contains(&payload.collection_id)
-            {
-                return Err(StorageError::OwnershipConflict);
-            }
-            out.push((id, payload));
-        }
-        Ok(out)
+        parse_scrolled_points(scope, &body)
     }
 
     async fn assert_owned_or_absent(
@@ -714,6 +815,28 @@ fn parse_search_hits(body: &Value) -> Result<Vec<SearchHit>, StorageError> {
         });
     }
     Ok(hits)
+}
+
+fn parse_scrolled_points(
+    scope: &VectorScope,
+    body: &Value,
+) -> Result<Vec<(Uuid, ChunkPointPayload)>, StorageError> {
+    let points = body
+        .pointer("/result/points")
+        .and_then(Value::as_array)
+        .ok_or(StorageError::Backend)?;
+    let mut out = Vec::new();
+    for point in points {
+        let id = parse_point_id(point.get("id").ok_or(StorageError::Backend)?)?;
+        let payload =
+            ChunkPointPayload::from_json(point.get("payload").ok_or(StorageError::Backend)?)?;
+        if payload.org_id != scope.org_id || !scope.collection_ids.contains(&payload.collection_id)
+        {
+            return Err(StorageError::OwnershipConflict);
+        }
+        out.push((id, payload));
+    }
+    Ok(out)
 }
 
 fn parse_point_id(value: &Value) -> Result<Uuid, StorageError> {

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -889,8 +889,8 @@ impl ConvertWorker {
             eprintln!(
                 "fileconv-server: injected conversion quota refund failure; reservation_key={quota_reservation_key}"
             );
-            // TODO(I07): durable dead-letter GC/reconciliation should consume the
-            // checkpointed staging keys and quota marker if retries are exhausted.
+            // I07 reconciliation consumes checkpointed staging keys after dead-letter;
+            // quota markers remain bounded by the I02 expiry sweep.
             deferred = true;
         } else if let Err(error) = quota::refund(&self.db_pool, ctx, quota_reservation_key).await {
             eprintln!(
@@ -900,8 +900,8 @@ impl ConvertWorker {
             );
             // I02 quota reservations are bounded by expires_at; the sweep path is
             // the durable backstop if inline refund cannot settle this attempt.
-            // TODO(I07): emit/consume a durable conversion-cleanup marker for
-            // permanently dead-lettered conversion attempts.
+            // Future cleanup markers can make quota refunds explicit for permanently
+            // dead-lettered conversion attempts; I02 expiry is the current backstop.
             deferred = true;
         }
         if deferred {

--- a/crates/server/src/workers/delete.rs
+++ b/crates/server/src/workers/delete.rs
@@ -1,0 +1,216 @@
+//! Durable delete job worker.
+
+use std::time::Duration;
+
+use deadpool_postgres::Pool;
+use thiserror::Error;
+use tokio::time::{timeout_at, Instant as TokioInstant};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::models::{Job, JobStatus, JobType};
+use crate::jobs::{self, JobError};
+use crate::services::deletion::{self, DeletionError, PurgeDocumentInput, PurgeDocumentOutcome};
+use crate::storage::minio::MinioClient;
+use crate::storage::qdrant::QdrantClient;
+
+const DEFAULT_CLAIM_LIMIT: u32 = 1;
+const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 5;
+const DEFAULT_MAX_JOB_DURATION_SECS: u64 = 300;
+
+#[derive(Debug, Clone)]
+pub struct DeleteWorkerConfig {
+    pub worker_id: String,
+    pub lease_ttl: Duration,
+    pub heartbeat_interval: Duration,
+    pub max_job_duration: Duration,
+}
+
+impl DeleteWorkerConfig {
+    pub fn new(worker_id: impl Into<String>) -> Self {
+        Self {
+            worker_id: worker_id.into(),
+            lease_ttl: Duration::from_secs(60),
+            heartbeat_interval: Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL_SECS),
+            max_job_duration: Duration::from_secs(DEFAULT_MAX_JOB_DURATION_SECS),
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), DeleteWorkerError> {
+        if self.heartbeat_interval.is_zero()
+            || self.lease_ttl.is_zero()
+            || self.heartbeat_interval > self.lease_ttl / 3
+        {
+            return Err(DeleteWorkerError::InvalidHeartbeatConfig);
+        }
+        if self.max_job_duration.is_zero() {
+            return Err(DeleteWorkerError::InvalidMaxJobDuration);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct DeleteWorker {
+    db_pool: Pool,
+    storage: MinioClient,
+    qdrant: QdrantClient,
+    config: DeleteWorkerConfig,
+}
+
+impl DeleteWorker {
+    pub fn new(
+        db_pool: Pool,
+        storage: MinioClient,
+        qdrant: QdrantClient,
+        config: DeleteWorkerConfig,
+    ) -> Result<Self, DeleteWorkerError> {
+        config.validate()?;
+        Ok(Self {
+            db_pool,
+            storage,
+            qdrant,
+            config,
+        })
+    }
+
+    pub async fn run_once(&self, ctx: &OrgContext) -> Result<DeleteWorkerRun, DeleteWorkerError> {
+        let jobs = jobs::claim_type(
+            &self.db_pool,
+            ctx,
+            JobType::Delete,
+            &self.config.worker_id,
+            DEFAULT_CLAIM_LIMIT,
+            self.config.lease_ttl,
+        )
+        .await?;
+        let Some(job) = jobs.into_iter().next() else {
+            return Ok(DeleteWorkerRun::NoJob);
+        };
+        self.process_claimed_job(ctx, job).await
+    }
+
+    pub async fn process_claimed_job(
+        &self,
+        ctx: &OrgContext,
+        job: Job,
+    ) -> Result<DeleteWorkerRun, DeleteWorkerError> {
+        let lease_token = job
+            .lease_owner
+            .as_deref()
+            .ok_or(DeleteWorkerError::MissingLease)?
+            .to_string();
+        let attempts = job.attempts;
+        let deadline = TokioInstant::now() + self.config.max_job_duration;
+        let input = PurgeDocumentInput {
+            job: &job,
+            lease_token: &lease_token,
+            attempts,
+            lease_ttl: self.config.lease_ttl,
+            heartbeat_interval: self.config.heartbeat_interval,
+            deadline,
+        };
+        let result = timeout_at(
+            deadline,
+            deletion::purge_document(&self.db_pool, &self.storage, &self.qdrant, ctx, input),
+        )
+        .await;
+        match result {
+            Ok(Ok(PurgeDocumentOutcome::Purged {
+                job_id,
+                deleted_chunks,
+            })) => Ok(DeleteWorkerRun::Completed {
+                job_id,
+                deleted_chunks,
+            }),
+            Ok(Ok(PurgeDocumentOutcome::AlreadyPurged { job_id })) => {
+                Ok(DeleteWorkerRun::Completed {
+                    job_id,
+                    deleted_chunks: 0,
+                })
+            }
+            Ok(Err(DeletionError::Job(JobError::LeaseLost))) => {
+                Ok(DeleteWorkerRun::LeaseLost { job_id: job.id })
+            }
+            Ok(Err(error)) if error.is_retryable_job_failure() => {
+                self.fail_claimed(ctx, &job, &lease_token, attempts, error.safe_job_error())
+                    .await
+            }
+            Ok(Err(error)) => Err(DeleteWorkerError::Deletion(error)),
+            Err(_) => {
+                self.fail_claimed(
+                    ctx,
+                    &job,
+                    &lease_token,
+                    attempts,
+                    DeleteWorkerError::JobTimedOut.safe_job_error(),
+                )
+                .await
+            }
+        }
+    }
+
+    async fn fail_claimed(
+        &self,
+        ctx: &OrgContext,
+        job: &Job,
+        lease_token: &str,
+        attempts: i32,
+        last_error: &str,
+    ) -> Result<DeleteWorkerRun, DeleteWorkerError> {
+        match jobs::fail(
+            &self.db_pool,
+            ctx,
+            job.id,
+            lease_token,
+            attempts,
+            last_error,
+        )
+        .await
+        {
+            Ok(failed) => Ok(DeleteWorkerRun::Failed {
+                job_id: failed.id,
+                terminal: failed.status == JobStatus::DeadLetter,
+            }),
+            Err(JobError::LeaseLost) => Ok(DeleteWorkerRun::LeaseLost { job_id: job.id }),
+            Err(error) => Err(DeleteWorkerError::Job(error)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeleteWorkerRun {
+    NoJob,
+    Completed { job_id: Uuid, deleted_chunks: u64 },
+    Failed { job_id: Uuid, terminal: bool },
+    LeaseLost { job_id: Uuid },
+}
+
+#[derive(Debug, Error)]
+pub enum DeleteWorkerError {
+    #[error("job error")]
+    Job(#[from] JobError),
+    #[error("delete error")]
+    Deletion(#[from] DeletionError),
+    #[error("claimed job is missing a lease token")]
+    MissingLease,
+    #[error("worker heartbeat interval must be <= one third of lease ttl")]
+    InvalidHeartbeatConfig,
+    #[error("worker max job duration must be positive")]
+    InvalidMaxJobDuration,
+    #[error("delete job exceeded configured maximum duration")]
+    JobTimedOut,
+}
+
+impl DeleteWorkerError {
+    pub fn safe_job_error(&self) -> &'static str {
+        match self {
+            Self::Job(_) => "delete job error",
+            Self::Deletion(error) => error.safe_job_error(),
+            Self::MissingLease => "delete missing lease",
+            Self::InvalidHeartbeatConfig => "delete heartbeat config invalid",
+            Self::InvalidMaxJobDuration => "delete max job duration invalid",
+            Self::JobTimedOut => "delete job timed out",
+        }
+    }
+}

--- a/crates/server/src/workers/index.rs
+++ b/crates/server/src/workers/index.rs
@@ -161,6 +161,16 @@ impl IndexWorker {
                     Err(error) => Err(IndexWorkerError::Job(error)),
                 }
             }
+            Ok(Ok(IndexVersionOutcome::Aborted)) | Ok(Err(IndexingError::DocumentDeleted)) => {
+                self.fail_claimed(
+                    ctx,
+                    &job,
+                    &lease_token,
+                    attempts,
+                    IndexingError::DocumentDeleted.safe_job_error(),
+                )
+                .await
+            }
             Ok(Err(IndexingError::Job(JobError::LeaseLost))) => {
                 Ok(IndexWorkerRun::LeaseLost { job_id: job.id })
             }

--- a/crates/server/src/workers/mod.rs
+++ b/crates/server/src/workers/mod.rs
@@ -1,6 +1,8 @@
 //! Background workers for Markhand Web.
 
 pub mod convert;
+pub mod delete;
 pub mod index;
 pub mod limits;
+pub mod reconcile;
 pub mod sandbox;

--- a/crates/server/src/workers/reconcile.rs
+++ b/crates/server/src/workers/reconcile.rs
@@ -1,0 +1,331 @@
+//! Durable reconciliation job worker.
+
+use std::time::Duration;
+
+use deadpool_postgres::Pool;
+use thiserror::Error;
+use tokio::time::Instant as TokioInstant;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::models::{Job, JobStatus, JobType};
+use crate::jobs::{self, HeartbeatClaim, HeartbeatError, JobError};
+use crate::services::reconciliation::{self, ReconcileMode, ReconcileReport, ReconciliationError};
+use crate::storage::minio::MinioClient;
+use crate::storage::qdrant::QdrantClient;
+
+const DEFAULT_CLAIM_LIMIT: u32 = 1;
+const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 5;
+const DEFAULT_MAX_JOB_DURATION_SECS: u64 = 300;
+
+#[derive(Debug, Clone)]
+pub struct ReconcileWorkerConfig {
+    pub worker_id: String,
+    pub lease_ttl: Duration,
+    pub heartbeat_interval: Duration,
+    pub max_job_duration: Duration,
+    pub mode: ReconcileMode,
+}
+
+impl ReconcileWorkerConfig {
+    pub fn new(worker_id: impl Into<String>) -> Self {
+        Self {
+            worker_id: worker_id.into(),
+            lease_ttl: Duration::from_secs(60),
+            heartbeat_interval: Duration::from_secs(DEFAULT_HEARTBEAT_INTERVAL_SECS),
+            max_job_duration: Duration::from_secs(DEFAULT_MAX_JOB_DURATION_SECS),
+            mode: ReconcileMode::DryRun,
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), ReconcileWorkerError> {
+        if self.heartbeat_interval.is_zero()
+            || self.lease_ttl.is_zero()
+            || self.heartbeat_interval > self.lease_ttl / 3
+        {
+            return Err(ReconcileWorkerError::InvalidHeartbeatConfig);
+        }
+        if self.max_job_duration.is_zero() {
+            return Err(ReconcileWorkerError::InvalidMaxJobDuration);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct ReconcileWorker {
+    db_pool: Pool,
+    storage: MinioClient,
+    qdrant: QdrantClient,
+    config: ReconcileWorkerConfig,
+}
+
+impl ReconcileWorker {
+    pub fn new(
+        db_pool: Pool,
+        storage: MinioClient,
+        qdrant: QdrantClient,
+        config: ReconcileWorkerConfig,
+    ) -> Result<Self, ReconcileWorkerError> {
+        config.validate()?;
+        Ok(Self {
+            db_pool,
+            storage,
+            qdrant,
+            config,
+        })
+    }
+
+    pub async fn run_once(
+        &self,
+        ctx: &OrgContext,
+    ) -> Result<ReconcileWorkerRun, ReconcileWorkerError> {
+        let jobs = jobs::claim_type(
+            &self.db_pool,
+            ctx,
+            JobType::Reconcile,
+            &self.config.worker_id,
+            DEFAULT_CLAIM_LIMIT,
+            self.config.lease_ttl,
+        )
+        .await?;
+        let Some(job) = jobs.into_iter().next() else {
+            return Ok(ReconcileWorkerRun::NoJob);
+        };
+        self.process_claimed_job(ctx, job).await
+    }
+
+    pub async fn process_claimed_job(
+        &self,
+        ctx: &OrgContext,
+        job: Job,
+    ) -> Result<ReconcileWorkerRun, ReconcileWorkerError> {
+        let lease_token = job
+            .lease_owner
+            .as_deref()
+            .ok_or(ReconcileWorkerError::MissingLease)?
+            .to_string();
+        let attempts = job.attempts;
+        let deadline = TokioInstant::now() + self.config.max_job_duration;
+        let result = self
+            .heartbeat_while(
+                ctx,
+                &job,
+                &lease_token,
+                attempts,
+                deadline,
+                self.reconcile_claimed(ctx, &job),
+            )
+            .await;
+        match result {
+            Ok(report) => {
+                if let Err(ReconcileWorkerError::Job(JobError::LeaseLost)) = self
+                    .heartbeat_once(ctx, &job, &lease_token, attempts, deadline)
+                    .await
+                {
+                    return Ok(ReconcileWorkerRun::LeaseLost { job_id: job.id });
+                }
+                match jobs::complete(&self.db_pool, ctx, job.id, &lease_token, attempts).await {
+                    Ok(completed) => Ok(ReconcileWorkerRun::Completed {
+                        job_id: completed.id,
+                        report,
+                    }),
+                    Err(JobError::LeaseLost) => {
+                        Ok(ReconcileWorkerRun::LeaseLost { job_id: job.id })
+                    }
+                    Err(error) => Err(ReconcileWorkerError::Job(error)),
+                }
+            }
+            Err(ReconcileWorkerError::Job(JobError::LeaseLost))
+            | Err(ReconcileWorkerError::Reconciliation(ReconciliationError::Job(
+                JobError::LeaseLost,
+            ))) => Ok(ReconcileWorkerRun::LeaseLost { job_id: job.id }),
+            Err(ReconcileWorkerError::Reconciliation(error))
+                if error.is_retryable_job_failure() =>
+            {
+                self.fail_claimed(ctx, &job, &lease_token, attempts, error.safe_job_error())
+                    .await
+            }
+            Err(ReconcileWorkerError::JobTimedOut) => {
+                self.fail_claimed(
+                    ctx,
+                    &job,
+                    &lease_token,
+                    attempts,
+                    ReconcileWorkerError::JobTimedOut.safe_job_error(),
+                )
+                .await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn reconcile_claimed(
+        &self,
+        ctx: &OrgContext,
+        job: &Job,
+    ) -> Result<ReconcileReport, ReconciliationError> {
+        let payload = jobs::decode_job_payload(job.payload_version, job.payload.clone())?;
+        let mut report = if let Some(document_id) = payload.document_id {
+            reconciliation::reconcile_document(
+                &self.db_pool,
+                &self.storage,
+                &self.qdrant,
+                ctx,
+                document_id,
+                self.config.mode,
+            )
+            .await?
+        } else {
+            ReconcileReport::default()
+        };
+        let gc_report = reconciliation::reconcile_dead_letter_jobs(
+            &self.db_pool,
+            &self.storage,
+            ctx,
+            self.config.mode,
+        )
+        .await?;
+        report.repaired.staged_objects = gc_report.repaired.staged_objects;
+        Ok(report)
+    }
+
+    async fn heartbeat_once(
+        &self,
+        ctx: &OrgContext,
+        job: &Job,
+        lease_token: &str,
+        attempts: i32,
+        deadline: TokioInstant,
+    ) -> Result<(), ReconcileWorkerError> {
+        jobs::heartbeat_once_claimed(self.heartbeat_claim(
+            ctx,
+            job,
+            lease_token,
+            attempts,
+            deadline,
+        ))
+        .await
+        .map_err(Into::into)
+    }
+
+    async fn heartbeat_while<T, Fut>(
+        &self,
+        ctx: &OrgContext,
+        job: &Job,
+        lease_token: &str,
+        attempts: i32,
+        deadline: TokioInstant,
+        future: Fut,
+    ) -> Result<T, ReconcileWorkerError>
+    where
+        Fut: std::future::Future<Output = Result<T, ReconciliationError>>,
+    {
+        jobs::heartbeat_while_claimed(
+            self.heartbeat_claim(ctx, job, lease_token, attempts, deadline),
+            async move { future.await.map_err(ReconcileWorkerError::Reconciliation) },
+        )
+        .await
+    }
+
+    fn heartbeat_claim<'a>(
+        &'a self,
+        ctx: &'a OrgContext,
+        job: &'a Job,
+        lease_token: &'a str,
+        attempts: i32,
+        deadline: TokioInstant,
+    ) -> HeartbeatClaim<'a> {
+        HeartbeatClaim {
+            db_pool: &self.db_pool,
+            ctx,
+            job_id: job.id,
+            lease_token,
+            attempts,
+            lease_ttl: self.config.lease_ttl,
+            heartbeat_interval: self.config.heartbeat_interval,
+            deadline,
+        }
+    }
+
+    async fn fail_claimed(
+        &self,
+        ctx: &OrgContext,
+        job: &Job,
+        lease_token: &str,
+        attempts: i32,
+        last_error: &str,
+    ) -> Result<ReconcileWorkerRun, ReconcileWorkerError> {
+        match jobs::fail(
+            &self.db_pool,
+            ctx,
+            job.id,
+            lease_token,
+            attempts,
+            last_error,
+        )
+        .await
+        {
+            Ok(failed) => Ok(ReconcileWorkerRun::Failed {
+                job_id: failed.id,
+                terminal: failed.status == JobStatus::DeadLetter,
+            }),
+            Err(JobError::LeaseLost) => Ok(ReconcileWorkerRun::LeaseLost { job_id: job.id }),
+            Err(error) => Err(ReconcileWorkerError::Job(error)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconcileWorkerRun {
+    NoJob,
+    Completed {
+        job_id: Uuid,
+        report: ReconcileReport,
+    },
+    Failed {
+        job_id: Uuid,
+        terminal: bool,
+    },
+    LeaseLost {
+        job_id: Uuid,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum ReconcileWorkerError {
+    #[error("job error")]
+    Job(#[from] JobError),
+    #[error("reconcile error")]
+    Reconciliation(#[from] ReconciliationError),
+    #[error("claimed job is missing a lease token")]
+    MissingLease,
+    #[error("worker heartbeat interval must be <= one third of lease ttl")]
+    InvalidHeartbeatConfig,
+    #[error("worker max job duration must be positive")]
+    InvalidMaxJobDuration,
+    #[error("reconcile job exceeded configured maximum duration")]
+    JobTimedOut,
+}
+
+impl From<HeartbeatError> for ReconcileWorkerError {
+    fn from(value: HeartbeatError) -> Self {
+        match value {
+            HeartbeatError::Job(error) => Self::Job(error),
+            HeartbeatError::TimedOut => Self::JobTimedOut,
+        }
+    }
+}
+
+impl ReconcileWorkerError {
+    pub fn safe_job_error(&self) -> &'static str {
+        match self {
+            Self::Job(_) => "reconcile job error",
+            Self::Reconciliation(error) => error.safe_job_error(),
+            Self::MissingLease => "reconcile missing lease",
+            Self::InvalidHeartbeatConfig => "reconcile heartbeat config invalid",
+            Self::InvalidMaxJobDuration => "reconcile max job duration invalid",
+            Self::JobTimedOut => "reconcile job timed out",
+        }
+    }
+}

--- a/crates/server/tests/deletion_reconcile.rs
+++ b/crates/server/tests/deletion_reconcile.rs
@@ -1,0 +1,1368 @@
+//! Live tests for tombstone delete and reconciliation.
+//!
+//! These tests skip cleanly unless PostgreSQL, MinIO, and Qdrant test endpoints
+//! are provided in the environment.
+
+use bytes::Bytes;
+use deadpool_postgres::Pool;
+use fileconv_knowledge::embedding::LOCAL_VECTOR_DIMENSIONS;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::config::{MinioConfig, SecretString};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::collections::{self, NewCollection};
+use fileconv_server::db::documents::{self, NewDocument};
+use fileconv_server::db::models::{ArtifactKind, CollectionVisibility, Document, DocumentState};
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::jobs::{self, CheckpointPayload, EventPayload, CURRENT_EVENT_PAYLOAD_VERSION};
+use fileconv_server::services::deletion::{request_delete, DeleteRequestOutcome};
+use fileconv_server::services::index_signature::collection_name_for_digest;
+use fileconv_server::services::indexing::{
+    compensate_batch_points, enqueue_compensation_reconcile, OutboxJobSink,
+};
+use fileconv_server::services::reconciliation::{
+    enqueue_reconcile, reconcile_dead_letter_jobs, reconcile_document, ReconcileMode,
+};
+use fileconv_server::storage::keys::parse_key_for_org;
+use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
+use fileconv_server::storage::qdrant::{
+    point_id_from_org_collection_and_chunk, ChunkPointPayload, QdrantClient, UpsertPoint,
+    VectorScope,
+};
+use fileconv_server::storage::trusted_key;
+use fileconv_server::workers::delete::{DeleteWorker, DeleteWorkerConfig, DeleteWorkerRun};
+use fileconv_server::workers::index::{IndexWorker, IndexWorkerConfig, IndexWorkerRun};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn test_minio_client() -> Option<MinioClient> {
+    let endpoint = match std::env::var("MARKHAND_TEST_MINIO_ENDPOINT") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ENDPOINT unset");
+            return None;
+        }
+    };
+    let access_key = std::env::var("MARKHAND_TEST_MINIO_ACCESS_KEY").ok()?;
+    let secret_key = std::env::var("MARKHAND_TEST_MINIO_SECRET_KEY").ok()?;
+    let region = std::env::var("MARKHAND_TEST_MINIO_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let bucket = format!("markhand-delete-reconcile-{}", Uuid::new_v4().simple());
+    std::env::set_var("RUST_S3_SKIP_LOCATION_CONSTRAINT", "true");
+    let config = MinioConfig::new(
+        endpoint,
+        SecretString::new(access_key),
+        SecretString::new(secret_key),
+        bucket,
+        region,
+        true,
+    )
+    .expect("minio config");
+    Some(MinioClient::from_config(&config).expect("minio client"))
+}
+
+fn test_qdrant_client() -> Option<QdrantClient> {
+    let url = match std::env::var("MARKHAND_TEST_QDRANT_URL") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_QDRANT_URL unset");
+            return None;
+        }
+    };
+    let api_key = std::env::var("MARKHAND_TEST_QDRANT_API_KEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(SecretString::new);
+    Some(QdrantClient::with_api_key(url, api_key).expect("qdrant client"))
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_delete_reconcile_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+struct LiveEnv {
+    db: EphemeralDb,
+    pool: Pool,
+    storage: MinioClient,
+    qdrant: QdrantClient,
+    ctx: OrgContext,
+}
+
+impl LiveEnv {
+    async fn boot() -> Option<Self> {
+        let base_url = test_database_url()?;
+        let storage = test_minio_client()?;
+        let qdrant = test_qdrant_client()?;
+        storage.ensure_bucket().await.expect("ensure bucket");
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("apply migrations");
+        let pool = create_pool(&db.url).expect("pool");
+        let ctx = OrgContext::try_new(Uuid::new_v4(), Uuid::new_v4(), ["doc.upload"], [])
+            .expect("org context");
+        Some(Self {
+            db,
+            pool,
+            storage,
+            qdrant,
+            ctx,
+        })
+    }
+
+    async fn drop(self) {
+        self.db.drop().await;
+    }
+}
+
+async fn ensure_org(pool: &Pool, ctx: &OrgContext) {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &ctx, "delete-reconcile-org", "Delete Reconcile Org")
+                    .await?;
+                orgs::ensure_user(
+                    txn,
+                    &ctx,
+                    ctx.user_id(),
+                    "delete-reconcile@example.test",
+                    "Worker",
+                )
+                .await?;
+                orgs::ensure_membership(txn, &ctx).await?;
+                txn.execute(
+                    "INSERT INTO org_quotas (
+                        org_id, max_storage_bytes, max_documents,
+                        max_concurrent_jobs, max_monthly_tokens
+                     )
+                     VALUES ($1, 1000000000, 100000, 100, 1000000000)
+                     ON CONFLICT (org_id) DO NOTHING",
+                    &[&ctx.org_id()],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("ensure org");
+}
+
+async fn seed_converted_document(env: &LiveEnv, markdown: &str) -> (Uuid, Uuid, Uuid, String) {
+    let collection_id = Uuid::new_v4();
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let artifact_id = Uuid::new_v4();
+    let outbox_key = format!("index-request:{version_id}");
+    let object_key =
+        trusted_key(env.ctx.org_id(), version_id, Uuid::new_v4(), None).expect("trusted key");
+    let object_key_string = object_key.as_str();
+    let sha256 = hex::encode(Sha256::digest(markdown.as_bytes()));
+    let markdown_len = markdown.len() as i64;
+    env.storage
+        .put_object(
+            env.ctx.org_id(),
+            &object_key,
+            Bytes::copy_from_slice(markdown.as_bytes()),
+            &ObjectIdentityMeta {
+                org_id: env.ctx.org_id(),
+                collection_id: Some(collection_id),
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                original_filename: None,
+                canonical_format: Some("md".into()),
+                content_sha256: Some(sha256.clone()),
+                content_length: Some(markdown.len() as u64),
+                disposition: Some("trusted".into()),
+            },
+            "text/markdown; charset=utf-8",
+        )
+        .await
+        .expect("put markdown");
+
+    ensure_org(&env.pool, &env.ctx).await;
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        let object_key_string = object_key_string.clone();
+        let sha256 = sha256.clone();
+        move |txn| {
+            Box::pin(async move {
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: collection_id,
+                        name: "Delete Reconcile Collection",
+                        slug: &format!("delete-reconcile-{collection_id}"),
+                        description: None,
+                        visibility: CollectionVisibility::Private,
+                    },
+                )
+                .await?;
+                documents::insert(
+                    txn,
+                    &ctx,
+                    NewDocument {
+                        id: document_id,
+                        collection_id,
+                        title: "Delete Reconcile Doc",
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key, markdown_object_key,
+                        source_content_type, byte_size, created_by_user_id
+                     )
+                     VALUES ($1, $2, $3, 1, 'published', true, $4, $5, $5,
+                             'text/markdown', $6, $7)",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &sha256,
+                        &object_key_string,
+                        &markdown_len,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                let kind = ArtifactKind::Markdown.as_str();
+                txn.execute(
+                    "INSERT INTO derived_artifacts (
+                        id, org_id, document_id, version_id, artifact_kind,
+                        object_key, content_sha256, content_type, byte_size
+                     )
+                     VALUES ($1, $2, $3, $4, $5, $6, $7,
+                             'text/markdown; charset=utf-8', $8)",
+                    &[
+                        &artifact_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &version_id,
+                        &kind,
+                        &object_key_string,
+                        &sha256,
+                        &markdown_len,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE documents
+                     SET state = 'converted', current_version_id = $3, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id, &version_id],
+                )
+                .await?;
+                let payload = EventPayload {
+                    job_id: None,
+                    document_id: Some(document_id),
+                    version_id: Some(version_id),
+                    outbox_event_id: None,
+                }
+                .to_json()
+                .expect("event payload");
+                txn.execute(
+                    "INSERT INTO outbox_events (
+                        org_id, event_type, payload_version, payload, idempotency_key
+                     )
+                     VALUES ($1, 'document.index_requested', $2, $3, $4)",
+                    &[
+                        &ctx.org_id(),
+                        &CURRENT_EVENT_PAYLOAD_VERSION,
+                        &payload,
+                        &outbox_key,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed converted document");
+    (document_id, version_id, collection_id, object_key_string)
+}
+
+fn index_worker(env: &LiveEnv) -> IndexWorker {
+    let mut config = IndexWorkerConfig::new(format!("index-worker-{}", Uuid::new_v4()));
+    config.lease_ttl = Duration::from_secs(30);
+    config.heartbeat_interval = Duration::from_secs(5);
+    config.max_job_duration = Duration::from_secs(60);
+    config.embedding_batch_size = 2;
+    IndexWorker::new(
+        env.pool.clone(),
+        env.storage.clone(),
+        env.qdrant.clone(),
+        config,
+        None,
+    )
+    .expect("index worker")
+}
+
+fn delete_worker(env: &LiveEnv) -> DeleteWorker {
+    let mut config = DeleteWorkerConfig::new(format!("delete-worker-{}", Uuid::new_v4()));
+    config.lease_ttl = Duration::from_secs(30);
+    config.heartbeat_interval = Duration::from_secs(5);
+    config.max_job_duration = Duration::from_secs(60);
+    DeleteWorker::new(
+        env.pool.clone(),
+        env.storage.clone(),
+        env.qdrant.clone(),
+        config,
+    )
+    .expect("delete worker")
+}
+
+async fn relay(env: &LiveEnv) {
+    let sink = Arc::new(OutboxJobSink::new());
+    jobs::relay_outbox_with_sink(&env.pool, &env.ctx, 32, &sink)
+        .await
+        .expect("relay outbox");
+}
+
+async fn index_seeded(env: &LiveEnv, markdown: &str) -> (Uuid, Uuid, Uuid, String, String) {
+    let (document_id, version_id, collection_id, object_key) =
+        seed_converted_document(env, markdown).await;
+    relay(env).await;
+    let run = index_worker(env)
+        .run_once(&env.ctx)
+        .await
+        .expect("index run");
+    let IndexWorkerRun::Completed { .. } = run else {
+        panic!("unexpected index run: {run:?}");
+    };
+    let signature = active_signature(env, collection_id)
+        .await
+        .expect("active signature");
+    (
+        document_id,
+        version_id,
+        collection_id,
+        object_key,
+        signature,
+    )
+}
+
+async fn active_signature(env: &LiveEnv, collection_id: Uuid) -> Option<String> {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                Ok(
+                    fileconv_server::db::index_metadata::find_active(
+                        txn,
+                        &ctx,
+                        Some(collection_id),
+                    )
+                    .await?
+                    .map(|metadata| metadata.index_signature_sha256),
+                )
+            })
+        }
+    })
+    .await
+    .expect("active signature")
+}
+
+async fn document(env: &LiveEnv, document_id: Uuid) -> Document {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| Box::pin(async move { documents::get_by_id(txn, &ctx, document_id).await })
+    })
+    .await
+    .expect("document")
+}
+
+async fn chunk_count(env: &LiveEnv, document_id: Uuid) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint FROM chunks WHERE org_id = $1 AND document_id = $2",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("chunk count")
+}
+
+async fn points_for_doc(
+    env: &LiveEnv,
+    collection_id: Uuid,
+    document_id: Uuid,
+    signature: &str,
+) -> usize {
+    let collection = collection_name_for_digest(signature).expect("collection name");
+    env.qdrant
+        .scroll_points(
+            &collection,
+            &VectorScope::new(env.ctx.org_id(), [collection_id]),
+            &[json!({
+                "key": "document_id",
+                "match": { "value": document_id.to_string() }
+            })],
+            1000,
+        )
+        .await
+        .expect("scroll points")
+        .len()
+}
+
+async fn object_exists(env: &LiveEnv, raw_key: &str) -> bool {
+    let key = parse_key_for_org(raw_key, env.ctx.org_id()).expect("parse key");
+    env.storage
+        .object_exists(env.ctx.org_id(), &key)
+        .await
+        .expect("object exists")
+}
+
+async fn delete_job_count(env: &LiveEnv) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM jobs
+                         WHERE org_id = $1 AND job_type = 'delete'",
+                        &[&ctx.org_id()],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("delete job count")
+}
+
+async fn reconcile_job_count(env: &LiveEnv, document_id: Uuid) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM jobs
+                         WHERE org_id = $1 AND job_type = 'reconcile' AND document_id = $2",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("reconcile job count")
+}
+
+async fn reconcile_job_count_by_key(env: &LiveEnv, key: &str) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        let key = key.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM jobs
+                         WHERE org_id = $1 AND job_type = 'reconcile' AND idempotency_key = $2",
+                        &[&ctx.org_id(), &key],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("reconcile job count by key")
+}
+
+async fn outbox_count(env: &LiveEnv, event_type: &str) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        let event_type = event_type.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM outbox_events
+                         WHERE org_id = $1 AND event_type = $2",
+                        &[&ctx.org_id(), &event_type],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("outbox count")
+}
+
+async fn audit_count(env: &LiveEnv, action: &str) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        let action = action.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM audit_log
+                         WHERE org_id = $1 AND action = $2",
+                        &[&ctx.org_id(), &action],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("audit count")
+}
+
+async fn immutable_inventory_counts(env: &LiveEnv, document_id: Uuid) -> (i64, i64, i64) {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let versions = txn
+                    .query_one(
+                        "SELECT count(*)::bigint FROM document_versions WHERE org_id = $1 AND document_id = $2",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?
+                    .get(0);
+                let artifacts = txn
+                    .query_one(
+                        "SELECT count(*)::bigint FROM derived_artifacts WHERE org_id = $1 AND document_id = $2",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?
+                    .get(0);
+                let metadata = txn
+                    .query_one(
+                        "SELECT count(*)::bigint FROM index_metadata WHERE org_id = $1",
+                        &[&ctx.org_id()],
+                    )
+                    .await?
+                    .get(0);
+                Ok((versions, artifacts, metadata))
+            })
+        }
+    })
+    .await
+    .expect("inventory counts")
+}
+
+async fn reset_delete_job_to_pending(env: &LiveEnv) {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE jobs
+                     SET status = 'pending', lease_owner = NULL, lease_expires_at = NULL,
+                         heartbeat_at = NULL, checkpoint = NULL, available_at = clock_timestamp(),
+                         finished_at = NULL, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND job_type = 'delete'",
+                    &[&ctx.org_id()],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("reset delete job");
+}
+
+async fn tombstone_directly(env: &LiveEnv, document_id: Uuid) {
+    request_delete(&env.pool, &env.ctx, document_id)
+        .await
+        .expect("request delete");
+}
+
+async fn insert_dead_letter_with_id(env: &LiveEnv, job_id: Uuid, staged_key: &str) {
+    ensure_org(&env.pool, &env.ctx).await;
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        let staged_key = staged_key.to_string();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO jobs (
+                        id, org_id, job_type, status, payload_version, payload,
+                        attempts, max_attempts, checkpoint, idempotency_key,
+                        available_at, finished_at
+                     )
+                     VALUES ($1, $2, 'convert', 'dead_letter', 2, $3,
+                             5, 5, $4, $5, clock_timestamp(), clock_timestamp())",
+                    &[
+                        &job_id,
+                        &ctx.org_id(),
+                        &json!({}),
+                        &json!(CheckpointPayload {
+                            staged_object_keys: vec![staged_key],
+                            ..CheckpointPayload::default()
+                        }),
+                        &format!("dead-letter-{job_id}"),
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("insert dead letter");
+}
+
+async fn first_chunk_identity(env: &LiveEnv, document_id: Uuid) -> String {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT chunk_identity_sha256
+                         FROM chunks
+                         WHERE org_id = $1 AND document_id = $2
+                         ORDER BY ordinal
+                         LIMIT 1",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("first chunk")
+}
+
+async fn set_document_state_and_delete_chunks(
+    env: &LiveEnv,
+    document_id: Uuid,
+    state: DocumentState,
+) {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let state = state.as_str();
+                txn.execute(
+                    "UPDATE documents
+                     SET state = $3, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id, &state],
+                )
+                .await?;
+                txn.execute(
+                    "DELETE FROM chunks WHERE org_id = $1 AND document_id = $2",
+                    &[&ctx.org_id(), &document_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("set state and delete chunks");
+}
+
+async fn insert_index_job(env: &LiveEnv, document_id: Uuid, version_id: Uuid) -> Uuid {
+    let job_id = Uuid::new_v4();
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO jobs (
+                        id, org_id, job_type, status, payload_version, payload,
+                        attempts, max_attempts, idempotency_key, document_id, version_id,
+                        available_at
+                     )
+                     VALUES ($1, $2, 'index', 'pending', $3, $4,
+                             0, 5, $5, $6, $7, clock_timestamp())",
+                    &[
+                        &job_id,
+                        &ctx.org_id(),
+                        &jobs::CURRENT_JOB_PAYLOAD_VERSION,
+                        &json!({
+                            "document_id": document_id,
+                            "version_id": version_id,
+                        }),
+                        &format!("manual-index-{job_id}"),
+                        &document_id,
+                        &version_id,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("insert index job");
+    job_id
+}
+
+async fn job_status(env: &LiveEnv, job_id: Uuid) -> String {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT status FROM jobs WHERE org_id = $1 AND id = $2",
+                        &[&ctx.org_id(), &job_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("job status")
+}
+
+async fn upsert_test_point(
+    env: &LiveEnv,
+    collection_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    signature: &str,
+    chunk_identity: &str,
+) {
+    let collection = collection_name_for_digest(signature).expect("collection name");
+    env.qdrant
+        .upsert_points(
+            &collection,
+            &VectorScope::new(env.ctx.org_id(), [collection_id]),
+            &[UpsertPoint {
+                chunk_identity: chunk_identity.to_string(),
+                vector: {
+                    let mut vector = vec![0.0; LOCAL_VECTOR_DIMENSIONS];
+                    vector[0] = 1.0;
+                    vector
+                },
+                payload: ChunkPointPayload {
+                    org_id: env.ctx.org_id(),
+                    collection_id,
+                    document_id,
+                    version_id,
+                    chunk_id: chunk_identity.to_string(),
+                    ordinal: 0,
+                    is_current: true,
+                    is_effective: true,
+                    index_generation: 1,
+                },
+            }],
+        )
+        .await
+        .expect("upsert test point");
+}
+
+fn sample_markdown() -> &'static str {
+    "# Chương I\n\nMở đầu.\n\n## Điều 1\n\nNội dung điều 1.\n\n## Điều 2\n\nNội dung điều 2.\n"
+}
+
+#[tokio::test]
+async fn live_enqueue_reconcile_is_reason_scoped_and_idempotent() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (document_id, _version_id, _collection_id, _object_key, _signature) =
+        index_seeded(&env, sample_markdown()).await;
+
+    let first = enqueue_reconcile(&env.pool, &env.ctx, document_id, "manual-hour-1")
+        .await
+        .expect("enqueue first reconcile");
+    assert!(first.created);
+    let replay = enqueue_reconcile(&env.pool, &env.ctx, document_id, "manual-hour-1")
+        .await
+        .expect("replay first reconcile");
+    assert!(!replay.created);
+    assert_eq!(first.job.id, replay.job.id);
+    let second = enqueue_reconcile(&env.pool, &env.ctx, document_id, "manual-hour-2")
+        .await
+        .expect("enqueue second reconcile");
+    assert!(second.created);
+    assert_ne!(first.job.id, second.job.id);
+    assert_eq!(reconcile_job_count(&env, document_id).await, 2);
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_delete_tombstones_then_purges() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let markdown = sample_markdown();
+    let (document_id, version_id, collection_id, object_key, signature) =
+        index_seeded(&env, markdown).await;
+    let orphan_chunk_identity = first_chunk_identity(&env, document_id).await;
+    assert!(points_for_doc(&env, collection_id, document_id, &signature).await > 0);
+
+    let outcome = request_delete(&env.pool, &env.ctx, document_id)
+        .await
+        .expect("request delete");
+    let DeleteRequestOutcome::Requested(tombstoned) = outcome else {
+        panic!("expected tombstone");
+    };
+    assert_eq!(tombstoned.state, DocumentState::Tombstoned);
+    assert!(tombstoned.deleted_at.is_some());
+    assert_eq!(outbox_count(&env, "document.delete_requested").await, 1);
+
+    relay(&env).await;
+    assert_eq!(delete_job_count(&env).await, 1);
+    let run = delete_worker(&env)
+        .run_once(&env.ctx)
+        .await
+        .expect("delete run");
+    let DeleteWorkerRun::Completed { .. } = run else {
+        panic!("unexpected delete run: {run:?}");
+    };
+
+    let purged = document(&env, document_id).await;
+    assert_eq!(purged.state, DocumentState::Purged);
+    assert_eq!(chunk_count(&env, document_id).await, 0);
+    assert_eq!(
+        points_for_doc(&env, collection_id, document_id, &signature).await,
+        0
+    );
+    assert!(!object_exists(&env, &object_key).await);
+    let (versions, artifacts, metadata) = immutable_inventory_counts(&env, document_id).await;
+    assert_eq!(versions, 1);
+    assert_eq!(artifacts, 1);
+    assert_eq!(metadata, 1);
+    assert_eq!(audit_count(&env, "document.purge").await, 1);
+
+    upsert_test_point(
+        &env,
+        collection_id,
+        document_id,
+        version_id,
+        &signature,
+        &orphan_chunk_identity,
+    )
+    .await;
+    assert_eq!(
+        points_for_doc(&env, collection_id, document_id, &signature).await,
+        1
+    );
+    let report = reconcile_document(
+        &env.pool,
+        &env.storage,
+        &env.qdrant,
+        &env.ctx,
+        document_id,
+        ReconcileMode::Repair,
+    )
+    .await
+    .expect("post-purge reconcile");
+    assert_eq!(report.repaired.orphan_vectors, 1);
+    assert_eq!(
+        points_for_doc(&env, collection_id, document_id, &signature).await,
+        0
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_delete_replay_is_idempotent() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (document_id, _version_id, _collection_id, _object_key, _signature) =
+        index_seeded(&env, sample_markdown()).await;
+    request_delete(&env.pool, &env.ctx, document_id)
+        .await
+        .expect("request delete");
+    relay(&env).await;
+    assert!(matches!(
+        delete_worker(&env)
+            .run_once(&env.ctx)
+            .await
+            .expect("delete run"),
+        DeleteWorkerRun::Completed { .. }
+    ));
+    reset_delete_job_to_pending(&env).await;
+    assert!(matches!(
+        delete_worker(&env)
+            .run_once(&env.ctx)
+            .await
+            .expect("delete replay"),
+        DeleteWorkerRun::Completed { .. }
+    ));
+    assert_eq!(
+        document(&env, document_id).await.state,
+        DocumentState::Purged
+    );
+    assert_eq!(chunk_count(&env, document_id).await, 0);
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_reconcile_repairs_orphan_vectors() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (document_id, _version_id, collection_id, _object_key, signature) =
+        index_seeded(&env, sample_markdown()).await;
+    let before = points_for_doc(&env, collection_id, document_id, &signature).await;
+    assert!(before > 0);
+    tombstone_directly(&env, document_id).await;
+
+    let dry = reconcile_document(
+        &env.pool,
+        &env.storage,
+        &env.qdrant,
+        &env.ctx,
+        document_id,
+        ReconcileMode::DryRun,
+    )
+    .await
+    .expect("dry run");
+    assert_eq!(dry.orphan_vectors, before);
+    assert_eq!(
+        points_for_doc(&env, collection_id, document_id, &signature).await,
+        before
+    );
+
+    let repaired = reconcile_document(
+        &env.pool,
+        &env.storage,
+        &env.qdrant,
+        &env.ctx,
+        document_id,
+        ReconcileMode::Repair,
+    )
+    .await
+    .expect("repair");
+    assert_eq!(repaired.repaired.orphan_vectors, before);
+    assert_eq!(
+        points_for_doc(&env, collection_id, document_id, &signature).await,
+        0
+    );
+    let repeat = reconcile_document(
+        &env.pool,
+        &env.storage,
+        &env.qdrant,
+        &env.ctx,
+        document_id,
+        ReconcileMode::Repair,
+    )
+    .await
+    .expect("repeat repair");
+    assert_eq!(repeat.orphan_vectors, 0);
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_reconcile_does_not_delete_in_flight_vectors() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (document_id, version_id, collection_id, _object_key, signature) =
+        index_seeded(&env, sample_markdown()).await;
+    let chunk_identity = first_chunk_identity(&env, document_id).await;
+    set_document_state_and_delete_chunks(&env, document_id, DocumentState::Indexing).await;
+    assert_eq!(chunk_count(&env, document_id).await, 0);
+    assert!(points_for_doc(&env, collection_id, document_id, &signature).await > 0);
+
+    let report = reconcile_document(
+        &env.pool,
+        &env.storage,
+        &env.qdrant,
+        &env.ctx,
+        document_id,
+        ReconcileMode::Repair,
+    )
+    .await
+    .expect("repair skips in-flight");
+    assert!(report.in_flight_vectors > 0);
+    assert_eq!(report.repaired.orphan_vectors, 0);
+    assert!(points_for_doc(&env, collection_id, document_id, &signature).await > 0);
+
+    upsert_test_point(
+        &env,
+        collection_id,
+        document_id,
+        version_id,
+        &signature,
+        &chunk_identity,
+    )
+    .await;
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_delete_cancels_index_jobs_and_rejects_stale_index_attempts() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (document_id, version_id, collection_id, _object_key, signature) =
+        index_seeded(&env, sample_markdown()).await;
+    let chunks_before = chunk_count(&env, document_id).await;
+    let pending_job_id = insert_index_job(&env, document_id, version_id).await;
+    request_delete(&env.pool, &env.ctx, document_id)
+        .await
+        .expect("request delete");
+    assert_eq!(job_status(&env, pending_job_id).await, "cancelled");
+
+    let stale_job_id = insert_index_job(&env, document_id, version_id).await;
+    let run = index_worker(&env)
+        .run_once(&env.ctx)
+        .await
+        .expect("stale index worker");
+    let IndexWorkerRun::Failed { job_id, .. } = run else {
+        panic!("unexpected stale index run: {run:?}");
+    };
+    assert_eq!(job_id, stale_job_id);
+    assert_eq!(chunk_count(&env, document_id).await, chunks_before);
+
+    relay(&env).await;
+    assert!(matches!(
+        delete_worker(&env)
+            .run_once(&env.ctx)
+            .await
+            .expect("delete run"),
+        DeleteWorkerRun::Completed { .. }
+    ));
+    assert_eq!(
+        points_for_doc(&env, collection_id, document_id, &signature).await,
+        0
+    );
+    assert_eq!(
+        document(&env, document_id).await.state,
+        DocumentState::Purged
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_reconcile_exact_point_ids_do_not_delete_other_document_payloads() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (document_id, version_id, collection_id, _object_key, signature) =
+        index_seeded(&env, sample_markdown()).await;
+    let chunk_identity = first_chunk_identity(&env, document_id).await;
+    let other_document_id = Uuid::new_v4();
+    upsert_test_point(
+        &env,
+        collection_id,
+        other_document_id,
+        version_id,
+        &signature,
+        &chunk_identity,
+    )
+    .await;
+    set_document_state_and_delete_chunks(&env, document_id, DocumentState::Indexed).await;
+
+    let report = reconcile_document(
+        &env.pool,
+        &env.storage,
+        &env.qdrant,
+        &env.ctx,
+        document_id,
+        ReconcileMode::Repair,
+    )
+    .await
+    .expect("repair target document");
+    // The target document's own points (its chunks were deleted) are GC'd by exact
+    // point id; the foreign point that merely reuses the same chunk_identity string
+    // but carries a different payload.document_id must NOT be collaterally deleted.
+    assert_eq!(report.repaired.orphan_vectors, 2);
+    assert_eq!(
+        points_for_doc(&env, collection_id, document_id, &signature).await,
+        0
+    );
+    assert_eq!(
+        points_for_doc(&env, collection_id, other_document_id, &signature).await,
+        1
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_compensate_batch_points_deletes_only_target_document_ids() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (document_id, version_id, collection_id, _object_key, signature) =
+        index_seeded(&env, sample_markdown()).await;
+    let other_document_id = Uuid::new_v4();
+    let target_chunk_a = format!("{:064x}", 10_u8);
+    let target_chunk_b = format!("{:064x}", 11_u8);
+    let other_chunk = format!("{:064x}", 12_u8);
+    upsert_test_point(
+        &env,
+        collection_id,
+        document_id,
+        version_id,
+        &signature,
+        &target_chunk_a,
+    )
+    .await;
+    upsert_test_point(
+        &env,
+        collection_id,
+        document_id,
+        version_id,
+        &signature,
+        &target_chunk_b,
+    )
+    .await;
+    upsert_test_point(
+        &env,
+        collection_id,
+        other_document_id,
+        version_id,
+        &signature,
+        &other_chunk,
+    )
+    .await;
+
+    let collection = collection_name_for_digest(&signature).expect("collection name");
+    let scope = VectorScope::new(env.ctx.org_id(), [collection_id]);
+    let target_ids = vec![
+        point_id_from_org_collection_and_chunk(env.ctx.org_id(), collection_id, &target_chunk_a)
+            .expect("point id a"),
+        point_id_from_org_collection_and_chunk(env.ctx.org_id(), collection_id, &target_chunk_b)
+            .expect("point id b"),
+    ];
+    let other_id =
+        point_id_from_org_collection_and_chunk(env.ctx.org_id(), collection_id, &other_chunk)
+            .expect("other point id");
+
+    let mut requested_delete_ids = target_ids.clone();
+    requested_delete_ids.push(other_id);
+    compensate_batch_points(
+        &env.qdrant,
+        &collection,
+        &scope,
+        document_id,
+        &requested_delete_ids,
+    )
+    .await
+    .expect("compensate target batch");
+
+    assert!(env
+        .qdrant
+        .get_points(&collection, &scope, &target_ids)
+        .await
+        .expect("target points")
+        .is_empty());
+    assert_eq!(
+        env.qdrant
+            .get_points(&collection, &scope, &[other_id])
+            .await
+            .expect("other point")
+            .len(),
+        1
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_compensation_failure_incident_reconcile_is_enqueued_and_cleans_orphan() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (document_id, version_id, collection_id, _object_key, signature) =
+        index_seeded(&env, sample_markdown()).await;
+    request_delete(&env.pool, &env.ctx, document_id)
+        .await
+        .expect("request delete");
+    relay(&env).await;
+    assert!(matches!(
+        delete_worker(&env)
+            .run_once(&env.ctx)
+            .await
+            .expect("delete run"),
+        DeleteWorkerRun::Completed { .. }
+    ));
+    assert_eq!(
+        document(&env, document_id).await.state,
+        DocumentState::Purged
+    );
+
+    let orphan_chunk = format!("{:064x}", 42_u8);
+    upsert_test_point(
+        &env,
+        collection_id,
+        document_id,
+        version_id,
+        &signature,
+        &orphan_chunk,
+    )
+    .await;
+    assert_eq!(
+        points_for_doc(&env, collection_id, document_id, &signature).await,
+        1
+    );
+
+    // Models the production path where compensation itself failed; the helper is
+    // best-effort and schedules a unique reconcile incident for durable cleanup.
+    let index_job_id = Uuid::new_v4();
+    enqueue_compensation_reconcile(&env.pool, &env.ctx, document_id, index_job_id, 3, 0).await;
+    let incident_key = format!("reconcile:{document_id}:{index_job_id}:3:0");
+    assert_eq!(reconcile_job_count_by_key(&env, &incident_key).await, 1);
+    enqueue_compensation_reconcile(&env.pool, &env.ctx, document_id, index_job_id, 3, 0).await;
+    assert_eq!(reconcile_job_count_by_key(&env, &incident_key).await, 1);
+
+    let report = reconcile_document(
+        &env.pool,
+        &env.storage,
+        &env.qdrant,
+        &env.ctx,
+        document_id,
+        ReconcileMode::Repair,
+    )
+    .await
+    .expect("incident reconcile repair");
+    assert_eq!(report.repaired.orphan_vectors, 1);
+    assert_eq!(
+        points_for_doc(&env, collection_id, document_id, &signature).await,
+        0
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_reconcile_dead_letter_staging_gc() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (referenced_document_id, _referenced_version_id, _collection_id, referenced_key, _sig) =
+        index_seeded(&env, sample_markdown()).await;
+    let version_id = Uuid::new_v4();
+    let document_id = Uuid::new_v4();
+    let collection_id = Uuid::new_v4();
+    let key = trusted_key(env.ctx.org_id(), version_id, Uuid::new_v4(), None).expect("trusted key");
+    let key_string = key.as_str();
+    env.storage
+        .put_object(
+            env.ctx.org_id(),
+            &key,
+            Bytes::from_static(b"staged"),
+            &ObjectIdentityMeta {
+                org_id: env.ctx.org_id(),
+                collection_id: Some(collection_id),
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                original_filename: None,
+                canonical_format: Some("md".into()),
+                content_sha256: Some(hex::encode(Sha256::digest(b"staged"))),
+                content_length: Some(6),
+                disposition: Some("trusted".into()),
+            },
+            "text/markdown; charset=utf-8",
+        )
+        .await
+        .expect("put staged");
+    for index in 1..=500_u128 {
+        insert_dead_letter_with_id(&env, Uuid::from_u128(index), &referenced_key).await;
+    }
+    insert_dead_letter_with_id(&env, Uuid::from_u128(501), &key_string).await;
+    assert!(object_exists(&env, &key_string).await);
+    assert!(object_exists(&env, &referenced_key).await);
+
+    let report =
+        reconcile_dead_letter_jobs(&env.pool, &env.storage, &env.ctx, ReconcileMode::Repair)
+            .await
+            .expect("dead letter repair");
+    assert_eq!(report.repaired.staged_objects, 1);
+    assert!(!object_exists(&env, &key_string).await);
+    assert!(object_exists(&env, &referenced_key).await);
+    assert_eq!(
+        document(&env, referenced_document_id).await.state,
+        DocumentState::Indexed
+    );
+    reconcile_dead_letter_jobs(&env.pool, &env.storage, &env.ctx, ReconcileMode::Repair)
+        .await
+        .expect("dead letter repeat");
+    env.drop().await;
+}

--- a/crates/server/tests/index_worker.rs
+++ b/crates/server/tests/index_worker.rs
@@ -17,7 +17,7 @@ use fileconv_server::db::pool::{create_pool, with_org_txn};
 use fileconv_server::jobs::{self, EventPayload, CURRENT_EVENT_PAYLOAD_VERSION};
 use fileconv_server::services::chunking::prepare_chunks;
 use fileconv_server::services::embedding::{approved_plan, embed_bodies};
-use fileconv_server::services::indexing::IndexingOutboxSink;
+use fileconv_server::services::indexing::OutboxJobSink;
 use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
 use fileconv_server::storage::qdrant::{
     point_id_from_org_collection_and_chunk, ChunkPointPayload, QdrantClient, UpsertPoint,
@@ -494,7 +494,7 @@ fn index_worker(
 }
 
 async fn relay(env: &LiveEnv) {
-    let sink = Arc::new(IndexingOutboxSink::new());
+    let sink = Arc::new(OutboxJobSink::new());
     jobs::relay_outbox_with_sink(&env.pool, &env.ctx, 32, &sink)
         .await
         .expect("relay outbox");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Implements **P1B-I07 (#90)** — the destructive document lifecycle: soft-delete (tombstone) with immediate read suppression, durable **purge** across PostgreSQL + Qdrant + MinIO, and a **PG-authoritative reconcile/GC** (detect missing / repair orphan+stale) across the three stores. Resolves every `TODO(I07)` left by I04/I06 (orphan-vector GC, dead-lettered conversion staging GC). Stacked on `cursor/p1b-i06-index-worker-f084` (#227).

## Scope

- **Tombstone request** (`services/deletion.rs::request_delete`): one RLS txn — CAS `Indexed→Tombstoned` + `deleted_at` (immediate read suppression), emit `document.delete_requested`, **cancel in-flight Index/EmbeddingBatch jobs**, scoped destructive audit.
- **Relay dispatch**: `IndexingOutboxSink`→`OutboxJobSink` now dispatches `document.index_requested`→`Index` and `document.delete_requested`→`Delete`, so any relaying worker enqueues the correct durable job.
- **DeleteWorker / purge** (`workers/delete.rs`, `services/deletion.rs`): idempotent, checkpointed cleanup — Qdrant points by `(org,collection,document)` scope, MinIO objects by org-bound keys, PG `chunks` — then lease-fenced `Tombstoned→Purged` + audit + final scoped Qdrant sweep. Immutable `document_versions`/`derived_artifacts`/`index_metadata` retained as inventory (`documents` row kept as `purged`).
- **ReconcileWorker / reconcile** (`workers/reconcile.rs`, `services/reconciliation.rs`): PG-authoritative; detect missing vectors/objects; conservatively repair orphan/stale vectors via an **exact-point-id, `org+collection+document`-scoped** Qdrant delete; **reason-scoped re-runnable** reconcile; dead-letter conversion-staging GC (keyset-paginated, PG-reference-checked); bounded scoped `scroll_points` enumeration. Mode via `MARKHAND_RECONCILE_MODE` (config, not payload).
- **Resurrection safety** (`services/indexing.rs`): the index worker rejects tombstoned/purged docs in its fenced persist/finalize txns and **compensates just-upserted batch vectors** (with an incident-specific reconcile fallback) so a racing in-flight index job cannot resurrect content after purge.
- Worker kinds `delete`/`reconcile` wired in `bin/worker.rs`.

## Evidence

- [x] Tests: unit `cargo test -p fileconv-server --lib` (74) green. Live integration (self-skipping) run against real **PostgreSQL 5432 / Qdrant 6333 / MinIO 9000** — `deletion_reconcile` (10) + `index_worker` (5) pass, covering tombstone→purge, replay idempotency, exact-ID scoping (foreign-doc vector preserved), in-flight-vector protection, tombstone-cancels-writers + persist-rejects-deleted, compensation + incident-reconcile backstop, dead-letter staging GC (reference-skip + pagination), reason-scoped re-runnable reconcile. Full server suite green (no regression).
- [x] Manual/benchmark/migration evidence: **no migration** (uses existing schema + immutability triggers). CI-parity preflight green: `make check-rust` (workspace clippy `-D warnings` + `Clippy legacy baseline has no new warnings`), `cargo fmt --all -- --check`, `cargo metadata --locked` (no new deps), `check-dependency-policy.py`.

## Boundary and security review

- [x] Dependency boundary check passed (no new deps; one scoped Qdrant enumerator added).
- [x] Tenant/ACL impact reviewed: every PG delete under `with_org_txn` (RLS `FORCE`); every Qdrant delete atomically filtered by `org+collection+document_id(+has_id)`; every MinIO delete org-bound via `parse_key_for_org`; `collection_id` resolved from the document row.
- [x] Sensitive logging/secret/egress impact reviewed: ID-only payloads/checkpoints/audit; no keys/paths/content in logs or `Debug`.
- [x] Security review trigger checked: **strict security review over 4 rounds → PASS** (tombstone-first, PG-authoritative, lease-fenced `Tombstoned→Purged`, exact-ID scoped deletes, no cross-tenant/live-data deletion, resurrection prevented, durable reconcile backstop).

## Follow-up

- Non-blocking (tracked): incident reconcile enqueue is best-effort (a simultaneous Qdrant + PG failure defers to periodic reconcile); production reconcile workers must run in `repair` mode; periodic reconcile **scheduling** is ops/O-series wiring.
- Aligns with the master done-tasks review report: server integration tests still self-skip in CI (`MARKHAND_TEST_DATABASE_URL` unset) — wiring live PG/Qdrant/MinIO into the CI rust job is a separate cross-cutting task.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

