### PR TITLE
feat(server): P1B-R01 tenant-scoped hybrid retrieval

### DIFF
--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -11,3 +11,4 @@ pub mod models;
 pub mod orgs;
 pub mod pool;
 pub mod quota;
+pub mod search;

--- a/crates/server/src/db/search.rs
+++ b/crates/server/src/db/search.rs
@@ -1,0 +1,272 @@
+//! Tenant-scoped retrieval search queries.
+
+use chrono::{DateTime, Utc};
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SearchVersionMode {
+    Current,
+    AsOf(DateTime<Utc>),
+    History {
+        document_id: Uuid,
+    },
+    Compare {
+        document_id: Uuid,
+        version_ids: Vec<Uuid>,
+    },
+}
+
+impl SearchVersionMode {
+    pub fn sql_discriminator(&self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::AsOf(_) => "as_of",
+            Self::History { .. } => "history",
+            Self::Compare { .. } => "compare",
+        }
+    }
+
+    fn as_of_or_now(&self) -> DateTime<Utc> {
+        match self {
+            Self::AsOf(timestamp) => *timestamp,
+            _ => Utc::now(),
+        }
+    }
+
+    fn document_id_or_nil(&self) -> Uuid {
+        match self {
+            Self::History { document_id } | Self::Compare { document_id, .. } => *document_id,
+            _ => Uuid::nil(),
+        }
+    }
+
+    fn version_ids_or_empty(&self) -> Vec<Uuid> {
+        match self {
+            Self::Compare { version_ids, .. } => version_ids.clone(),
+            _ => Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LexicalCandidate {
+    pub chunk_id: Uuid,
+    pub chunk_identity: String,
+    pub lexical_score: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HydratedChunk {
+    pub chunk_id: Uuid,
+    pub chunk_identity: String,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub collection_id: Uuid,
+    pub version_number: i32,
+    pub content_sha256: String,
+    pub heading_path: Vec<String>,
+    pub body: String,
+    pub page: Option<i32>,
+    pub slide: Option<i32>,
+    pub sheet: Option<String>,
+    pub span_start: Option<i32>,
+    pub span_end: Option<i32>,
+    pub is_current: bool,
+    pub effective_from: DateTime<Utc>,
+    pub effective_to: Option<DateTime<Utc>>,
+}
+
+pub async fn lexical_candidates(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    authorized_collection_ids: &[Uuid],
+    query: &str,
+    mode: &SearchVersionMode,
+    limit: i64,
+    index_signature: &str,
+) -> Result<Vec<LexicalCandidate>, DbError> {
+    let mode_name = mode.sql_discriminator();
+    let as_of = mode.as_of_or_now();
+    let document_id = mode.document_id_or_nil();
+    let version_ids = mode.version_ids_or_empty();
+    let rows = txn
+        .query(
+            "WITH query AS (
+                SELECT websearch_to_tsquery('simple', $3) AS tsq
+             )
+             SELECT c.id AS chunk_id,
+                    c.chunk_identity_sha256 AS chunk_identity,
+                    ts_rank(c.tsv, query.tsq)::real AS lexical_score
+             FROM chunks c
+             JOIN documents d
+               ON d.org_id = c.org_id AND d.id = c.document_id
+             JOIN document_versions v
+               ON v.org_id = c.org_id
+              AND v.document_id = c.document_id
+              AND v.id = c.version_id
+             CROSS JOIN query
+             WHERE c.org_id = $1
+               AND d.collection_id = ANY($2::uuid[])
+               AND d.state = 'indexed'
+               AND d.deleted_at IS NULL
+               AND c.index_signature = $9
+               AND c.tsv @@ query.tsq
+               AND (
+                    ($5 = 'current' AND v.is_current)
+                 OR ($5 = 'as_of'
+                     AND v.effective_from <= $6
+                     AND (v.effective_to IS NULL OR v.effective_to > $6))
+                 OR ($5 = 'history' AND d.id = $7)
+                 OR ($5 = 'compare' AND d.id = $7 AND v.id = ANY($8::uuid[]))
+               )
+             ORDER BY lexical_score DESC, c.id ASC
+             LIMIT $4",
+            &[
+                &ctx.org_id(),
+                &authorized_collection_ids,
+                &query,
+                &limit,
+                &mode_name,
+                &as_of,
+                &document_id,
+                &version_ids,
+                &index_signature,
+            ],
+        )
+        .await?;
+    rows.iter().map(map_lexical_candidate).collect()
+}
+
+pub async fn hydrate_chunks(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    authorized_collection_ids: &[Uuid],
+    chunk_identities: &[String],
+    mode: &SearchVersionMode,
+    index_signature: &str,
+) -> Result<Vec<HydratedChunk>, DbError> {
+    if chunk_identities.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mode_name = mode.sql_discriminator();
+    let as_of = mode.as_of_or_now();
+    let document_id = mode.document_id_or_nil();
+    let version_ids = mode.version_ids_or_empty();
+    let rows = txn
+        .query(
+            "SELECT c.id AS chunk_id,
+                    c.chunk_identity_sha256 AS chunk_identity,
+                    c.document_id,
+                    c.version_id,
+                    d.collection_id,
+                    v.version_number,
+                    v.content_sha256,
+                    c.heading_path,
+                    c.body,
+                    c.page,
+                    c.slide,
+                    c.sheet,
+                    c.span_start,
+                    c.span_end,
+                    v.is_current,
+                    v.effective_from,
+                    v.effective_to
+             FROM chunks c
+             JOIN documents d
+               ON d.org_id = c.org_id AND d.id = c.document_id
+             JOIN document_versions v
+               ON v.org_id = c.org_id
+              AND v.document_id = c.document_id
+              AND v.id = c.version_id
+             WHERE c.org_id = $1
+               AND d.collection_id = ANY($2::uuid[])
+               AND c.chunk_identity_sha256 = ANY($3::text[])
+               AND d.state = 'indexed'
+               AND d.deleted_at IS NULL
+               AND c.index_signature = $4
+               AND (
+                    ($5 = 'current' AND v.is_current)
+                 OR ($5 = 'as_of'
+                     AND v.effective_from <= $6
+                     AND (v.effective_to IS NULL OR v.effective_to > $6))
+                 OR ($5 = 'history' AND d.id = $7)
+                 OR ($5 = 'compare' AND d.id = $7 AND v.id = ANY($8::uuid[]))
+               )
+             ORDER BY c.chunk_identity_sha256 ASC",
+            &[
+                &ctx.org_id(),
+                &authorized_collection_ids,
+                &chunk_identities,
+                &index_signature,
+                &mode_name,
+                &as_of,
+                &document_id,
+                &version_ids,
+            ],
+        )
+        .await?;
+    rows.iter().map(map_hydrated_chunk).collect()
+}
+
+fn map_lexical_candidate(row: &Row) -> Result<LexicalCandidate, DbError> {
+    Ok(LexicalCandidate {
+        chunk_id: row.get("chunk_id"),
+        chunk_identity: row.get("chunk_identity"),
+        lexical_score: row.get("lexical_score"),
+    })
+}
+
+fn map_hydrated_chunk(row: &Row) -> Result<HydratedChunk, DbError> {
+    Ok(HydratedChunk {
+        chunk_id: row.get("chunk_id"),
+        chunk_identity: row.get("chunk_identity"),
+        document_id: row.get("document_id"),
+        version_id: row.get("version_id"),
+        collection_id: row.get("collection_id"),
+        version_number: row.get("version_number"),
+        content_sha256: row.get("content_sha256"),
+        heading_path: row.get("heading_path"),
+        body: row.get("body"),
+        page: row.get("page"),
+        slide: row.get("slide"),
+        sheet: row.get("sheet"),
+        span_start: row.get("span_start"),
+        span_end: row.get("span_end"),
+        is_current: row.get("is_current"),
+        effective_from: row.get("effective_from"),
+        effective_to: row.get("effective_to"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SearchVersionMode;
+    use uuid::Uuid;
+
+    #[test]
+    fn version_mode_maps_to_sql_discriminator() {
+        let document_id = Uuid::new_v4();
+        let version_id = Uuid::new_v4();
+        assert_eq!(SearchVersionMode::Current.sql_discriminator(), "current");
+        assert_eq!(
+            SearchVersionMode::AsOf(chrono::Utc::now()).sql_discriminator(),
+            "as_of"
+        );
+        assert_eq!(
+            SearchVersionMode::History { document_id }.sql_discriminator(),
+            "history"
+        );
+        assert_eq!(
+            SearchVersionMode::Compare {
+                document_id,
+                version_ids: vec![version_id],
+            }
+            .sql_discriminator(),
+            "compare"
+        );
+    }
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -11,4 +11,5 @@ pub mod indexing;
 pub mod promotion;
 pub mod quota;
 pub mod reconciliation;
+pub mod retrieval;
 pub mod upload;

--- a/crates/server/src/services/retrieval/fts.rs
+++ b/crates/server/src/services/retrieval/fts.rs
@@ -1,0 +1,43 @@
+//! PostgreSQL FTS candidate retrieval.
+
+use deadpool_postgres::Pool;
+
+use crate::auth::context::OrgContext;
+use crate::db::pool::with_org_txn_typed;
+use crate::db::search::{self, LexicalCandidate};
+use crate::services::retrieval::{RetrievalError, VersionMode, LEXICAL_CANDIDATES};
+
+pub async fn search(
+    pool: &Pool,
+    ctx: &OrgContext,
+    query: &str,
+    mode: &VersionMode,
+    index_signature: &str,
+) -> Result<Vec<LexicalCandidate>, RetrievalError> {
+    let txn_ctx = ctx.clone();
+    let query_ctx = txn_ctx.clone();
+    let query = query.to_string();
+    let index_signature = index_signature.to_string();
+    let mode = search::SearchVersionMode::from(mode);
+    let authorized = txn_ctx
+        .allowed_collection_ids()
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+    with_org_txn_typed(pool, &txn_ctx, move |txn| {
+        Box::pin(async move {
+            search::lexical_candidates(
+                txn,
+                &query_ctx,
+                &authorized,
+                &query,
+                &mode,
+                LEXICAL_CANDIDATES as i64,
+                &index_signature,
+            )
+            .await
+            .map_err(RetrievalError::from)
+        })
+    })
+    .await
+}

--- a/crates/server/src/services/retrieval/hydrate.rs
+++ b/crates/server/src/services/retrieval/hydrate.rs
@@ -1,0 +1,95 @@
+//! PG-authoritative candidate hydration and security recheck.
+
+use deadpool_postgres::Pool;
+use fileconv_knowledge::citation::extract_snippet;
+use fileconv_knowledge::query::PreparedQuery;
+use fileconv_knowledge::rank::hybrid_rerank_score;
+
+use crate::auth::context::OrgContext;
+use crate::db::pool::with_org_txn_typed;
+use crate::db::search;
+use crate::services::retrieval::{Candidate, GroundedHit, RetrievalError, VersionMode};
+
+pub async fn hydrate(
+    pool: &Pool,
+    ctx: &OrgContext,
+    candidates: &[Candidate],
+    mode: &VersionMode,
+    index_signature: &str,
+    prepared: &PreparedQuery,
+) -> Result<Vec<GroundedHit>, RetrievalError> {
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+    let txn_ctx = ctx.clone();
+    let query_ctx = txn_ctx.clone();
+    let identities = candidates
+        .iter()
+        .map(|candidate| candidate.chunk_identity.clone())
+        .collect::<Vec<_>>();
+    let authorized = txn_ctx
+        .allowed_collection_ids()
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+    let mode = search::SearchVersionMode::from(mode);
+    let index_signature = index_signature.to_string();
+    let rows = with_org_txn_typed(pool, &txn_ctx, move |txn| {
+        Box::pin(async move {
+            search::hydrate_chunks(
+                txn,
+                &query_ctx,
+                &authorized,
+                &identities,
+                &mode,
+                &index_signature,
+            )
+            .await
+            .map_err(RetrievalError::from)
+        })
+    })
+    .await?;
+
+    let mut hits = Vec::new();
+    for row in rows {
+        let Some(candidate) = candidates
+            .iter()
+            .find(|candidate| candidate.chunk_identity == row.chunk_identity)
+        else {
+            continue;
+        };
+        let heading_joined = row.heading_path.join(" ");
+        let snippet = extract_snippet(&row.body, &prepared.tokens);
+        let rerank_score = hybrid_rerank_score(
+            candidate.lexical_rank,
+            candidate.vector_rank,
+            candidate.vector_score,
+            &prepared.tokens,
+            &heading_joined,
+            &row.body,
+        );
+        hits.push(GroundedHit {
+            chunk_id: row.chunk_id,
+            chunk_identity: row.chunk_identity,
+            document_id: row.document_id,
+            version_id: row.version_id,
+            collection_id: row.collection_id,
+            version_number: row.version_number,
+            content_sha256: row.content_sha256,
+            heading_path: row.heading_path,
+            snippet,
+            page: row.page,
+            slide: row.slide,
+            sheet: row.sheet,
+            span_start: row.span_start,
+            span_end: row.span_end,
+            lexical_score: candidate.lexical_score,
+            vector_score: candidate.vector_score,
+            rerank_score,
+            is_current: row.is_current,
+            effective_from: row.effective_from,
+            effective_to: row.effective_to,
+        });
+    }
+    Ok(hits)
+}

--- a/crates/server/src/services/retrieval/mod.rs
+++ b/crates/server/src/services/retrieval/mod.rs
@@ -1,0 +1,307 @@
+//! Tenant-scoped hybrid retrieval engine.
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Pool;
+use fileconv_knowledge::embedding::{local_vector, LOCAL_VECTOR_DIMENSIONS};
+use fileconv_knowledge::query::PreparedQuery;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db;
+use crate::services::embedding;
+use crate::services::index_signature::collection_name_for_digest;
+use crate::storage::qdrant::QdrantClient;
+use crate::storage::StorageError;
+
+pub(crate) mod fts;
+pub(crate) mod hydrate;
+pub(crate) mod vector;
+
+pub const VECTOR_CANDIDATES: usize = 500;
+pub const LEXICAL_CANDIDATES: usize = 250;
+pub const MAX_RETRIEVAL_LIMIT: usize = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetrievalRequest {
+    pub query: String,
+    pub limit: usize,
+    pub mode: VersionMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionMode {
+    Current,
+    AsOf(DateTime<Utc>),
+    History {
+        document_id: Uuid,
+    },
+    Compare {
+        document_id: Uuid,
+        version_ids: Vec<Uuid>,
+    },
+}
+
+impl Default for VersionMode {
+    fn default() -> Self {
+        Self::Current
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetrievalResponse {
+    pub hits: Vec<GroundedHit>,
+    pub degraded: Option<Degradation>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Degradation {
+    VectorUnavailable,
+    LexicalUnavailable,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroundedHit {
+    pub chunk_id: Uuid,
+    pub chunk_identity: String,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub collection_id: Uuid,
+    pub version_number: i32,
+    pub content_sha256: String,
+    pub heading_path: Vec<String>,
+    pub snippet: String,
+    pub page: Option<i32>,
+    pub slide: Option<i32>,
+    pub sheet: Option<String>,
+    pub span_start: Option<i32>,
+    pub span_end: Option<i32>,
+    pub lexical_score: f32,
+    pub vector_score: f32,
+    pub rerank_score: f32,
+    pub is_current: bool,
+    pub effective_from: DateTime<Utc>,
+    pub effective_to: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Error)]
+pub enum RetrievalError {
+    #[error("retrieval scope is empty")]
+    EmptyScope,
+    #[error("database error")]
+    Db(#[from] db::error::DbError),
+    #[error("storage error")]
+    Storage(#[from] StorageError),
+    #[error("knowledge error")]
+    Knowledge(#[from] fileconv_knowledge::KnowledgeError),
+    #[error("embedding task failed")]
+    EmbeddingJoin,
+    #[error("both retrieval candidate legs are unavailable")]
+    BothLegsUnavailable,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Candidate {
+    pub chunk_identity: String,
+    pub lexical_score: f32,
+    pub vector_score: f32,
+    pub lexical_rank: Option<usize>,
+    pub vector_rank: Option<usize>,
+}
+
+pub async fn retrieve(
+    pool: &Pool,
+    qdrant: &QdrantClient,
+    ctx: &OrgContext,
+    request: RetrievalRequest,
+) -> Result<RetrievalResponse, RetrievalError> {
+    if ctx.org_id().is_nil() || ctx.allowed_collection_ids().is_empty() {
+        return Err(RetrievalError::EmptyScope);
+    }
+
+    let limit = request.limit.clamp(1, MAX_RETRIEVAL_LIMIT);
+    let prepared = PreparedQuery::new(&request.query);
+    if prepared.is_empty() {
+        return Ok(RetrievalResponse {
+            hits: Vec::new(),
+            degraded: None,
+        });
+    }
+
+    let index_signature = active_index_signature_digest()?;
+    let collection_name = collection_name_for_digest(&index_signature)?;
+    let query_for_embed = request.query.clone();
+    let query_vector = tokio::task::spawn_blocking(move || local_vector(&query_for_embed))
+        .await
+        .map_err(|_| RetrievalError::EmbeddingJoin)?
+        .into_values();
+
+    let vector_future = vector::search(
+        qdrant,
+        &collection_name,
+        ctx.org_id(),
+        ctx.allowed_collection_ids().iter().copied(),
+        &query_vector,
+        &request.mode,
+    );
+    let fts_future = fts::search(pool, ctx, &request.query, &request.mode, &index_signature);
+    let (vector_result, lexical_result) = tokio::join!(vector_future, fts_future);
+
+    let (candidates, degraded) = merge_leg_results(vector_result, lexical_result)?;
+    if candidates.is_empty() {
+        return Ok(RetrievalResponse {
+            hits: Vec::new(),
+            degraded,
+        });
+    }
+
+    let mut hits = hydrate::hydrate(
+        pool,
+        ctx,
+        &candidates,
+        &request.mode,
+        &index_signature,
+        &prepared,
+    )
+    .await?;
+    sort_hits_deterministically(&mut hits);
+    hits.truncate(limit);
+
+    Ok(RetrievalResponse { hits, degraded })
+}
+
+fn active_index_signature_digest() -> Result<String, RetrievalError> {
+    Ok(embedding::approved_plan()
+        .index_signature(LOCAL_VECTOR_DIMENSIONS)?
+        .digest())
+}
+
+fn merge_leg_results(
+    vector_result: Result<Vec<vector::VectorCandidate>, StorageError>,
+    lexical_result: Result<Vec<db::search::LexicalCandidate>, RetrievalError>,
+) -> Result<(Vec<Candidate>, Option<Degradation>), RetrievalError> {
+    let degraded = match (&vector_result, &lexical_result) {
+        (Ok(_), Ok(_)) => None,
+        (Err(_), Ok(_)) => Some(Degradation::VectorUnavailable),
+        (Ok(_), Err(_)) => Some(Degradation::LexicalUnavailable),
+        (Err(_), Err(_)) => return Err(RetrievalError::BothLegsUnavailable),
+    };
+
+    let mut merged: BTreeMap<String, Candidate> = BTreeMap::new();
+    if let Ok(vector_candidates) = vector_result {
+        for candidate in vector_candidates {
+            let entry = merged
+                .entry(candidate.chunk_identity.clone())
+                .or_insert_with(|| Candidate {
+                    chunk_identity: candidate.chunk_identity,
+                    lexical_score: 0.0,
+                    vector_score: 0.0,
+                    lexical_rank: None,
+                    vector_rank: None,
+                });
+            entry.vector_score = candidate.vector_score;
+            entry.vector_rank = Some(candidate.rank);
+        }
+    }
+    if let Ok(lexical_candidates) = lexical_result {
+        for (rank, candidate) in lexical_candidates.into_iter().enumerate() {
+            let entry = merged
+                .entry(candidate.chunk_identity.clone())
+                .or_insert_with(|| Candidate {
+                    chunk_identity: candidate.chunk_identity,
+                    lexical_score: 0.0,
+                    vector_score: 0.0,
+                    lexical_rank: None,
+                    vector_rank: None,
+                });
+            entry.lexical_score = candidate.lexical_score;
+            entry.lexical_rank = Some(rank);
+        }
+    }
+
+    Ok((merged.into_values().collect(), degraded))
+}
+
+pub(crate) fn sort_hits_deterministically(hits: &mut [GroundedHit]) {
+    hits.sort_by(|left, right| {
+        right
+            .rerank_score
+            .partial_cmp(&left.rerank_score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| left.chunk_identity.cmp(&right.chunk_identity))
+    });
+}
+
+impl From<&VersionMode> for db::search::SearchVersionMode {
+    fn from(value: &VersionMode) -> Self {
+        match value {
+            VersionMode::Current => Self::Current,
+            VersionMode::AsOf(timestamp) => Self::AsOf(*timestamp),
+            VersionMode::History { document_id } => Self::History {
+                document_id: *document_id,
+            },
+            VersionMode::Compare {
+                document_id,
+                version_ids,
+            } => Self::Compare {
+                document_id: *document_id,
+                version_ids: version_ids.clone(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_hit(identity: &str, score: f32) -> GroundedHit {
+        let id = Uuid::new_v4();
+        GroundedHit {
+            chunk_id: id,
+            chunk_identity: identity.to_string(),
+            document_id: Uuid::new_v4(),
+            version_id: Uuid::new_v4(),
+            collection_id: Uuid::new_v4(),
+            version_number: 1,
+            content_sha256: "a".repeat(64),
+            heading_path: Vec::new(),
+            snippet: String::new(),
+            page: None,
+            slide: None,
+            sheet: None,
+            span_start: None,
+            span_end: None,
+            lexical_score: 0.0,
+            vector_score: 0.0,
+            rerank_score: score,
+            is_current: true,
+            effective_from: Utc::now(),
+            effective_to: None,
+        }
+    }
+
+    #[test]
+    fn deterministic_sort_ties_by_chunk_identity() {
+        let mut hits = vec![
+            test_hit("bbbb", 1.0),
+            test_hit("aaaa", 1.0),
+            test_hit("cccc", 0.5),
+        ];
+        sort_hits_deterministically(&mut hits);
+        let identities = hits
+            .iter()
+            .map(|hit| hit.chunk_identity.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(identities, ["aaaa", "bbbb", "cccc"]);
+    }
+
+    #[test]
+    fn prepared_empty_token_query_is_empty() {
+        let prepared = PreparedQuery::new("!? .");
+        assert!(prepared.is_empty());
+    }
+}

--- a/crates/server/src/services/retrieval/vector.rs
+++ b/crates/server/src/services/retrieval/vector.rs
@@ -1,0 +1,117 @@
+//! Vector candidate retrieval fenced by Qdrant tenant filters.
+
+use serde_json::{json, Value as JsonValue};
+use uuid::Uuid;
+
+use crate::services::index_signature::CollectionName;
+use crate::services::retrieval::{VersionMode, VECTOR_CANDIDATES};
+use crate::storage::qdrant::{QdrantClient, VectorScope};
+use crate::storage::StorageError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorCandidate {
+    pub chunk_identity: String,
+    pub vector_score: f32,
+    pub rank: usize,
+}
+
+pub async fn search(
+    qdrant: &QdrantClient,
+    collection_name: &CollectionName,
+    org_id: Uuid,
+    authorized_collection_ids: impl IntoIterator<Item = Uuid>,
+    vector: &[f32],
+    mode: &VersionMode,
+) -> Result<Vec<VectorCandidate>, StorageError> {
+    let scope = VectorScope::new(org_id, authorized_collection_ids);
+    let extra_must = mode_extra_must(mode);
+    let hits = qdrant
+        .search_filtered(
+            collection_name,
+            &scope,
+            vector,
+            VECTOR_CANDIDATES,
+            &extra_must,
+        )
+        .await?;
+    Ok(hits
+        .into_iter()
+        .enumerate()
+        .map(|(rank, hit)| VectorCandidate {
+            chunk_identity: hit.payload.chunk_id,
+            vector_score: hit.score,
+            rank,
+        })
+        .collect())
+}
+
+pub fn mode_extra_must(mode: &VersionMode) -> Vec<JsonValue> {
+    let mut filters = Vec::new();
+    match mode {
+        VersionMode::Current => {
+            filters.push(json!({
+                "key": "is_effective",
+                "match": { "value": true }
+            }));
+            filters.push(json!({
+                "key": "is_current",
+                "match": { "value": true }
+            }));
+        }
+        VersionMode::AsOf(_) => {
+            filters.push(json!({
+                "key": "is_effective",
+                "match": { "value": true }
+            }));
+        }
+        VersionMode::History { document_id } => {
+            filters.push(json!({
+                "key": "document_id",
+                "match": { "value": document_id.to_string() }
+            }));
+        }
+        VersionMode::Compare {
+            document_id,
+            version_ids,
+        } => {
+            filters.push(json!({
+                "key": "document_id",
+                "match": { "value": document_id.to_string() }
+            }));
+            let versions: Vec<String> = version_ids.iter().map(Uuid::to_string).collect();
+            filters.push(json!({
+                "key": "version_id",
+                "match": { "any": versions }
+            }));
+        }
+    }
+    filters
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mode_extra_must;
+    use crate::services::retrieval::VersionMode;
+    use uuid::Uuid;
+
+    #[test]
+    fn current_filter_requires_effective_current_points() {
+        let filters = mode_extra_must(&VersionMode::Current);
+        assert_eq!(filters.len(), 2);
+        assert!(filters.iter().any(|filter| filter["key"] == "is_effective"));
+        assert!(filters.iter().any(|filter| filter["key"] == "is_current"));
+    }
+
+    #[test]
+    fn compare_filter_fences_document_and_versions() {
+        let document_id = Uuid::new_v4();
+        let version_id = Uuid::new_v4();
+        let filters = mode_extra_must(&VersionMode::Compare {
+            document_id,
+            version_ids: vec![version_id],
+        });
+        assert_eq!(filters.len(), 2);
+        assert_eq!(filters[0]["key"], "document_id");
+        assert_eq!(filters[1]["key"], "version_id");
+    }
+}

--- a/crates/server/src/storage/qdrant.rs
+++ b/crates/server/src/storage/qdrant.rs
@@ -371,10 +371,25 @@ impl QdrantClient {
         vector: &[f32],
         limit: usize,
     ) -> Result<Vec<SearchHit>, StorageError> {
+        self.search_filtered(collection_name, scope, vector, limit, &[])
+            .await
+    }
+
+    /// Search with mandatory tenant scope plus caller-supplied extra `must` filters.
+    pub async fn search_filtered(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        vector: &[f32],
+        limit: usize,
+        extra_must: &[Value],
+    ) -> Result<Vec<SearchHit>, StorageError> {
         scope.validate()?;
         if limit == 0 {
             return Err(StorageError::PreconditionFailed);
         }
+        let mut must = mandatory_filter_must(scope);
+        must.extend(extra_must.iter().cloned());
         let url = format!(
             "{}/collections/{}/points/query",
             self.base_url,
@@ -382,7 +397,7 @@ impl QdrantClient {
         );
         let body = json!({
             "query": vector,
-            "filter": mandatory_filter(scope),
+            "filter": { "must": must },
             "limit": limit,
             "with_payload": true,
         });
@@ -394,7 +409,7 @@ impl QdrantClient {
             .map_err(|_| StorageError::Transport)?;
         if response.status().as_u16() == 404 || !response.status().is_success() {
             return self
-                .search_legacy(collection_name, scope, vector, limit)
+                .search_legacy(collection_name, scope, vector, limit, extra_must)
                 .await;
         }
         let payload: Value = response.json().await.map_err(|_| StorageError::Backend)?;
@@ -409,7 +424,10 @@ impl QdrantClient {
         scope: &VectorScope,
         vector: &[f32],
         limit: usize,
+        extra_must: &[Value],
     ) -> Result<Vec<SearchHit>, StorageError> {
+        let mut must = mandatory_filter_must(scope);
+        must.extend(extra_must.iter().cloned());
         let url = format!(
             "{}/collections/{}/points/search",
             self.base_url,
@@ -417,7 +435,7 @@ impl QdrantClient {
         );
         let body = json!({
             "vector": vector,
-            "filter": mandatory_filter(scope),
+            "filter": { "must": must },
             "limit": limit,
             "with_payload": true,
         });
@@ -765,10 +783,6 @@ pub fn point_id_from_org_collection_and_chunk(
 
 fn distance_matches(existing: &str, expected: &str) -> bool {
     existing.eq_ignore_ascii_case(expected)
-}
-
-fn mandatory_filter(scope: &VectorScope) -> Value {
-    json!({ "must": mandatory_filter_must(scope) })
 }
 
 fn mandatory_filter_must(scope: &VectorScope) -> Vec<Value> {

--- a/crates/server/tests/retrieval.rs
+++ b/crates/server/tests/retrieval.rs
@@ -1,0 +1,842 @@
+//! Live tests for tenant-scoped hybrid retrieval.
+//!
+//! These tests skip cleanly unless PostgreSQL, MinIO, and Qdrant test endpoints
+//! are provided in the environment. They are intentionally not part of the normal
+//! library test gate.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use deadpool_postgres::Pool;
+use fileconv_knowledge::embedding::{local_vector, LOCAL_VECTOR_DIMENSIONS};
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::config::{MinioConfig, SecretString};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::collections::{self, NewCollection};
+use fileconv_server::db::documents::{self, NewDocument};
+use fileconv_server::db::models::{ArtifactKind, CollectionVisibility};
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::jobs::{self, EventPayload, CURRENT_EVENT_PAYLOAD_VERSION};
+use fileconv_server::services::deletion;
+use fileconv_server::services::embedding::approved_plan;
+use fileconv_server::services::indexing::OutboxJobSink;
+use fileconv_server::services::retrieval::{
+    retrieve, Degradation, RetrievalError, RetrievalRequest, VersionMode,
+};
+use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
+use fileconv_server::storage::qdrant::{ChunkPointPayload, QdrantClient, UpsertPoint, VectorScope};
+use fileconv_server::storage::trusted_key;
+use fileconv_server::workers::index::{IndexWorker, IndexWorkerConfig, IndexWorkerRun};
+use sha2::{Digest, Sha256};
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn test_minio_client() -> Option<MinioClient> {
+    let endpoint = match std::env::var("MARKHAND_TEST_MINIO_ENDPOINT") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ENDPOINT unset");
+            return None;
+        }
+    };
+    let access_key = match std::env::var("MARKHAND_TEST_MINIO_ACCESS_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ACCESS_KEY unset");
+            return None;
+        }
+    };
+    let secret_key = match std::env::var("MARKHAND_TEST_MINIO_SECRET_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_SECRET_KEY unset");
+            return None;
+        }
+    };
+    let region = std::env::var("MARKHAND_TEST_MINIO_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let bucket = format!("markhand-retrieval-{}", Uuid::new_v4().simple());
+    std::env::set_var("RUST_S3_SKIP_LOCATION_CONSTRAINT", "true");
+    let config = MinioConfig::new(
+        endpoint,
+        SecretString::new(access_key),
+        SecretString::new(secret_key),
+        bucket,
+        region,
+        true,
+    )
+    .expect("minio config");
+    Some(MinioClient::from_config(&config).expect("minio client"))
+}
+
+fn test_qdrant_client() -> Option<QdrantClient> {
+    let url = match std::env::var("MARKHAND_TEST_QDRANT_URL") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_QDRANT_URL unset");
+            return None;
+        }
+    };
+    let api_key = std::env::var("MARKHAND_TEST_QDRANT_API_KEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(SecretString::new);
+    Some(QdrantClient::with_api_key(url, api_key).expect("qdrant client"))
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_retrieval_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+struct LiveEnv {
+    db: EphemeralDb,
+    pool: Pool,
+    storage: MinioClient,
+    qdrant: QdrantClient,
+    base_ctx: OrgContext,
+}
+
+impl LiveEnv {
+    async fn boot() -> Option<Self> {
+        let base_url = test_database_url()?;
+        let storage = test_minio_client()?;
+        let qdrant = test_qdrant_client()?;
+        storage.ensure_bucket().await.expect("ensure bucket");
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("apply migrations");
+        let pool = create_pool(&db.url).expect("pool");
+        let base_ctx = OrgContext::try_new(Uuid::new_v4(), Uuid::new_v4(), ["doc.upload"], [])
+            .expect("org context");
+        Some(Self {
+            db,
+            pool,
+            storage,
+            qdrant,
+            base_ctx,
+        })
+    }
+
+    fn retrieval_ctx(&self, collection_ids: impl IntoIterator<Item = Uuid>) -> OrgContext {
+        OrgContext::try_new(
+            self.base_ctx.org_id(),
+            self.base_ctx.user_id(),
+            self.base_ctx.permissions().iter().cloned(),
+            collection_ids,
+        )
+        .expect("retrieval context")
+    }
+
+    async fn drop(self) {
+        self.db.drop().await;
+    }
+}
+
+async fn seed_converted_document(
+    env: &LiveEnv,
+    collection_id: Uuid,
+    title: &str,
+    markdown: &str,
+) -> (Uuid, Uuid) {
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let artifact_id = Uuid::new_v4();
+    let outbox_key = format!("index-request:{version_id}");
+    let object_key =
+        trusted_key(env.base_ctx.org_id(), version_id, Uuid::new_v4(), None).expect("trusted key");
+    let object_key_string = object_key.as_str();
+    let sha256 = hex::encode(Sha256::digest(markdown.as_bytes()));
+    let markdown_len = markdown.len() as i64;
+    env.storage
+        .put_object(
+            env.base_ctx.org_id(),
+            &object_key,
+            Bytes::copy_from_slice(markdown.as_bytes()),
+            &ObjectIdentityMeta {
+                org_id: env.base_ctx.org_id(),
+                collection_id: Some(collection_id),
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                original_filename: None,
+                canonical_format: Some("md".into()),
+                content_sha256: Some(sha256.clone()),
+                content_length: Some(markdown.len() as u64),
+                disposition: Some("trusted".into()),
+            },
+            "text/markdown; charset=utf-8",
+        )
+        .await
+        .expect("put markdown");
+
+    with_org_txn(&env.pool, &env.base_ctx, {
+        let ctx = env.base_ctx.clone();
+        let object_key_string = object_key_string.clone();
+        let sha256 = sha256.clone();
+        let title = title.to_string();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &ctx, "retrieval-org", "Retrieval Org").await?;
+                orgs::ensure_user(
+                    txn,
+                    &ctx,
+                    ctx.user_id(),
+                    "retrieval@example.test",
+                    "Retrieval",
+                )
+                .await?;
+                orgs::ensure_membership(txn, &ctx).await?;
+                txn.execute(
+                    "INSERT INTO org_quotas (
+                        org_id, max_storage_bytes, max_documents,
+                        max_concurrent_jobs, max_monthly_tokens
+                     )
+                     VALUES ($1, 1000000000, 100000, 100, 1000000000)
+                     ON CONFLICT (org_id) DO NOTHING",
+                    &[&ctx.org_id()],
+                )
+                .await?;
+                let collection_name = format!("Retrieval Collection {collection_id}");
+                let collection_slug = format!("retrieval-{collection_id}");
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: collection_id,
+                        name: &collection_name,
+                        slug: &collection_slug,
+                        description: None,
+                        visibility: CollectionVisibility::Private,
+                    },
+                )
+                .await?;
+                documents::insert(
+                    txn,
+                    &ctx,
+                    NewDocument {
+                        id: document_id,
+                        collection_id,
+                        title: &title,
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key, markdown_object_key,
+                        source_content_type, byte_size, created_by_user_id
+                     )
+                     VALUES ($1, $2, $3, 1, 'published', true, $4, $5, $5,
+                             'text/markdown', $6, $7)",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &sha256,
+                        &object_key_string,
+                        &markdown_len,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                let kind = ArtifactKind::Markdown.as_str();
+                txn.execute(
+                    "INSERT INTO derived_artifacts (
+                        id, org_id, document_id, version_id, artifact_kind,
+                        object_key, content_sha256, content_type, byte_size
+                     )
+                     VALUES ($1, $2, $3, $4, $5, $6, $7,
+                             'text/markdown; charset=utf-8', $8)",
+                    &[
+                        &artifact_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &version_id,
+                        &kind,
+                        &object_key_string,
+                        &sha256,
+                        &markdown_len,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE documents
+                     SET state = 'converted', current_version_id = $3, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id, &version_id],
+                )
+                .await?;
+                let payload = EventPayload {
+                    job_id: None,
+                    document_id: Some(document_id),
+                    version_id: Some(version_id),
+                    outbox_event_id: None,
+                }
+                .to_json()
+                .expect("event payload");
+                txn.execute(
+                    "INSERT INTO outbox_events (
+                        org_id, event_type, payload_version, payload, idempotency_key
+                     )
+                     VALUES ($1, 'document.index_requested', $2, $3, $4)",
+                    &[
+                        &ctx.org_id(),
+                        &CURRENT_EVENT_PAYLOAD_VERSION,
+                        &payload,
+                        &outbox_key,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed converted document");
+    (document_id, version_id)
+}
+
+async fn seed_promoted_current_version(
+    env: &LiveEnv,
+    document_id: Uuid,
+    previous_version_id: Uuid,
+    markdown: &str,
+) -> Uuid {
+    let version_id = Uuid::new_v4();
+    let artifact_id = Uuid::new_v4();
+    let outbox_key = format!("index-request:{version_id}");
+    let object_key =
+        trusted_key(env.base_ctx.org_id(), version_id, Uuid::new_v4(), None).expect("trusted key");
+    let object_key_string = object_key.as_str();
+    let sha256 = hex::encode(Sha256::digest(markdown.as_bytes()));
+    let markdown_len = markdown.len() as i64;
+    env.storage
+        .put_object(
+            env.base_ctx.org_id(),
+            &object_key,
+            Bytes::copy_from_slice(markdown.as_bytes()),
+            &ObjectIdentityMeta {
+                org_id: env.base_ctx.org_id(),
+                collection_id: None,
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                original_filename: None,
+                canonical_format: Some("md".into()),
+                content_sha256: Some(sha256.clone()),
+                content_length: Some(markdown.len() as u64),
+                disposition: Some("trusted".into()),
+            },
+            "text/markdown; charset=utf-8",
+        )
+        .await
+        .expect("put promoted markdown");
+
+    with_org_txn(&env.pool, &env.base_ctx, {
+        let ctx = env.base_ctx.clone();
+        let object_key_string = object_key_string.clone();
+        let sha256 = sha256.clone();
+        move |txn| {
+            Box::pin(async move {
+                let effective_to = txn
+                    .query_one("SELECT clock_timestamp()", &[])
+                    .await?
+                    .get::<_, chrono::DateTime<chrono::Utc>>(0);
+                txn.execute(
+                    "UPDATE document_versions
+                     SET is_current = false, effective_to = $4
+                     WHERE org_id = $1 AND document_id = $2 AND id = $3",
+                    &[
+                        &ctx.org_id(),
+                        &document_id,
+                        &previous_version_id,
+                        &effective_to,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key, markdown_object_key,
+                        source_content_type, byte_size, created_by_user_id
+                     )
+                     SELECT $1, $2, $3, COALESCE(MAX(version_number), 0)::integer + 1,
+                            'published', true, $4, $5, $5, 'text/markdown', $6, $7
+                     FROM document_versions
+                     WHERE org_id = $2 AND document_id = $3",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &sha256,
+                        &object_key_string,
+                        &markdown_len,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                let kind = ArtifactKind::Markdown.as_str();
+                txn.execute(
+                    "INSERT INTO derived_artifacts (
+                        id, org_id, document_id, version_id, artifact_kind,
+                        object_key, content_sha256, content_type, byte_size
+                     )
+                     VALUES ($1, $2, $3, $4, $5, $6, $7,
+                             'text/markdown; charset=utf-8', $8)",
+                    &[
+                        &artifact_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &version_id,
+                        &kind,
+                        &object_key_string,
+                        &sha256,
+                        &markdown_len,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE documents
+                     SET current_version_id = $3, state = 'converted', updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id, &version_id],
+                )
+                .await?;
+                let payload = EventPayload {
+                    job_id: None,
+                    document_id: Some(document_id),
+                    version_id: Some(version_id),
+                    outbox_event_id: None,
+                }
+                .to_json()
+                .expect("event payload");
+                txn.execute(
+                    "INSERT INTO outbox_events (
+                        org_id, event_type, payload_version, payload, idempotency_key
+                     )
+                     VALUES ($1, 'document.index_requested', $2, $3, $4)",
+                    &[
+                        &ctx.org_id(),
+                        &CURRENT_EVENT_PAYLOAD_VERSION,
+                        &payload,
+                        &outbox_key,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed promoted version");
+    version_id
+}
+
+fn index_worker(env: &LiveEnv) -> IndexWorker {
+    let mut config = IndexWorkerConfig::new(format!("retrieval-worker-{}", Uuid::new_v4()));
+    config.lease_ttl = Duration::from_secs(30);
+    config.heartbeat_interval = Duration::from_secs(5);
+    config.max_job_duration = Duration::from_secs(60);
+    config.embedding_batch_size = 2;
+    IndexWorker::new(
+        env.pool.clone(),
+        env.storage.clone(),
+        env.qdrant.clone(),
+        config,
+        None,
+    )
+    .expect("worker")
+}
+
+async fn relay(env: &LiveEnv) {
+    let sink = Arc::new(OutboxJobSink::new());
+    jobs::relay_outbox_with_sink(&env.pool, &env.base_ctx, 32, &sink)
+        .await
+        .expect("relay outbox");
+}
+
+async fn run_next_index(env: &LiveEnv) {
+    relay(env).await;
+    let run = index_worker(env)
+        .run_once(&env.base_ctx)
+        .await
+        .expect("index run");
+    assert!(matches!(run, IndexWorkerRun::Completed { .. }));
+}
+
+async fn retrieve_once(
+    env: &LiveEnv,
+    ctx: &OrgContext,
+    query: &str,
+) -> fileconv_server::services::retrieval::RetrievalResponse {
+    retrieve(
+        &env.pool,
+        &env.qdrant,
+        ctx,
+        RetrievalRequest {
+            query: query.to_string(),
+            limit: 10,
+            mode: VersionMode::Current,
+        },
+    )
+    .await
+    .expect("retrieve")
+}
+
+#[tokio::test]
+async fn live_hybrid_retrieval_ranks_and_grounds() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let collection_id = Uuid::new_v4();
+    let markdown = "# Đối soát\n\nNội dung thanh toán mã đặc biệt VANGANH-2026 cần đối soát theo ngày.\n\n## Phụ lục\n\nDòng khác về hóa đơn.\n";
+    seed_converted_document(&env, collection_id, "Grounded", markdown).await;
+    run_next_index(&env).await;
+    let ctx = env.retrieval_ctx([collection_id]);
+
+    let first = retrieve_once(&env, &ctx, "VANGANH-2026").await;
+    let second = retrieve_once(&env, &ctx, "VANGANH-2026").await;
+    assert!(!first.hits.is_empty());
+    assert_eq!(
+        first
+            .hits
+            .iter()
+            .map(|hit| hit.chunk_identity.clone())
+            .collect::<Vec<_>>(),
+        second
+            .hits
+            .iter()
+            .map(|hit| hit.chunk_identity.clone())
+            .collect::<Vec<_>>()
+    );
+    let hit = &first.hits[0];
+    assert!(hit.snippet.contains("VANGANH-2026"));
+    assert!(hit.lexical_score >= 0.0);
+    assert!(hit.vector_score >= 0.0);
+    assert!(hit.rerank_score.is_finite());
+    assert_eq!(hit.collection_id, collection_id);
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_retrieval_denies_empty_scope() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let empty = env.retrieval_ctx([]);
+    let error = retrieve(
+        &env.pool,
+        &env.qdrant,
+        &empty,
+        RetrievalRequest {
+            query: "anything".into(),
+            limit: 10,
+            mode: VersionMode::Current,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(error, RetrievalError::EmptyScope));
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_retrieval_excludes_other_collection() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let allowed_collection = Uuid::new_v4();
+    let denied_collection = Uuid::new_v4();
+    seed_converted_document(
+        &env,
+        allowed_collection,
+        "Allowed",
+        "# A\n\nNội dung được phép với KHOAPHAM-2026.\n",
+    )
+    .await;
+    run_next_index(&env).await;
+    seed_converted_document(
+        &env,
+        denied_collection,
+        "Denied",
+        "# B\n\nNội dung bị chặn với KHOAPHAM-2026.\n",
+    )
+    .await;
+    run_next_index(&env).await;
+    let ctx = env.retrieval_ctx([allowed_collection]);
+
+    let response = retrieve_once(&env, &ctx, "KHOAPHAM-2026").await;
+    assert!(!response.hits.is_empty());
+    assert!(response
+        .hits
+        .iter()
+        .all(|hit| hit.collection_id == allowed_collection));
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_retrieval_excludes_tombstoned() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let collection_id = Uuid::new_v4();
+    let (document_id, _) = seed_converted_document(
+        &env,
+        collection_id,
+        "Deleted",
+        "# Xóa\n\nTài liệu có mã XOANG-2026 sẽ bị tombstone.\n",
+    )
+    .await;
+    run_next_index(&env).await;
+    deletion::request_delete(&env.pool, &env.base_ctx, document_id)
+        .await
+        .expect("request delete");
+    let ctx = env.retrieval_ctx([collection_id]);
+
+    let response = retrieve_once(&env, &ctx, "XOANG-2026").await;
+    assert!(response.hits.is_empty());
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_retrieval_current_excludes_superseded() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let collection_id = Uuid::new_v4();
+    let (document_id, old_version) = seed_converted_document(
+        &env,
+        collection_id,
+        "Versions",
+        "# Cũ\n\nPhiên bản cũ chứa mã CUONGOLD-2026.\n",
+    )
+    .await;
+    run_next_index(&env).await;
+    let new_version = seed_promoted_current_version(
+        &env,
+        document_id,
+        old_version,
+        "# Mới\n\nPhiên bản mới chứa mã CUONGNEW-2026.\n",
+    )
+    .await;
+    run_next_index(&env).await;
+    let ctx = env.retrieval_ctx([collection_id]);
+
+    // Current mode must never surface the superseded version's chunks. (The
+    // near-identical current-version chunk may still fuzzy-match the query via
+    // the local-hash vector, so assert on version exclusion, not emptiness.)
+    let old_response = retrieve_once(&env, &ctx, "CUONGOLD-2026").await;
+    assert!(
+        old_response
+            .hits
+            .iter()
+            .all(|hit| hit.version_id != old_version),
+        "current mode returned a superseded version chunk"
+    );
+    let new_response = retrieve_once(&env, &ctx, "CUONGNEW-2026").await;
+    assert!(!new_response.hits.is_empty());
+    assert!(new_response
+        .hits
+        .iter()
+        .all(|hit| hit.version_id == new_version && hit.is_current));
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_retrieval_as_of_returns_effective_version() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let collection_id = Uuid::new_v4();
+    let (document_id, old_version) = seed_converted_document(
+        &env,
+        collection_id,
+        "As Of",
+        "# Cũ\n\nPhiên bản hiệu lực cũ chứa mã ASOFOLD-2026.\n",
+    )
+    .await;
+    run_next_index(&env).await;
+    let as_of_old = chrono::Utc::now();
+    let new_version = seed_promoted_current_version(
+        &env,
+        document_id,
+        old_version,
+        "# Mới\n\nPhiên bản hiệu lực mới chứa mã ASOFNEW-2026.\n",
+    )
+    .await;
+    run_next_index(&env).await;
+    let ctx = env.retrieval_ctx([collection_id]);
+
+    let old_response = retrieve(
+        &env.pool,
+        &env.qdrant,
+        &ctx,
+        RetrievalRequest {
+            query: "ASOFOLD-2026".into(),
+            limit: 10,
+            mode: VersionMode::AsOf(as_of_old),
+        },
+    )
+    .await
+    .expect("as-of old retrieve");
+    assert!(!old_response.hits.is_empty());
+    assert!(old_response
+        .hits
+        .iter()
+        .all(|hit| hit.version_id == old_version && !hit.is_current));
+    let current_response = retrieve_once(&env, &ctx, "ASOFNEW-2026").await;
+    assert!(current_response
+        .hits
+        .iter()
+        .all(|hit| hit.version_id == new_version));
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_retrieval_stale_vector_no_text() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let collection_id = Uuid::new_v4();
+    let ctx = env.retrieval_ctx([collection_id]);
+    let plan = approved_plan();
+    let signature = plan
+        .index_signature(LOCAL_VECTOR_DIMENSIONS)
+        .expect("signature");
+    let collection_name = env
+        .qdrant
+        .ensure_collection_for_signature(&signature)
+        .await
+        .expect("ensure collection");
+    let query = "vector only stale PHANTOM-2026";
+    env.qdrant
+        .upsert_points(
+            &collection_name,
+            &VectorScope::new(env.base_ctx.org_id(), [collection_id]),
+            &[UpsertPoint {
+                chunk_identity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .into(),
+                vector: local_vector(query).into_values(),
+                payload: ChunkPointPayload {
+                    org_id: env.base_ctx.org_id(),
+                    collection_id,
+                    document_id: Uuid::new_v4(),
+                    version_id: Uuid::new_v4(),
+                    chunk_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        .into(),
+                    ordinal: 0,
+                    is_current: true,
+                    is_effective: true,
+                    index_generation: 1,
+                },
+            }],
+        )
+        .await
+        .expect("upsert stale point");
+
+    let response = retrieve_once(&env, &ctx, query).await;
+    assert!(response.hits.is_empty());
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_retrieval_one_leg_outage() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let collection_id = Uuid::new_v4();
+    seed_converted_document(
+        &env,
+        collection_id,
+        "Outage",
+        "# Sự cố\n\nFTS vẫn tìm thấy mã SONGHAN-2026 khi vector lỗi.\n",
+    )
+    .await;
+    run_next_index(&env).await;
+    let ctx = env.retrieval_ctx([collection_id]);
+    let broken_qdrant = QdrantClient::new("http://127.0.0.1:1").expect("broken client");
+
+    let response = retrieve(
+        &env.pool,
+        &broken_qdrant,
+        &ctx,
+        RetrievalRequest {
+            query: "SONGHAN-2026".into(),
+            limit: 10,
+            mode: VersionMode::Current,
+        },
+    )
+    .await
+    .expect("retrieve with vector outage");
+    assert_eq!(response.degraded, Some(Degradation::VectorUnavailable));
+    assert!(!response.hits.is_empty());
+    assert!(response
+        .hits
+        .iter()
+        .all(|hit| hit.collection_id == collection_id));
+    env.drop().await;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Implements **P1B-R01 (#91)** — the tenant-scoped hybrid retrieval **engine** (no HTTP route; that's R05). It fuses Qdrant vector search + PostgreSQL FTS, reranks with the frozen `fileconv-knowledge` weights, and returns **grounded** chunk hits restricted to the tenant, the caller's authorized collections, and committed PG state. Stacked on `cursor/p1b-i07-tombstone-reconcile-f084` (#230).

## Scope

- New `services/retrieval/{mod,vector,fts,hydrate}.rs` + `db/search.rs`; extended `storage/qdrant.rs` with a scoped `search_filtered` (pushes `is_current`/`is_effective` into the mandatory org+collection filter).
- **Pipeline**: fail-closed (nil org / empty authorized collections → deny; limit clamped `1..=100`; empty-token query → empty) → local query embed (`local_vector`, spawn_blocking) → parallel Qdrant (top 500) + PG FTS (top 250) legs, both tenant+ACL scoped from `ctx.allowed_collection_ids()` → union by chunk identity → **authoritative PG hydrate + recheck** (org/ACL/`state='indexed'`/`deleted_at IS NULL`/`index_signature`/version mode) → rerank (frozen RRF weights) → deterministic order (`rerank desc, chunk_identity asc`) → grounded hits.
- **Version modes**: `Current` (excludes superseded), `AsOf` (effective version), `History`/`Compare` (document lineage / version set).
- **One-leg outage**: degrades to the healthy leg (still hydrated from PG) with a `degraded` flag; both down → error.

## Evidence

- [x] Tests: unit `cargo test -p fileconv-server --lib` (79) green. Live integration (`tests/retrieval.rs`, self-skipping) run against real **PostgreSQL 5432 / Qdrant 6333 / MinIO 9000** — 8 pass: ranks+grounds & deterministic, empty-scope deny, other-collection exclusion, tombstoned exclusion, current-excludes-superseded, AsOf effective version, stale-vector-no-text, one-leg (vector) outage degradation. Full server suite green (no regression).
- [x] Manual/benchmark/migration evidence: **no migration** (uses existing `chunks.tsv` FTS + Qdrant). CI-parity preflight green: `make check-rust`, `cargo fmt --all -- --check`, `cargo metadata --locked` (no new deps).

## Boundary and security review

- [x] Dependency boundary check passed (no new deps; reuses `fileconv-knowledge` rank/query/citation).
- [x] Tenant/ACL impact reviewed: both legs scoped to org + `ctx.allowed_collection_ids()`; authoritative PG hydrate re-applies org/ACL/state/version/signature before any text is returned; vector payload is a candidate fence only (never returned as text).
- [x] Sensitive logging/secret/egress impact reviewed: parameterized SQL (`websearch_to_tsquery`), RLS via `with_org_txn`, no query/body/secret in logs.
- [x] Security review trigger checked: **strict security review → PASS** (no cross-tenant/collection/deleted leakage; fail-closed scope; injection-safe). Also applied the reviewer's non-blocking recall fix (FTS candidate query now filters `index_signature`).

## Follow-up

- Non-blocking (tracked): bound query length + `Compare.version_ids` when R05 exposes an HTTP route; add explicit cross-org + vector-only degradation live tests.
- R02 (citation/preview/download auth), R03 (grounded Q&A), R05 (search/ask HTTP API) build on this engine.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

