### PR TITLE
feat(server): P1B-R03 grounded Q&A with streaming and extractive fallback

### DIFF
--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -12,6 +12,7 @@ pub mod index_signature;
 pub mod indexing;
 pub mod preview;
 pub mod promotion;
+pub mod qa;
 pub mod quota;
 pub mod reconciliation;
 pub mod retrieval;

--- a/crates/server/src/services/qa/grounding.rs
+++ b/crates/server/src/services/qa/grounding.rs
@@ -1,0 +1,54 @@
+//! Citation subset validation for grounded Q&A answers.
+
+use std::collections::BTreeSet;
+
+use fileconv_knowledge::ask::valid_citation_ids;
+use fileconv_knowledge::citation::validate_grounded_answer;
+
+pub fn validate(answer: &str, hit_count: usize) -> Result<(), Vec<String>> {
+    validate_grounded_answer(answer, &valid_citation_ids(hit_count))
+}
+
+pub fn cited_hit_indices(answer: &str, hit_count: usize) -> Vec<usize> {
+    cited_ids(answer)
+        .into_iter()
+        .filter_map(|id| citation_index(&id))
+        .filter(|index| *index < hit_count)
+        .collect()
+}
+
+pub fn cited_ids(answer: &str) -> Vec<String> {
+    answer
+        .split(|character: char| {
+            character.is_whitespace() || matches!(character, '[' | ']' | '(' | ')' | ',' | '.')
+        })
+        .filter(|part| part.starts_with("CITE-"))
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn citation_index(id: &str) -> Option<usize> {
+    let value = id.strip_prefix("CITE-")?.parse::<usize>().ok()?;
+    value.checked_sub(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cited_hit_indices, validate};
+
+    #[test]
+    fn validates_citations_as_subset_of_retrieved_ids() {
+        assert!(validate("Có căn cứ rõ ràng. [CITE-0001]", 1).is_ok());
+        assert!(validate("Có citation ngoài tập retrieval. [CITE-9999]", 1).is_err());
+        assert!(validate("Không có citation nào trong câu trả lời đủ dài này.", 1).is_err());
+    }
+
+    #[test]
+    fn maps_cited_ids_back_to_ordered_hit_indices() {
+        let indices = cited_hit_indices("A [CITE-0002], B [CITE-0001].", 3);
+        assert_eq!(indices, vec![0, 1]);
+        assert!(cited_hit_indices("A [CITE-9999]", 3).is_empty());
+    }
+}

--- a/crates/server/src/services/qa/mod.rs
+++ b/crates/server/src/services/qa/mod.rs
@@ -1,0 +1,8 @@
+//! Grounded Q&A engine over tenant-authorized retrieval hits.
+
+pub mod grounding;
+pub mod prompt;
+pub mod provider;
+pub mod stream;
+
+pub use stream::{answer_question, QaAnswerMode, QaCitation, QaError, QaEvent, QaRequest};

--- a/crates/server/src/services/qa/prompt.rs
+++ b/crates/server/src/services/qa/prompt.rs
@@ -1,0 +1,153 @@
+//! Prompt construction from already-authorized retrieval hits.
+
+use fileconv_knowledge::ask::{grounded_user_prompt, retrieval_context, GROUNDED_SYSTEM_PROMPT};
+use fileconv_knowledge::types::{HybridSearchHit, SourceAnchor};
+
+use crate::services::retrieval::GroundedHit;
+
+pub const MAX_PROMPT_CITATIONS: usize = 40;
+pub const MAX_PROMPT_SNIPPET_CHARS: usize = 600;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GroundedPrompt {
+    pub system: String,
+    pub user: String,
+    pub citations: Vec<PromptCitation>,
+    pub context_hits: Vec<HybridSearchHit>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PromptCitation {
+    pub id: String,
+    pub hit: GroundedHit,
+}
+
+pub fn build_grounded_prompt(question: &str, hits: &[GroundedHit]) -> GroundedPrompt {
+    let citations = hits
+        .iter()
+        .take(MAX_PROMPT_CITATIONS)
+        .enumerate()
+        .map(|(index, hit)| PromptCitation {
+            id: format!("CITE-{:04}", index + 1),
+            hit: capped_hit(hit),
+        })
+        .collect::<Vec<_>>();
+    let context_hits = citations
+        .iter()
+        .map(|citation| hybrid_hit_from_grounded(&citation.hit))
+        .collect::<Vec<_>>();
+    let context = retrieval_context(&context_hits);
+    GroundedPrompt {
+        system: GROUNDED_SYSTEM_PROMPT.to_string(),
+        user: grounded_user_prompt(question, &context),
+        citations,
+        context_hits,
+    }
+}
+
+pub fn hybrid_hit_from_grounded(hit: &GroundedHit) -> HybridSearchHit {
+    HybridSearchHit {
+        chunk_id: hit.chunk_id.to_string(),
+        source_rel: format!("document:{}", hit.document_id),
+        md_rel: format!("version:{}", hit.version_id),
+        heading: heading_for_prompt(hit),
+        snippet: cap_chars(&hit.snippet, MAX_PROMPT_SNIPPET_CHARS),
+        lexical_score: hit.lexical_score,
+        vector_score: hit.vector_score,
+        rerank_score: hit.rerank_score,
+        anchor: SourceAnchor {
+            page: non_negative_u32(hit.page),
+            slide: non_negative_u32(hit.slide),
+            sheet: hit.sheet.clone(),
+            start: non_negative_usize(hit.span_start).unwrap_or(0),
+            end: non_negative_usize(hit.span_end).unwrap_or(hit.snippet.len()),
+        },
+    }
+}
+
+fn capped_hit(hit: &GroundedHit) -> GroundedHit {
+    let mut hit = hit.clone();
+    hit.snippet = cap_chars(&hit.snippet, MAX_PROMPT_SNIPPET_CHARS);
+    hit
+}
+
+fn heading_for_prompt(hit: &GroundedHit) -> String {
+    if hit.heading_path.is_empty() {
+        format!("chunk:{}", hit.chunk_id)
+    } else {
+        hit.heading_path.join(" > ")
+    }
+}
+
+fn cap_chars(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+fn non_negative_u32(value: Option<i32>) -> Option<u32> {
+    value.and_then(|value| u32::try_from(value).ok())
+}
+
+fn non_negative_usize(value: Option<i32>) -> Option<usize> {
+    value.and_then(|value| usize::try_from(value).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    use super::{build_grounded_prompt, MAX_PROMPT_CITATIONS, MAX_PROMPT_SNIPPET_CHARS};
+    use crate::services::retrieval::GroundedHit;
+
+    fn hit(index: usize, snippet: String) -> GroundedHit {
+        GroundedHit {
+            chunk_id: Uuid::new_v4(),
+            chunk_identity: format!("{index:064}"),
+            document_id: Uuid::new_v4(),
+            version_id: Uuid::new_v4(),
+            collection_id: Uuid::new_v4(),
+            version_number: 1,
+            content_sha256: "a".repeat(64),
+            heading_path: vec![format!("Heading {index}")],
+            snippet,
+            page: Some(1),
+            slide: None,
+            sheet: None,
+            span_start: Some(0),
+            span_end: Some(10),
+            lexical_score: 1.0,
+            vector_score: 0.5,
+            rerank_score: 1.5,
+            is_current: true,
+            effective_from: Utc::now(),
+            effective_to: None,
+        }
+    }
+
+    #[test]
+    fn prompt_caps_citation_count_and_snippet_length() {
+        let long = "x".repeat(MAX_PROMPT_SNIPPET_CHARS + 20);
+        let hits = (0..(MAX_PROMPT_CITATIONS + 5))
+            .map(|index| hit(index, long.clone()))
+            .collect::<Vec<_>>();
+        let prompt = build_grounded_prompt("Nội dung?", &hits);
+        assert_eq!(prompt.citations.len(), MAX_PROMPT_CITATIONS);
+        assert_eq!(prompt.context_hits.len(), MAX_PROMPT_CITATIONS);
+        assert!(prompt
+            .context_hits
+            .iter()
+            .all(|hit| hit.snippet.chars().count() == MAX_PROMPT_SNIPPET_CHARS));
+    }
+
+    #[test]
+    fn prompt_citation_ids_align_with_hit_order() {
+        let hits = vec![hit(1, "Một".into()), hit(2, "Hai".into())];
+        let prompt = build_grounded_prompt("Nội dung?", &hits);
+        assert_eq!(prompt.citations[0].id, "CITE-0001");
+        assert_eq!(prompt.citations[0].hit.chunk_id, hits[0].chunk_id);
+        assert_eq!(prompt.citations[1].id, "CITE-0002");
+        assert_eq!(prompt.citations[1].hit.chunk_id, hits[1].chunk_id);
+        assert!(prompt.user.contains("id=\"CITE-0001\""));
+        assert!(prompt.user.contains("id=\"CITE-0002\""));
+    }
+}

--- a/crates/server/src/services/qa/provider.rs
+++ b/crates/server/src/services/qa/provider.rs
@@ -1,0 +1,346 @@
+//! Server-owned OpenAI-compatible streaming chat client for grounded Q&A.
+
+use std::collections::VecDeque;
+use std::fmt;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures::stream::{BoxStream, StreamExt};
+use serde_json::Value;
+use thiserror::Error;
+use tokio::time::{timeout_at, Instant};
+
+use crate::config::SecretString;
+
+const DEFAULT_MODEL: &str = "gpt-4o";
+const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const TOTAL_TIMEOUT: Duration = Duration::from_secs(120);
+pub const MAX_SSE_LINE_BYTES: usize = 64 * 1024;
+pub const MAX_DECODED_ANSWER_BYTES: usize = 256 * 1024;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct LlmChatConfig {
+    provider: LlmProvider,
+    model: String,
+    base_url: String,
+    api_key: SecretString,
+}
+
+impl fmt::Debug for LlmChatConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LlmChatConfig")
+            .field("provider", &self.provider)
+            .field("model", &self.model)
+            .field("base_url", &self.base_url)
+            .field("api_key", &self.api_key)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LlmProvider {
+    OpenAi,
+    OpenAiCompatible,
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum LlmError {
+    #[error("LLM provider request timed out")]
+    Timeout,
+    #[error("LLM provider transport error")]
+    Transport,
+    #[error("LLM provider returned HTTP {0}")]
+    HttpStatus(u16),
+    #[error("LLM provider returned an invalid streaming response")]
+    InvalidResponse,
+    #[error("LLM provider streaming response exceeded size limits")]
+    ResponseTooLarge,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ParsedSseLine {
+    Delta(String),
+    Done,
+    Ignore,
+}
+
+impl LlmChatConfig {
+    pub fn from_env() -> Option<Self> {
+        let provider_name =
+            std::env::var("FILECONV_LLM_PROVIDER").unwrap_or_else(|_| "openai".into());
+        let provider = match provider_name.trim().to_ascii_lowercase().as_str() {
+            "openai" => LlmProvider::OpenAi,
+            "openai-compatible" => LlmProvider::OpenAiCompatible,
+            _ => return None,
+        };
+        let api_key = std::env::var("FILECONV_LLM_API_KEY").ok()?;
+        let api_key = api_key.trim();
+        if api_key.is_empty() {
+            return None;
+        }
+        let model = env_or_default("FILECONV_LLM_MODEL", DEFAULT_MODEL);
+        let base_url = env_or_default("FILECONV_LLM_BASE_URL", DEFAULT_BASE_URL);
+        Some(Self {
+            provider,
+            model,
+            base_url,
+            api_key: SecretString::new(api_key),
+        })
+    }
+}
+
+fn env_or_default(name: &str, default: &str) -> String {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| default.to_string())
+}
+
+pub async fn stream_chat(
+    cfg: &LlmChatConfig,
+    system: &str,
+    user: &str,
+) -> Result<BoxStream<'static, Result<String, LlmError>>, LlmError> {
+    let deadline = Instant::now() + TOTAL_TIMEOUT;
+    let client = reqwest::Client::builder()
+        .use_rustls_tls()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .build()
+        .map_err(|_| LlmError::Transport)?;
+    let endpoint = chat_completions_endpoint(&cfg.base_url);
+    let request = client
+        .post(endpoint)
+        .bearer_auth(cfg.api_key.expose())
+        .json(&serde_json::json!({
+            "model": cfg.model,
+            "stream": true,
+            "temperature": 0,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user}
+            ]
+        }));
+    let response = timeout_at(deadline, request.send())
+        .await
+        .map_err(|_| LlmError::Timeout)?
+        .map_err(|_| LlmError::Transport)?;
+    if !response.status().is_success() {
+        return Err(LlmError::HttpStatus(response.status().as_u16()));
+    }
+    Ok(sse_delta_stream(response.bytes_stream().boxed(), deadline).boxed())
+}
+
+fn chat_completions_endpoint(base_url: &str) -> String {
+    format!("{}/chat/completions", base_url.trim().trim_end_matches('/'))
+}
+
+fn sse_delta_stream(
+    inner: BoxStream<'static, Result<Bytes, reqwest::Error>>,
+    deadline: Instant,
+) -> impl futures::Stream<Item = Result<String, LlmError>> {
+    futures::stream::unfold(
+        SseState {
+            inner,
+            deadline,
+            buffer: Vec::new(),
+            pending: VecDeque::new(),
+            decoded_answer_bytes: 0,
+            finished: false,
+        },
+        |mut state| async move {
+            loop {
+                if let Some(item) = state.pending.pop_front() {
+                    return Some((item, state));
+                }
+                if state.finished {
+                    return None;
+                }
+                match timeout_at(state.deadline, state.inner.next()).await {
+                    Ok(Some(Ok(bytes))) => {
+                        state.push_bytes(&bytes);
+                    }
+                    Ok(Some(Err(_))) => {
+                        state.finished = true;
+                        return Some((Err(LlmError::Transport), state));
+                    }
+                    Ok(None) => {
+                        state.finish_buffer();
+                    }
+                    Err(_) => {
+                        state.finished = true;
+                        return Some((Err(LlmError::Timeout), state));
+                    }
+                }
+            }
+        },
+    )
+}
+
+struct SseState {
+    inner: BoxStream<'static, Result<Bytes, reqwest::Error>>,
+    deadline: Instant,
+    buffer: Vec<u8>,
+    pending: VecDeque<Result<String, LlmError>>,
+    decoded_answer_bytes: usize,
+    finished: bool,
+}
+
+impl SseState {
+    fn push_bytes(&mut self, bytes: &[u8]) {
+        self.buffer.extend_from_slice(bytes);
+        if self.buffer.len() > MAX_SSE_LINE_BYTES && !self.buffer.contains(&b'\n') {
+            self.pending.push_back(Err(LlmError::ResponseTooLarge));
+            self.finished = true;
+            self.buffer.clear();
+            return;
+        }
+        self.drain_complete_lines();
+    }
+
+    fn finish_buffer(&mut self) {
+        if !self.buffer.is_empty() {
+            let line = std::mem::take(&mut self.buffer);
+            self.process_line(line);
+        }
+        self.finished = true;
+    }
+
+    fn drain_complete_lines(&mut self) {
+        while let Some(newline) = self.buffer.iter().position(|byte| *byte == b'\n') {
+            let line = self.buffer.drain(..=newline).collect::<Vec<_>>();
+            self.process_line(line);
+            if self.finished {
+                self.buffer.clear();
+                break;
+            }
+        }
+    }
+
+    fn process_line(&mut self, mut line: Vec<u8>) {
+        if line.len() > MAX_SSE_LINE_BYTES {
+            self.pending.push_back(Err(LlmError::ResponseTooLarge));
+            self.finished = true;
+            return;
+        }
+        if matches!(line.last(), Some(b'\n')) {
+            line.pop();
+        }
+        if matches!(line.last(), Some(b'\r')) {
+            line.pop();
+        }
+        let Ok(line) = std::str::from_utf8(&line) else {
+            self.pending.push_back(Err(LlmError::InvalidResponse));
+            self.finished = true;
+            return;
+        };
+        match parse_sse_line(line) {
+            Ok(ParsedSseLine::Delta(delta)) => {
+                match self.decoded_answer_bytes.checked_add(delta.len()) {
+                    Some(total) if total <= MAX_DECODED_ANSWER_BYTES => {
+                        self.decoded_answer_bytes = total;
+                        self.pending.push_back(Ok(delta));
+                    }
+                    _ => {
+                        self.pending.push_back(Err(LlmError::ResponseTooLarge));
+                        self.finished = true;
+                    }
+                }
+            }
+            Ok(ParsedSseLine::Done) => self.finished = true,
+            Ok(ParsedSseLine::Ignore) => {}
+            Err(error) => {
+                self.pending.push_back(Err(error));
+                self.finished = true;
+            }
+        }
+    }
+}
+
+pub(crate) fn parse_sse_line(line: &str) -> Result<ParsedSseLine, LlmError> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with(':') {
+        return Ok(ParsedSseLine::Ignore);
+    }
+    let Some(data) = line.strip_prefix("data:") else {
+        return Ok(ParsedSseLine::Ignore);
+    };
+    let data = data.trim();
+    if data == "[DONE]" {
+        return Ok(ParsedSseLine::Done);
+    }
+    if data.is_empty() {
+        return Ok(ParsedSseLine::Ignore);
+    }
+    let value: Value = serde_json::from_str(data).map_err(|_| LlmError::InvalidResponse)?;
+    let content = value
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .and_then(|choice| choice.get("delta"))
+        .and_then(|delta| delta.get("content"))
+        .and_then(Value::as_str);
+    Ok(match content {
+        Some(delta) if !delta.is_empty() => ParsedSseLine::Delta(delta.to_string()),
+        _ => ParsedSseLine::Ignore,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use futures::stream::{self, StreamExt};
+    use tokio::time::{Duration, Instant};
+
+    use super::{
+        parse_sse_line, sse_delta_stream, LlmError, ParsedSseLine, MAX_DECODED_ANSWER_BYTES,
+        MAX_SSE_LINE_BYTES,
+    };
+
+    #[test]
+    fn parses_openai_sse_content_deltas_and_done() {
+        let line = r#"data: {"choices":[{"delta":{"content":"xin chào"}}]}"#;
+        assert_eq!(
+            parse_sse_line(line).unwrap(),
+            ParsedSseLine::Delta("xin chào".into())
+        );
+        assert_eq!(parse_sse_line("data: [DONE]").unwrap(), ParsedSseLine::Done);
+        assert_eq!(
+            parse_sse_line(": keepalive").unwrap(),
+            ParsedSseLine::Ignore
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_sse_line() {
+        let line = format!("data: {}\n", "x".repeat(MAX_SSE_LINE_BYTES));
+        let inner = stream::iter([Ok(Bytes::from(line))]).boxed();
+        let mut stream = sse_delta_stream(inner, Instant::now() + Duration::from_secs(5)).boxed();
+        assert_eq!(stream.next().await, Some(Err(LlmError::ResponseTooLarge)));
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_decoded_answer() {
+        let delta = "a".repeat(32 * 1024);
+        let lines = (0..((MAX_DECODED_ANSWER_BYTES / delta.len()) + 1))
+            .map(|_| {
+                Ok(Bytes::from(format!(
+                    "data: {}\n\n",
+                    serde_json::json!({"choices":[{"delta":{"content":delta}}]})
+                )))
+            })
+            .collect::<Vec<Result<Bytes, reqwest::Error>>>();
+        let inner = stream::iter(lines).boxed();
+        let mut stream = sse_delta_stream(inner, Instant::now() + Duration::from_secs(5)).boxed();
+        let mut saw_cap = false;
+        while let Some(item) = stream.next().await {
+            if item == Err(LlmError::ResponseTooLarge) {
+                saw_cap = true;
+                break;
+            }
+        }
+        assert!(saw_cap);
+    }
+}

--- a/crates/server/src/services/qa/stream.rs
+++ b/crates/server/src/services/qa/stream.rs
@@ -1,0 +1,376 @@
+//! Grounded Q&A orchestration.
+//!
+//! LLM output follows a buffer-then-emit contract: provider deltas are accumulated
+//! privately, then grounding and live authorization/citation validation must pass
+//! before any LLM-origin `Token` is emitted. R05 can map these logical events to
+//! SSE knowing fallback streams never contain unvalidated LLM text.
+
+use deadpool_postgres::Pool;
+use fileconv_knowledge::ask::extractive_answer;
+use fileconv_knowledge::types::HybridSearchHit;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::auth::permissions::{require_permission, resolve_org_context_in_txn};
+use crate::services::citation::{resolve_citation, CitationPin};
+use crate::services::qa::grounding;
+use crate::services::qa::prompt::{build_grounded_prompt, GroundedPrompt};
+use crate::services::qa::provider::{stream_chat, LlmChatConfig};
+use crate::services::retrieval::{
+    retrieve, GroundedHit, RetrievalError, RetrievalRequest, VersionMode,
+};
+use crate::storage::qdrant::QdrantClient;
+
+pub const DEFAULT_QA_LIMIT: usize = 8;
+pub const MAX_QA_LIMIT: usize = 20;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QaRequest {
+    pub question: String,
+    pub limit: usize,
+    pub mode: VersionMode,
+}
+
+impl Default for QaRequest {
+    fn default() -> Self {
+        Self {
+            question: String::new(),
+            limit: DEFAULT_QA_LIMIT,
+            mode: VersionMode::Current,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QaEvent {
+    Token(String),
+    Citations(Vec<QaCitation>),
+    Warning(String),
+    Done { mode: QaAnswerMode },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QaAnswerMode {
+    CloudLlm,
+    FallbackExtractive,
+    OfflineExtractive,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QaCitation {
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub version_number: i32,
+    pub content_sha256: String,
+    pub chunk_id: Uuid,
+    pub heading_path: Vec<String>,
+    pub snippet: String,
+    pub page: Option<i32>,
+    pub slide: Option<i32>,
+    pub sheet: Option<String>,
+    pub is_current: bool,
+}
+
+impl QaCitation {
+    fn from_hit(hit: &GroundedHit) -> Self {
+        Self {
+            document_id: hit.document_id,
+            version_id: hit.version_id,
+            version_number: hit.version_number,
+            content_sha256: hit.content_sha256.clone(),
+            chunk_id: hit.chunk_id,
+            heading_path: hit.heading_path.clone(),
+            snippet: hit.snippet.clone(),
+            page: hit.page,
+            slide: hit.slide,
+            sheet: hit.sheet.clone(),
+            is_current: hit.is_current,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum QaError {
+    #[error("retrieval scope is empty")]
+    EmptyScope,
+    #[error("retrieval failed")]
+    Retrieval(RetrievalError),
+}
+
+impl From<RetrievalError> for QaError {
+    fn from(error: RetrievalError) -> Self {
+        match error {
+            RetrievalError::EmptyScope => Self::EmptyScope,
+            other => Self::Retrieval(other),
+        }
+    }
+}
+
+pub async fn answer_question(
+    pool: &Pool,
+    qdrant: &QdrantClient,
+    ctx: &OrgContext,
+    request: QaRequest,
+) -> Result<BoxStream<'static, QaEvent>, QaError> {
+    let limit = request.limit.clamp(1, MAX_QA_LIMIT);
+    let response = retrieve(
+        pool,
+        qdrant,
+        ctx,
+        RetrievalRequest {
+            query: request.question.clone(),
+            limit,
+            mode: request.mode,
+        },
+    )
+    .await
+    .map_err(QaError::from)?;
+    if response.hits.is_empty() {
+        let answer = extractive_answer(&request.question, &[]);
+        return Ok(futures::stream::iter([
+            QaEvent::Token(answer),
+            QaEvent::Done {
+                mode: QaAnswerMode::OfflineExtractive,
+            },
+        ])
+        .boxed());
+    }
+
+    let prompt = build_grounded_prompt(&request.question, &response.hits);
+    let pool = pool.clone();
+    let ctx = ctx.clone();
+    let question = request.question;
+    let (tx, rx) = mpsc::channel(32);
+    tokio::spawn(async move {
+        run_answer_stream(pool, ctx, question, prompt, tx).await;
+    });
+    Ok(receiver_stream(rx))
+}
+
+fn receiver_stream(rx: mpsc::Receiver<QaEvent>) -> BoxStream<'static, QaEvent> {
+    futures::stream::unfold(rx, |mut rx| async {
+        rx.recv().await.map(|event| (event, rx))
+    })
+    .boxed()
+}
+
+async fn run_answer_stream(
+    pool: Pool,
+    ctx: OrgContext,
+    question: String,
+    prompt: GroundedPrompt,
+    tx: mpsc::Sender<QaEvent>,
+) {
+    let Some(cfg) = LlmChatConfig::from_env() else {
+        emit_extractive(
+            &pool,
+            &ctx,
+            &question,
+            &prompt,
+            QaAnswerMode::OfflineExtractive,
+            &tx,
+        )
+        .await;
+        return;
+    };
+
+    let mut llm_stream = match stream_chat(&cfg, &prompt.system, &prompt.user).await {
+        Ok(stream) => stream,
+        Err(_) => {
+            send_warning(&tx, "LLM provider unavailable; using extractive fallback.").await;
+            emit_extractive(
+                &pool,
+                &ctx,
+                &question,
+                &prompt,
+                QaAnswerMode::FallbackExtractive,
+                &tx,
+            )
+            .await;
+            return;
+        }
+    };
+
+    let mut answer = String::new();
+    while let Some(delta) = llm_stream.next().await {
+        match delta {
+            Ok(delta) => answer.push_str(&delta),
+            Err(_) => {
+                send_warning(&tx, "LLM stream failed; using extractive fallback.").await;
+                emit_extractive(
+                    &pool,
+                    &ctx,
+                    &question,
+                    &prompt,
+                    QaAnswerMode::FallbackExtractive,
+                    &tx,
+                )
+                .await;
+                return;
+            }
+        }
+    }
+
+    if let Err(warnings) = grounding::validate(&answer, prompt.citations.len()) {
+        for warning in warnings {
+            send_warning(&tx, warning).await;
+        }
+        emit_extractive(
+            &pool,
+            &ctx,
+            &question,
+            &prompt,
+            QaAnswerMode::FallbackExtractive,
+            &tx,
+        )
+        .await;
+        return;
+    }
+
+    let cited_indices = grounding::cited_hit_indices(&answer, prompt.citations.len());
+    let finalized = finalize_citation_indices(&pool, &ctx, &prompt, cited_indices).await;
+    if finalized.has_unresolved() {
+        for warning in finalized.warnings {
+            send_warning(&tx, warning).await;
+        }
+        emit_extractive(
+            &pool,
+            &ctx,
+            &question,
+            &prompt,
+            QaAnswerMode::FallbackExtractive,
+            &tx,
+        )
+        .await;
+        return;
+    }
+    if tx.send(QaEvent::Token(answer)).await.is_err() {
+        return;
+    }
+    if !finalized.citations.is_empty()
+        && tx
+            .send(QaEvent::Citations(finalized.citations))
+            .await
+            .is_err()
+    {
+        return;
+    }
+    let _ = tx
+        .send(QaEvent::Done {
+            mode: QaAnswerMode::CloudLlm,
+        })
+        .await;
+}
+
+async fn emit_extractive(
+    pool: &Pool,
+    ctx: &OrgContext,
+    question: &str,
+    prompt: &GroundedPrompt,
+    requested_mode: QaAnswerMode,
+    tx: &mpsc::Sender<QaEvent>,
+) {
+    let all_indices = 0..prompt.citations.len();
+    let finalized = finalize_citation_indices(pool, ctx, prompt, all_indices).await;
+    let mode = if finalized.has_unresolved() {
+        for warning in finalized.warnings {
+            send_warning(tx, warning).await;
+        }
+        QaAnswerMode::FallbackExtractive
+    } else {
+        requested_mode
+    };
+    let answer = extractive_answer(question, &finalized.context_hits);
+    if tx.send(QaEvent::Token(answer)).await.is_err() {
+        return;
+    }
+    if !finalized.citations.is_empty()
+        && tx
+            .send(QaEvent::Citations(finalized.citations))
+            .await
+            .is_err()
+    {
+        return;
+    }
+    let _ = tx.send(QaEvent::Done { mode }).await;
+}
+
+async fn send_warning(tx: &mpsc::Sender<QaEvent>, warning: impl Into<String>) {
+    let _ = tx.send(QaEvent::Warning(warning.into())).await;
+}
+
+#[derive(Debug, Default)]
+struct FinalizedCitations {
+    citations: Vec<QaCitation>,
+    context_hits: Vec<HybridSearchHit>,
+    warnings: Vec<String>,
+}
+
+impl FinalizedCitations {
+    fn has_unresolved(&self) -> bool {
+        !self.warnings.is_empty()
+    }
+}
+
+async fn finalize_citation_indices(
+    pool: &Pool,
+    ctx: &OrgContext,
+    prompt: &GroundedPrompt,
+    indices: impl IntoIterator<Item = usize>,
+) -> FinalizedCitations {
+    let mut finalized = FinalizedCitations::default();
+    let fresh_ctx = match refresh_authorized_context(pool, ctx).await {
+        Ok(ctx) => ctx,
+        Err(warning) => {
+            finalized.warnings.push(warning);
+            return finalized;
+        }
+    };
+    for index in indices {
+        let Some(citation) = prompt.citations.get(index) else {
+            continue;
+        };
+        let pin = CitationPin {
+            document_id: citation.hit.document_id,
+            version_id: citation.hit.version_id,
+            version_number: citation.hit.version_number,
+            content_sha256: citation.hit.content_sha256.clone(),
+            chunk_id: citation.hit.chunk_id,
+            span_start: citation.hit.span_start,
+            span_end: citation.hit.span_end,
+            quote: None,
+        };
+        match resolve_citation(pool, &fresh_ctx, pin).await {
+            Ok(_) => {
+                finalized
+                    .citations
+                    .push(QaCitation::from_hit(&citation.hit));
+                if let Some(hit) = prompt.context_hits.get(index) {
+                    finalized.context_hits.push(hit.clone());
+                }
+            }
+            Err(_) => finalized.warnings.push(format!(
+                "Citation {} no longer resolves against live documents; using extractive fallback.",
+                citation.id
+            )),
+        }
+    }
+    finalized
+}
+
+async fn refresh_authorized_context(pool: &Pool, ctx: &OrgContext) -> Result<OrgContext, String> {
+    let fresh = resolve_org_context_in_txn(pool, ctx.org_id(), ctx.user_id())
+        .await
+        .map_err(|_| "Authorization changed during QA finalization; using extractive fallback.")?;
+    require_permission(&fresh, "qa.query")
+        .map_err(|_| "QA permission was revoked during finalization; using extractive fallback.")?;
+    Ok(fresh)
+}

--- a/crates/server/tests/qa.rs
+++ b/crates/server/tests/qa.rs
@@ -1,0 +1,770 @@
+//! Live tests for the grounded Q&A engine.
+//!
+//! These tests skip cleanly unless PostgreSQL and Qdrant test endpoints are
+//! provided. They are intentionally not part of the normal library test gate.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc::{self, Sender};
+use std::time::Duration;
+
+use deadpool_postgres::Pool;
+use fileconv_knowledge::embedding::{local_vector, LOCAL_VECTOR_DIMENSIONS};
+use fileconv_knowledge::identity::chunk_identity;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::config::SecretString;
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::chunks::{self, NewChunk};
+use fileconv_server::db::collections::{self, NewCollection};
+use fileconv_server::db::index_metadata::{self, EnsureGeneration};
+use fileconv_server::db::models::{CollectionVisibility, EmbeddingRuntimePath};
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::services::deletion;
+use fileconv_server::services::embedding::approved_plan;
+use fileconv_server::services::qa::grounding;
+use fileconv_server::services::qa::{answer_question, QaAnswerMode, QaError, QaEvent, QaRequest};
+use fileconv_server::services::retrieval::VersionMode;
+use fileconv_server::storage::qdrant::{ChunkPointPayload, QdrantClient, UpsertPoint, VectorScope};
+use futures::StreamExt;
+use sha2::{Digest, Sha256};
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+static LLM_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+const LLM_ENV_KEYS: &[&str] = &[
+    "FILECONV_LLM_PROVIDER",
+    "FILECONV_LLM_API_KEY",
+    "FILECONV_LLM_MODEL",
+    "FILECONV_LLM_BASE_URL",
+];
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn test_qdrant_client() -> Option<QdrantClient> {
+    let url = match std::env::var("MARKHAND_TEST_QDRANT_URL") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_QDRANT_URL unset");
+            return None;
+        }
+    };
+    let api_key = std::env::var("MARKHAND_TEST_QDRANT_API_KEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(SecretString::new);
+    Some(QdrantClient::with_api_key(url, api_key).expect("qdrant client"))
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_qa_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+struct LiveEnv {
+    db: EphemeralDb,
+    pool: Pool,
+    qdrant: QdrantClient,
+    base_ctx: OrgContext,
+}
+
+impl LiveEnv {
+    async fn boot() -> Option<Self> {
+        let base_url = test_database_url()?;
+        let qdrant = test_qdrant_client()?;
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("apply migrations");
+        let pool = create_pool(&db.url).expect("pool");
+        let base_ctx = OrgContext::try_new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            ["qa.query", "doc.delete"],
+            [],
+        )
+        .expect("org context");
+        Some(Self {
+            db,
+            pool,
+            qdrant,
+            base_ctx,
+        })
+    }
+
+    fn ctx_for(&self, collection_ids: impl IntoIterator<Item = Uuid>) -> OrgContext {
+        OrgContext::try_new(
+            self.base_ctx.org_id(),
+            self.base_ctx.user_id(),
+            self.base_ctx.permissions().iter().cloned(),
+            collection_ids,
+        )
+        .expect("scoped context")
+    }
+
+    async fn drop(self) {
+        self.db.drop().await;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SeededDocument {
+    document_id: Uuid,
+}
+
+async fn seed_indexed_document(
+    env: &LiveEnv,
+    collection_id: Uuid,
+    title: &str,
+    heading: &str,
+    body: &str,
+) -> SeededDocument {
+    let plan = approved_plan();
+    let signature = plan
+        .index_signature(LOCAL_VECTOR_DIMENSIONS)
+        .expect("index signature");
+    let signature_digest = signature.digest();
+    let runtime_path = signature.runtime_path.to_string();
+    let embedding_family = signature.embedding_family.to_string();
+    let embedding_revision = signature.embedding_revision.to_string();
+    let dimensions = signature.dimensions;
+    let normalized = signature.normalized;
+    let chunking_version = signature.chunking_version.to_string();
+    let body_text_version = signature.body_text_version.to_string();
+    let query_normalization_version = signature.query_normalization_version.to_string();
+    let collection_name = env
+        .qdrant
+        .ensure_collection_for_signature(&signature)
+        .await
+        .expect("ensure qdrant collection");
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let chunk_id = Uuid::new_v4();
+    let content_sha256 = hex::encode(Sha256::digest(body.as_bytes()));
+    let heading_path = vec![heading.to_string()];
+    let chunk_identity = chunk_identity(
+        &document_id.to_string(),
+        &version_id.to_string(),
+        0,
+        &heading_path.join(" > "),
+        body,
+        &body_text_version,
+    );
+    let metadata = with_org_txn(&env.pool, &env.base_ctx, {
+        let ctx = env.base_ctx.clone();
+        let title = title.to_string();
+        let heading_path = heading_path.clone();
+        let body = body.to_string();
+        let content_sha256 = content_sha256.clone();
+        let chunk_identity = chunk_identity.clone();
+        let signature_digest = signature_digest.clone();
+        let runtime_path = runtime_path.clone();
+        let embedding_family = embedding_family.clone();
+        let embedding_revision = embedding_revision.clone();
+        let chunking_version = chunking_version.clone();
+        let body_text_version = body_text_version.clone();
+        let query_normalization_version = query_normalization_version.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &ctx, "qa-org", "QA Org").await?;
+                orgs::ensure_user(txn, &ctx, ctx.user_id(), "qa@example.test", "QA").await?;
+                orgs::ensure_membership(txn, &ctx).await?;
+                seed_owner_permissions(txn, &ctx, &["qa.query", "doc.delete"]).await?;
+                let collection_name = format!("QA {collection_id}");
+                let collection_slug = format!("qa-{collection_id}");
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: collection_id,
+                        name: &collection_name,
+                        slug: &collection_slug,
+                        description: None,
+                        visibility: CollectionVisibility::Private,
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO documents (
+                        id, org_id, collection_id, title, state, created_by_user_id
+                     )
+                     VALUES ($1, $2, $3, $4, 'indexed', $5)",
+                    &[
+                        &document_id,
+                        &ctx.org_id(),
+                        &collection_id,
+                        &title,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                let object_key = format!("qa/{version_id}.md");
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key, markdown_object_key,
+                        source_content_type, byte_size, created_by_user_id
+                     )
+                     VALUES ($1, $2, $3, 1, 'published', true, $4, $5, $5,
+                             'text/markdown', $6, $7)",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &content_sha256,
+                        &object_key,
+                        &(body.len() as i64),
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE documents
+                     SET current_version_id = $3, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id, &version_id],
+                )
+                .await?;
+                let metadata = index_metadata::ensure_active_generation(
+                    txn,
+                    &ctx,
+                    EnsureGeneration {
+                        collection_id: Some(collection_id),
+                        signature_sha256: &signature_digest,
+                        chunking_version: &chunking_version,
+                        body_text_version: &body_text_version,
+                        query_normalization_version: &query_normalization_version,
+                        embedding_family: &embedding_family,
+                        embedding_revision: &embedding_revision,
+                        dimensions: i32::try_from(dimensions).expect("signature dimensions"),
+                        normalized,
+                        runtime_path: EmbeddingRuntimePath::parse(&runtime_path)
+                            .expect("runtime path"),
+                    },
+                )
+                .await?;
+                chunks::insert(
+                    txn,
+                    &ctx,
+                    NewChunk {
+                        id: chunk_id,
+                        document_id,
+                        version_id,
+                        ordinal: 0,
+                        heading_path: &heading_path,
+                        body: &body,
+                        body_text_version: &body_text_version,
+                        chunk_identity_sha256: &chunk_identity,
+                        index_metadata_id: metadata.id,
+                        index_signature: &signature_digest,
+                    },
+                )
+                .await?;
+                Ok(metadata)
+            })
+        }
+    })
+    .await
+    .expect("seed indexed document");
+    env.qdrant
+        .upsert_points(
+            &collection_name,
+            &VectorScope::new(env.base_ctx.org_id(), [collection_id]),
+            &[UpsertPoint {
+                chunk_identity: chunk_identity.clone(),
+                vector: local_vector(body).into_values(),
+                payload: ChunkPointPayload {
+                    org_id: env.base_ctx.org_id(),
+                    collection_id,
+                    document_id,
+                    version_id,
+                    chunk_id: chunk_identity,
+                    ordinal: 0,
+                    is_current: true,
+                    is_effective: true,
+                    index_generation: u32::try_from(metadata.generation)
+                        .expect("metadata generation"),
+                },
+            }],
+        )
+        .await
+        .expect("upsert qdrant point");
+    SeededDocument { document_id }
+}
+
+async fn seed_owner_permissions(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    codes: &[&str],
+) -> Result<(), fileconv_server::db::error::DbError> {
+    let role_id = Uuid::new_v4();
+    txn.execute(
+        "INSERT INTO roles (id, org_id, code, name, is_system)
+         VALUES ($1, $2, 'owner', 'Owner', true)
+         ON CONFLICT (org_id, code) DO NOTHING",
+        &[&role_id, &ctx.org_id()],
+    )
+    .await?;
+    let role_id: Uuid = txn
+        .query_one(
+            "SELECT id FROM roles WHERE org_id = $1 AND code = 'owner'",
+            &[&ctx.org_id()],
+        )
+        .await?
+        .get(0);
+    for code in codes {
+        txn.execute(
+            "INSERT INTO permissions (id, code, description)
+             VALUES ($1, $2, $2)
+             ON CONFLICT (code) DO NOTHING",
+            &[&Uuid::new_v4(), code],
+        )
+        .await?;
+        let permission_id: Uuid = txn
+            .query_one("SELECT id FROM permissions WHERE code = $1", &[code])
+            .await?
+            .get(0);
+        txn.execute(
+            "INSERT INTO role_permissions (org_id, role_id, permission_id)
+             VALUES ($1, $2, $3)
+             ON CONFLICT DO NOTHING",
+            &[&ctx.org_id(), &role_id, &permission_id],
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+struct LlmEnvGuard {
+    _guard: tokio::sync::MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl LlmEnvGuard {
+    async fn lock() -> Self {
+        let guard = LLM_ENV_LOCK.lock().await;
+        let saved = LLM_ENV_KEYS
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+        Self {
+            _guard: guard,
+            saved,
+        }
+    }
+
+    fn unset_all(&self) {
+        for key in LLM_ENV_KEYS {
+            std::env::remove_var(key);
+        }
+    }
+
+    fn set_openai(&self, api_key: &str, base_url: &str) {
+        std::env::set_var("FILECONV_LLM_PROVIDER", "openai");
+        std::env::set_var("FILECONV_LLM_API_KEY", api_key);
+        std::env::set_var("FILECONV_LLM_MODEL", "gpt-4o");
+        std::env::set_var("FILECONV_LLM_BASE_URL", base_url);
+    }
+}
+
+impl Drop for LlmEnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.saved {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+async fn collect_events(mut stream: futures::stream::BoxStream<'static, QaEvent>) -> Vec<QaEvent> {
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+    events
+}
+
+fn token_text(events: &[QaEvent]) -> String {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            QaEvent::Token(token) => Some(token.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn done_mode(events: &[QaEvent]) -> Option<QaAnswerMode> {
+    events.iter().rev().find_map(|event| match event {
+        QaEvent::Done { mode } => Some(*mode),
+        _ => None,
+    })
+}
+
+fn citation_count(events: &[QaEvent]) -> usize {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            QaEvent::Citations(citations) => Some(citations.len()),
+            _ => None,
+        })
+        .sum()
+}
+
+fn qa_request(question: &str) -> QaRequest {
+    QaRequest {
+        question: question.into(),
+        limit: 5,
+        mode: VersionMode::Current,
+    }
+}
+
+#[tokio::test]
+async fn live_qa_offline_extractive() {
+    let env_guard = LlmEnvGuard::lock().await;
+    env_guard.unset_all();
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let collection_id = Uuid::new_v4();
+    seed_indexed_document(
+        &env,
+        collection_id,
+        "Offline",
+        "Chính sách",
+        "Tài liệu nói mã QA-OFFLINE-2026 cần xử lý đối soát trong ngày.",
+    )
+    .await;
+    let ctx = env.ctx_for([collection_id]);
+    let stream = answer_question(&env.pool, &env.qdrant, &ctx, qa_request("QA-OFFLINE-2026"))
+        .await
+        .expect("qa answer");
+    let events = collect_events(stream).await;
+    let answer = token_text(&events);
+    assert!(answer.contains("QA-OFFLINE-2026"));
+    assert!(answer.contains("[CITE-0001]"));
+    assert_eq!(done_mode(&events), Some(QaAnswerMode::OfflineExtractive));
+    assert_eq!(citation_count(&events), 1);
+    assert!(grounding::validate(&answer, 1).is_ok());
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_qa_empty_scope_denied() {
+    let env_guard = LlmEnvGuard::lock().await;
+    env_guard.unset_all();
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let empty = env.ctx_for([]);
+    let result = answer_question(&env.pool, &env.qdrant, &empty, qa_request("anything")).await;
+    assert!(matches!(result, Err(QaError::EmptyScope)));
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_qa_cross_collection_excluded() {
+    let env_guard = LlmEnvGuard::lock().await;
+    env_guard.unset_all();
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let allowed = Uuid::new_v4();
+    let denied = Uuid::new_v4();
+    seed_indexed_document(
+        &env,
+        allowed,
+        "Allowed",
+        "A",
+        "Nội dung được phép chứa mã QA-CROSS-2026.",
+    )
+    .await;
+    let denied_doc = seed_indexed_document(
+        &env,
+        denied,
+        "Denied",
+        "B",
+        "Nội dung bị chặn chứa mã QA-CROSS-2026.",
+    )
+    .await;
+    let ctx = env.ctx_for([allowed]);
+    let stream = answer_question(&env.pool, &env.qdrant, &ctx, qa_request("QA-CROSS-2026"))
+        .await
+        .expect("qa answer");
+    let events = collect_events(stream).await;
+    let answer = token_text(&events);
+    assert!(answer.contains("được phép"));
+    assert!(!answer.contains("bị chặn"));
+    assert!(events.iter().all(|event| match event {
+        QaEvent::Citations(citations) => citations
+            .iter()
+            .all(|citation| citation.document_id != denied_doc.document_id),
+        _ => true,
+    }));
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_qa_provider_error_falls_back() {
+    let env_guard = LlmEnvGuard::lock().await;
+    env_guard.set_openai("dummy-key", "http://127.0.0.1:1/v1");
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let collection_id = Uuid::new_v4();
+    seed_indexed_document(
+        &env,
+        collection_id,
+        "Provider Error",
+        "Fallback",
+        "QA-PROVIDER-ERR-2026 là mã dùng để kiểm tra fallback.",
+    )
+    .await;
+    let ctx = env.ctx_for([collection_id]);
+    let stream = answer_question(
+        &env.pool,
+        &env.qdrant,
+        &ctx,
+        qa_request("QA-PROVIDER-ERR-2026"),
+    )
+    .await
+    .expect("qa answer");
+    let events = collect_events(stream).await;
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, QaEvent::Warning(_))));
+    assert!(token_text(&events).contains("## Trả lời trích xuất"));
+    assert_eq!(done_mode(&events), Some(QaAnswerMode::FallbackExtractive));
+    env.drop().await;
+}
+
+fn sse_delta(content: &str) -> String {
+    format!(
+        "data: {}\n\n",
+        serde_json::json!({"choices":[{"delta":{"content":content}}]})
+    )
+}
+
+fn start_sse_stub(first_delta: &str, wait_before_done: bool) -> (String, Option<Sender<()>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind sse stub");
+    let addr = listener.local_addr().expect("stub addr");
+    let (gate_tx, gate_rx) = wait_before_done.then(mpsc::channel).unzip();
+    let first = sse_delta(first_delta);
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept request");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("read timeout");
+        let mut request = Vec::new();
+        let mut buf = [0_u8; 512];
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let read = stream.read(&mut buf).expect("read request");
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buf[..read]);
+        }
+        stream
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n",
+            )
+            .expect("write headers");
+        stream
+            .write_all(first.as_bytes())
+            .expect("write first delta");
+        stream.flush().expect("flush first delta");
+        if let Some(rx) = gate_rx {
+            rx.recv_timeout(Duration::from_secs(10)).expect("wait gate");
+        }
+        stream.write_all(b"data: [DONE]\n\n").expect("write done");
+    });
+    (format!("http://{addr}/v1"), gate_tx)
+}
+
+#[tokio::test]
+async fn live_qa_grounding_failure_falls_back() {
+    let env_guard = LlmEnvGuard::lock().await;
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (base_url, _) = start_sse_stub("Câu trả lời dùng citation giả. [CITE-9999]", false);
+    env_guard.set_openai("dummy-key", &base_url);
+    let collection_id = Uuid::new_v4();
+    seed_indexed_document(
+        &env,
+        collection_id,
+        "Grounding",
+        "G",
+        "QA-GROUNDING-2026 là bằng chứng hợp lệ duy nhất.",
+    )
+    .await;
+    let ctx = env.ctx_for([collection_id]);
+    let stream = answer_question(
+        &env.pool,
+        &env.qdrant,
+        &ctx,
+        qa_request("QA-GROUNDING-2026"),
+    )
+    .await
+    .expect("qa answer");
+    let events = collect_events(stream).await;
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, QaEvent::Warning(_))));
+    assert!(token_text(&events).contains("## Trả lời trích xuất"));
+    assert_eq!(done_mode(&events), Some(QaAnswerMode::FallbackExtractive));
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_qa_delete_during_finalization() {
+    let env_guard = LlmEnvGuard::lock().await;
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let (base_url, gate) = start_sse_stub("QA-DELETE-2026 có trong tài liệu. [CITE-0001]", true);
+    env_guard.set_openai("dummy-key", &base_url);
+    let collection_id = Uuid::new_v4();
+    let doc = seed_indexed_document(
+        &env,
+        collection_id,
+        "Delete During Finalization",
+        "D",
+        "QA-DELETE-2026 là nội dung sẽ bị tombstone trước khi finalize citation.",
+    )
+    .await;
+    let ctx = env.ctx_for([collection_id]);
+    let stream = answer_question(&env.pool, &env.qdrant, &ctx, qa_request("QA-DELETE-2026"))
+        .await
+        .expect("qa answer");
+    deletion::request_delete(&env.pool, &ctx, doc.document_id)
+        .await
+        .expect("tombstone before finalization");
+    gate.expect("gate sender").send(()).expect("release stub");
+    let events = collect_events(stream).await;
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, QaEvent::Warning(_))));
+    assert_eq!(done_mode(&events), Some(QaAnswerMode::FallbackExtractive));
+    let answer = token_text(&events);
+    assert!(!answer.contains("QA-DELETE-2026 có trong tài liệu."));
+    assert!(answer.contains("Không tìm thấy bằng chứng phù hợp"));
+    assert!(events.iter().all(|event| match event {
+        QaEvent::Citations(citations) => citations
+            .iter()
+            .all(|citation| citation.document_id != doc.document_id),
+        _ => true,
+    }));
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_qa_cloud_llm_gpt4o() {
+    let env_guard = LlmEnvGuard::lock().await;
+    let api_key = match std::env::var("FILECONV_LLM_API_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipped: FILECONV_LLM_API_KEY unset");
+            return;
+        }
+    };
+    env_guard.set_openai(&api_key, "https://api.openai.com/v1");
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let collection_id = Uuid::new_v4();
+    let doc = seed_indexed_document(
+        &env,
+        collection_id,
+        "Đối soát",
+        "Đối soát",
+        "Quy trình đối soát giao dịch được thực hiện tự động mỗi ngày một lần vào lúc 02:00 sáng.",
+    )
+    .await;
+    let ctx = env.ctx_for([collection_id]);
+    let stream = answer_question(
+        &env.pool,
+        &env.qdrant,
+        &ctx,
+        qa_request("Quy trình đối soát giao dịch được thực hiện bao lâu một lần?"),
+    )
+    .await
+    .expect("qa answer");
+    let events = collect_events(stream).await;
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, QaEvent::Token(_))));
+    assert_eq!(done_mode(&events), Some(QaAnswerMode::CloudLlm));
+    assert!(events.iter().all(|event| match event {
+        QaEvent::Citations(citations) => citations
+            .iter()
+            .all(|citation| citation.document_id == doc.document_id),
+        _ => true,
+    }));
+    env.drop().await;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Implements **P1B-R03 (#93)** — the grounded Q&A **engine** (no HTTP route; R05 wires the resumable SSE API). It runs R01 retrieval for authorized top-K hits, builds a policy-separated prompt from **only** those passages, streams an answer from **OpenAI gpt-4o**, and falls back to a **deterministic extractive answer** when the LLM is unconfigured/errors/times out or the answer fails grounding. Stacked on `cursor/p1b-r02-citation-preview-download-f084` (#232).

## Scope

- `services/qa/provider.rs` — server-owned async **OpenAI-compatible streaming** client (`FILECONV_LLM_*`): `SecretString` key, **single 120s deadline** + 5s connect, **bounded SSE line (64 KiB) + answer (256 KiB)** to prevent memory exhaustion; openai/openai-compatible only (no tools/agents/web/memory).
- `services/qa/prompt.rs` — prompt built **exclusively from authorized hits** with `GROUNDED_SYSTEM_PROMPT` + untrusted-source framing; **≤40 citations, ≤600 chars each**; `CITE-000N` aligned to hit order.
- `services/qa/grounding.rs` — cited ids must be a **subset** of the retrieved set.
- `services/qa/stream.rs` — **buffer-then-emit**: LLM text is emitted **only after** grounding **and** live citation re-validation (R02 `resolve_citation` with a **freshly re-resolved `OrgContext`** + `qa.query`) pass; otherwise the stream emits only a warning + the extractive answer (no LLM-origin token). Ungrounded or post-deletion content is never presented as the answer.

## Evidence

- [x] Tests: unit `cargo test -p fileconv-server --lib` (88) green. Live integration (`tests/qa.rs`, self-skipping) vs real **PostgreSQL/Qdrant/MinIO** — deterministic paths (7): offline-extractive, empty-scope deny, cross-collection exclusion, provider-error fallback, grounding-failure fallback, delete-during-finalization (no LLM token leaks). **Real gpt-4o CloudLlm** path verified (grounded, cited answer, `Done{CloudLlm}`) — LLM-gated, self-skips without `FILECONV_LLM_API_KEY`. Full server suite green.
- [x] Manual/benchmark/migration evidence: **no migration, no new deps** (reuses `reqwest` stream + `fileconv-knowledge` ask/citation). CI-parity: `make check-rust`, `cargo fmt --all -- --check`, `cargo metadata --locked`.

## Boundary and security review

- [x] Dependency boundary check passed (no new deps/routes).
- [x] Tenant/ACL impact reviewed: prompt + citations only from R01-authorized hits; finalization re-resolves live membership/ACL + `qa.query` and re-validates citations against live PG (deleted/revoked → fallback).
- [x] Sensitive logging/secret/egress impact reviewed: LLM key `SecretString`, never logged; only top-K citations (≤40×600) sent to the provider; no query/answer/secret in logs.
- [x] Security review trigger checked: **strict security review → PASS** over 2 rounds (BLOCKER: never emit unvalidated/ungrounded/post-delete LLM tokens; HIGH: bounded provider buffering; single deadline; fresh finalization auth).

## Follow-up (tracked, non-blocking)

- Provider LLM key secret: add `FILECONV_LLM_API_KEY` (currently the OpenAI key is stored as `FILECONV_EMBEDDING_API_KEY`) so the server/CI can enable the cloud path; tests self-skip the cloud path without it.
- Incremental line-cap before buffering one transport frame; cancel provider task on dropped receiver (`tx.is_closed`).
- Conflict-claim warnings + full version compare/history answers deferred (claims/conflicts aren't populated by the current ingest path); R03 validates cited ids + version pins today.
- R05 maps these `QaEvent`s to the resumable SSE HTTP contract.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

