### PR TITLE
feat(server): P1B-R02 citation, preview and download authorization

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -33,6 +33,15 @@ pub use probe::{probe, FileInfo};
 
 use audio::AudioEngine;
 
+/// Normalize text to Unicode NFC using the converter's canonical Vietnamese text policy.
+pub fn normalize_nfc_text(text: &str) -> String {
+    use unicode_normalization::{is_nfc_quick, IsNormalized, UnicodeNormalization};
+    match is_nfc_quick(text.chars()) {
+        IsNormalized::Yes => text.to_string(),
+        _ => text.nfc().collect(),
+    }
+}
+
 /// Loại định dạng nhận diện được.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FormatKind {

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -20,6 +20,7 @@ use crate::config::QuotaSweepConfig;
 use crate::database;
 use crate::db::pool::create_pool;
 use crate::routes;
+use crate::services::download::{CapabilityKey, ConsumedDownloadNonces};
 use crate::services::quota;
 use crate::state::RuntimeState;
 
@@ -34,6 +35,8 @@ pub struct AppState {
     auth_provider: Option<PasswordAuthProvider>,
     /// Object store adapter (optional when credentials are absent in tests).
     object_store: Option<crate::storage::MinioClient>,
+    download_capability_key: Option<CapabilityKey>,
+    consumed_download_nonces: ConsumedDownloadNonces,
 }
 
 struct CachedReadiness {
@@ -69,6 +72,12 @@ impl AppState {
             Err(_) => None,
         };
         start_quota_sweep(pool.clone(), runtime.config().quota_sweep());
+        let download_capability_key = runtime
+            .config()
+            .auth()
+            .signing_key
+            .as_ref()
+            .map(CapabilityKey::derive_from_auth_signing_key);
         Ok(Self {
             runtime,
             http_client,
@@ -76,6 +85,8 @@ impl AppState {
             pool,
             auth_provider,
             object_store,
+            download_capability_key,
+            consumed_download_nonces: ConsumedDownloadNonces::new(),
         })
     }
 
@@ -102,6 +113,12 @@ impl AppState {
             .timeout(DEPENDENCY_TIMEOUT)
             .build()
             .map_err(|error| format!("cannot configure HTTP client: {error}"))?;
+        let download_capability_key = runtime
+            .config()
+            .auth()
+            .signing_key
+            .as_ref()
+            .map(CapabilityKey::derive_from_auth_signing_key);
         Ok(Self {
             runtime,
             http_client,
@@ -109,6 +126,8 @@ impl AppState {
             pool,
             auth_provider,
             object_store,
+            download_capability_key,
+            consumed_download_nonces: ConsumedDownloadNonces::new(),
         })
     }
 
@@ -126,6 +145,14 @@ impl AppState {
 
     pub fn object_store(&self) -> Option<&crate::storage::MinioClient> {
         self.object_store.as_ref()
+    }
+
+    pub fn download_capability_key(&self) -> Option<&CapabilityKey> {
+        self.download_capability_key.as_ref()
+    }
+
+    pub fn consumed_download_nonces(&self) -> &ConsumedDownloadNonces {
+        &self.consumed_download_nonces
     }
 }
 
@@ -168,6 +195,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/v1/health/live", get(liveness))
         .route("/api/v1/health/ready", get(readiness))
         .merge(routes::auth::router())
+        .merge(routes::documents::router())
         .merge(routes::uploads::router(max_upload_bytes))
         .with_state(Arc::new(state))
 }

--- a/crates/server/src/routes/documents.rs
+++ b/crates/server/src/routes/documents.rs
@@ -1,0 +1,285 @@
+//! Document citation, preview, and original-download routes.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use chrono::Utc;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::api::ApiError;
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::auth::permissions::require_permission;
+use crate::http::AppState;
+use crate::services::citation::{self, CitationPin};
+use crate::services::download::{self, DownloadError};
+use crate::services::preview::{self, PreviewError, MARKDOWN_CONTENT_TYPE};
+use crate::storage::StorageError;
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route(
+            "/api/v1/documents/{documentId}/versions/{versionId}/citations:resolve",
+            post(resolve_citation),
+        )
+        .route(
+            "/api/v1/documents/{documentId}/versions/{versionId}/preview",
+            get(markdown_preview),
+        )
+        .route(
+            "/api/v1/documents/{documentId}/versions/{versionId}/download",
+            post(authorize_download),
+        )
+        .route("/api/v1/documents/download/{token}", get(redeem_download))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VersionPath {
+    document_id: Uuid,
+    version_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenPath {
+    token: String,
+}
+
+async fn resolve_citation(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<VersionPath>,
+    Json(pin): Json<CitationPin>,
+) -> Result<Response, DocumentRouteError> {
+    let request_id = auth.request_id.clone();
+    require_permission(&auth.context, "qa.query")
+        .map_err(|_| DocumentRouteError::forbidden(request_id.clone()))?;
+    if path.document_id != pin.document_id || path.version_id != pin.version_id {
+        return Err(DocumentRouteError::validation(
+            "Citation pin does not match the requested document version",
+            request_id,
+        ));
+    }
+    let resolved = citation::resolve_citation(state.pool(), &auth.context, pin)
+        .await
+        .map_err(|error| DocumentRouteError::citation(error, request_id.clone()))?;
+    Ok(Json(resolved).into_response())
+}
+
+async fn markdown_preview(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<VersionPath>,
+) -> Result<Response, DocumentRouteError> {
+    let request_id = auth.request_id.clone();
+    require_permission(&auth.context, "qa.query")
+        .map_err(|_| DocumentRouteError::forbidden(request_id.clone()))?;
+    let storage = state
+        .object_store()
+        .ok_or_else(|| DocumentRouteError::service_unavailable(request_id.clone()))?;
+    let preview = preview::fetch_markdown_preview(
+        state.pool(),
+        storage,
+        &auth.context,
+        path.document_id,
+        path.version_id,
+    )
+    .await
+    .map_err(|error| DocumentRouteError::preview(error, request_id.clone()))?;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static(MARKDOWN_CONTENT_TYPE),
+    );
+    headers.insert(
+        "x-content-type-options",
+        HeaderValue::from_static("nosniff"),
+    );
+    Ok((headers, Body::from(preview.bytes)).into_response())
+}
+
+async fn authorize_download(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<VersionPath>,
+) -> Result<Response, DocumentRouteError> {
+    let request_id = auth.request_id.clone();
+    require_permission(&auth.context, "qa.query")
+        .map_err(|_| DocumentRouteError::forbidden(request_id.clone()))?;
+    let storage = state
+        .object_store()
+        .ok_or_else(|| DocumentRouteError::service_unavailable(request_id.clone()))?;
+    let key = state
+        .download_capability_key()
+        .ok_or_else(|| DocumentRouteError::service_unavailable(request_id.clone()))?;
+    let capability = download::authorize_download(
+        state.pool(),
+        storage,
+        &auth.context,
+        path.document_id,
+        path.version_id,
+        key,
+        Utc::now(),
+    )
+    .await
+    .map_err(|error| DocumentRouteError::download(error, request_id.clone()))?;
+    Ok(Json(capability).into_response())
+}
+
+async fn redeem_download(
+    State(state): State<Arc<AppState>>,
+    Path(path): Path<TokenPath>,
+) -> Result<Response, DocumentRouteError> {
+    let request_id = Uuid::new_v4().to_string();
+    let storage = state
+        .object_store()
+        .ok_or_else(|| DocumentRouteError::service_unavailable(request_id.clone()))?;
+    let key = state
+        .download_capability_key()
+        .ok_or_else(|| DocumentRouteError::service_unavailable(request_id.clone()))?;
+    let stream = download::redeem_download(
+        state.pool(),
+        storage,
+        key,
+        state.consumed_download_nonces(),
+        &path.token,
+        Utc::now(),
+    )
+    .await
+    .map_err(|error| DocumentRouteError::download(error, request_id.clone()))?;
+    let disposition = download::content_disposition_value(&stream.filename);
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_str(&stream.content_type)
+            .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream")),
+    );
+    headers.insert(
+        CONTENT_DISPOSITION,
+        HeaderValue::from_str(&disposition)
+            .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
+    );
+    headers.insert(
+        "x-content-type-options",
+        HeaderValue::from_static("nosniff"),
+    );
+    Ok((headers, Body::from(stream.bytes)).into_response())
+}
+
+struct DocumentRouteError {
+    status: StatusCode,
+    code: &'static str,
+    message: &'static str,
+    request_id: String,
+}
+
+impl DocumentRouteError {
+    fn validation(message: &'static str, request_id: String) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "validation_failed",
+            message,
+            request_id,
+        }
+    }
+
+    fn forbidden(request_id: String) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code: "permission_denied",
+            message: "Permission denied",
+            request_id,
+        }
+    }
+
+    fn not_found(request_id: String) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "not_found",
+            message: "Document source was not found",
+            request_id,
+        }
+    }
+
+    fn internal(request_id: String) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "internal_error",
+            message: "Document operation failed",
+            request_id,
+        }
+    }
+
+    fn service_unavailable(request_id: String) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "dependency_unavailable",
+            message: "A required document service is unavailable",
+            request_id,
+        }
+    }
+
+    fn citation(error: citation::CitationError, request_id: String) -> Self {
+        match error {
+            citation::CitationError::NotFound => Self::not_found(request_id),
+            citation::CitationError::Db(_) => Self::internal(request_id),
+        }
+    }
+
+    fn preview(error: PreviewError, request_id: String) -> Self {
+        match error {
+            PreviewError::NotFound
+            | PreviewError::Storage(
+                StorageError::NotFound
+                | StorageError::InvalidKey
+                | StorageError::KeyOrgMismatch
+                | StorageError::OwnershipConflict
+                | StorageError::MissingScope,
+            ) => Self::not_found(request_id),
+            PreviewError::Db(_) | PreviewError::Storage(_) | PreviewError::Integrity => {
+                Self::internal(request_id)
+            }
+        }
+    }
+
+    fn download(error: DownloadError, request_id: String) -> Self {
+        match error {
+            DownloadError::NotFound
+            | DownloadError::InvalidToken
+            | DownloadError::Expired
+            | DownloadError::Replay
+            | DownloadError::Storage(
+                StorageError::NotFound
+                | StorageError::InvalidKey
+                | StorageError::KeyOrgMismatch
+                | StorageError::OwnershipConflict
+                | StorageError::MissingScope,
+            ) => Self::not_found(request_id),
+            DownloadError::CapabilityUnavailable => Self::service_unavailable(request_id),
+            DownloadError::Db(_) | DownloadError::Storage(_) | DownloadError::Integrity => {
+                Self::internal(request_id)
+            }
+        }
+    }
+}
+
+impl IntoResponse for DocumentRouteError {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            Json(ApiError {
+                code: self.code.into(),
+                message: self.message.into(),
+                request_id: self.request_id,
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,4 +1,5 @@
 //! HTTP route modules.
 
 pub mod auth;
+pub mod documents;
 pub mod uploads;

--- a/crates/server/src/services/citation.rs
+++ b/crates/server/src/services/citation.rs
@@ -1,0 +1,213 @@
+//! Freshly authorized version-aware citation resolution.
+
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Pool;
+use fileconv_knowledge::citation::extract_snippet;
+use fileconv_knowledge::query::PreparedQuery;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::pool::with_org_txn_typed;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CitationPin {
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub version_number: i32,
+    pub content_sha256: String,
+    pub chunk_id: Uuid,
+    pub span_start: Option<i32>,
+    pub span_end: Option<i32>,
+    pub quote: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedCitation {
+    pub org_id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub version_number: i32,
+    pub content_sha256: String,
+    pub chunk_id: Uuid,
+    pub collection_id: Uuid,
+    pub heading_path: Vec<String>,
+    pub snippet: String,
+    pub page: Option<i32>,
+    pub slide: Option<i32>,
+    pub sheet: Option<String>,
+    pub span_start: Option<i32>,
+    pub span_end: Option<i32>,
+    pub quote: Option<String>,
+    pub effective_from: DateTime<Utc>,
+    pub effective_to: Option<DateTime<Utc>>,
+    pub is_current: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum CitationError {
+    #[error("citation source was not found")]
+    NotFound,
+    #[error("database error")]
+    Db(#[from] DbError),
+}
+
+#[derive(Debug)]
+struct CitationRow {
+    document_id: Uuid,
+    version_id: Uuid,
+    version_number: i32,
+    content_sha256: String,
+    collection_id: Uuid,
+    heading_path: Vec<String>,
+    body: String,
+    page: Option<i32>,
+    slide: Option<i32>,
+    sheet: Option<String>,
+    span_start: Option<i32>,
+    span_end: Option<i32>,
+    effective_from: DateTime<Utc>,
+    effective_to: Option<DateTime<Utc>>,
+    is_current: bool,
+}
+
+pub async fn resolve_citation(
+    pool: &Pool,
+    ctx: &OrgContext,
+    pin: CitationPin,
+) -> Result<ResolvedCitation, CitationError> {
+    if ctx.org_id().is_nil() || ctx.allowed_collection_ids().is_empty() {
+        return Err(CitationError::NotFound);
+    }
+
+    let authorized = ctx
+        .allowed_collection_ids()
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+    let txn_ctx = ctx.clone();
+    let query_ctx = txn_ctx.clone();
+    let chunk_id = pin.chunk_id;
+    let row = with_org_txn_typed(pool, &txn_ctx, move |txn| {
+        Box::pin(async move {
+            let row = txn
+                .query_opt(
+                    "SELECT c.document_id,
+                            c.version_id,
+                            d.collection_id,
+                            v.version_number,
+                            v.content_sha256,
+                            c.heading_path,
+                            c.body,
+                            c.page,
+                            c.slide,
+                            c.sheet,
+                            c.span_start,
+                            c.span_end,
+                            v.effective_from,
+                            v.effective_to,
+                            v.is_current
+                     FROM chunks c
+                     JOIN document_versions v
+                       ON v.org_id = c.org_id
+                      AND v.document_id = c.document_id
+                      AND v.id = c.version_id
+                     JOIN documents d
+                       ON d.org_id = c.org_id
+                      AND d.id = c.document_id
+                     WHERE c.org_id = $1
+                       AND c.id = $3
+                       AND d.collection_id = ANY($2::uuid[])
+                       AND d.state = 'indexed'
+                       AND d.deleted_at IS NULL",
+                    &[&query_ctx.org_id(), &authorized, &chunk_id],
+                )
+                .await
+                .map_err(DbError::from)?
+                .ok_or(CitationError::NotFound)?;
+            Ok::<_, CitationError>(CitationRow {
+                document_id: row.get("document_id"),
+                version_id: row.get("version_id"),
+                version_number: row.get("version_number"),
+                content_sha256: row.get("content_sha256"),
+                collection_id: row.get("collection_id"),
+                heading_path: row.get("heading_path"),
+                body: row.get("body"),
+                page: row.get("page"),
+                slide: row.get("slide"),
+                sheet: row.get("sheet"),
+                span_start: row.get("span_start"),
+                span_end: row.get("span_end"),
+                effective_from: row.get("effective_from"),
+                effective_to: row.get("effective_to"),
+                is_current: row.get("is_current"),
+            })
+        })
+    })
+    .await?;
+
+    verify_pin(&row, &pin)?;
+    let tokens = pin
+        .quote
+        .as_deref()
+        .map(PreparedQuery::new)
+        .unwrap_or_else(|| PreparedQuery::new(&row.body))
+        .tokens;
+    let snippet = extract_snippet(&row.body, &tokens);
+
+    Ok(ResolvedCitation {
+        org_id: ctx.org_id(),
+        document_id: row.document_id,
+        version_id: row.version_id,
+        version_number: row.version_number,
+        content_sha256: row.content_sha256,
+        chunk_id: pin.chunk_id,
+        collection_id: row.collection_id,
+        heading_path: row.heading_path,
+        snippet,
+        page: row.page,
+        slide: row.slide,
+        sheet: row.sheet,
+        span_start: row.span_start,
+        span_end: row.span_end,
+        quote: pin.quote,
+        effective_from: row.effective_from,
+        effective_to: row.effective_to,
+        is_current: row.is_current,
+    })
+}
+
+fn verify_pin(row: &CitationRow, pin: &CitationPin) -> Result<(), CitationError> {
+    if row.document_id != pin.document_id
+        || row.version_id != pin.version_id
+        || row.version_number != pin.version_number
+        || row.content_sha256 != pin.content_sha256
+    {
+        return Err(CitationError::NotFound);
+    }
+    if let Some(quote) = pin.quote.as_deref() {
+        let body = fileconv_core::normalize_nfc_text(&row.body);
+        let quote = fileconv_core::normalize_nfc_text(quote);
+        if !body.contains(&quote) {
+            return Err(CitationError::NotFound);
+        }
+    }
+    // When both the pin and the stored chunk carry a span, they must match.
+    // TODO(R-followup): tighten to exact Option equality once chunk anchor
+    // extraction populates spans, so a pin cannot claim a span the chunk lacks.
+    if let (Some(pin_start), Some(stored_start)) = (pin.span_start, row.span_start) {
+        if pin_start != stored_start {
+            return Err(CitationError::NotFound);
+        }
+    }
+    if let (Some(pin_end), Some(stored_end)) = (pin.span_end, row.span_end) {
+        if pin_end != stored_end {
+            return Err(CitationError::NotFound);
+        }
+    }
+    Ok(())
+}

--- a/crates/server/src/services/download.rs
+++ b/crates/server/src/services/download.rs
@@ -1,0 +1,605 @@
+//! Short-lived, one-time download capabilities for original quarantine objects.
+//!
+//! The consumed-nonce cache is process-local for the POC. Strict cross-instance
+//! one-time-use requires a durable nonce ledger in a later HA hardening issue.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Pool;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::auth::permissions::{require_permission, resolve_org_context_in_txn};
+use crate::config::SecretString;
+use crate::db::error::DbError;
+use crate::db::pool::with_org_txn_typed;
+use crate::storage::keys::parse_key_for_org;
+use crate::storage::minio::MinioClient;
+use crate::storage::{ObjectNamespace, StorageError};
+
+const CAPABILITY_DOMAIN: &[u8] = b"markhand-download-capability-v1";
+const CAPABILITY_KEY_DOMAIN: &[u8] = b"markhand-download-capability-key-v1";
+const TOKEN_VERSION: u8 = 1;
+const TOKEN_TTL_SECS: i64 = 60;
+const TOKEN_BYTES_WITHOUT_TAG: usize = 1 + 16 + 16 + 16 + 16 + 16 + 8;
+const TOKEN_BYTES: usize = TOKEN_BYTES_WITHOUT_TAG + 32;
+const NONCE_CACHE_GRACE: Duration = Duration::from_secs(60);
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct CapabilityKey([u8; 32]);
+
+impl std::fmt::Debug for CapabilityKey {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("CapabilityKey([REDACTED])")
+    }
+}
+
+impl CapabilityKey {
+    pub fn derive_from_auth_signing_key(signing_key: &SecretString) -> Self {
+        Self(hmac_sha256(
+            signing_key.expose().as_bytes(),
+            CAPABILITY_KEY_DOMAIN,
+        ))
+    }
+
+    #[cfg(test)]
+    fn from_test_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ConsumedDownloadNonces {
+    inner: Mutex<HashMap<Uuid, Instant>>,
+}
+
+impl ConsumedDownloadNonces {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn consume_once(
+        &self,
+        nonce: Uuid,
+        expires_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<(), DownloadError> {
+        let mut guard = self.inner.lock().await;
+        let instant_now = Instant::now();
+        guard.retain(|_, expires| *expires > instant_now);
+        if guard.contains_key(&nonce) {
+            return Err(DownloadError::Replay);
+        }
+        let ttl = expires_at
+            .signed_duration_since(now)
+            .to_std()
+            .unwrap_or(Duration::ZERO)
+            .saturating_add(NONCE_CACHE_GRACE);
+        guard.insert(nonce, instant_now + ttl);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadCapability {
+    pub token: String,
+    pub download_path: String,
+    pub expires_at: DateTime<Utc>,
+    pub filename: String,
+    pub content_type: String,
+    pub byte_size: u64,
+    pub content_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DownloadStream {
+    pub bytes: Bytes,
+    pub content_type: String,
+    pub filename: String,
+    pub byte_size: u64,
+    pub content_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SafeDownloadFilename {
+    pub filename: String,
+    pub ascii_fallback: String,
+    pub filename_star: String,
+}
+
+#[derive(Debug, Error)]
+pub enum DownloadError {
+    #[error("download source was not found")]
+    NotFound,
+    #[error("download capability service is unavailable")]
+    CapabilityUnavailable,
+    #[error("download capability token is invalid")]
+    InvalidToken,
+    #[error("download capability token is expired")]
+    Expired,
+    #[error("download capability token was already used")]
+    Replay,
+    #[error("database error")]
+    Db(#[from] DbError),
+    #[error("storage error")]
+    Storage(#[from] StorageError),
+    #[error("download object integrity check failed")]
+    Integrity,
+}
+
+#[derive(Debug, Clone)]
+struct AuthorizedDownload {
+    org_id: Uuid,
+    user_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    original_object_key: String,
+    source_filename: Option<String>,
+    byte_size: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+struct VerifiedToken {
+    org_id: Uuid,
+    user_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    nonce: Uuid,
+    expires_at: DateTime<Utc>,
+}
+
+pub async fn authorize_download(
+    pool: &Pool,
+    storage: &MinioClient,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+    capability_key: &CapabilityKey,
+    now: DateTime<Utc>,
+) -> Result<DownloadCapability, DownloadError> {
+    let source = authorize_original_source(pool, ctx, document_id, version_id).await?;
+    let key = parse_key_for_org(&source.original_object_key, ctx.org_id())?;
+    if key.namespace() != ObjectNamespace::Quarantine {
+        return Err(DownloadError::NotFound);
+    }
+    let metadata = storage.head_metadata(ctx.org_id(), &key).await?;
+    let object_sha256 =
+        metadata_value(&metadata, "content-sha256").ok_or(DownloadError::Integrity)?;
+    let byte_size = match byte_size_from_metadata(&metadata) {
+        Some(result) => result?,
+        None => db_byte_size(source.byte_size)?,
+    };
+    let content_type = content_type_from_metadata(&metadata);
+    let safe_name = sanitize_download_filename(source.source_filename.as_deref(), document_id);
+    let expires_at = now + chrono::Duration::seconds(TOKEN_TTL_SECS);
+    let token = encode_token(
+        capability_key,
+        TokenClaims {
+            org_id: source.org_id,
+            user_id: source.user_id,
+            document_id: source.document_id,
+            version_id: source.version_id,
+            nonce: Uuid::new_v4(),
+            expires_at,
+        },
+    );
+
+    Ok(DownloadCapability {
+        download_path: format!("/api/v1/documents/download/{token}"),
+        token,
+        expires_at,
+        filename: safe_name.filename,
+        content_type,
+        byte_size,
+        content_sha256: object_sha256.to_string(),
+    })
+}
+
+pub async fn redeem_download(
+    pool: &Pool,
+    storage: &MinioClient,
+    capability_key: &CapabilityKey,
+    consumed_nonces: &ConsumedDownloadNonces,
+    token: &str,
+    now: DateTime<Utc>,
+) -> Result<DownloadStream, DownloadError> {
+    let verified = verify_token(capability_key, token, now)?;
+    consumed_nonces
+        .consume_once(verified.nonce, verified.expires_at, now)
+        .await?;
+    let ctx = resolve_org_context_in_txn(pool, verified.org_id, verified.user_id)
+        .await
+        .map_err(|_| DownloadError::NotFound)?;
+    require_permission(&ctx, "qa.query").map_err(|_| DownloadError::NotFound)?;
+    let source =
+        authorize_original_source(pool, &ctx, verified.document_id, verified.version_id).await?;
+    let key = parse_key_for_org(&source.original_object_key, ctx.org_id())?;
+    if key.namespace() != ObjectNamespace::Quarantine {
+        return Err(DownloadError::NotFound);
+    }
+    let metadata = storage.head_metadata(ctx.org_id(), &key).await?;
+    let content_type = content_type_from_metadata(&metadata);
+    let filename =
+        sanitize_download_filename(source.source_filename.as_deref(), source.document_id).filename;
+    let expected_sha256 =
+        metadata_value(&metadata, "content-sha256").ok_or(DownloadError::Integrity)?;
+    let bytes = storage.get_object(ctx.org_id(), &key).await?;
+    let actual_sha256 = hex::encode(Sha256::digest(&bytes));
+    if actual_sha256 != expected_sha256 {
+        return Err(DownloadError::Integrity);
+    }
+    Ok(DownloadStream {
+        byte_size: bytes.len() as u64,
+        bytes,
+        content_type,
+        filename,
+        content_sha256: actual_sha256,
+    })
+}
+
+async fn authorize_original_source(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<AuthorizedDownload, DownloadError> {
+    if ctx.org_id().is_nil() || ctx.allowed_collection_ids().is_empty() {
+        return Err(DownloadError::NotFound);
+    }
+    let authorized = ctx
+        .allowed_collection_ids()
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+    let txn_ctx = ctx.clone();
+    let query_ctx = txn_ctx.clone();
+    with_org_txn_typed(pool, &txn_ctx, move |txn| {
+        Box::pin(async move {
+            let row = txn
+                .query_opt(
+                    "SELECT v.document_id,
+                            v.id AS version_id,
+                            v.original_object_key,
+                            v.source_filename,
+                            v.byte_size
+                     FROM document_versions v
+                     JOIN documents d
+                       ON d.org_id = v.org_id
+                      AND d.id = v.document_id
+                     WHERE v.org_id = $1
+                       AND v.document_id = $3
+                       AND v.id = $4
+                       AND d.collection_id = ANY($2::uuid[])
+                       AND d.state = 'indexed'
+                       AND d.deleted_at IS NULL",
+                    &[&query_ctx.org_id(), &authorized, &document_id, &version_id],
+                )
+                .await
+                .map_err(DbError::from)?
+                .ok_or(DownloadError::NotFound)?;
+            Ok::<_, DownloadError>(AuthorizedDownload {
+                org_id: query_ctx.org_id(),
+                user_id: query_ctx.user_id(),
+                document_id: row.get("document_id"),
+                version_id: row.get("version_id"),
+                original_object_key: row.get("original_object_key"),
+                source_filename: row.get("source_filename"),
+                byte_size: row.get("byte_size"),
+            })
+        })
+    })
+    .await
+}
+
+fn metadata_value<'a>(metadata: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    metadata
+        .get(key)
+        .or_else(|| metadata.get(&format!("x-amz-meta-{key}")))
+        .map(String::as_str)
+}
+
+fn byte_size_from_metadata(
+    metadata: &HashMap<String, String>,
+) -> Option<Result<u64, DownloadError>> {
+    metadata_value(metadata, "content-length-bytes")
+        .or_else(|| metadata_value(metadata, "content-length"))
+        .map(|value| value.parse::<u64>().map_err(|_| DownloadError::Integrity))
+}
+
+fn db_byte_size(byte_size: Option<i64>) -> Result<u64, DownloadError> {
+    let byte_size = byte_size.ok_or(DownloadError::Integrity)?;
+    u64::try_from(byte_size).map_err(|_| DownloadError::Integrity)
+}
+
+fn content_type_from_metadata(metadata: &HashMap<String, String>) -> String {
+    if let Some(content_type) = metadata_value(metadata, "content-type")
+        .filter(|value| !value.trim().is_empty())
+        .filter(|value| !value.contains('\r') && !value.contains('\n'))
+    {
+        return content_type.to_string();
+    }
+    metadata_value(metadata, "canonical-format")
+        .and_then(content_type_for_format)
+        .unwrap_or("application/octet-stream")
+        .to_string()
+}
+
+fn content_type_for_format(format: &str) -> Option<&'static str> {
+    match format {
+        "pdf" => Some("application/pdf"),
+        "docx" => Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        "pptx" => Some("application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+        "xlsx" => Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+        "ods" => Some("application/vnd.oasis.opendocument.spreadsheet"),
+        "xls" => Some("application/vnd.ms-excel"),
+        "xlsb" => Some("application/vnd.ms-excel.sheet.binary.macroEnabled.12"),
+        "csv" => Some("text/csv; charset=utf-8"),
+        "html" => Some("text/html; charset=utf-8"),
+        "txt" => Some("text/plain; charset=utf-8"),
+        "png" => Some("image/png"),
+        "jpeg" | "jpg" => Some("image/jpeg"),
+        "webp" => Some("image/webp"),
+        "tiff" => Some("image/tiff"),
+        "bmp" => Some("image/bmp"),
+        "wav" => Some("audio/wav"),
+        "mp3" => Some("audio/mpeg"),
+        "ogg" => Some("audio/ogg"),
+        "flac" => Some("audio/flac"),
+        "m4a" => Some("audio/mp4"),
+        "zip" => Some("application/zip"),
+        _ => None,
+    }
+}
+
+pub fn sanitize_download_filename(input: Option<&str>, document_id: Uuid) -> SafeDownloadFilename {
+    let fallback = format!("document-{document_id}");
+    let mut filename = input
+        .unwrap_or("")
+        .chars()
+        .filter(|ch| !ch.is_control() && !matches!(*ch, '/' | '\\' | '"' | ';'))
+        .collect::<String>();
+    filename = filename.trim().to_string();
+    if filename.is_empty() || filename == "." || filename == ".." {
+        filename = fallback.clone();
+    }
+    filename = filename.chars().take(180).collect();
+    if filename.is_empty() {
+        filename = fallback.clone();
+    }
+    let mut ascii_fallback = filename
+        .chars()
+        .filter(|ch| ch.is_ascii() && !ch.is_control() && !matches!(*ch, '"' | '\\' | ';'))
+        .collect::<String>()
+        .trim()
+        .to_string();
+    if ascii_fallback.is_empty() || ascii_fallback == "." || ascii_fallback == ".." {
+        ascii_fallback = fallback;
+    }
+    ascii_fallback = ascii_fallback.chars().take(120).collect();
+    let filename_star = percent_encode_filename(&filename);
+    SafeDownloadFilename {
+        filename,
+        ascii_fallback,
+        filename_star,
+    }
+}
+
+pub fn content_disposition_value(filename: &str) -> String {
+    let safe = sanitize_download_filename(Some(filename), Uuid::nil());
+    format!(
+        "attachment; filename=\"{}\"; filename*=UTF-8''{}",
+        safe.ascii_fallback, safe.filename_star
+    )
+}
+
+fn percent_encode_filename(filename: &str) -> String {
+    let mut encoded = String::new();
+    for byte in filename.as_bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(*byte, b'.' | b'_' | b'-') {
+            encoded.push(*byte as char);
+        } else {
+            encoded.push('%');
+            encoded.push_str(&format!("{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TokenClaims {
+    org_id: Uuid,
+    user_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    nonce: Uuid,
+    expires_at: DateTime<Utc>,
+}
+
+fn encode_token(key: &CapabilityKey, claims: TokenClaims) -> String {
+    let mut payload = token_payload_without_tag(claims);
+    let tag = capability_tag(key, &payload);
+    payload.extend_from_slice(&tag);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload)
+}
+
+fn verify_token(
+    key: &CapabilityKey,
+    token: &str,
+    now: DateTime<Utc>,
+) -> Result<VerifiedToken, DownloadError> {
+    if token.len() > 256 {
+        return Err(DownloadError::InvalidToken);
+    }
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(token)
+        .map_err(|_| DownloadError::InvalidToken)?;
+    if decoded.len() != TOKEN_BYTES || decoded[0] != TOKEN_VERSION {
+        return Err(DownloadError::InvalidToken);
+    }
+    let (payload, tag) = decoded.split_at(TOKEN_BYTES_WITHOUT_TAG);
+    let expected = capability_tag(key, payload);
+    if !constant_time_eq(tag, &expected) {
+        return Err(DownloadError::InvalidToken);
+    }
+    let claims = parse_claims(payload)?;
+    if now.timestamp() >= claims.expires_at.timestamp() {
+        return Err(DownloadError::Expired);
+    }
+    Ok(VerifiedToken {
+        org_id: claims.org_id,
+        user_id: claims.user_id,
+        document_id: claims.document_id,
+        version_id: claims.version_id,
+        nonce: claims.nonce,
+        expires_at: claims.expires_at,
+    })
+}
+
+fn token_payload_without_tag(claims: TokenClaims) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(TOKEN_BYTES_WITHOUT_TAG);
+    payload.push(TOKEN_VERSION);
+    payload.extend_from_slice(claims.nonce.as_bytes());
+    payload.extend_from_slice(claims.org_id.as_bytes());
+    payload.extend_from_slice(claims.user_id.as_bytes());
+    payload.extend_from_slice(claims.document_id.as_bytes());
+    payload.extend_from_slice(claims.version_id.as_bytes());
+    payload.extend_from_slice(&claims.expires_at.timestamp().to_be_bytes());
+    payload
+}
+
+fn parse_claims(payload: &[u8]) -> Result<TokenClaims, DownloadError> {
+    if payload.len() != TOKEN_BYTES_WITHOUT_TAG || payload[0] != TOKEN_VERSION {
+        return Err(DownloadError::InvalidToken);
+    }
+    let nonce = uuid_from_slice(&payload[1..17])?;
+    let org_id = uuid_from_slice(&payload[17..33])?;
+    let user_id = uuid_from_slice(&payload[33..49])?;
+    let document_id = uuid_from_slice(&payload[49..65])?;
+    let version_id = uuid_from_slice(&payload[65..81])?;
+    let mut exp_bytes = [0_u8; 8];
+    exp_bytes.copy_from_slice(&payload[81..89]);
+    let expires_at = DateTime::<Utc>::from_timestamp(i64::from_be_bytes(exp_bytes), 0)
+        .ok_or(DownloadError::InvalidToken)?;
+    Ok(TokenClaims {
+        org_id,
+        user_id,
+        document_id,
+        version_id,
+        nonce,
+        expires_at,
+    })
+}
+
+fn uuid_from_slice(bytes: &[u8]) -> Result<Uuid, DownloadError> {
+    let mut array = [0_u8; 16];
+    array.copy_from_slice(bytes);
+    let id = Uuid::from_bytes(array);
+    if id.is_nil() {
+        return Err(DownloadError::InvalidToken);
+    }
+    Ok(id)
+}
+
+fn capability_tag(key: &CapabilityKey, payload: &[u8]) -> [u8; 32] {
+    let mut message = Vec::with_capacity(CAPABILITY_DOMAIN.len() + payload.len());
+    message.extend_from_slice(CAPABILITY_DOMAIN);
+    message.extend_from_slice(payload);
+    hmac_sha256(&key.0, &message)
+}
+
+fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    const BLOCK: usize = 64;
+    let mut key_block = [0_u8; BLOCK];
+    if key.len() > BLOCK {
+        key_block[..32].copy_from_slice(&Sha256::digest(key));
+    } else {
+        key_block[..key.len()].copy_from_slice(key);
+    }
+    let mut ipad = [0x36_u8; BLOCK];
+    let mut opad = [0x5c_u8; BLOCK];
+    for index in 0..BLOCK {
+        ipad[index] ^= key_block[index];
+        opad[index] ^= key_block[index];
+    }
+    let mut inner = Sha256::new();
+    inner.update(ipad);
+    inner.update(message);
+    let inner = inner.finalize();
+    let mut outer = Sha256::new();
+    outer.update(opad);
+    outer.update(inner);
+    outer.finalize().into()
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut diff = 0_u8;
+    for (left, right) in left.iter().zip(right) {
+        diff |= left ^ right;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Duration as ChronoDuration;
+
+    use super::*;
+
+    #[test]
+    fn sanitizes_download_filename_and_builds_rfc5987_header() {
+        let document_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let safe = sanitize_download_filename(Some("../Báo cáo\nQ1;final.pdf"), document_id);
+        assert_eq!(safe.filename, "..Báo cáoQ1final.pdf");
+        assert_eq!(safe.ascii_fallback, "..Bo coQ1final.pdf");
+        assert!(safe.filename_star.contains("%C3%A1"));
+        let header = content_disposition_value(&safe.filename);
+        assert!(
+            header.starts_with("attachment; filename=\"..Bo coQ1final.pdf\"; filename*=UTF-8''")
+        );
+        assert!(!header.contains('\n'));
+
+        let fallback = sanitize_download_filename(Some("////"), document_id);
+        assert_eq!(fallback.filename, format!("document-{document_id}"));
+    }
+
+    #[test]
+    fn hmac_token_validates_expiry_and_tampering() {
+        let key = CapabilityKey::from_test_bytes([7; 32]);
+        let now = Utc::now();
+        let claims = TokenClaims {
+            org_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            document_id: Uuid::new_v4(),
+            version_id: Uuid::new_v4(),
+            nonce: Uuid::new_v4(),
+            expires_at: now + ChronoDuration::seconds(60),
+        };
+        let token = encode_token(&key, claims);
+        let verified = verify_token(&key, &token, now).expect("valid token");
+        assert_eq!(verified.org_id, claims.org_id);
+        assert_eq!(verified.version_id, claims.version_id);
+
+        let mut tampered = token.clone();
+        tampered.push('A');
+        assert!(matches!(
+            verify_token(&key, &tampered, now),
+            Err(DownloadError::InvalidToken)
+        ));
+        assert!(matches!(
+            verify_token(&key, &token, now + ChronoDuration::seconds(61)),
+            Err(DownloadError::Expired)
+        ));
+    }
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -2,12 +2,15 @@
 
 pub mod artifacts;
 pub mod chunking;
+pub mod citation;
 pub mod conversion;
 pub mod deletion;
 pub mod document_state;
+pub mod download;
 pub mod embedding;
 pub mod index_signature;
 pub mod indexing;
+pub mod preview;
 pub mod promotion;
 pub mod quota;
 pub mod reconciliation;

--- a/crates/server/src/services/preview.rs
+++ b/crates/server/src/services/preview.rs
@@ -1,0 +1,117 @@
+//! Trusted Markdown preview retrieval with fresh document authorization.
+
+use bytes::Bytes;
+use deadpool_postgres::Pool;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::document_versions;
+use crate::db::error::DbError;
+use crate::db::pool::with_org_txn_typed;
+use crate::storage::keys::{authorize_key_for_version, parse_key_for_org};
+use crate::storage::minio::MinioClient;
+use crate::storage::{ObjectNamespace, StorageError};
+
+pub const MARKDOWN_CONTENT_TYPE: &str = "text/markdown; charset=utf-8";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkdownPreview {
+    #[serde(skip_serializing)]
+    pub bytes: Bytes,
+    pub content_type: &'static str,
+    pub content_sha256: String,
+    pub version_id: Uuid,
+    pub version_number: i32,
+    pub byte_size: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum PreviewError {
+    #[error("preview was not found")]
+    NotFound,
+    #[error("database error")]
+    Db(#[from] DbError),
+    #[error("storage error")]
+    Storage(#[from] StorageError),
+    #[error("preview integrity check failed")]
+    Integrity,
+}
+
+#[derive(Debug)]
+struct AuthorizedPreview {
+    version_number: i32,
+}
+
+pub async fn fetch_markdown_preview(
+    pool: &Pool,
+    storage: &MinioClient,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<MarkdownPreview, PreviewError> {
+    if ctx.org_id().is_nil() || ctx.allowed_collection_ids().is_empty() {
+        return Err(PreviewError::NotFound);
+    }
+    let authorized = ctx
+        .allowed_collection_ids()
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+    let txn_ctx = ctx.clone();
+    let query_ctx = txn_ctx.clone();
+    let (source, artifact) = with_org_txn_typed(pool, &txn_ctx, move |txn| {
+        Box::pin(async move {
+            let row = txn
+                .query_opt(
+                    "SELECT v.version_number
+                     FROM document_versions v
+                     JOIN documents d
+                       ON d.org_id = v.org_id
+                      AND d.id = v.document_id
+                     WHERE v.org_id = $1
+                       AND v.document_id = $3
+                       AND v.id = $4
+                       AND d.collection_id = ANY($2::uuid[])
+                       AND d.state = 'indexed'
+                       AND d.deleted_at IS NULL",
+                    &[&query_ctx.org_id(), &authorized, &document_id, &version_id],
+                )
+                .await
+                .map_err(DbError::from)?
+                .ok_or(PreviewError::NotFound)?;
+            let artifact = document_versions::find_markdown_artifact(txn, &query_ctx, version_id)
+                .await?
+                .ok_or(PreviewError::NotFound)?;
+            Ok::<_, PreviewError>((
+                AuthorizedPreview {
+                    version_number: row.get("version_number"),
+                },
+                artifact,
+            ))
+        })
+    })
+    .await?;
+
+    let key = parse_key_for_org(&artifact.object_key, ctx.org_id())?;
+    if key.namespace() != ObjectNamespace::Trusted {
+        return Err(PreviewError::NotFound);
+    }
+    authorize_key_for_version(&key, version_id).map_err(|_| PreviewError::NotFound)?;
+    let bytes = storage.get_object(ctx.org_id(), &key).await?;
+    let actual_sha256 = hex::encode(Sha256::digest(&bytes));
+    if actual_sha256 != artifact.content_sha256 {
+        return Err(PreviewError::Integrity);
+    }
+    Ok(MarkdownPreview {
+        byte_size: bytes.len() as u64,
+        bytes,
+        content_type: MARKDOWN_CONTENT_TYPE,
+        content_sha256: artifact.content_sha256,
+        version_id,
+        version_number: source.version_number,
+    })
+}

--- a/crates/server/src/storage/minio.rs
+++ b/crates/server/src/storage/minio.rs
@@ -651,6 +651,12 @@ fn insert_header(
 
 fn metadata_map(head: &HeadObjectResult) -> HashMap<String, String> {
     let mut meta = HashMap::new();
+    if let Some(content_type) = &head.content_type {
+        meta.insert("content-type".to_string(), content_type.clone());
+    }
+    if let Some(content_length) = head.content_length {
+        meta.insert("content-length".to_string(), content_length.to_string());
+    }
     if let Some(map) = &head.metadata {
         for (k, v) in map {
             meta.insert(k.to_ascii_lowercase(), v.clone());

--- a/crates/server/tests/citation_preview_download.rs
+++ b/crates/server/tests/citation_preview_download.rs
@@ -1,0 +1,649 @@
+//! Live tests for citation, preview, and original-download authorization.
+//!
+//! These tests skip cleanly unless PostgreSQL, MinIO, and Qdrant test endpoints
+//! are provided in the environment. They are intentionally not run by the normal
+//! library test gate.
+
+use bytes::Bytes;
+use chrono::{Duration as ChronoDuration, Utc};
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::config::{MinioConfig, SecretString};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::collections::{self, NewCollection};
+use fileconv_server::db::models::{ArtifactKind, CollectionVisibility};
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::services::citation::{resolve_citation, CitationError, CitationPin};
+use fileconv_server::services::deletion;
+use fileconv_server::services::download::{
+    authorize_download, redeem_download, CapabilityKey, ConsumedDownloadNonces, DownloadError,
+};
+use fileconv_server::services::preview::{fetch_markdown_preview, PreviewError};
+use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
+use fileconv_server::storage::{quarantine_key, trusted_key};
+use sha2::{Digest, Sha256};
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+const POC_ORG_ID: &str = "11111111-1111-1111-1111-111111111111";
+const POC_USER_ID: &str = "22222222-2222-2222-2222-222222222201";
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn test_minio_client() -> Option<MinioClient> {
+    let endpoint = match std::env::var("MARKHAND_TEST_MINIO_ENDPOINT") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ENDPOINT unset");
+            return None;
+        }
+    };
+    let access_key = match std::env::var("MARKHAND_TEST_MINIO_ACCESS_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ACCESS_KEY unset");
+            return None;
+        }
+    };
+    let secret_key = match std::env::var("MARKHAND_TEST_MINIO_SECRET_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_SECRET_KEY unset");
+            return None;
+        }
+    };
+    let region = std::env::var("MARKHAND_TEST_MINIO_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let bucket = format!("markhand-r02-{}", Uuid::new_v4().simple());
+    std::env::set_var("RUST_S3_SKIP_LOCATION_CONSTRAINT", "true");
+    let config = MinioConfig::new(
+        endpoint,
+        SecretString::new(access_key),
+        SecretString::new(secret_key),
+        bucket,
+        region,
+        true,
+    )
+    .expect("minio config");
+    Some(MinioClient::from_config(&config).expect("minio client"))
+}
+
+fn require_qdrant_url() -> Option<()> {
+    match std::env::var("MARKHAND_TEST_QDRANT_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(()),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_QDRANT_URL unset");
+            None
+        }
+    }
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_r02_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+struct LiveEnv {
+    db: EphemeralDb,
+    pool: Pool,
+    storage: MinioClient,
+    base_ctx: OrgContext,
+    capability_key: CapabilityKey,
+}
+
+impl LiveEnv {
+    async fn boot() -> Option<Self> {
+        let base_url = test_database_url()?;
+        let storage = test_minio_client()?;
+        require_qdrant_url()?;
+        storage.ensure_bucket().await.expect("ensure bucket");
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("apply migrations");
+        let pool = create_pool(&db.url).expect("pool");
+        let org_id = Uuid::parse_str(POC_ORG_ID).expect("org id");
+        let user_id = Uuid::parse_str(POC_USER_ID).expect("user id");
+        let base_ctx = OrgContext::try_new(org_id, user_id, ["qa.query", "doc.delete"], [])
+            .expect("org context");
+        let capability_key = CapabilityKey::derive_from_auth_signing_key(&SecretString::new(
+            "r02-live-test-signing-key-at-least-32-bytes",
+        ));
+        Some(Self {
+            db,
+            pool,
+            storage,
+            base_ctx,
+            capability_key,
+        })
+    }
+
+    fn ctx_for(&self, collection_ids: impl IntoIterator<Item = Uuid>) -> OrgContext {
+        OrgContext::try_new(
+            self.base_ctx.org_id(),
+            self.base_ctx.user_id(),
+            self.base_ctx.permissions().iter().cloned(),
+            collection_ids,
+        )
+        .expect("scoped context")
+    }
+
+    async fn drop(self) {
+        self.db.drop().await;
+    }
+}
+
+struct SeededDocument {
+    collection_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    chunk_id: Uuid,
+    markdown_sha256: String,
+    original_sha256: String,
+    markdown: Vec<u8>,
+    original: Vec<u8>,
+}
+
+async fn seed_indexed_document(env: &LiveEnv, title: &str) -> SeededDocument {
+    let collection_id = Uuid::new_v4();
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let chunk_id = Uuid::new_v4();
+    let artifact_id = Uuid::new_v4();
+    let index_metadata_id = Uuid::new_v4();
+    let markdown =
+        format!("# R02\n\nNội dung đáng tin R02-HOATDONG-2026 trong tài liệu {title}.\n")
+            .into_bytes();
+    let original = format!("%PDF-1.7 original bytes for {title}").into_bytes();
+    let markdown_sha256 = hex::encode(Sha256::digest(&markdown));
+    let original_sha256 = hex::encode(Sha256::digest(&original));
+    let markdown_len = markdown.len() as i64;
+    let trusted =
+        trusted_key(env.base_ctx.org_id(), version_id, Uuid::new_v4(), None).expect("trusted key");
+    let quarantine = quarantine_key(
+        env.base_ctx.org_id(),
+        Uuid::new_v4(),
+        Some("../Báo cáo\nR02.pdf"),
+    )
+    .expect("quarantine key");
+    env.storage
+        .put_object(
+            env.base_ctx.org_id(),
+            &trusted,
+            Bytes::copy_from_slice(&markdown),
+            &ObjectIdentityMeta {
+                org_id: env.base_ctx.org_id(),
+                collection_id: Some(collection_id),
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                original_filename: Some("preview.md".into()),
+                canonical_format: Some("md".into()),
+                content_sha256: Some(markdown_sha256.clone()),
+                content_length: Some(markdown.len() as u64),
+                disposition: Some("trusted".into()),
+            },
+            "text/markdown; charset=utf-8",
+        )
+        .await
+        .expect("put markdown");
+    env.storage
+        .put_object(
+            env.base_ctx.org_id(),
+            &quarantine,
+            Bytes::copy_from_slice(&original),
+            &ObjectIdentityMeta {
+                org_id: env.base_ctx.org_id(),
+                collection_id: Some(collection_id),
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                // Stored object metadata is always sanitized at upload (control
+                // chars/newlines are invalid S3 header values). The adversarial
+                // name lives in PG source_filename below, which the download
+                // service must sanitize for the Content-Disposition header.
+                original_filename: Some("R02.pdf".into()),
+                canonical_format: Some("pdf".into()),
+                content_sha256: Some(original_sha256.clone()),
+                content_length: Some(original.len() as u64),
+                disposition: Some("accepted".into()),
+            },
+            "application/pdf",
+        )
+        .await
+        .expect("put original");
+
+    let trusted_key = trusted.as_str();
+    let quarantine_key = quarantine.as_str();
+    let title = title.to_string();
+    let body = String::from_utf8(markdown.clone()).expect("markdown utf8");
+    let index_signature = "a".repeat(64);
+    with_org_txn(&env.pool, &env.base_ctx, {
+        let ctx = env.base_ctx.clone();
+        let markdown_sha256 = markdown_sha256.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_user(txn, &ctx, ctx.user_id(), "admin@poc.example", "POC Admin")
+                    .await?;
+                let collection_name = format!("R02 {collection_id}");
+                let collection_slug = format!("r02-{collection_id}");
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: collection_id,
+                        name: &collection_name,
+                        slug: &collection_slug,
+                        description: None,
+                        visibility: CollectionVisibility::Private,
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO documents (
+                        id, org_id, collection_id, title, state, created_by_user_id
+                     )
+                     VALUES ($1, $2, $3, $4, 'indexed', $5)",
+                    &[
+                        &document_id,
+                        &ctx.org_id(),
+                        &collection_id,
+                        &title,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key, markdown_object_key,
+                        source_filename, source_content_type, byte_size, created_by_user_id
+                     )
+                     VALUES ($1, $2, $3, 1, 'published', true, $4, $5, $6,
+                             $7, 'application/pdf', $8, $9)",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &markdown_sha256,
+                        &quarantine_key,
+                        &trusted_key,
+                        &Some("../Báo cáo\nR02.pdf"),
+                        &markdown_len,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                let artifact_kind = ArtifactKind::Markdown.as_str();
+                txn.execute(
+                    "UPDATE documents
+                     SET current_version_id = $3, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id, &version_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO derived_artifacts (
+                        id, org_id, document_id, version_id, artifact_kind,
+                        object_key, content_sha256, content_type, byte_size
+                     )
+                     VALUES ($1, $2, $3, $4, $5, $6, $7,
+                             'text/markdown; charset=utf-8', $8)",
+                    &[
+                        &artifact_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &version_id,
+                        &artifact_kind,
+                        &trusted_key,
+                        &markdown_sha256,
+                        &markdown_len,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO index_metadata (
+                        id, org_id, collection_id, index_signature_sha256,
+                        embedding_family, embedding_revision, dimensions,
+                        normalized, runtime_path
+                     )
+                     VALUES ($1, $2, $3, $4, 'local-hash', 'r02-test', 16,
+                             true, 'local-hash')",
+                    &[
+                        &index_metadata_id,
+                        &ctx.org_id(),
+                        &collection_id,
+                        &index_signature,
+                    ],
+                )
+                .await?;
+                let chunk_identity = hex::encode(Sha256::digest(format!("{version_id}:{body}")));
+                let heading_path = vec!["R02".to_string()];
+                txn.execute(
+                    "INSERT INTO chunks (
+                        id, org_id, document_id, version_id, ordinal,
+                        heading_path, body, body_text_version, chunk_identity_sha256,
+                        index_metadata_id, index_signature, page, span_start, span_end
+                     )
+                     VALUES ($1, $2, $3, $4, 0, $5, $6, 'nfc-v1', $7,
+                             $8, $9, 1, 0, $10)",
+                    &[
+                        &chunk_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &version_id,
+                        &heading_path,
+                        &body,
+                        &chunk_identity,
+                        &index_metadata_id,
+                        &index_signature,
+                        &(body.len() as i32),
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed indexed document");
+
+    SeededDocument {
+        collection_id,
+        document_id,
+        version_id,
+        chunk_id,
+        markdown_sha256,
+        original_sha256,
+        markdown,
+        original,
+    }
+}
+
+fn pin_for(doc: &SeededDocument) -> CitationPin {
+    CitationPin {
+        document_id: doc.document_id,
+        version_id: doc.version_id,
+        version_number: 1,
+        content_sha256: doc.markdown_sha256.clone(),
+        chunk_id: doc.chunk_id,
+        span_start: Some(0),
+        span_end: None,
+        quote: Some("R02-HOATDONG-2026".into()),
+    }
+}
+
+#[tokio::test]
+async fn live_citation_preview_download_authorization() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let doc = seed_indexed_document(&env, "authorized").await;
+    let ctx = env.ctx_for([doc.collection_id]);
+    let resolved = resolve_citation(&env.pool, &ctx, pin_for(&doc))
+        .await
+        .expect("resolve citation");
+    assert_eq!(resolved.document_id, doc.document_id);
+    assert_eq!(resolved.version_id, doc.version_id);
+    assert_eq!(resolved.content_sha256, doc.markdown_sha256);
+    assert_eq!(resolved.chunk_id, doc.chunk_id);
+    assert!(resolved.snippet.contains("R02-HOATDONG-2026"));
+
+    let mut wrong_hash = pin_for(&doc);
+    wrong_hash.content_sha256 = "b".repeat(64);
+    assert!(matches!(
+        resolve_citation(&env.pool, &ctx, wrong_hash).await,
+        Err(CitationError::NotFound)
+    ));
+    let mut wrong_version = pin_for(&doc);
+    wrong_version.version_number = 2;
+    assert!(matches!(
+        resolve_citation(&env.pool, &ctx, wrong_version).await,
+        Err(CitationError::NotFound)
+    ));
+    let mut wrong_chunk = pin_for(&doc);
+    wrong_chunk.chunk_id = Uuid::new_v4();
+    assert!(matches!(
+        resolve_citation(&env.pool, &ctx, wrong_chunk).await,
+        Err(CitationError::NotFound)
+    ));
+    let mut wrong_quote = pin_for(&doc);
+    wrong_quote.quote = Some("not in the immutable chunk".into());
+    assert!(matches!(
+        resolve_citation(&env.pool, &ctx, wrong_quote).await,
+        Err(CitationError::NotFound)
+    ));
+
+    let preview = fetch_markdown_preview(
+        &env.pool,
+        &env.storage,
+        &ctx,
+        doc.document_id,
+        doc.version_id,
+    )
+    .await
+    .expect("preview");
+    assert_eq!(preview.bytes.as_ref(), doc.markdown.as_slice());
+    assert_ne!(preview.bytes.as_ref(), doc.original.as_slice());
+    assert_eq!(preview.content_sha256, doc.markdown_sha256);
+
+    let capability = authorize_download(
+        &env.pool,
+        &env.storage,
+        &ctx,
+        doc.document_id,
+        doc.version_id,
+        &env.capability_key,
+        Utc::now(),
+    )
+    .await
+    .expect("download capability");
+    assert_eq!(capability.content_sha256, doc.original_sha256);
+    assert_eq!(capability.byte_size, doc.original.len() as u64);
+    assert!(!capability.token.contains('/'));
+    assert!(capability
+        .download_path
+        .starts_with("/api/v1/documents/download/"));
+    assert!(!capability.filename.contains('/'));
+    assert!(!capability.filename.contains('\n'));
+    let consumed = ConsumedDownloadNonces::new();
+    let stream = redeem_download(
+        &env.pool,
+        &env.storage,
+        &env.capability_key,
+        &consumed,
+        &capability.token,
+        Utc::now(),
+    )
+    .await
+    .expect("redeem");
+    assert_eq!(stream.bytes.as_ref(), doc.original.as_slice());
+    assert_eq!(stream.content_sha256, doc.original_sha256);
+    assert!(matches!(
+        redeem_download(
+            &env.pool,
+            &env.storage,
+            &env.capability_key,
+            &consumed,
+            &capability.token,
+            Utc::now(),
+        )
+        .await,
+        Err(DownloadError::Replay)
+    ));
+
+    let expired = authorize_download(
+        &env.pool,
+        &env.storage,
+        &ctx,
+        doc.document_id,
+        doc.version_id,
+        &env.capability_key,
+        Utc::now() - ChronoDuration::seconds(120),
+    )
+    .await
+    .expect("expired capability");
+    assert!(matches!(
+        redeem_download(
+            &env.pool,
+            &env.storage,
+            &env.capability_key,
+            &ConsumedDownloadNonces::new(),
+            &expired.token,
+            Utc::now(),
+        )
+        .await,
+        Err(DownloadError::Expired)
+    ));
+    // Flip the last base64 char (part of the HMAC tag) to a guaranteed-different
+    // value so the tag verification fails deterministically. (The first char is
+    // always 'A' because the token's version byte is 1, so tampering byte 0 is a
+    // no-op.)
+    let mut tampered = capability.token.clone();
+    let last = tampered.pop().expect("non-empty token");
+    tampered.push(if last == 'A' { 'B' } else { 'A' });
+    assert!(matches!(
+        redeem_download(
+            &env.pool,
+            &env.storage,
+            &env.capability_key,
+            &ConsumedDownloadNonces::new(),
+            &tampered,
+            Utc::now(),
+        )
+        .await,
+        Err(DownloadError::InvalidToken)
+    ));
+
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_cross_collection_and_tombstone_are_non_disclosing() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let doc = seed_indexed_document(&env, "denied").await;
+    let denied_ctx = env.ctx_for([Uuid::new_v4()]);
+    assert!(matches!(
+        resolve_citation(&env.pool, &denied_ctx, pin_for(&doc)).await,
+        Err(CitationError::NotFound)
+    ));
+    assert!(matches!(
+        fetch_markdown_preview(
+            &env.pool,
+            &env.storage,
+            &denied_ctx,
+            doc.document_id,
+            doc.version_id,
+        )
+        .await,
+        Err(PreviewError::NotFound)
+    ));
+    assert!(matches!(
+        authorize_download(
+            &env.pool,
+            &env.storage,
+            &denied_ctx,
+            doc.document_id,
+            doc.version_id,
+            &env.capability_key,
+            Utc::now(),
+        )
+        .await,
+        Err(DownloadError::NotFound)
+    ));
+
+    let ctx = env.ctx_for([doc.collection_id]);
+    deletion::request_delete(&env.pool, &ctx, doc.document_id)
+        .await
+        .expect("tombstone");
+    assert!(matches!(
+        resolve_citation(&env.pool, &ctx, pin_for(&doc)).await,
+        Err(CitationError::NotFound)
+    ));
+    assert!(matches!(
+        fetch_markdown_preview(
+            &env.pool,
+            &env.storage,
+            &ctx,
+            doc.document_id,
+            doc.version_id,
+        )
+        .await,
+        Err(PreviewError::NotFound)
+    ));
+    assert!(matches!(
+        authorize_download(
+            &env.pool,
+            &env.storage,
+            &ctx,
+            doc.document_id,
+            doc.version_id,
+            &env.capability_key,
+            Utc::now(),
+        )
+        .await,
+        Err(DownloadError::NotFound)
+    ));
+    env.drop().await;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Implements **P1B-R02 (#92)** — version-aware **citation resolution**, trusted **markdown preview**, and a short-lived **single-purpose original-download capability**, each with fresh per-request authorization (never trusting the citation blob, path params, or token alone). Stacked on `cursor/p1b-r01-hybrid-retrieval-f084` (#231).

## Scope

- `services/citation.rs` — resolve a citation pin (document/version/version_number/`content_sha256`/chunk + quote/anchor) under `with_org_txn`, re-checking org + `allowed_collection_ids` + `state='indexed'` + `deleted_at IS NULL`; non-disclosing `NotFound` on any mismatch (IDOR-safe); quote verified (NFC substring) via a new `fileconv-core` NFC helper.
- `services/preview.rs` — serve the **trusted markdown artifact only** (Trusted namespace + version-authorized key + sha256 verify), `X-Content-Type-Options: nosniff`.
- `services/download.rs` — mint an **HMAC** (domain-separated, derived from the auth signing key), **short-TTL, single-purpose** capability over the **quarantine original**; redeem re-resolves a live `OrgContext`, re-authorizes (+`qa.query`), enforces expiry + **one-time nonce (replay denied)**, and server-proxies bytes with `Content-Disposition: attachment` + sanitized RFC5987 filename + `nosniff`. **Never** returns object key/bucket/URL/credentials.
- `routes/documents.rs` — `POST …/citations:resolve`, `GET …/preview`, `POST …/download` (Bearer + `qa.query`), and `GET …/documents/download/{token}` (capability + re-auth gated). Wired in `http.rs` with the capability key (**fail-closed 503** if the signing key is absent) + the consumed-nonce cache.

## Evidence

- [x] Tests: unit `cargo test -p fileconv-server --lib` (incl. filename-sanitization + HMAC token valid/expired/tampered) + `cargo test -p fileconv-core` green. Live integration (`tests/citation_preview_download.rs`, self-skipping) vs real **PostgreSQL/Qdrant/MinIO** — 2 pass: authorized resolve + pin-mismatch denials + preview bytes + download mint/redeem + expired/replayed/tampered-token denial; and cross-collection/tombstone non-disclosing denial. `retrieval` (8) still green. Full server suite green.
- [x] Manual/benchmark/migration evidence: **no migration** (in-memory one-time nonce for the single-instance POC). CI-parity preflight green: `make check-rust`, `cargo fmt --all -- --check`, `cargo metadata --locked` (no new deps).

## Boundary and security review

- [x] Dependency boundary check passed (no new deps; small shared `fileconv-core` NFC helper).
- [x] Tenant/ACL impact reviewed: fresh re-auth (org + collection ACL + indexed/non-deleted + version pin) on **every** resolve/preview/download-authorize/redeem; token never trusted alone.
- [x] Sensitive logging/secret/egress impact reviewed: no object key/bucket/URL/credential in responses or logs; safe static errors; attachment + sanitized filename + nosniff.
- [x] Security review trigger checked: **strict security review → PASS** (no IDOR/cross-tenant/deleted-content leakage; capability HMAC constant-time + domain-separated + short-TTL + one-time; fail-closed on missing key).

## Follow-up (tracked, non-blocking)

- Process-local one-time nonce → durable store (PG/Redis) for HA replay-safety.
- Server-proxied download buffers the full object → switch to bounded streaming (bounded by the 200 MiB upload cap today).
- Exact `Option` span pinning once chunk anchor extraction populates spans (`TODO(R-followup)` in `citation.rs`).
- R04 (document CRUD), R05 (search/ask HTTP+SSE) and R06 (OpenAPI) formalize the wire contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

