### PR TITLE
feat(server): P1B-R04 collection/document/job REST API

### DIFF
--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -746,6 +746,13 @@ impl ServerConfig {
         Self::test_with_endpoints_for_role(endpoints, RuntimeRole::Api)
     }
 
+    /// Test helper for authenticated HTTP integration tests.
+    pub fn test_with_endpoints_and_auth(endpoints: RuntimeEndpoints, auth: AuthConfig) -> Self {
+        let mut config = Self::test_with_endpoints_for_role(endpoints, RuntimeRole::Api);
+        config.auth = auth;
+        config
+    }
+
     /// Test helper for worker-role runtime state.
     pub fn test_worker_with_endpoints(endpoints: RuntimeEndpoints) -> Self {
         Self::test_with_endpoints_for_role(endpoints, RuntimeRole::Worker)

--- a/crates/server/src/db/collections.rs
+++ b/crates/server/src/db/collections.rs
@@ -79,6 +79,51 @@ pub async fn list(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<Vec<Collect
     rows.iter().map(map_collection).collect()
 }
 
+/// Lists non-deleted collections the resolved caller context may access.
+pub async fn list_authorized(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    allowed_ids: &[Uuid],
+    after: Option<(String, Uuid)>,
+    limit: i64,
+) -> Result<Vec<Collection>, DbError> {
+    if allowed_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows = match after {
+        Some((after_name, after_id)) => {
+            txn.query(
+                "SELECT id, org_id, name, slug, description, owner_user_id,
+                        visibility, created_at, updated_at, deleted_at
+                 FROM collections
+                 WHERE org_id = $1
+                   AND id = ANY($2)
+                   AND deleted_at IS NULL
+                   AND (name, id) > ($3, $4)
+                 ORDER BY name, id
+                 LIMIT $5",
+                &[&ctx.org_id(), &allowed_ids, &after_name, &after_id, &limit],
+            )
+            .await?
+        }
+        None => {
+            txn.query(
+                "SELECT id, org_id, name, slug, description, owner_user_id,
+                        visibility, created_at, updated_at, deleted_at
+                 FROM collections
+                 WHERE org_id = $1
+                   AND id = ANY($2)
+                   AND deleted_at IS NULL
+                 ORDER BY name, id
+                 LIMIT $3",
+                &[&ctx.org_id(), &allowed_ids, &limit],
+            )
+            .await?
+        }
+    };
+    rows.iter().map(map_collection).collect()
+}
+
 fn map_collection(row: &Row) -> Result<Collection, DbError> {
     let visibility: String = row.get("visibility");
     Ok(Collection {

--- a/crates/server/src/db/document_versions.rs
+++ b/crates/server/src/db/document_versions.rs
@@ -44,6 +44,17 @@ pub struct NewDerivedArtifact<'a> {
     pub byte_size: i64,
 }
 
+#[derive(Debug, Clone)]
+pub struct NewSourceVersion<'a> {
+    pub id: Uuid,
+    pub document_id: Uuid,
+    pub original_object_key: &'a str,
+    pub content_sha256: &'a str,
+    pub source_filename: Option<&'a str>,
+    pub source_content_type: Option<&'a str>,
+    pub byte_size: i64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArtifactInsertOutcome {
     pub id: Uuid,
@@ -98,6 +109,40 @@ pub async fn find_by_id(
         )
         .await?;
     row.map(|row| map_version(&row)).transpose()
+}
+
+pub async fn insert_source_version(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewSourceVersion<'_>,
+) -> Result<DocumentVersion, DbError> {
+    let publication_state = "draft";
+    let row = txn
+        .query_one(
+            "INSERT INTO document_versions (
+                id, org_id, document_id, version_number, publication_state, is_current,
+                content_sha256, original_object_key, source_filename, source_content_type,
+                byte_size, created_by_user_id
+             ) VALUES ($1, $2, $3, 1, $4, false, $5, $6, $7, $8, $9, $10)
+             RETURNING id, org_id, document_id, version_number, parent_version_id,
+                       publication_state, is_current, content_sha256, original_object_key,
+                       markdown_object_key, source_filename, source_content_type, byte_size,
+                       effective_from, effective_to, change_summary, created_by_user_id, created_at",
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &input.document_id,
+                &publication_state,
+                &input.content_sha256,
+                &input.original_object_key,
+                &input.source_filename,
+                &input.source_content_type,
+                &Some(input.byte_size),
+                &ctx.user_id(),
+            ],
+        )
+        .await?;
+    map_version(&row)
 }
 
 pub async fn insert_published_version_if_absent(
@@ -313,6 +358,54 @@ pub async fn list_by_document(
             &[&ctx.org_id(), &document_id],
         )
         .await?;
+    rows.iter().map(map_version).collect()
+}
+
+pub async fn list_by_document_paginated(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    after: Option<(i32, Uuid)>,
+    limit: i64,
+) -> Result<Vec<DocumentVersion>, DbError> {
+    let rows = match after {
+        Some((after_number, after_id)) => {
+            txn.query(
+                "SELECT id, org_id, document_id, version_number, parent_version_id,
+                        publication_state, is_current, content_sha256, original_object_key,
+                        markdown_object_key, source_filename, source_content_type, byte_size,
+                        effective_from, effective_to, change_summary, created_by_user_id, created_at
+                 FROM document_versions
+                 WHERE org_id = $1
+                   AND document_id = $2
+                   AND (version_number, id) > ($3, $4)
+                 ORDER BY version_number, id
+                 LIMIT $5",
+                &[
+                    &ctx.org_id(),
+                    &document_id,
+                    &after_number,
+                    &after_id,
+                    &limit,
+                ],
+            )
+            .await?
+        }
+        None => {
+            txn.query(
+                "SELECT id, org_id, document_id, version_number, parent_version_id,
+                        publication_state, is_current, content_sha256, original_object_key,
+                        markdown_object_key, source_filename, source_content_type, byte_size,
+                        effective_from, effective_to, change_summary, created_by_user_id, created_at
+                 FROM document_versions
+                 WHERE org_id = $1 AND document_id = $2
+                 ORDER BY version_number, id
+                 LIMIT $3",
+                &[&ctx.org_id(), &document_id, &limit],
+            )
+            .await?
+        }
+    };
     rows.iter().map(map_version).collect()
 }
 

--- a/crates/server/src/db/documents.rs
+++ b/crates/server/src/db/documents.rs
@@ -86,6 +86,56 @@ pub async fn get_by_id(
     map_document(&row)
 }
 
+/// Lists visible documents in a collection, ordered by stable creation key.
+pub async fn list_by_collection(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    collection_id: Uuid,
+    after: Option<(chrono::DateTime<chrono::Utc>, Uuid)>,
+    limit: i64,
+) -> Result<Vec<Document>, DbError> {
+    let rows = match after {
+        Some((after_created_at, after_id)) => {
+            txn.query(
+                "SELECT id, org_id, collection_id, title, state, current_version_id,
+                        created_by_user_id, created_at, updated_at, deleted_at
+                 FROM documents
+                 WHERE org_id = $1
+                   AND collection_id = $2
+                   AND deleted_at IS NULL
+                   AND state <> 'purged'
+                   AND (created_at, id) > ($3, $4)
+                 ORDER BY created_at, id
+                 LIMIT $5",
+                &[
+                    &ctx.org_id(),
+                    &collection_id,
+                    &after_created_at,
+                    &after_id,
+                    &limit,
+                ],
+            )
+            .await?
+        }
+        None => {
+            txn.query(
+                "SELECT id, org_id, collection_id, title, state, current_version_id,
+                        created_by_user_id, created_at, updated_at, deleted_at
+                 FROM documents
+                 WHERE org_id = $1
+                   AND collection_id = $2
+                   AND deleted_at IS NULL
+                   AND state <> 'purged'
+                 ORDER BY created_at, id
+                 LIMIT $3",
+                &[&ctx.org_id(), &collection_id, &limit],
+            )
+            .await?
+        }
+    };
+    rows.iter().map(map_document).collect()
+}
+
 /// Locks the document row for an atomic state transition (`SELECT … FOR UPDATE`).
 ///
 /// Intended for the document state machine (and tests that exercise lock contention).

--- a/crates/server/src/db/jobs.rs
+++ b/crates/server/src/db/jobs.rs
@@ -211,6 +211,24 @@ pub async fn get_by_id_for_update(
     row.map(|row| map_job(&row)).transpose()
 }
 
+pub async fn get_by_id(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+) -> Result<Option<Job>, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "SELECT {JOB_COLUMNS}
+                 FROM jobs
+                 WHERE org_id = $1 AND id = $2"
+            ),
+            &[&ctx.org_id(), &job_id],
+        )
+        .await?;
+    row.map(|row| map_job(&row)).transpose()
+}
+
 pub async fn claim_pending(
     txn: &Transaction<'_>,
     ctx: &OrgContext,

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -195,7 +195,9 @@ pub fn router(state: AppState) -> Router {
         .route("/api/v1/health/live", get(liveness))
         .route("/api/v1/health/ready", get(readiness))
         .merge(routes::auth::router())
+        .merge(routes::collections::router())
         .merge(routes::documents::router())
+        .merge(routes::jobs::router())
         .merge(routes::uploads::router(max_upload_bytes))
         .with_state(Arc::new(state))
 }

--- a/crates/server/src/routes/collections.rs
+++ b/crates/server/src/routes/collections.rs
@@ -1,0 +1,282 @@
+//! Collection REST routes.
+
+use std::sync::Arc;
+
+use axum::extract::rejection::{JsonRejection, QueryRejection};
+use axum::extract::{DefaultBodyLimit, Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api::PageInfo;
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::db::collections::{self, NewCollection};
+use crate::db::models::{Collection, CollectionVisibility};
+use crate::db::pool::with_org_txn_typed;
+use crate::http::AppState;
+use crate::routes::common::{
+    decode_cursor, encode_cursor, page_info, parse_page_limit, parse_uuid,
+    require_collection_or_404, require_permission_or_403, ListResponse, PageParams, RestError,
+    TxnRestError,
+};
+
+const JSON_BODY_LIMIT: usize = 16 * 1024;
+const COLLECTION_CURSOR: &str = "collection.name_id.v1";
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route(
+            "/api/v1/collections",
+            get(list_collections).post(create_collection),
+        )
+        .route("/api/v1/collections/{collectionId}", get(get_collection))
+        .route_layer(DefaultBodyLimit::max(JSON_BODY_LIMIT))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CollectionPath {
+    collection_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CollectionCursor {
+    name: String,
+    id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateCollectionRequest {
+    name: String,
+    slug: String,
+    description: Option<String>,
+    visibility: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CollectionResponse {
+    id: Uuid,
+    name: String,
+    slug: String,
+    description: Option<String>,
+    owner_user_id: Uuid,
+    visibility: &'static str,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<Collection> for CollectionResponse {
+    fn from(value: Collection) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            slug: value.slug,
+            description: value.description,
+            owner_user_id: value.owner_user_id,
+            visibility: value.visibility.as_str(),
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+        }
+    }
+}
+
+async fn list_collections(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    query: Result<Query<PageParams>, QueryRejection>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let Query(params) =
+        query.map_err(|_| RestError::validation("query string is invalid", &request_id))?;
+    let page_limit = parse_page_limit(&params, &request_id)?;
+    let cursor_key = state
+        .download_capability_key()
+        .ok_or_else(|| RestError::service_unavailable(&request_id))?;
+    let after: Option<CollectionCursor> = decode_cursor(
+        cursor_key,
+        COLLECTION_CURSOR,
+        params.cursor.as_deref(),
+        &request_id,
+    )?;
+    let allowed: Vec<Uuid> = auth
+        .context
+        .allowed_collection_ids()
+        .iter()
+        .copied()
+        .collect();
+
+    let result = with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        move |txn| {
+            Box::pin(async move {
+                let after = after.map(|cursor| (cursor.name, cursor.id));
+                let collections =
+                    collections::list_authorized(txn, &ctx, &allowed, after, page_limit.fetch_size)
+                        .await?;
+                Ok::<_, TxnRestError>(collections)
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+
+    let (items, page_info) = collection_page(cursor_key, result, page_limit.page_size)?;
+    Ok(Json(ListResponse { items, page_info }).into_response())
+}
+
+async fn create_collection(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    body: Result<Json<CreateCollectionRequest>, JsonRejection>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let Json(body) =
+        body.map_err(|_| RestError::validation("request body is invalid", &request_id))?;
+    let input = validate_create_collection(body, &request_id)?;
+    let collection = with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_permission_or_403(&ctx, "doc.upload", &request_id)?;
+                let collection = collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: Uuid::new_v4(),
+                        name: &input.name,
+                        slug: &input.slug,
+                        description: input.description.as_deref(),
+                        visibility: input.visibility,
+                    },
+                )
+                .await?;
+                Ok::<_, TxnRestError>(collection)
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+    Ok((
+        StatusCode::CREATED,
+        Json(CollectionResponse::from(collection)),
+    )
+        .into_response())
+}
+
+async fn get_collection(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<CollectionPath>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let collection_id = parse_uuid(&path.collection_id, &request_id)?;
+    let collection = with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_collection_or_404(&ctx, collection_id, &request_id)?;
+                let collection = collections::get_by_id(txn, &ctx, collection_id).await?;
+                Ok::<_, TxnRestError>(collection)
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+    Ok(Json(CollectionResponse::from(collection)).into_response())
+}
+
+struct ValidCreateCollection {
+    name: String,
+    slug: String,
+    description: Option<String>,
+    visibility: CollectionVisibility,
+}
+
+fn validate_create_collection(
+    body: CreateCollectionRequest,
+    request_id: &str,
+) -> Result<ValidCreateCollection, RestError> {
+    let name = body.name.trim().to_string();
+    if name.is_empty() || name.len() > 255 {
+        return Err(RestError::validation(
+            "name must be between 1 and 255 bytes",
+            request_id,
+        ));
+    }
+    let slug = body.slug.trim().to_string();
+    if !valid_slug(&slug) {
+        return Err(RestError::validation("slug is invalid", request_id));
+    }
+    let description = body
+        .description
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if description.as_ref().is_some_and(|value| value.len() > 4096) {
+        return Err(RestError::validation("description is too long", request_id));
+    }
+    let visibility = match body.visibility.as_str() {
+        "private" => CollectionVisibility::Private,
+        "org" => CollectionVisibility::Org,
+        _ => {
+            return Err(RestError::validation(
+                "visibility must be private or org",
+                request_id,
+            ));
+        }
+    };
+    Ok(ValidCreateCollection {
+        name,
+        slug,
+        description,
+        visibility,
+    })
+}
+
+fn valid_slug(value: &str) -> bool {
+    let len = value.len();
+    (2..=63).contains(&len)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        && value
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+}
+
+fn collection_page(
+    cursor_key: &crate::services::download::CapabilityKey,
+    mut rows: Vec<Collection>,
+    page_size: usize,
+) -> Result<(Vec<CollectionResponse>, PageInfo), RestError> {
+    let has_more = rows.len() > page_size;
+    if has_more {
+        rows.truncate(page_size);
+    }
+    let next_cursor = if has_more {
+        rows.last()
+            .map(|item| {
+                encode_cursor(
+                    cursor_key,
+                    COLLECTION_CURSOR,
+                    &CollectionCursor {
+                        name: item.name.clone(),
+                        id: item.id,
+                    },
+                )
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    let items = rows.into_iter().map(CollectionResponse::from).collect();
+    Ok((items, page_info(next_cursor)))
+}

--- a/crates/server/src/routes/common.rs
+++ b/crates/server/src/routes/common.rs
@@ -1,0 +1,291 @@
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api::{ApiError, PageInfo};
+use crate::auth::context::OrgContext;
+use crate::auth::permissions::{require_collection, require_permission};
+use crate::db::error::DbError;
+use crate::services::download::CapabilityKey;
+
+const DEFAULT_LIMIT: usize = 25;
+const MAX_LIMIT: usize = 100;
+const CURSOR_DOMAIN: &[u8] = b"markhand-rest-cursor-v1";
+
+#[derive(Debug)]
+pub(crate) struct RestError {
+    status: StatusCode,
+    code: &'static str,
+    message: String,
+    request_id: String,
+}
+
+impl RestError {
+    pub(crate) fn validation(message: impl Into<String>, request_id: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "validation_failed",
+            message: message.into(),
+            request_id: request_id.into(),
+        }
+    }
+
+    pub(crate) fn forbidden(request_id: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code: "permission_denied",
+            message: "Permission denied".into(),
+            request_id: request_id.into(),
+        }
+    }
+
+    pub(crate) fn not_found(request_id: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "not_found",
+            message: "Resource was not found".into(),
+            request_id: request_id.into(),
+        }
+    }
+
+    pub(crate) fn conflict(message: impl Into<String>, request_id: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "state_conflict",
+            message: message.into(),
+            request_id: request_id.into(),
+        }
+    }
+
+    pub(crate) fn internal(request_id: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "internal_error",
+            message: "Request failed".into(),
+            request_id: request_id.into(),
+        }
+    }
+
+    pub(crate) fn service_unavailable(request_id: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "dependency_unavailable",
+            message: "A required service is unavailable".into(),
+            request_id: request_id.into(),
+        }
+    }
+}
+
+impl IntoResponse for RestError {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            Json(ApiError {
+                code: self.code.into(),
+                message: self.message,
+                request_id: self.request_id,
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PageParams {
+    pub(crate) limit: Option<String>,
+    pub(crate) cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PageLimit {
+    pub(crate) page_size: usize,
+    pub(crate) fetch_size: i64,
+}
+
+pub(crate) fn parse_page_limit(
+    params: &PageParams,
+    request_id: &str,
+) -> Result<PageLimit, RestError> {
+    let page_size = match params.limit.as_deref() {
+        Some(raw) => raw
+            .parse::<usize>()
+            .map_err(|_| RestError::validation("limit must be an integer", request_id))?,
+        None => DEFAULT_LIMIT,
+    };
+    if !(1..=MAX_LIMIT).contains(&page_size) {
+        return Err(RestError::validation(
+            "limit must be between 1 and 100",
+            request_id,
+        ));
+    }
+    Ok(PageLimit {
+        page_size,
+        fetch_size: (page_size + 1) as i64,
+    })
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CursorPayload<T> {
+    kind: String,
+    value: T,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CursorEnvelope<T> {
+    payload: CursorPayload<T>,
+    tag: String,
+}
+
+pub(crate) fn encode_cursor<T: Serialize>(
+    key: &CapabilityKey,
+    kind: &str,
+    value: &T,
+) -> Result<String, RestError> {
+    let payload = CursorPayload {
+        kind: kind.to_string(),
+        value,
+    };
+    let payload_bytes = serde_json::to_vec(&payload)
+        .map_err(|_| RestError::internal(Uuid::new_v4().to_string()))?;
+    let tag = URL_SAFE_NO_PAD.encode(key.sign_domain_separated(CURSOR_DOMAIN, &payload_bytes));
+    let envelope = CursorEnvelope { payload, tag };
+    let bytes = serde_json::to_vec(&envelope)
+        .map_err(|_| RestError::internal(Uuid::new_v4().to_string()))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+pub(crate) fn decode_cursor<T: DeserializeOwned + Serialize>(
+    key: &CapabilityKey,
+    kind: &str,
+    cursor: Option<&str>,
+    request_id: &str,
+) -> Result<Option<T>, RestError> {
+    let Some(cursor) = cursor else {
+        return Ok(None);
+    };
+    if cursor.is_empty() || cursor.len() > 512 || cursor.bytes().any(|byte| byte.is_ascii_control())
+    {
+        return Err(RestError::validation("cursor is invalid", request_id));
+    }
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| RestError::validation("cursor is invalid", request_id))?;
+    let envelope: CursorEnvelope<T> = serde_json::from_slice(&bytes)
+        .map_err(|_| RestError::validation("cursor is invalid", request_id))?;
+    if envelope.payload.kind != kind {
+        return Err(RestError::validation("cursor is invalid", request_id));
+    }
+    let payload_bytes = serde_json::to_vec(&envelope.payload)
+        .map_err(|_| RestError::validation("cursor is invalid", request_id))?;
+    let tag = URL_SAFE_NO_PAD
+        .decode(envelope.tag)
+        .map_err(|_| RestError::validation("cursor is invalid", request_id))?;
+    if !key.verify_domain_separated(CURSOR_DOMAIN, &payload_bytes, &tag) {
+        return Err(RestError::validation("cursor is invalid", request_id));
+    }
+    Ok(Some(envelope.payload.value))
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ListResponse<T> {
+    pub(crate) items: Vec<T>,
+    pub(crate) page_info: PageInfo,
+}
+
+pub(crate) fn page_info(next_cursor: Option<String>) -> PageInfo {
+    PageInfo {
+        has_more: next_cursor.is_some(),
+        next_cursor,
+    }
+}
+
+pub(crate) fn parse_uuid(value: &str, request_id: &str) -> Result<Uuid, RestError> {
+    Uuid::parse_str(value)
+        .map_err(|_| RestError::validation("UUID path parameter is invalid", request_id))
+}
+
+pub(crate) fn require_permission_or_403(
+    ctx: &OrgContext,
+    permission: &str,
+    request_id: &str,
+) -> Result<(), RestError> {
+    require_permission(ctx, permission).map_err(|_| RestError::forbidden(request_id))
+}
+
+pub(crate) fn require_collection_or_404(
+    ctx: &OrgContext,
+    collection_id: Uuid,
+    request_id: &str,
+) -> Result<(), RestError> {
+    require_collection(ctx, collection_id).map_err(|_| RestError::not_found(request_id))
+}
+
+pub(crate) fn db_or_404(error: DbError, request_id: &str) -> RestError {
+    match error {
+        DbError::NotFound => RestError::not_found(request_id),
+        _ => RestError::internal(request_id),
+    }
+}
+
+pub(crate) enum TxnRestError {
+    Db(DbError),
+    Rest(RestError),
+}
+
+impl From<DbError> for TxnRestError {
+    fn from(value: DbError) -> Self {
+        Self::Db(value)
+    }
+}
+
+impl From<RestError> for TxnRestError {
+    fn from(value: RestError) -> Self {
+        Self::Rest(value)
+    }
+}
+
+impl TxnRestError {
+    pub(crate) fn into_rest(self, request_id: &str) -> RestError {
+        match self {
+            Self::Db(error) => db_or_404(error, request_id),
+            Self::Rest(error) => error,
+        }
+    }
+}
+
+pub(crate) fn validate_idempotency_header(
+    headers: &HeaderMap,
+    request_id: &str,
+) -> Result<Option<String>, RestError> {
+    let Some(value) = headers.get("idempotency-key") else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .map_err(|_| RestError::validation("Idempotency-Key must be visible ASCII", request_id))?;
+    if value.is_empty() || value.len() > 128 {
+        return Err(RestError::validation(
+            "Idempotency-Key must be between 1 and 128 bytes",
+            request_id,
+        ));
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b':'))
+    {
+        return Err(RestError::validation(
+            "Idempotency-Key contains unsupported characters",
+            request_id,
+        ));
+    }
+    Ok(Some(value.to_string()))
+}

--- a/crates/server/src/routes/documents.rs
+++ b/crates/server/src/routes/documents.rs
@@ -1,29 +1,59 @@
 //! Document citation, preview, and original-download routes.
 
-use std::sync::Arc;
-
 use axum::body::Body;
-use axum::extract::{Path, State};
+use axum::extract::rejection::{JsonRejection, QueryRejection};
+use axum::extract::{DefaultBodyLimit, Path, Query, State};
 use axum::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use chrono::Utc;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::api::ApiError;
+use crate::api::{ApiError, PageInfo};
+use crate::auth::context::OrgContext;
 use crate::auth::middleware::AuthenticatedOrg;
 use crate::auth::permissions::require_permission;
+use crate::db::document_versions::{self, NewSourceVersion};
+use crate::db::documents::{self, NewDocument};
+use crate::db::models::{Document, DocumentState, DocumentVersion, Job, JobType, PublicationState};
+use crate::db::pool::with_org_txn_typed;
 use crate::http::AppState;
+use crate::jobs::{self, EnqueueJob, JobPayload};
+use crate::routes::common::{
+    db_or_404, decode_cursor, encode_cursor, page_info, parse_page_limit, parse_uuid,
+    require_collection_or_404, require_permission_or_403, validate_idempotency_header,
+    ListResponse, PageParams, RestError, TxnRestError,
+};
 use crate::services::citation::{self, CitationPin};
+use crate::services::deletion::{self, DeleteRequestOutcome, DeletionError};
 use crate::services::download::{self, DownloadError};
 use crate::services::preview::{self, PreviewError, MARKDOWN_CONTENT_TYPE};
-use crate::storage::StorageError;
+use crate::storage::{parse_key_for_org, quarantine_key, ObjectKey, ObjectNamespace, StorageError};
+
+const JSON_BODY_LIMIT: usize = 16 * 1024;
+const DOCUMENT_CURSOR: &str = "document.created_id.v1";
+const VERSION_CURSOR: &str = "document_version.number_id.v1";
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
+        .route(
+            "/api/v1/collections/{collectionId}/documents",
+            get(list_collection_documents).post(create_document_from_upload),
+        )
+        .route(
+            "/api/v1/documents/{documentId}",
+            get(get_document)
+                .delete(delete_document)
+                .post(reindex_document),
+        )
+        .route(
+            "/api/v1/documents/{documentId}/versions",
+            get(list_document_versions),
+        )
         .route(
             "/api/v1/documents/{documentId}/versions/{versionId}/citations:resolve",
             post(resolve_citation),
@@ -37,6 +67,159 @@ pub fn router() -> Router<Arc<AppState>> {
             post(authorize_download),
         )
         .route("/api/v1/documents/download/{token}", get(redeem_download))
+        .route_layer(DefaultBodyLimit::max(JSON_BODY_LIMIT))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CollectionDocumentsPath {
+    collection_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DocumentPath {
+    document_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DocumentCursor {
+    created_at: chrono::DateTime<chrono::Utc>,
+    id: Uuid,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct VersionCursor {
+    version_number: i32,
+    id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateDocumentRequest {
+    object_key: Option<String>,
+    object_id: Option<String>,
+    title: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DocumentResponse {
+    id: Uuid,
+    collection_id: Uuid,
+    title: String,
+    state: &'static str,
+    current_version_id: Option<Uuid>,
+    created_by_user_id: Uuid,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<Document> for DocumentResponse {
+    fn from(value: Document) -> Self {
+        Self {
+            id: value.id,
+            collection_id: value.collection_id,
+            title: value.title,
+            state: value.state.as_str(),
+            current_version_id: value.current_version_id,
+            created_by_user_id: value.created_by_user_id,
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DocumentVersionResponse {
+    id: Uuid,
+    document_id: Uuid,
+    version_number: i32,
+    parent_version_id: Option<Uuid>,
+    publication_state: &'static str,
+    is_current: bool,
+    content_sha256: String,
+    source_filename: Option<String>,
+    source_content_type: Option<String>,
+    byte_size: Option<i64>,
+    effective_from: chrono::DateTime<chrono::Utc>,
+    effective_to: Option<chrono::DateTime<chrono::Utc>>,
+    change_summary: Option<String>,
+    created_by_user_id: Uuid,
+    created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<DocumentVersion> for DocumentVersionResponse {
+    fn from(value: DocumentVersion) -> Self {
+        Self {
+            id: value.id,
+            document_id: value.document_id,
+            version_number: value.version_number,
+            parent_version_id: value.parent_version_id,
+            publication_state: publication_state_str(value.publication_state),
+            is_current: value.is_current,
+            content_sha256: value.content_sha256,
+            source_filename: value.source_filename,
+            source_content_type: value.source_content_type,
+            byte_size: value.byte_size,
+            effective_from: value.effective_from,
+            effective_to: value.effective_to,
+            change_summary: value.change_summary,
+            created_by_user_id: value.created_by_user_id,
+            created_at: value.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateDocumentResponse {
+    document: DocumentResponse,
+    version: DocumentVersionResponse,
+    job_id: Uuid,
+    job_status: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeleteDocumentResponse {
+    document: DocumentResponse,
+    delete_requested: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JobSummaryResponse {
+    id: Uuid,
+    status: &'static str,
+}
+
+impl From<Job> for JobSummaryResponse {
+    fn from(value: Job) -> Self {
+        Self {
+            id: value.id,
+            status: value.status.as_str(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SourceObjectMetadata {
+    document_id: Uuid,
+    version_id: Uuid,
+    content_sha256: String,
+    byte_size: i64,
+    source_filename: Option<String>,
+    source_content_type: Option<String>,
+}
+
+#[derive(Debug)]
+struct ValidCreateDocument {
+    object_key: ObjectKey,
+    title: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -49,6 +232,304 @@ struct VersionPath {
 #[derive(Debug, Deserialize)]
 struct TokenPath {
     token: String,
+}
+
+async fn list_collection_documents(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<CollectionDocumentsPath>,
+    query: Result<Query<PageParams>, QueryRejection>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let collection_id = parse_uuid(&path.collection_id, &request_id)?;
+    let Query(params) =
+        query.map_err(|_| RestError::validation("query string is invalid", &request_id))?;
+    let page_limit = parse_page_limit(&params, &request_id)?;
+    let cursor_key = state
+        .download_capability_key()
+        .ok_or_else(|| RestError::service_unavailable(&request_id))?;
+    let after: Option<DocumentCursor> = decode_cursor(
+        cursor_key,
+        DOCUMENT_CURSOR,
+        params.cursor.as_deref(),
+        &request_id,
+    )?;
+
+    let rows = with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_permission_or_403(&ctx, "qa.query", &request_id)?;
+                require_collection_or_404(&ctx, collection_id, &request_id)?;
+                let after = after.map(|cursor| (cursor.created_at, cursor.id));
+                let documents = documents::list_by_collection(
+                    txn,
+                    &ctx,
+                    collection_id,
+                    after,
+                    page_limit.fetch_size,
+                )
+                .await?;
+                Ok::<_, TxnRestError>(documents)
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+
+    let (items, page_info) = document_page(cursor_key, rows, page_limit.page_size)?;
+    Ok(Json(ListResponse { items, page_info }).into_response())
+}
+
+async fn create_document_from_upload(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<CollectionDocumentsPath>,
+    body: Result<Json<CreateDocumentRequest>, JsonRejection>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let collection_id = parse_uuid(&path.collection_id, &request_id)?;
+    let Json(body) =
+        body.map_err(|_| RestError::validation("request body is invalid", &request_id))?;
+    let input = validate_create_document(body, auth.context.org_id(), &request_id)?;
+
+    with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_permission_or_403(&ctx, "doc.upload", &request_id)?;
+                require_collection_or_404(&ctx, collection_id, &request_id)?;
+                crate::db::collections::get_by_id(txn, &ctx, collection_id).await?;
+                Ok::<_, TxnRestError>(())
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+
+    let storage = state
+        .object_store()
+        .ok_or_else(|| RestError::service_unavailable(&request_id))?;
+    let metadata = storage
+        .head_metadata(auth.context.org_id(), &input.object_key)
+        .await
+        .map_err(|error| storage_error_for_create(error, &request_id))?;
+    let source = parse_source_metadata(&metadata, auth.context.org_id(), &request_id)?;
+    let object_key = input.object_key.as_str();
+    let title = input.title;
+
+    let (document, version, job) = with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_permission_or_403(&ctx, "doc.upload", &request_id)?;
+                require_collection_or_404(&ctx, collection_id, &request_id)?;
+                crate::db::collections::get_by_id(txn, &ctx, collection_id).await?;
+                let document = documents::insert(
+                    txn,
+                    &ctx,
+                    NewDocument {
+                        id: source.document_id,
+                        collection_id,
+                        title: &title,
+                    },
+                )
+                .await?;
+                let version = document_versions::insert_source_version(
+                    txn,
+                    &ctx,
+                    NewSourceVersion {
+                        id: source.version_id,
+                        document_id: document.id,
+                        original_object_key: &object_key,
+                        content_sha256: &source.content_sha256,
+                        source_filename: source.source_filename.as_deref(),
+                        source_content_type: source.source_content_type.as_deref(),
+                        byte_size: source.byte_size,
+                    },
+                )
+                .await?;
+                let outcome = jobs::enqueue_within_txn(
+                    txn,
+                    &ctx,
+                    EnqueueJob::new(
+                        JobType::Convert,
+                        JobPayload {
+                            document_id: Some(document.id),
+                            version_id: Some(version.id),
+                            ..JobPayload::default()
+                        },
+                        format!("convert:{}", version.id),
+                    ),
+                )
+                .await
+                .map_err(|_| RestError::internal(&request_id))?;
+                Ok::<_, TxnRestError>((document, version, outcome.job))
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateDocumentResponse {
+            document: DocumentResponse::from(document),
+            version: DocumentVersionResponse::from(version),
+            job_id: job.id,
+            job_status: job.status.as_str(),
+        }),
+    )
+        .into_response())
+}
+
+async fn get_document(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<DocumentPath>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let document_id = parse_plain_document_id(&path.document_id, &request_id)?;
+    let document = load_visible_document(state, &auth, document_id).await?;
+    Ok(Json(DocumentResponse::from(document)).into_response())
+}
+
+async fn delete_document(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    headers: HeaderMap,
+    Path(path): Path<DocumentPath>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    validate_idempotency_header(&headers, &request_id)?;
+    let document_id = parse_plain_document_id(&path.document_id, &request_id)?;
+    with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_permission_or_403(&ctx, "doc.delete", &request_id)?;
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                require_collection_or_404(&ctx, document.collection_id, &request_id)?;
+                Ok::<_, TxnRestError>(())
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+
+    let outcome = deletion::request_delete(state.pool(), &auth.context, document_id)
+        .await
+        .map_err(|error| deletion_error(error, &request_id))?;
+    match outcome {
+        DeleteRequestOutcome::Requested(document) => Ok((
+            StatusCode::ACCEPTED,
+            Json(DeleteDocumentResponse {
+                document: DocumentResponse::from(document),
+                delete_requested: true,
+            }),
+        )
+            .into_response()),
+        DeleteRequestOutcome::AlreadyRequested(document) => Ok(Json(DeleteDocumentResponse {
+            document: DocumentResponse::from(document),
+            delete_requested: false,
+        })
+        .into_response()),
+    }
+}
+
+async fn reindex_document(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<DocumentPath>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let document_id = parse_document_action_id(&path.document_id, "reindex", &request_id)?;
+    let job = with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_reindex_permission(&ctx, &request_id)?;
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                authorize_visible_document(&ctx, &document, &request_id)?;
+                let version_id = document.current_version_id.ok_or_else(|| {
+                    RestError::conflict("document has no current version", &request_id)
+                })?;
+                let outcome = jobs::enqueue_within_txn(
+                    txn,
+                    &ctx,
+                    EnqueueJob::new(
+                        JobType::Index,
+                        JobPayload {
+                            document_id: Some(document.id),
+                            version_id: Some(version_id),
+                            ..JobPayload::default()
+                        },
+                        format!("index:{version_id}"),
+                    ),
+                )
+                .await
+                .map_err(|_| RestError::internal(&request_id))?;
+                Ok::<_, TxnRestError>(outcome.job)
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+    Ok((StatusCode::ACCEPTED, Json(JobSummaryResponse::from(job))).into_response())
+}
+
+async fn list_document_versions(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<DocumentPath>,
+    query: Result<Query<PageParams>, QueryRejection>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let document_id = parse_uuid(&path.document_id, &request_id)?;
+    let Query(params) =
+        query.map_err(|_| RestError::validation("query string is invalid", &request_id))?;
+    let page_limit = parse_page_limit(&params, &request_id)?;
+    let cursor_key = state
+        .download_capability_key()
+        .ok_or_else(|| RestError::service_unavailable(&request_id))?;
+    let after: Option<VersionCursor> = decode_cursor(
+        cursor_key,
+        VERSION_CURSOR,
+        params.cursor.as_deref(),
+        &request_id,
+    )?;
+
+    let rows = with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_permission_or_403(&ctx, "qa.query", &request_id)?;
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                authorize_visible_document(&ctx, &document, &request_id)?;
+                let after = after.map(|cursor| (cursor.version_number, cursor.id));
+                let versions = document_versions::list_by_document_paginated(
+                    txn,
+                    &ctx,
+                    document_id,
+                    after,
+                    page_limit.fetch_size,
+                )
+                .await?;
+                Ok::<_, TxnRestError>(versions)
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+
+    let (items, page_info) = version_page(cursor_key, rows, page_limit.page_size)?;
+    Ok(Json(ListResponse { items, page_info }).into_response())
 }
 
 async fn resolve_citation(
@@ -170,6 +651,293 @@ async fn redeem_download(
         HeaderValue::from_static("nosniff"),
     );
     Ok((headers, Body::from(stream.bytes)).into_response())
+}
+
+async fn load_visible_document(
+    state: Arc<AppState>,
+    auth: &AuthenticatedOrg,
+    document_id: Uuid,
+) -> Result<Document, RestError> {
+    let request_id = auth.request_id.clone();
+    with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_permission_or_403(&ctx, "qa.query", &request_id)?;
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                authorize_visible_document(&ctx, &document, &request_id)?;
+                Ok::<_, TxnRestError>(document)
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))
+}
+
+fn authorize_visible_document(
+    ctx: &OrgContext,
+    document: &Document,
+    request_id: &str,
+) -> Result<(), RestError> {
+    require_collection_or_404(ctx, document.collection_id, request_id)?;
+    if document.deleted_at.is_some() || document.state == DocumentState::Purged {
+        return Err(RestError::not_found(request_id));
+    }
+    Ok(())
+}
+
+fn require_reindex_permission(ctx: &OrgContext, request_id: &str) -> Result<(), RestError> {
+    if ctx.has_permission("doc.publish") || ctx.has_permission("doc.upload") {
+        Ok(())
+    } else {
+        Err(RestError::forbidden(request_id))
+    }
+}
+
+fn parse_plain_document_id(value: &str, request_id: &str) -> Result<Uuid, RestError> {
+    if value.contains(':') {
+        return Err(RestError::validation("document id is invalid", request_id));
+    }
+    parse_uuid(value, request_id)
+}
+
+fn parse_document_action_id(
+    value: &str,
+    action: &str,
+    request_id: &str,
+) -> Result<Uuid, RestError> {
+    let suffix = format!(":{action}");
+    let Some(document_id) = value.strip_suffix(&suffix) else {
+        return Err(RestError::validation(
+            "document action route is invalid",
+            request_id,
+        ));
+    };
+    if document_id.contains(':') {
+        return Err(RestError::validation(
+            "document action route is invalid",
+            request_id,
+        ));
+    }
+    parse_uuid(document_id, request_id)
+}
+
+fn validate_create_document(
+    body: CreateDocumentRequest,
+    org_id: Uuid,
+    request_id: &str,
+) -> Result<ValidCreateDocument, RestError> {
+    let title = body.title.trim().to_string();
+    if title.is_empty() || title.len() > 512 {
+        return Err(RestError::validation(
+            "title must be between 1 and 512 bytes",
+            request_id,
+        ));
+    }
+    let object_key = match (body.object_key, body.object_id) {
+        (Some(_), Some(_)) | (None, None) => {
+            return Err(RestError::validation(
+                "exactly one of objectKey or objectId is required",
+                request_id,
+            ));
+        }
+        (Some(raw), None) => {
+            let key = parse_key_for_org(&raw, org_id).map_err(|error| match error {
+                StorageError::KeyOrgMismatch => RestError::not_found(request_id),
+                StorageError::InvalidKey | StorageError::MissingScope => {
+                    RestError::validation("objectKey is invalid", request_id)
+                }
+                _ => RestError::internal(request_id),
+            })?;
+            if key.namespace() != ObjectNamespace::Quarantine {
+                return Err(RestError::validation(
+                    "objectKey must reference a quarantine object",
+                    request_id,
+                ));
+            }
+            key
+        }
+        (None, Some(raw)) => {
+            let object_id = Uuid::parse_str(&raw)
+                .map_err(|_| RestError::validation("objectId is invalid", request_id))?;
+            quarantine_key(org_id, object_id, None)
+                .map_err(|_| RestError::validation("objectId is invalid", request_id))?
+        }
+    };
+    Ok(ValidCreateDocument { object_key, title })
+}
+
+fn parse_source_metadata(
+    metadata: &std::collections::HashMap<String, String>,
+    org_id: Uuid,
+    request_id: &str,
+) -> Result<SourceObjectMetadata, RestError> {
+    let stored_org = metadata
+        .get("org-id")
+        .ok_or_else(|| RestError::not_found(request_id))?;
+    let stored_org = Uuid::parse_str(stored_org).map_err(|_| RestError::not_found(request_id))?;
+    if stored_org != org_id {
+        return Err(RestError::not_found(request_id));
+    }
+    let content_sha256 = metadata
+        .get("content-sha256")
+        .filter(|value| is_lower_sha256(value))
+        .cloned()
+        .ok_or_else(|| {
+            RestError::validation("stored content metadata is incomplete", request_id)
+        })?;
+    let byte_size_u64 = metadata
+        .get("content-length-bytes")
+        .ok_or_else(|| RestError::validation("stored content metadata is incomplete", request_id))?
+        .parse::<u64>()
+        .map_err(|_| RestError::validation("stored content metadata is invalid", request_id))?;
+    let byte_size = i64::try_from(byte_size_u64)
+        .map_err(|_| RestError::validation("stored content metadata is invalid", request_id))?;
+    let canonical_format = metadata
+        .get("canonical-format")
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            RestError::validation("stored content metadata is incomplete", request_id)
+        })?;
+    let source_content_type = metadata
+        .get("content-type")
+        .cloned()
+        .or_else(|| Some(format!("application/x-markhand-{canonical_format}")));
+    let document_id = parse_optional_metadata_uuid(metadata, "document-id", request_id)?
+        .unwrap_or_else(Uuid::new_v4);
+    let version_id = parse_optional_metadata_uuid(metadata, "version-id", request_id)?
+        .unwrap_or_else(Uuid::new_v4);
+    Ok(SourceObjectMetadata {
+        document_id,
+        version_id,
+        content_sha256,
+        byte_size,
+        source_filename: metadata.get("original-filename").cloned(),
+        source_content_type,
+    })
+}
+
+fn parse_optional_metadata_uuid(
+    metadata: &std::collections::HashMap<String, String>,
+    key: &str,
+    request_id: &str,
+) -> Result<Option<Uuid>, RestError> {
+    metadata
+        .get(key)
+        .map(|value| {
+            Uuid::parse_str(value).map_err(|_| {
+                RestError::validation("stored identity metadata is invalid", request_id)
+            })
+        })
+        .transpose()
+}
+
+fn is_lower_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn storage_error_for_create(error: StorageError, request_id: &str) -> RestError {
+    match error {
+        StorageError::NotFound
+        | StorageError::KeyOrgMismatch
+        | StorageError::OwnershipConflict
+        | StorageError::MissingScope => RestError::not_found(request_id),
+        StorageError::InvalidKey => RestError::validation("objectKey is invalid", request_id),
+        StorageError::ConfigInvalid
+        | StorageError::ConfigMissingCredentials
+        | StorageError::Transport
+        | StorageError::Backend
+        | StorageError::PreconditionFailed
+        | StorageError::CollectionMismatch => RestError::service_unavailable(request_id),
+    }
+}
+
+fn deletion_error(error: DeletionError, request_id: &str) -> RestError {
+    match error {
+        DeletionError::Db(db) => db_or_404(db, request_id),
+        DeletionError::UnexpectedState(_) => RestError::conflict(
+            "document cannot be deleted in its current state",
+            request_id,
+        ),
+        DeletionError::Job(_) => RestError::internal(request_id),
+        DeletionError::Storage(_) => RestError::service_unavailable(request_id),
+        DeletionError::InvalidPayload | DeletionError::InvalidCheckpoint => {
+            RestError::internal(request_id)
+        }
+        DeletionError::JobTimedOut => RestError::service_unavailable(request_id),
+    }
+}
+
+fn document_page(
+    cursor_key: &crate::services::download::CapabilityKey,
+    mut rows: Vec<Document>,
+    page_size: usize,
+) -> Result<(Vec<DocumentResponse>, PageInfo), RestError> {
+    let has_more = rows.len() > page_size;
+    if has_more {
+        rows.truncate(page_size);
+    }
+    let next_cursor = if has_more {
+        rows.last()
+            .map(|item| {
+                encode_cursor(
+                    cursor_key,
+                    DOCUMENT_CURSOR,
+                    &DocumentCursor {
+                        created_at: item.created_at,
+                        id: item.id,
+                    },
+                )
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    let items = rows.into_iter().map(DocumentResponse::from).collect();
+    Ok((items, page_info(next_cursor)))
+}
+
+fn version_page(
+    cursor_key: &crate::services::download::CapabilityKey,
+    mut rows: Vec<DocumentVersion>,
+    page_size: usize,
+) -> Result<(Vec<DocumentVersionResponse>, PageInfo), RestError> {
+    let has_more = rows.len() > page_size;
+    if has_more {
+        rows.truncate(page_size);
+    }
+    let next_cursor = if has_more {
+        rows.last()
+            .map(|item| {
+                encode_cursor(
+                    cursor_key,
+                    VERSION_CURSOR,
+                    &VersionCursor {
+                        version_number: item.version_number,
+                        id: item.id,
+                    },
+                )
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    let items = rows
+        .into_iter()
+        .map(DocumentVersionResponse::from)
+        .collect();
+    Ok((items, page_info(next_cursor)))
+}
+
+fn publication_state_str(value: PublicationState) -> &'static str {
+    match value {
+        PublicationState::Draft => "draft",
+        PublicationState::Published => "published",
+    }
 }
 
 struct DocumentRouteError {

--- a/crates/server/src/routes/jobs.rs
+++ b/crates/server/src/routes/jobs.rs
@@ -1,0 +1,96 @@
+//! Job status REST routes.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::db::models::Job;
+use crate::db::pool::with_org_txn_typed;
+use crate::db::{documents, jobs};
+use crate::http::AppState;
+use crate::routes::common::{
+    parse_uuid, require_collection_or_404, require_permission_or_403, RestError, TxnRestError,
+};
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().route("/api/v1/jobs/{jobId}", get(get_job))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JobPath {
+    job_id: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JobResponse {
+    id: Uuid,
+    job_type: &'static str,
+    status: &'static str,
+    attempts: i32,
+    max_attempts: i32,
+    document_id: Option<Uuid>,
+    version_id: Option<Uuid>,
+    available_at: DateTime<Utc>,
+    started_at: Option<DateTime<Utc>>,
+    finished_at: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+impl From<Job> for JobResponse {
+    fn from(value: Job) -> Self {
+        Self {
+            id: value.id,
+            job_type: value.job_type.as_str(),
+            status: value.status.as_str(),
+            attempts: value.attempts,
+            max_attempts: value.max_attempts,
+            document_id: value.document_id,
+            version_id: value.version_id,
+            available_at: value.available_at,
+            started_at: value.started_at,
+            finished_at: value.finished_at,
+            created_at: value.created_at,
+            updated_at: value.updated_at,
+        }
+    }
+}
+
+async fn get_job(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<JobPath>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let job_id = parse_uuid(&path.job_id, &request_id)?;
+    let job = with_org_txn_typed(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_permission_or_403(&ctx, "qa.query", &request_id)?;
+                let job = jobs::get_by_id(txn, &ctx, job_id)
+                    .await?
+                    .ok_or_else(|| RestError::not_found(&request_id))?;
+                let document_id = job
+                    .document_id
+                    .ok_or_else(|| RestError::not_found(&request_id))?;
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                require_collection_or_404(&ctx, document.collection_id, &request_id)?;
+                Ok::<_, TxnRestError>(job)
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
+    Ok(Json(JobResponse::from(job)).into_response())
+}

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,5 +1,8 @@
 //! HTTP route modules.
 
 pub mod auth;
+pub mod collections;
+pub(crate) mod common;
 pub mod documents;
+pub mod jobs;
 pub mod uploads;

--- a/crates/server/src/services/download.rs
+++ b/crates/server/src/services/download.rs
@@ -50,6 +50,20 @@ impl CapabilityKey {
         ))
     }
 
+    pub fn sign_domain_separated(&self, domain: &[u8], payload: &[u8]) -> [u8; 32] {
+        let domain_len = u32::try_from(domain.len()).unwrap_or(u32::MAX);
+        let mut message = Vec::with_capacity(4 + domain.len() + payload.len());
+        message.extend_from_slice(&domain_len.to_be_bytes());
+        message.extend_from_slice(domain);
+        message.extend_from_slice(payload);
+        hmac_sha256(&self.0, &message)
+    }
+
+    pub fn verify_domain_separated(&self, domain: &[u8], payload: &[u8], tag: &[u8]) -> bool {
+        let expected = self.sign_domain_separated(domain, payload);
+        constant_time_eq(tag, &expected)
+    }
+
     #[cfg(test)]
     fn from_test_bytes(bytes: [u8; 32]) -> Self {
         Self(bytes)

--- a/crates/server/tests/rest_api.rs
+++ b/crates/server/tests/rest_api.rs
@@ -1,0 +1,1116 @@
+//! Live HTTP integration tests for the P1B-R04 REST API.
+//!
+//! These tests self-skip unless PostgreSQL and MinIO test endpoints are provided.
+//! They are intentionally not run by the normal `cargo test -p fileconv-server --lib`
+//! gate, but they compile under all-target checks.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use bytes::Bytes;
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::auth::jwt::JwtKeys;
+use fileconv_server::auth::provider::{AuthProvider, AuthRequestMeta, PasswordAuthProvider};
+use fileconv_server::auth::session;
+use fileconv_server::config::{
+    Argon2Config, AuthConfig, JwtAlgorithm, MinioConfig, RuntimeEndpoints, SecretString,
+    ServerConfig,
+};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::http::{router, AppState};
+use fileconv_server::state::RuntimeState;
+use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
+use fileconv_server::storage::{quarantine_key, trusted_key};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn test_minio_client() -> Option<MinioClient> {
+    let endpoint = match std::env::var("MARKHAND_TEST_MINIO_ENDPOINT") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ENDPOINT unset");
+            return None;
+        }
+    };
+    let access_key = match std::env::var("MARKHAND_TEST_MINIO_ACCESS_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ACCESS_KEY unset");
+            return None;
+        }
+    };
+    let secret_key = match std::env::var("MARKHAND_TEST_MINIO_SECRET_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_SECRET_KEY unset");
+            return None;
+        }
+    };
+    let region = std::env::var("MARKHAND_TEST_MINIO_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let bucket = format!("markhand-r04-{}", Uuid::new_v4().simple());
+    std::env::set_var("RUST_S3_SKIP_LOCATION_CONSTRAINT", "true");
+    let config = MinioConfig::new(
+        endpoint,
+        SecretString::new(access_key),
+        SecretString::new(secret_key),
+        bucket,
+        region,
+        true,
+    )
+    .expect("minio config");
+    Some(MinioClient::from_config(&config).expect("minio client"))
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_r04_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+fn test_auth_config() -> AuthConfig {
+    AuthConfig {
+        issuer: Some("https://issuer.r04.markhand.test".into()),
+        audience: Some("markhand-api".into()),
+        signing_key: Some(SecretString::new("r04-integration-signing-key-32b!")),
+        alg: JwtAlgorithm::Hs256,
+        kid: Some("r04-test-kid".into()),
+        access_token_ttl_secs: 900,
+        refresh_token_ttl_secs: 3_600,
+        argon2: Argon2Config {
+            memory_kib: 8_192,
+            time_cost: 1,
+            parallelism: 1,
+        },
+    }
+}
+
+fn test_runtime(database_url: &str) -> RuntimeState {
+    RuntimeState::from_config(ServerConfig::test_with_endpoints_and_auth(
+        RuntimeEndpoints {
+            database_url: SecretString::new(database_url),
+            qdrant_url: "http://127.0.0.1:1".into(),
+            minio_url: "http://127.0.0.1:1".into(),
+        },
+        test_auth_config(),
+    ))
+    .expect("runtime")
+}
+
+struct LiveEnv {
+    db: EphemeralDb,
+    pool: Pool,
+    storage: MinioClient,
+    provider: PasswordAuthProvider,
+    app: axum::Router,
+}
+
+impl LiveEnv {
+    async fn boot() -> Option<Self> {
+        let base_url = test_database_url()?;
+        let storage = test_minio_client()?;
+        storage.ensure_bucket().await.expect("ensure bucket");
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("apply migrations");
+        let pool = create_pool(&db.url).expect("pool");
+        let auth = test_auth_config();
+        let provider = PasswordAuthProvider::new(
+            pool.clone(),
+            auth.clone(),
+            JwtKeys::from_auth(&auth).expect("jwt keys"),
+        );
+        let app = router(
+            AppState::from_parts_with_store(
+                test_runtime(&db.url),
+                pool.clone(),
+                Some(PasswordAuthProvider::new(
+                    pool.clone(),
+                    auth.clone(),
+                    JwtKeys::from_auth(&auth).expect("jwt keys"),
+                )),
+                Some(storage.clone()),
+            )
+            .expect("app state"),
+        );
+        Some(Self {
+            db,
+            pool,
+            storage,
+            provider,
+            app,
+        })
+    }
+
+    async fn token(&self, email: &str, password: &str) -> String {
+        self.provider
+            .login_password(
+                email,
+                password,
+                &AuthRequestMeta {
+                    request_id: Uuid::new_v4().to_string(),
+                },
+            )
+            .await
+            .expect("login")
+            .tokens
+            .access_token
+            .expose()
+            .to_string()
+    }
+
+    async fn drop(self) {
+        self.db.drop().await;
+    }
+}
+
+#[derive(Clone)]
+struct Seeded {
+    collection_id: Uuid,
+    denied_collection_id: Uuid,
+    document_id: Uuid,
+    denied_document_id: Uuid,
+    cross_org_document_id: Uuid,
+    allowed_job_id: Uuid,
+    denied_job_id: Uuid,
+    upload_key: String,
+    trusted_key: String,
+    other_org_key: String,
+    upload_sha: String,
+}
+
+async fn seed(env: &LiveEnv) -> Seeded {
+    let org_id = Uuid::new_v4();
+    let other_org_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let viewer_id = Uuid::new_v4();
+    let no_query_id = Uuid::new_v4();
+    let other_user_id = Uuid::new_v4();
+    let cross_user_id = Uuid::new_v4();
+    let collection_id = Uuid::new_v4();
+    let denied_collection_id = Uuid::new_v4();
+    let cross_collection_id = Uuid::new_v4();
+    let document_id = Uuid::new_v4();
+    let denied_document_id = Uuid::new_v4();
+    let cross_org_document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let second_version_id = Uuid::new_v4();
+    let denied_version_id = Uuid::new_v4();
+    let cross_version_id = Uuid::new_v4();
+    let allowed_job_id = Uuid::new_v4();
+    let denied_job_id = Uuid::new_v4();
+    let upload_document_id = Uuid::new_v4();
+    let upload_version_id = Uuid::new_v4();
+    let upload_object_id = Uuid::new_v4();
+    let trusted_object_id = Uuid::new_v4();
+    let other_org_object_id = Uuid::new_v4();
+    let upload_key = quarantine_key(org_id, upload_object_id, None).expect("upload key");
+    let trusted_key =
+        trusted_key(org_id, Uuid::new_v4(), trusted_object_id, None).expect("trusted key");
+    let other_org_key =
+        quarantine_key(other_org_id, other_org_object_id, None).expect("other org key");
+    let upload_bytes = Bytes::from_static(b"server measured upload bytes");
+    let upload_sha = hex::encode(Sha256::digest(&upload_bytes));
+    env.storage
+        .put_object(
+            org_id,
+            &upload_key,
+            upload_bytes,
+            &ObjectIdentityMeta {
+                org_id,
+                collection_id: None,
+                document_id: Some(upload_document_id),
+                version_id: Some(upload_version_id),
+                original_filename: Some("upload.txt".into()),
+                canonical_format: Some("txt".into()),
+                content_sha256: Some(upload_sha.clone()),
+                content_length: Some(28),
+                disposition: Some("accepted".into()),
+            },
+            "text/plain",
+        )
+        .await
+        .expect("put upload");
+
+    let owner_ctx = OrgContext::try_new(
+        org_id,
+        user_id,
+        ["doc.upload", "doc.delete", "doc.publish", "qa.query"],
+        [collection_id],
+    )
+    .expect("owner ctx");
+    seed_org_rows(
+        &env.pool,
+        &owner_ctx,
+        SeedIds {
+            org_id,
+            user_id,
+            viewer_id,
+            no_query_id,
+            other_user_id,
+            collection_id,
+            denied_collection_id,
+            document_id,
+            denied_document_id,
+            version_id,
+            second_version_id,
+            denied_version_id,
+            allowed_job_id,
+            denied_job_id,
+        },
+    )
+    .await;
+    let cross_ctx = OrgContext::try_new(
+        other_org_id,
+        cross_user_id,
+        ["doc.upload"],
+        [cross_collection_id],
+    )
+    .expect("cross ctx");
+    seed_cross_org_rows(
+        &env.pool,
+        &cross_ctx,
+        other_org_id,
+        cross_user_id,
+        cross_collection_id,
+        cross_org_document_id,
+        cross_version_id,
+    )
+    .await;
+    session::set_password_hash(
+        &env.pool,
+        user_id,
+        "owner-password",
+        &test_auth_config().argon2,
+    )
+    .await
+    .expect("owner password");
+    session::set_password_hash(
+        &env.pool,
+        viewer_id,
+        "viewer-password",
+        &test_auth_config().argon2,
+    )
+    .await
+    .expect("viewer password");
+    session::set_password_hash(
+        &env.pool,
+        no_query_id,
+        "no-query-password",
+        &test_auth_config().argon2,
+    )
+    .await
+    .expect("no-query password");
+
+    Seeded {
+        collection_id,
+        denied_collection_id,
+        document_id,
+        denied_document_id,
+        cross_org_document_id,
+        allowed_job_id,
+        denied_job_id,
+        upload_key: upload_key.as_str(),
+        trusted_key: trusted_key.as_str(),
+        other_org_key: other_org_key.as_str(),
+        upload_sha,
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SeedIds {
+    org_id: Uuid,
+    user_id: Uuid,
+    viewer_id: Uuid,
+    no_query_id: Uuid,
+    other_user_id: Uuid,
+    collection_id: Uuid,
+    denied_collection_id: Uuid,
+    document_id: Uuid,
+    denied_document_id: Uuid,
+    version_id: Uuid,
+    second_version_id: Uuid,
+    denied_version_id: Uuid,
+    allowed_job_id: Uuid,
+    denied_job_id: Uuid,
+}
+
+async fn seed_org_rows(pool: &Pool, ctx: &OrgContext, ids: SeedIds) {
+    with_org_txn(pool, ctx, move |txn| {
+        Box::pin(async move {
+            txn.execute(
+                "INSERT INTO orgs (id, slug, name)
+                 VALUES ($1, 'r04-org', 'R04 Org')",
+                &[&ids.org_id],
+            )
+            .await?;
+            for (user_id, email, name) in [
+                (ids.user_id, "owner-r04@example.test", "Owner R04"),
+                (ids.viewer_id, "viewer-r04@example.test", "Viewer R04"),
+                (ids.no_query_id, "no-query-r04@example.test", "No Query R04"),
+                (ids.other_user_id, "other-r04@example.test", "Other R04"),
+            ] {
+                txn.execute(
+                    "INSERT INTO users (id, email, display_name)
+                     VALUES ($1, $2, $3)",
+                    &[&user_id, &email, &name],
+                )
+                .await?;
+            }
+            txn.execute(
+                "INSERT INTO org_memberships (org_id, user_id, role)
+                 VALUES
+                   ($1, $2, 'owner'),
+                   ($1, $3, 'viewer'),
+                   ($1, $4, 'editor'),
+                   ($1, $5, 'owner')",
+                &[
+                    &ids.org_id,
+                    &ids.user_id,
+                    &ids.viewer_id,
+                    &ids.no_query_id,
+                    &ids.other_user_id,
+                ],
+            )
+            .await?;
+            seed_roles_and_permissions(txn, ids).await?;
+            seed_collections_documents_and_jobs(txn, ids).await
+        })
+    })
+    .await
+    .expect("seed rows");
+}
+
+async fn seed_cross_org_rows(
+    pool: &Pool,
+    ctx: &OrgContext,
+    org_id: Uuid,
+    user_id: Uuid,
+    collection_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+) {
+    with_org_txn(pool, ctx, move |txn| {
+        Box::pin(async move {
+            txn.execute(
+                "INSERT INTO orgs (id, slug, name)
+                 VALUES ($1, 'r04-other', 'R04 Other')",
+                &[&org_id],
+            )
+            .await?;
+            txn.execute(
+                "INSERT INTO users (id, email, display_name)
+                 VALUES ($1, 'cross-r04@example.test', 'Cross R04')",
+                &[&user_id],
+            )
+            .await?;
+            txn.execute(
+                "INSERT INTO org_memberships (org_id, user_id, role)
+                 VALUES ($1, $2, 'owner')",
+                &[&org_id, &user_id],
+            )
+            .await?;
+            txn.execute(
+                "INSERT INTO collections (id, org_id, name, slug, owner_user_id, visibility)
+                 VALUES ($1, $2, 'Other', 'other', $3, 'private')",
+                &[&collection_id, &org_id, &user_id],
+            )
+            .await?;
+            insert_indexed_document(
+                txn,
+                org_id,
+                collection_id,
+                user_id,
+                document_id,
+                version_id,
+                None,
+                "Cross org document",
+            )
+            .await
+        })
+    })
+    .await
+    .expect("seed cross org rows");
+}
+
+async fn seed_roles_and_permissions(
+    txn: &tokio_postgres::Transaction<'_>,
+    ids: SeedIds,
+) -> Result<(), fileconv_server::db::error::DbError> {
+    for permission in ["doc.upload", "doc.delete", "doc.publish", "qa.query"] {
+        let description = format!("{permission} permission");
+        txn.execute(
+            "INSERT INTO permissions (id, code, description)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (code) DO NOTHING",
+            &[&Uuid::new_v4(), &permission, &description],
+        )
+        .await?;
+    }
+    for (code, name) in [
+        ("owner", "Owner"),
+        ("viewer", "Viewer"),
+        ("editor", "Editor"),
+    ] {
+        txn.execute(
+            "INSERT INTO roles (id, org_id, code, name, is_system)
+             VALUES ($1, $2, $3, $4, true)",
+            &[&Uuid::new_v4(), &ids.org_id, &code, &name],
+        )
+        .await?;
+    }
+    for permission in ["doc.upload", "doc.delete", "doc.publish", "qa.query"] {
+        grant_permission(txn, ids.org_id, "owner", permission).await?;
+    }
+    grant_permission(txn, ids.org_id, "viewer", "qa.query").await?;
+    grant_permission(txn, ids.org_id, "editor", "doc.upload").await?;
+    Ok(())
+}
+
+async fn grant_permission(
+    txn: &tokio_postgres::Transaction<'_>,
+    org_id: Uuid,
+    role_code: &str,
+    permission: &str,
+) -> Result<(), fileconv_server::db::error::DbError> {
+    let role_id: Uuid = txn
+        .query_one(
+            "SELECT id FROM roles WHERE org_id = $1 AND code = $2",
+            &[&org_id, &role_code],
+        )
+        .await?
+        .get(0);
+    let permission_id: Uuid = txn
+        .query_one("SELECT id FROM permissions WHERE code = $1", &[&permission])
+        .await?
+        .get(0);
+    txn.execute(
+        "INSERT INTO role_permissions (org_id, role_id, permission_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT DO NOTHING",
+        &[&org_id, &role_id, &permission_id],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn seed_collections_documents_and_jobs(
+    txn: &tokio_postgres::Transaction<'_>,
+    ids: SeedIds,
+) -> Result<(), fileconv_server::db::error::DbError> {
+    txn.execute(
+        "INSERT INTO collections (id, org_id, name, slug, owner_user_id, visibility)
+         VALUES
+           ($1, $2, 'Allowed', 'allowed', $3, 'private'),
+           ($4, $2, 'Denied', 'denied', $5, 'private')",
+        &[
+            &ids.collection_id,
+            &ids.org_id,
+            &ids.user_id,
+            &ids.denied_collection_id,
+            &ids.other_user_id,
+        ],
+    )
+    .await?;
+    txn.execute(
+        "INSERT INTO collection_user_access (id, org_id, collection_id, user_id, access_level)
+         VALUES
+           ($1, $2, $3, $4, 'read'),
+           ($5, $2, $3, $6, 'read'),
+           ($7, $2, $8, $9, 'read')",
+        &[
+            &Uuid::new_v4(),
+            &ids.org_id,
+            &ids.collection_id,
+            &ids.viewer_id,
+            &Uuid::new_v4(),
+            &ids.no_query_id,
+            &Uuid::new_v4(),
+            &ids.denied_collection_id,
+            &ids.user_id,
+        ],
+    )
+    .await?;
+    insert_indexed_document(
+        txn,
+        ids.org_id,
+        ids.collection_id,
+        ids.user_id,
+        ids.document_id,
+        ids.version_id,
+        Some(ids.second_version_id),
+        "Allowed document",
+    )
+    .await?;
+    insert_indexed_document(
+        txn,
+        ids.org_id,
+        ids.denied_collection_id,
+        ids.other_user_id,
+        ids.denied_document_id,
+        ids.denied_version_id,
+        None,
+        "Denied document",
+    )
+    .await?;
+    let payload = json!({ "document_id": ids.document_id, "version_id": ids.version_id });
+    let denied_payload =
+        json!({ "document_id": ids.denied_document_id, "version_id": ids.denied_version_id });
+    txn.execute(
+        "INSERT INTO jobs (
+            id, org_id, job_type, payload_version, payload, idempotency_key,
+            document_id, version_id, last_error
+         )
+         VALUES
+           ($1, $2, 'convert', 2, $3, 'status-allowed', $4, $5, 'raw secret error'),
+           ($6, $2, 'convert', 2, $7, 'status-denied', $8, $9, 'raw secret error')",
+        &[
+            &ids.allowed_job_id,
+            &ids.org_id,
+            &payload,
+            &ids.document_id,
+            &ids.version_id,
+            &ids.denied_job_id,
+            &denied_payload,
+            &ids.denied_document_id,
+            &ids.denied_version_id,
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_indexed_document(
+    txn: &tokio_postgres::Transaction<'_>,
+    org_id: Uuid,
+    collection_id: Uuid,
+    user_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    second_version_id: Option<Uuid>,
+    title: &str,
+) -> Result<(), fileconv_server::db::error::DbError> {
+    let sha = "a".repeat(64);
+    let key = format!("quarantine/test/{version_id}");
+    txn.execute(
+        "INSERT INTO documents (id, org_id, collection_id, title, state, created_by_user_id)
+         VALUES ($1, $2, $3, $4, 'indexed', $5)",
+        &[&document_id, &org_id, &collection_id, &title, &user_id],
+    )
+    .await?;
+    txn.execute(
+        "INSERT INTO document_versions (
+            id, org_id, document_id, version_number, publication_state, is_current,
+            content_sha256, original_object_key, source_content_type, byte_size,
+            created_by_user_id
+         )
+         VALUES ($1, $2, $3, 1, 'published', true, $4, $5, 'text/plain', 10, $6)",
+        &[&version_id, &org_id, &document_id, &sha, &key, &user_id],
+    )
+    .await?;
+    if let Some(second_version_id) = second_version_id {
+        let second_key = format!("quarantine/test/{second_version_id}");
+        txn.execute(
+            "INSERT INTO document_versions (
+                id, org_id, document_id, version_number, publication_state, is_current,
+                content_sha256, original_object_key, source_content_type, byte_size,
+                created_by_user_id
+             )
+             VALUES ($1, $2, $3, 2, 'draft', false, $4, $5, 'text/plain', 11, $6)",
+            &[
+                &second_version_id,
+                &org_id,
+                &document_id,
+                &sha,
+                &second_key,
+                &user_id,
+            ],
+        )
+        .await?;
+    }
+    txn.execute(
+        "UPDATE documents
+         SET current_version_id = $3, updated_at = clock_timestamp()
+         WHERE org_id = $1 AND id = $2",
+        &[&org_id, &document_id, &version_id],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn json_request(
+    app: axum::Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+    bearer: &str,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {bearer}"));
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let request = builder
+        .body(match body {
+            Some(value) => Body::from(serde_json::to_vec(&value).expect("serialize body")),
+            None => Body::empty(),
+        })
+        .expect("request");
+    let response = app.oneshot(request).await.expect("response");
+    let status = response.status();
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body")
+        .to_bytes();
+    let body = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).expect("json body")
+    };
+    (status, body)
+}
+
+fn tamper_cursor(cursor: &str) -> String {
+    let mut bytes = cursor.as_bytes().to_vec();
+    let last = bytes.last_mut().expect("cursor is non-empty");
+    *last = if *last == b'A' { b'B' } else { b'A' };
+    String::from_utf8(bytes).expect("cursor remains utf8")
+}
+
+#[tokio::test]
+async fn collection_document_job_rest_api_contract() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let seeded = seed(&env).await;
+    let owner_token = env.token("owner-r04@example.test", "owner-password").await;
+    let viewer_token = env
+        .token("viewer-r04@example.test", "viewer-password")
+        .await;
+    let no_query_token = env
+        .token("no-query-r04@example.test", "no-query-password")
+        .await;
+
+    let (status, page1) = json_request(
+        env.app.clone(),
+        "GET",
+        "/api/v1/collections?limit=1",
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{page1}");
+    assert_eq!(page1["items"].as_array().unwrap().len(), 1);
+    assert_eq!(page1["pageInfo"]["hasMore"], true);
+    let cursor = page1["pageInfo"]["nextCursor"].as_str().unwrap();
+    let tampered_cursor = tamper_cursor(cursor);
+    let (status, tampered) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/collections?limit=1&cursor={tampered_cursor}"),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{tampered}");
+    assert_eq!(tampered["code"], "validation_failed");
+    let (status, page2) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/collections?limit=1&cursor={cursor}"),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{page2}");
+    assert_eq!(page2["pageInfo"]["hasMore"], false);
+    assert_eq!(
+        page2["items"][0]["id"],
+        seeded.denied_collection_id.to_string()
+    );
+
+    let (status, viewer_collections) = json_request(
+        env.app.clone(),
+        "GET",
+        "/api/v1/collections",
+        None,
+        &viewer_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{viewer_collections}");
+    assert_eq!(viewer_collections["items"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        viewer_collections["items"][0]["id"],
+        seeded.collection_id.to_string()
+    );
+
+    let (status, owner_doc) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/documents/{}", seeded.document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{owner_doc}");
+    assert_eq!(owner_doc["id"], seeded.document_id.to_string());
+    let (status, get_action_rejected) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/documents/{}:reindex", seeded.document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{get_action_rejected}");
+    let (status, viewer_doc) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/documents/{}", seeded.document_id),
+        None,
+        &viewer_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{viewer_doc}");
+    let (status, no_query_doc) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/documents/{}", seeded.document_id),
+        None,
+        &no_query_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{no_query_doc}");
+    assert_eq!(no_query_doc["code"], "permission_denied");
+
+    let (status, unauthorized_doc) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/documents/{}", seeded.denied_document_id),
+        None,
+        &viewer_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(unauthorized_doc["code"], "not_found");
+    let (status, cross_org_doc) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/documents/{}", seeded.cross_org_document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(cross_org_doc["code"], "not_found");
+
+    let (status, documents) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!(
+            "/api/v1/collections/{}/documents",
+            seeded.denied_collection_id
+        ),
+        None,
+        &viewer_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{documents}");
+
+    let (status, created) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/collections/{}/documents", seeded.collection_id),
+        Some(json!({
+            "objectKey": seeded.upload_key,
+            "title": "Created from quarantine",
+            "contentSha256": "0".repeat(64)
+        })),
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{created}");
+    assert_eq!(created["version"]["contentSha256"], seeded.upload_sha);
+    assert!(created["jobId"].as_str().is_some());
+
+    let (status, trusted_rejected) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/collections/{}/documents", seeded.collection_id),
+        Some(json!({ "objectKey": seeded.trusted_key, "title": "Bad key" })),
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{trusted_rejected}");
+    let (status, other_org_rejected) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/collections/{}/documents", seeded.collection_id),
+        Some(json!({ "objectKey": seeded.other_org_key, "title": "Other org" })),
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{other_org_rejected}");
+
+    let (status, versions1) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/documents/{}/versions?limit=1", seeded.document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{versions1}");
+    assert_eq!(versions1["items"].as_array().unwrap().len(), 1);
+    assert_eq!(versions1["pageInfo"]["hasMore"], true);
+    let (status, no_query_versions) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/documents/{}/versions", seeded.document_id),
+        None,
+        &no_query_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{no_query_versions}");
+    assert_eq!(no_query_versions["code"], "permission_denied");
+    let version_cursor = versions1["pageInfo"]["nextCursor"].as_str().unwrap();
+    let (status, versions2) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!(
+            "/api/v1/documents/{}/versions?limit=1&cursor={version_cursor}",
+            seeded.document_id
+        ),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{versions2}");
+    assert_eq!(versions2["items"][0]["versionNumber"], 2);
+
+    let (status, reindex_plain_rejected) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/documents/{}", seeded.document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{reindex_plain_rejected}");
+    let (status, reindex1) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/documents/{}:reindex", seeded.document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED, "{reindex1}");
+    let (status, reindex2) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/documents/{}:reindex", seeded.document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED, "{reindex2}");
+    assert_eq!(reindex1["id"], reindex2["id"]);
+
+    let (status, viewer_reindex) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/documents/{}:reindex", seeded.document_id),
+        None,
+        &viewer_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{viewer_reindex}");
+
+    let (status, job) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/jobs/{}", seeded.allowed_job_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{job}");
+    for forbidden in [
+        "payload",
+        "checkpoint",
+        "leaseOwner",
+        "leaseExpiresAt",
+        "heartbeatAt",
+        "lastError",
+    ] {
+        assert!(job.get(forbidden).is_none(), "{forbidden} leaked in {job}");
+    }
+    let (status, no_query_job) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/jobs/{}", seeded.allowed_job_id),
+        None,
+        &no_query_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{no_query_job}");
+    assert_eq!(no_query_job["code"], "permission_denied");
+    let (status, denied_job) = json_request(
+        env.app.clone(),
+        "GET",
+        &format!("/api/v1/jobs/{}", seeded.denied_job_id),
+        None,
+        &viewer_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{denied_job}");
+
+    let (status, delete_action_rejected) = json_request(
+        env.app.clone(),
+        "DELETE",
+        &format!("/api/v1/documents/{}:reindex", seeded.document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{delete_action_rejected}");
+    assert_eq!(delete_action_rejected["code"], "validation_failed");
+
+    let (status, deleted) = json_request(
+        env.app.clone(),
+        "DELETE",
+        &format!("/api/v1/documents/{}", seeded.document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED, "{deleted}");
+    assert_eq!(deleted["document"]["state"], "tombstoned");
+    let (status, deleted_again) = json_request(
+        env.app.clone(),
+        "DELETE",
+        &format!("/api/v1/documents/{}", seeded.document_id),
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{deleted_again}");
+    let (status, viewer_delete) = json_request(
+        env.app.clone(),
+        "DELETE",
+        &format!("/api/v1/documents/{}", seeded.denied_document_id),
+        None,
+        &viewer_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{viewer_delete}");
+
+    let (status, viewer_create) = json_request(
+        env.app.clone(),
+        "POST",
+        "/api/v1/collections",
+        Some(json!({
+            "name": "Viewer create",
+            "slug": "viewer-create",
+            "visibility": "private"
+        })),
+        &viewer_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{viewer_create}");
+    let (status, malformed) = json_request(
+        env.app.clone(),
+        "GET",
+        "/api/v1/documents/not-a-uuid",
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(malformed["code"], "validation_failed");
+    let (status, oversized) = json_request(
+        env.app.clone(),
+        "GET",
+        "/api/v1/collections?limit=101",
+        None,
+        &owner_token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(oversized["code"], "validation_failed");
+
+    env.drop().await;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-R04 — Collection/document/job REST API

Tenant-scoped `/api/v1` CRUD surface, stacked on F04/I01/I03/I07/R01/R02/R03. Closes #94.

### Endpoints
| Method | Path | Perm | Notes |
|---|---|---|---|
| `GET` | `/collections` | membership | authorized-collection list, paginated |
| `POST` | `/collections` | `doc.upload` | create (private/org), owner = caller |
| `GET` | `/collections/{id}` | ACL | 404 if unauthorized |
| `GET` | `/collections/{id}/documents` | `qa.query` + ACL | paginated, excludes purged |
| `POST` | `/collections/{id}/documents` | `doc.upload` + ACL | create from uploaded quarantine object → enqueue convert |
| `GET` | `/documents/{id}` | `qa.query` + ACL | |
| `DELETE` | `/documents/{id}` | `doc.delete` + ACL | tombstone via `deletion::request_delete` (idempotent) |
| `POST` | `/documents/{id}:reindex` | `doc.publish`/`doc.upload` + ACL | idempotent `index:{versionId}` |
| `GET` | `/documents/{id}/versions` | `qa.query` + ACL | paginated |
| `GET` | `/jobs/{id}` | `qa.query` + ACL (via document) | safe fields only |

### Security
- `AuthenticatedOrg` (live PG-resolved context) + RLS `with_org_txn` on **every** route; `require_permission` then collection ACL via `allowed_collection_ids()`.
- **Non-disclosing 404** for cross-tenant / unauthorized-collection / missing (permission → 403 first, then ACL → 404, no existence leak).
- **Create-document** trusts only server-read quarantine-object metadata (org match + `Quarantine` namespace + stored sha256/size/canonical-format); client-supplied integrity values ignored; non-quarantine/other-org keys rejected.
- **Job status** DTO exposes only `id, jobType, status, attempts, maxAttempts, documentId, versionId, availableAt, startedAt, finishedAt, createdAt, updatedAt` — no payload/checkpoint/lease/heartbeat/raw error.
- Opaque, **HMAC-signed, domain-separated, length-framed** pagination cursors (reuses the R02 `CapabilityKey`, no new config/migration); bounded `limit` (1..=100) and 16 KiB bodies; stable `ApiError` codes; server-minted request-id.
- Delete = tombstone-first re-auth; reindex/create idempotent via `jobs::enqueue` `ON CONFLICT`.

### Files
- `routes/{collections,jobs,common}.rs` (new), `routes/documents.rs` (extended), `routes/mod.rs`, `http.rs`
- `db/{collections,documents,document_versions,jobs}.rs` (ACL-paginated list + source-version insert + read-only job lookup)
- `services/download.rs` (length-framed domain-separated MAC helper, shared with cursors), `config.rs`
- `crates/server/tests/rest_api.rs` (new, self-skipping live HTTP contract tests)

### Tests / gates
- Live HTTP contract test (multi-collection ACL scoping, IDOR 404s, create-from-quarantine, idempotent delete/reindex, safe job DTO, 4-combo route grammar incl. `:reindex`, permission matrix, signed-cursor round-trip/tamper) — **passes** against native PG/Qdrant/MinIO; R02 download regression re-run green.
- `cargo fmt --all -- --check`, `clippy --all-targets -D warnings`, 88 lib tests, `cargo metadata --locked`, dependency-policy — all green.

### Security review
`gpt-5.6-sol-high`, 2 rounds → **PASS**. Round 1 caught a HIGH (inverted GET/`:reindex` route parsing — mutation reachable under wrong URI) + 2 MEDIUMs (missing `qa.query` on read endpoints; unauthenticated cursors); all fixed and re-verified, plus a LOW MAC-framing hardening applied to the shared helper.

### Deferred (non-blocking)
Conflict routes and version diff (no conflict repo/data in the POC); search/ask/SSE = R05; OpenAPI completeness + rate limit = R06.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

