### PR TITLE
feat(server): P1B-R05 search/ask/resumable SSE API

### DIFF
--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+pub mod sse;
+
 /// Canonical error body returned by `/api/v1` endpoints.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -1,0 +1,233 @@
+//! SSE helpers and bounded replay state for resumable API streams.
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::response::sse::Event;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::api::SseEnvelope;
+
+const SSE_VERSION: u16 = 1;
+const ASK_STREAM_TTL: Duration = Duration::from_secs(5 * 60);
+const MAX_EVENTS_PER_STREAM: usize = 128;
+const MAX_BYTES_PER_STREAM: usize = 300 * 1024;
+const MAX_CONCURRENT_STREAMS_PER_CALLER: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StreamCaller {
+    pub(crate) org_id: Uuid,
+    pub(crate) user_id: Uuid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StreamRegistryError {
+    TooManyStreams,
+    BufferLimitExceeded,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AskStreamRegistry {
+    inner: Arc<Mutex<RegistryInner>>,
+}
+
+#[derive(Debug, Default)]
+struct RegistryInner {
+    streams: HashMap<Uuid, AskStreamRecord>,
+}
+
+#[derive(Debug, Clone)]
+struct AskStreamRecord {
+    caller: StreamCaller,
+    envelopes: Vec<SseEnvelope>,
+    done: bool,
+    created_at: Instant,
+    bytes: usize,
+}
+
+impl Default for AskStreamRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AskStreamRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(RegistryInner::default())),
+        }
+    }
+
+    pub(crate) fn start_stream(&self, caller: StreamCaller) -> Result<Uuid, StreamRegistryError> {
+        let mut inner = self.inner.lock().expect("ask stream registry poisoned");
+        inner.evict_expired();
+        let active = inner
+            .streams
+            .values()
+            .filter(|record| record.caller == caller && !record.done)
+            .count();
+        if active >= MAX_CONCURRENT_STREAMS_PER_CALLER {
+            return Err(StreamRegistryError::TooManyStreams);
+        }
+        let stream_id = Uuid::new_v4();
+        inner.streams.insert(
+            stream_id,
+            AskStreamRecord {
+                caller,
+                envelopes: Vec::new(),
+                done: false,
+                created_at: Instant::now(),
+                bytes: 0,
+            },
+        );
+        Ok(stream_id)
+    }
+
+    pub(crate) fn append(
+        &self,
+        stream_id: Uuid,
+        envelope: SseEnvelope,
+    ) -> Result<(), StreamRegistryError> {
+        let mut inner = self.inner.lock().expect("ask stream registry poisoned");
+        inner.evict_expired();
+        let Some(record) = inner.streams.get_mut(&stream_id) else {
+            return Ok(());
+        };
+        let bytes = envelope_size(&envelope);
+        if record.envelopes.len() >= MAX_EVENTS_PER_STREAM
+            || record.bytes.saturating_add(bytes) > MAX_BYTES_PER_STREAM
+        {
+            inner.streams.remove(&stream_id);
+            return Err(StreamRegistryError::BufferLimitExceeded);
+        }
+        record.bytes += bytes;
+        record.envelopes.push(envelope);
+        Ok(())
+    }
+
+    pub(crate) fn mark_done(&self, stream_id: Uuid) {
+        let mut inner = self.inner.lock().expect("ask stream registry poisoned");
+        inner.evict_expired();
+        if let Some(record) = inner.streams.get_mut(&stream_id) {
+            record.done = true;
+        }
+    }
+
+    pub(crate) fn replay_after(
+        &self,
+        stream_id: Uuid,
+        after_sequence: u64,
+        caller: StreamCaller,
+    ) -> Option<Vec<SseEnvelope>> {
+        let mut inner = self.inner.lock().expect("ask stream registry poisoned");
+        inner.evict_expired();
+        let record = inner.streams.get(&stream_id)?;
+        if record.caller != caller {
+            return None;
+        }
+        Some(
+            record
+                .envelopes
+                .iter()
+                .filter(|envelope| envelope.sequence > after_sequence)
+                .cloned()
+                .collect(),
+        )
+    }
+}
+
+impl RegistryInner {
+    fn evict_expired(&mut self) {
+        let now = Instant::now();
+        self.streams
+            .retain(|_, record| now.duration_since(record.created_at) <= ASK_STREAM_TTL);
+    }
+}
+
+pub(crate) fn envelope(
+    sequence: u64,
+    event: impl Into<String>,
+    request_id: &str,
+    data: Value,
+) -> SseEnvelope {
+    SseEnvelope {
+        version: SSE_VERSION,
+        sequence,
+        event: event.into(),
+        request_id: request_id.to_string(),
+        data,
+    }
+}
+
+pub(crate) fn event_from_envelope(
+    stream_id: Uuid,
+    envelope: &SseEnvelope,
+) -> Result<Event, Infallible> {
+    let data = serde_json::to_string(envelope).expect("SSE envelope is serializable");
+    Ok(Event::default()
+        .id(format!("{stream_id}:{}", envelope.sequence))
+        .event(envelope.event.clone())
+        .data(data))
+}
+
+pub(crate) fn parse_last_event_id(value: &str) -> Option<(Uuid, u64)> {
+    let (stream_id, sequence) = value.split_once(':')?;
+    let stream_id = Uuid::parse_str(stream_id).ok()?;
+    let sequence = sequence.parse::<u64>().ok()?;
+    Some((stream_id, sequence))
+}
+
+fn envelope_size(envelope: &SseEnvelope) -> usize {
+    envelope.request_id.len()
+        + envelope.event.len()
+        + envelope.data.to_string().len()
+        + std::mem::size_of_val(&envelope.version)
+        + std::mem::size_of_val(&envelope.sequence)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn replay_is_bound_to_the_original_caller() {
+        let registry = AskStreamRegistry::new();
+        let caller = StreamCaller {
+            org_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+        };
+        let other = StreamCaller {
+            org_id: caller.org_id,
+            user_id: Uuid::new_v4(),
+        };
+        let stream_id = registry.start_stream(caller).unwrap();
+        registry
+            .append(
+                stream_id,
+                envelope(1, "ask.token", "req", json!({"token":"a"})),
+            )
+            .unwrap();
+
+        assert_eq!(
+            registry.replay_after(stream_id, 0, caller).unwrap().len(),
+            1
+        );
+        assert!(registry.replay_after(stream_id, 0, other).is_none());
+    }
+
+    #[test]
+    fn last_event_id_parser_requires_stream_and_sequence() {
+        let stream_id = Uuid::new_v4();
+        assert_eq!(
+            parse_last_event_id(&format!("{stream_id}:12")),
+            Some((stream_id, 12))
+        );
+        assert!(parse_last_event_id("not-a-stream").is_none());
+        assert!(parse_last_event_id(&format!("{stream_id}:nope")).is_none());
+    }
+}

--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -1,8 +1,8 @@
 //! SSE helpers and bounded replay state for resumable API streams.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::convert::Infallible;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use axum::response::sse::Event;
@@ -16,6 +16,8 @@ const ASK_STREAM_TTL: Duration = Duration::from_secs(5 * 60);
 const MAX_EVENTS_PER_STREAM: usize = 128;
 const MAX_BYTES_PER_STREAM: usize = 300 * 1024;
 const MAX_CONCURRENT_STREAMS_PER_CALLER: usize = 4;
+const MAX_RETAINED_STREAMS_PER_CALLER: usize = 8;
+const MAX_TOTAL_STREAMS: usize = 512;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct StreamCaller {
@@ -42,6 +44,7 @@ struct RegistryInner {
 #[derive(Debug, Clone)]
 struct AskStreamRecord {
     caller: StreamCaller,
+    collection_scope: BTreeSet<Uuid>,
     envelopes: Vec<SseEnvelope>,
     done: bool,
     created_at: Instant,
@@ -61,15 +64,24 @@ impl AskStreamRegistry {
         }
     }
 
-    pub(crate) fn start_stream(&self, caller: StreamCaller) -> Result<Uuid, StreamRegistryError> {
-        let mut inner = self.inner.lock().expect("ask stream registry poisoned");
+    pub(crate) fn start_stream(
+        &self,
+        caller: StreamCaller,
+        collection_scope: impl IntoIterator<Item = Uuid>,
+    ) -> Result<Uuid, StreamRegistryError> {
+        let mut inner = self.lock_inner();
         inner.evict_expired();
-        let active = inner
-            .streams
-            .values()
-            .filter(|record| record.caller == caller && !record.done)
-            .count();
-        if active >= MAX_CONCURRENT_STREAMS_PER_CALLER {
+        if inner.active_count_for_caller(caller) >= MAX_CONCURRENT_STREAMS_PER_CALLER {
+            return Err(StreamRegistryError::TooManyStreams);
+        }
+        if inner.total_count_for_caller(caller) >= MAX_RETAINED_STREAMS_PER_CALLER {
+            inner.evict_oldest_done_for_caller(caller);
+        }
+        if inner.total_count_for_caller(caller) >= MAX_RETAINED_STREAMS_PER_CALLER {
+            return Err(StreamRegistryError::TooManyStreams);
+        }
+        while inner.streams.len() >= MAX_TOTAL_STREAMS && inner.evict_oldest_done() {}
+        if inner.streams.len() >= MAX_TOTAL_STREAMS {
             return Err(StreamRegistryError::TooManyStreams);
         }
         let stream_id = Uuid::new_v4();
@@ -77,6 +89,7 @@ impl AskStreamRegistry {
             stream_id,
             AskStreamRecord {
                 caller,
+                collection_scope: collection_scope.into_iter().collect(),
                 envelopes: Vec::new(),
                 done: false,
                 created_at: Instant::now(),
@@ -91,7 +104,7 @@ impl AskStreamRegistry {
         stream_id: Uuid,
         envelope: SseEnvelope,
     ) -> Result<(), StreamRegistryError> {
-        let mut inner = self.inner.lock().expect("ask stream registry poisoned");
+        let mut inner = self.lock_inner();
         inner.evict_expired();
         let Some(record) = inner.streams.get_mut(&stream_id) else {
             return Ok(());
@@ -109,11 +122,17 @@ impl AskStreamRegistry {
     }
 
     pub(crate) fn mark_done(&self, stream_id: Uuid) {
-        let mut inner = self.inner.lock().expect("ask stream registry poisoned");
+        let mut inner = self.lock_inner();
         inner.evict_expired();
         if let Some(record) = inner.streams.get_mut(&stream_id) {
             record.done = true;
         }
+    }
+
+    pub(crate) fn remove(&self, stream_id: Uuid) {
+        let mut inner = self.lock_inner();
+        inner.evict_expired();
+        inner.streams.remove(&stream_id);
     }
 
     pub(crate) fn replay_after(
@@ -121,11 +140,16 @@ impl AskStreamRegistry {
         stream_id: Uuid,
         after_sequence: u64,
         caller: StreamCaller,
+        current_allowed: impl IntoIterator<Item = Uuid>,
     ) -> Option<Vec<SseEnvelope>> {
-        let mut inner = self.inner.lock().expect("ask stream registry poisoned");
+        let mut inner = self.lock_inner();
         inner.evict_expired();
         let record = inner.streams.get(&stream_id)?;
         if record.caller != caller {
+            return None;
+        }
+        let current_allowed: BTreeSet<Uuid> = current_allowed.into_iter().collect();
+        if !record.collection_scope.is_subset(&current_allowed) {
             return None;
         }
         Some(
@@ -137,6 +161,12 @@ impl AskStreamRegistry {
                 .collect(),
         )
     }
+
+    fn lock_inner(&self) -> MutexGuard<'_, RegistryInner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 }
 
 impl RegistryInner {
@@ -144,6 +174,50 @@ impl RegistryInner {
         let now = Instant::now();
         self.streams
             .retain(|_, record| now.duration_since(record.created_at) <= ASK_STREAM_TTL);
+    }
+
+    fn active_count_for_caller(&self, caller: StreamCaller) -> usize {
+        self.streams
+            .values()
+            .filter(|record| record.caller == caller && !record.done)
+            .count()
+    }
+
+    fn total_count_for_caller(&self, caller: StreamCaller) -> usize {
+        self.streams
+            .values()
+            .filter(|record| record.caller == caller)
+            .count()
+    }
+
+    fn evict_oldest_done_for_caller(&mut self, caller: StreamCaller) -> bool {
+        let oldest = self
+            .streams
+            .iter()
+            .filter(|(_, record)| record.caller == caller && record.done)
+            .min_by_key(|(_, record)| record.created_at)
+            .map(|(stream_id, _)| *stream_id);
+        if let Some(stream_id) = oldest {
+            self.streams.remove(&stream_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn evict_oldest_done(&mut self) -> bool {
+        let oldest = self
+            .streams
+            .iter()
+            .filter(|(_, record)| record.done)
+            .min_by_key(|(_, record)| record.created_at)
+            .map(|(stream_id, _)| *stream_id);
+        if let Some(stream_id) = oldest {
+            self.streams.remove(&stream_id);
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -197,6 +271,7 @@ mod tests {
     #[test]
     fn replay_is_bound_to_the_original_caller() {
         let registry = AskStreamRegistry::new();
+        let collection = Uuid::new_v4();
         let caller = StreamCaller {
             org_id: Uuid::new_v4(),
             user_id: Uuid::new_v4(),
@@ -205,7 +280,7 @@ mod tests {
             org_id: caller.org_id,
             user_id: Uuid::new_v4(),
         };
-        let stream_id = registry.start_stream(caller).unwrap();
+        let stream_id = registry.start_stream(caller, [collection]).unwrap();
         registry
             .append(
                 stream_id,
@@ -214,10 +289,108 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            registry.replay_after(stream_id, 0, caller).unwrap().len(),
+            registry
+                .replay_after(stream_id, 0, caller, [collection])
+                .unwrap()
+                .len(),
             1
         );
-        assert!(registry.replay_after(stream_id, 0, other).is_none());
+        assert!(registry
+            .replay_after(stream_id, 0, other, [collection])
+            .is_none());
+    }
+
+    #[test]
+    fn replay_requires_current_collection_scope() {
+        let registry = AskStreamRegistry::new();
+        let caller = StreamCaller {
+            org_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+        };
+        let collection = Uuid::new_v4();
+        let stream_id = registry.start_stream(caller, [collection]).unwrap();
+        registry
+            .append(
+                stream_id,
+                envelope(1, "ask.token", "req", json!({"token":"a"})),
+            )
+            .unwrap();
+        registry.mark_done(stream_id);
+
+        assert!(registry
+            .replay_after(stream_id, 0, caller, [collection])
+            .is_some());
+        assert!(registry.replay_after(stream_id, 0, caller, []).is_none());
+    }
+
+    #[test]
+    fn active_streams_are_capped_per_caller() {
+        let registry = AskStreamRegistry::new();
+        let caller = StreamCaller {
+            org_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+        };
+        let collection = Uuid::new_v4();
+        for _ in 0..MAX_CONCURRENT_STREAMS_PER_CALLER {
+            registry.start_stream(caller, [collection]).unwrap();
+        }
+
+        assert_eq!(
+            registry.start_stream(caller, [collection]).unwrap_err(),
+            StreamRegistryError::TooManyStreams
+        );
+    }
+
+    #[test]
+    fn retained_streams_are_capped_per_caller_by_evicting_done_records() {
+        let registry = AskStreamRegistry::new();
+        let caller = StreamCaller {
+            org_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+        };
+        let collection = Uuid::new_v4();
+        let mut retained = Vec::new();
+        for _ in 0..MAX_RETAINED_STREAMS_PER_CALLER {
+            let stream_id = registry.start_stream(caller, [collection]).unwrap();
+            registry.mark_done(stream_id);
+            retained.push(stream_id);
+        }
+
+        let new_stream = registry.start_stream(caller, [collection]).unwrap();
+        registry.mark_done(new_stream);
+
+        assert!(registry
+            .replay_after(retained[0], 0, caller, [collection])
+            .is_none());
+        assert!(registry
+            .replay_after(new_stream, 0, caller, [collection])
+            .is_some());
+        assert_eq!(
+            registry.lock_inner().total_count_for_caller(caller),
+            MAX_RETAINED_STREAMS_PER_CALLER
+        );
+    }
+
+    #[test]
+    fn global_stream_cap_evicts_done_records() {
+        let registry = AskStreamRegistry::new();
+        let collection = Uuid::new_v4();
+        for _ in 0..MAX_TOTAL_STREAMS {
+            let caller = StreamCaller {
+                org_id: Uuid::new_v4(),
+                user_id: Uuid::new_v4(),
+            };
+            let stream_id = registry.start_stream(caller, [collection]).unwrap();
+            registry.mark_done(stream_id);
+        }
+        let caller = StreamCaller {
+            org_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+        };
+
+        registry.start_stream(caller, [collection]).unwrap();
+
+        assert_eq!(registry.lock_inner().streams.len(), MAX_TOTAL_STREAMS);
     }
 
     #[test]

--- a/crates/server/src/api/sse.rs
+++ b/crates/server/src/api/sse.rs
@@ -14,6 +14,10 @@ use crate::api::SseEnvelope;
 const SSE_VERSION: u16 = 1;
 const ASK_STREAM_TTL: Duration = Duration::from_secs(5 * 60);
 const MAX_EVENTS_PER_STREAM: usize = 128;
+/// Per-stream replay budget. Accounted bytes include stored collection-scope
+/// UUIDs plus serialized envelope payload estimates; total retained replay
+/// memory is bounded by `MAX_TOTAL_STREAMS * MAX_BYTES_PER_STREAM` plus O(1)
+/// fixed overhead per retained record.
 const MAX_BYTES_PER_STREAM: usize = 300 * 1024;
 const MAX_CONCURRENT_STREAMS_PER_CALLER: usize = 4;
 const MAX_RETAINED_STREAMS_PER_CALLER: usize = 8;
@@ -44,7 +48,7 @@ struct RegistryInner {
 #[derive(Debug, Clone)]
 struct AskStreamRecord {
     caller: StreamCaller,
-    collection_scope: BTreeSet<Uuid>,
+    collection_scope: Box<[Uuid]>,
     envelopes: Vec<SseEnvelope>,
     done: bool,
     created_at: Instant,
@@ -69,6 +73,11 @@ impl AskStreamRegistry {
         caller: StreamCaller,
         collection_scope: impl IntoIterator<Item = Uuid>,
     ) -> Result<Uuid, StreamRegistryError> {
+        let collection_scope = normalized_scope(collection_scope);
+        let scope_bytes = collection_scope_bytes(collection_scope.len());
+        if scope_bytes > MAX_BYTES_PER_STREAM {
+            return Err(StreamRegistryError::BufferLimitExceeded);
+        }
         let mut inner = self.lock_inner();
         inner.evict_expired();
         if inner.active_count_for_caller(caller) >= MAX_CONCURRENT_STREAMS_PER_CALLER {
@@ -89,11 +98,11 @@ impl AskStreamRegistry {
             stream_id,
             AskStreamRecord {
                 caller,
-                collection_scope: collection_scope.into_iter().collect(),
+                collection_scope,
                 envelopes: Vec::new(),
                 done: false,
                 created_at: Instant::now(),
-                bytes: 0,
+                bytes: scope_bytes,
             },
         );
         Ok(stream_id)
@@ -149,7 +158,11 @@ impl AskStreamRegistry {
             return None;
         }
         let current_allowed: BTreeSet<Uuid> = current_allowed.into_iter().collect();
-        if !record.collection_scope.is_subset(&current_allowed) {
+        if !record
+            .collection_scope
+            .iter()
+            .all(|collection_id| current_allowed.contains(collection_id))
+        {
             return None;
         }
         Some(
@@ -262,6 +275,18 @@ fn envelope_size(envelope: &SseEnvelope) -> usize {
         + std::mem::size_of_val(&envelope.sequence)
 }
 
+fn normalized_scope(scope: impl IntoIterator<Item = Uuid>) -> Box<[Uuid]> {
+    scope
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn collection_scope_bytes(len: usize) -> usize {
+    len.saturating_mul(std::mem::size_of::<Uuid>())
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -321,6 +346,37 @@ mod tests {
             .replay_after(stream_id, 0, caller, [collection])
             .is_some());
         assert!(registry.replay_after(stream_id, 0, caller, []).is_none());
+    }
+
+    #[test]
+    fn record_accounted_bytes_include_collection_scope() {
+        let registry = AskStreamRegistry::new();
+        let caller = StreamCaller {
+            org_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+        };
+        let scope = [Uuid::new_v4(), Uuid::new_v4()];
+        let stream_id = registry.start_stream(caller, scope).unwrap();
+
+        let inner = registry.lock_inner();
+        let record = inner.streams.get(&stream_id).expect("record");
+        assert_eq!(record.bytes, collection_scope_bytes(scope.len()));
+    }
+
+    #[test]
+    fn scope_larger_than_per_stream_budget_is_rejected() {
+        let registry = AskStreamRegistry::new();
+        let caller = StreamCaller {
+            org_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+        };
+        let oversized_scope =
+            (0..=(MAX_BYTES_PER_STREAM / std::mem::size_of::<Uuid>())).map(|_| Uuid::new_v4());
+
+        assert_eq!(
+            registry.start_stream(caller, oversized_scope).unwrap_err(),
+            StreamRegistryError::BufferLimitExceeded
+        );
     }
 
     #[test]

--- a/crates/server/src/auth/context.rs
+++ b/crates/server/src/auth/context.rs
@@ -78,6 +78,26 @@ impl OrgContext {
     pub fn allows_collection(&self, collection_id: Uuid) -> bool {
         self.allowed_collection_ids.contains(&collection_id)
     }
+
+    /// Returns a context whose collection allow-list is the intersection of the
+    /// current allow-list and `requested_collection_ids`.
+    pub fn with_narrowed_collections(
+        &self,
+        requested_collection_ids: impl IntoIterator<Item = Uuid>,
+    ) -> Self {
+        let requested: BTreeSet<Uuid> = requested_collection_ids.into_iter().collect();
+        let allowed_collection_ids = self
+            .allowed_collection_ids
+            .intersection(&requested)
+            .copied()
+            .collect();
+        Self {
+            org_id: self.org_id,
+            user_id: self.user_id,
+            permissions: self.permissions.clone(),
+            allowed_collection_ids,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -108,5 +128,20 @@ mod tests {
         assert_eq!(ctx.user_id(), user);
         assert!(ctx.has_permission("doc.upload"));
         assert!(ctx.allows_collection(collection));
+    }
+
+    #[test]
+    fn narrowed_context_can_only_shrink_collection_scope() {
+        let org = Uuid::new_v4();
+        let user = Uuid::new_v4();
+        let allowed = Uuid::new_v4();
+        let denied = Uuid::new_v4();
+        let ctx = OrgContext::try_new(org, user, ["qa.query"], [allowed]).unwrap();
+
+        let narrowed = ctx.with_narrowed_collections([allowed, denied]);
+
+        assert!(narrowed.allows_collection(allowed));
+        assert!(!narrowed.allows_collection(denied));
+        assert!(narrowed.has_permission("qa.query"));
     }
 }

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -182,7 +182,7 @@ impl AppState {
         self.object_store.as_ref()
     }
 
-    pub fn qdrant(&self) -> &crate::storage::QdrantClient {
+    pub fn vector_store(&self) -> &crate::storage::QdrantClient {
         &self.qdrant
     }
 

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use tokio::time::timeout;
 use uuid::Uuid;
 
+use crate::api::sse::AskStreamRegistry;
 use crate::api::ApiError;
 use crate::auth::jwt::JwtKeys;
 use crate::auth::provider::PasswordAuthProvider;
@@ -35,6 +36,8 @@ pub struct AppState {
     auth_provider: Option<PasswordAuthProvider>,
     /// Object store adapter (optional when credentials are absent in tests).
     object_store: Option<crate::storage::MinioClient>,
+    qdrant: crate::storage::QdrantClient,
+    ask_streams: AskStreamRegistry,
     download_capability_key: Option<CapabilityKey>,
     consumed_download_nonces: ConsumedDownloadNonces,
 }
@@ -64,12 +67,27 @@ impl AppState {
             Err(crate::auth::jwt::JwtError::NotConfigured) => None,
             Err(error) => return Err(format!("cannot configure authentication: {error}")),
         };
-        let object_store = match runtime.config().storage_config() {
-            Ok(storage) => Some(
-                crate::storage::MinioClient::from_config(storage.minio())
-                    .map_err(|error| format!("cannot configure object store: {error}"))?,
-            ),
-            Err(_) => None,
+        let (object_store, qdrant) = match runtime.config().storage_config() {
+            Ok(storage) => {
+                let qdrant = crate::storage::QdrantClient::with_api_key(
+                    storage.qdrant_url(),
+                    storage.qdrant_api_key().cloned(),
+                )
+                .map_err(|error| format!("cannot configure qdrant client: {}", error.code()))?;
+                let object_store = Some(
+                    crate::storage::MinioClient::from_config(storage.minio())
+                        .map_err(|error| format!("cannot configure object store: {error}"))?,
+                );
+                (object_store, qdrant)
+            }
+            Err(error) => {
+                let qdrant = crate::storage::QdrantClient::new(&runtime.endpoints().qdrant_url)
+                    .map_err(|error| format!("cannot configure qdrant client: {}", error.code()))?;
+                if runtime.config().profile() == crate::config::Profile::Prod {
+                    return Err(error);
+                }
+                (None, qdrant)
+            }
         };
         start_quota_sweep(pool.clone(), runtime.config().quota_sweep());
         let download_capability_key = runtime
@@ -85,6 +103,8 @@ impl AppState {
             pool,
             auth_provider,
             object_store,
+            qdrant,
+            ask_streams: AskStreamRegistry::new(),
             download_capability_key,
             consumed_download_nonces: ConsumedDownloadNonces::new(),
         })
@@ -106,6 +126,19 @@ impl AppState {
         auth_provider: Option<PasswordAuthProvider>,
         object_store: Option<crate::storage::MinioClient>,
     ) -> Result<Self, String> {
+        let qdrant = crate::storage::QdrantClient::new(&runtime.endpoints().qdrant_url)
+            .map_err(|error| format!("cannot configure qdrant client: {}", error.code()))?;
+        Self::from_parts_with_clients(runtime, pool, auth_provider, object_store, qdrant)
+    }
+
+    /// Builds state for tests with explicit object-store and vector clients.
+    pub fn from_parts_with_clients(
+        runtime: RuntimeState,
+        pool: Pool,
+        auth_provider: Option<PasswordAuthProvider>,
+        object_store: Option<crate::storage::MinioClient>,
+        qdrant: crate::storage::QdrantClient,
+    ) -> Result<Self, String> {
         if !runtime.is_api_role() {
             return Err("HTTP application requires API runtime configuration".into());
         }
@@ -126,6 +159,8 @@ impl AppState {
             pool,
             auth_provider,
             object_store,
+            qdrant,
+            ask_streams: AskStreamRegistry::new(),
             download_capability_key,
             consumed_download_nonces: ConsumedDownloadNonces::new(),
         })
@@ -145,6 +180,14 @@ impl AppState {
 
     pub fn object_store(&self) -> Option<&crate::storage::MinioClient> {
         self.object_store.as_ref()
+    }
+
+    pub fn qdrant(&self) -> &crate::storage::QdrantClient {
+        &self.qdrant
+    }
+
+    pub(crate) fn ask_streams(&self) -> AskStreamRegistry {
+        self.ask_streams.clone()
     }
 
     pub fn download_capability_key(&self) -> Option<&CapabilityKey> {
@@ -198,6 +241,9 @@ pub fn router(state: AppState) -> Router {
         .merge(routes::collections::router())
         .merge(routes::documents::router())
         .merge(routes::jobs::router())
+        .merge(routes::search::router())
+        .merge(routes::ask::router())
+        .merge(routes::events::router())
         .merge(routes::uploads::router(max_upload_bytes))
         .with_state(Arc::new(state))
 }

--- a/crates/server/src/routes/ask.rs
+++ b/crates/server/src/routes/ask.rs
@@ -72,7 +72,7 @@ async fn ask(
     let input = validate_ask_request(body, &auth.context, &request_id)?;
     let stream = answer_question(
         state.pool(),
-        state.qdrant(),
+        state.vector_store(),
         &input.ctx,
         QaRequest {
             question: input.question,
@@ -107,7 +107,12 @@ async fn ask_stream(
             parse_last_event_id(last_event_id).ok_or_else(|| RestError::not_found(&request_id))?;
         let envelopes = state
             .ask_streams()
-            .replay_after(stream_id, sequence, caller)
+            .replay_after(
+                stream_id,
+                sequence,
+                caller,
+                auth.context.allowed_collection_ids().iter().copied(),
+            )
             .ok_or_else(|| RestError::not_found(&request_id))?;
         let stream = stream::iter(
             envelopes
@@ -120,9 +125,14 @@ async fn ask_stream(
     let body: AskRequestBody = serde_json::from_slice(&body)
         .map_err(|_| RestError::validation("request body is invalid", &request_id))?;
     let input = validate_ask_request(body, &auth.context, &request_id)?;
+    let collection_scope = input.ctx.allowed_collection_ids().iter().copied();
+    let stream_id = state
+        .ask_streams()
+        .start_stream(caller, collection_scope)
+        .map_err(|error| map_registry_error(error, &request_id))?;
     let qa_stream = answer_question(
         state.pool(),
-        state.qdrant(),
+        state.vector_store(),
         &input.ctx,
         QaRequest {
             question: input.question,
@@ -131,11 +141,10 @@ async fn ask_stream(
         },
     )
     .await
-    .map_err(|error| map_qa_error(error, &request_id))?;
-    let stream_id = state
-        .ask_streams()
-        .start_stream(caller)
-        .map_err(|error| map_registry_error(error, &request_id))?;
+    .map_err(|error| {
+        state.ask_streams().remove(stream_id);
+        map_qa_error(error, &request_id)
+    })?;
     let stream = qa_sse_stream(
         stream_id,
         request_id.clone(),

--- a/crates/server/src/routes/ask.rs
+++ b/crates/server/src/routes/ask.rs
@@ -1,0 +1,318 @@
+//! Ask API routes backed by the grounded QA engine.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Bytes;
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{DefaultBodyLimit, State};
+use axum::http::HeaderMap;
+use axum::response::sse::{KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use futures::stream::{self, BoxStream};
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::api::sse::{
+    envelope, event_from_envelope, parse_last_event_id, StreamCaller, StreamRegistryError,
+};
+use crate::api::SseEnvelope;
+use crate::auth::context::OrgContext;
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::http::AppState;
+use crate::routes::common::{require_permission_or_403, RestError};
+use crate::routes::search::{narrowed_context, validate_limit, JSON_BODY_LIMIT, MAX_QUERY_CHARS};
+use crate::services::qa::stream::{DEFAULT_QA_LIMIT, MAX_QA_LIMIT};
+use crate::services::qa::{answer_question, QaAnswerMode, QaCitation, QaError, QaEvent, QaRequest};
+use crate::services::retrieval::VersionMode;
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/v1/ask", post(ask))
+        .route("/api/v1/ask/stream", post(ask_stream))
+        .route_layer(DefaultBodyLimit::max(JSON_BODY_LIMIT))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AskRequestBody {
+    question: String,
+    limit: Option<u32>,
+    collection_ids: Option<Vec<uuid::Uuid>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AskResponse {
+    answer: String,
+    citations: Vec<QaCitation>,
+    warnings: Vec<String>,
+    mode: QaAnswerMode,
+}
+
+struct ValidAskRequest {
+    question: String,
+    limit: usize,
+    ctx: OrgContext,
+}
+
+async fn ask(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    body: Result<Json<AskRequestBody>, JsonRejection>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let Json(body) =
+        body.map_err(|_| RestError::validation("request body is invalid", &request_id))?;
+    require_permission_or_403(&auth.context, "qa.query", &request_id)?;
+    let input = validate_ask_request(body, &auth.context, &request_id)?;
+    let stream = answer_question(
+        state.pool(),
+        state.qdrant(),
+        &input.ctx,
+        QaRequest {
+            question: input.question,
+            limit: input.limit,
+            mode: VersionMode::Current,
+        },
+    )
+    .await
+    .map_err(|error| map_qa_error(error, &request_id))?;
+    let response = collect_answer(stream, &request_id).await?;
+    Ok(Json(response).into_response())
+}
+
+async fn ask_stream(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    require_permission_or_403(&auth.context, "qa.query", &request_id)?;
+    let caller = StreamCaller {
+        org_id: auth.context.org_id(),
+        user_id: auth.context.user_id(),
+    };
+
+    if let Some(last_event_id) = headers
+        .get("last-event-id")
+        .and_then(|value| value.to_str().ok())
+    {
+        let (stream_id, sequence) =
+            parse_last_event_id(last_event_id).ok_or_else(|| RestError::not_found(&request_id))?;
+        let envelopes = state
+            .ask_streams()
+            .replay_after(stream_id, sequence, caller)
+            .ok_or_else(|| RestError::not_found(&request_id))?;
+        let stream = stream::iter(
+            envelopes
+                .into_iter()
+                .map(move |envelope| event_from_envelope(stream_id, &envelope)),
+        );
+        return Ok(sse_response(stream));
+    }
+
+    let body: AskRequestBody = serde_json::from_slice(&body)
+        .map_err(|_| RestError::validation("request body is invalid", &request_id))?;
+    let input = validate_ask_request(body, &auth.context, &request_id)?;
+    let qa_stream = answer_question(
+        state.pool(),
+        state.qdrant(),
+        &input.ctx,
+        QaRequest {
+            question: input.question,
+            limit: input.limit,
+            mode: VersionMode::Current,
+        },
+    )
+    .await
+    .map_err(|error| map_qa_error(error, &request_id))?;
+    let stream_id = state
+        .ask_streams()
+        .start_stream(caller)
+        .map_err(|error| map_registry_error(error, &request_id))?;
+    let stream = qa_sse_stream(
+        stream_id,
+        request_id.clone(),
+        state.ask_streams(),
+        qa_stream,
+    );
+    Ok(sse_response(stream))
+}
+
+fn sse_response<S>(stream: S) -> Response
+where
+    S: futures::Stream<Item = Result<axum::response::sse::Event, Infallible>> + Send + 'static,
+{
+    Sse::new(stream)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("keep-alive"),
+        )
+        .into_response()
+}
+
+fn qa_sse_stream(
+    stream_id: uuid::Uuid,
+    request_id: String,
+    registry: crate::api::sse::AskStreamRegistry,
+    qa_stream: BoxStream<'static, QaEvent>,
+) -> BoxStream<'static, Result<axum::response::sse::Event, Infallible>> {
+    struct State {
+        stream_id: uuid::Uuid,
+        request_id: String,
+        registry: crate::api::sse::AskStreamRegistry,
+        qa_stream: BoxStream<'static, QaEvent>,
+        sequence: u64,
+    }
+
+    stream::unfold(
+        State {
+            stream_id,
+            request_id,
+            registry,
+            qa_stream,
+            sequence: 0,
+        },
+        |mut state| async move {
+            let Some(event) = state.qa_stream.next().await else {
+                state.registry.mark_done(state.stream_id);
+                return None;
+            };
+            state.sequence += 1;
+            let envelope = envelope_from_qa_event(state.sequence, &state.request_id, event);
+            let is_done = envelope.event == "ask.done";
+            let _ = state.registry.append(state.stream_id, envelope.clone());
+            if is_done {
+                state.registry.mark_done(state.stream_id);
+            }
+            Some((event_from_envelope(state.stream_id, &envelope), state))
+        },
+    )
+    .boxed()
+}
+
+async fn collect_answer(
+    mut stream: BoxStream<'static, QaEvent>,
+    request_id: &str,
+) -> Result<AskResponse, RestError> {
+    let mut answer = String::new();
+    let mut citations = Vec::new();
+    let mut warnings = Vec::new();
+    let mut mode = None;
+    while let Some(event) = stream.next().await {
+        match event {
+            QaEvent::Token(token) => answer.push_str(&token),
+            QaEvent::Citations(values) => citations.extend(values),
+            QaEvent::Warning(warning) => warnings.push(warning),
+            QaEvent::Done { mode: value } => mode = Some(value),
+        }
+    }
+    let mode = mode.ok_or_else(|| RestError::internal(request_id))?;
+    Ok(AskResponse {
+        answer,
+        citations,
+        warnings,
+        mode,
+    })
+}
+
+fn validate_ask_request(
+    body: AskRequestBody,
+    ctx: &OrgContext,
+    request_id: &str,
+) -> Result<ValidAskRequest, RestError> {
+    let question = body.question.trim().to_string();
+    if question.is_empty() {
+        return Err(RestError::validation(
+            "question must not be empty",
+            request_id,
+        ));
+    }
+    if question.chars().count() > MAX_QUERY_CHARS {
+        return Err(RestError::validation("question is too long", request_id));
+    }
+    Ok(ValidAskRequest {
+        question,
+        limit: validate_limit(
+            body.limit.or(Some(DEFAULT_QA_LIMIT as u32)),
+            MAX_QA_LIMIT,
+            request_id,
+        )?,
+        ctx: narrowed_context(ctx, body.collection_ids),
+    })
+}
+
+fn envelope_from_qa_event(sequence: u64, request_id: &str, event: QaEvent) -> SseEnvelope {
+    match event {
+        QaEvent::Token(token) => {
+            envelope(sequence, "ask.token", request_id, json!({ "token": token }))
+        }
+        QaEvent::Citations(citations) => envelope(
+            sequence,
+            "ask.citations",
+            request_id,
+            json!({ "citations": citations }),
+        ),
+        QaEvent::Warning(warning) => envelope(
+            sequence,
+            "ask.warning",
+            request_id,
+            json!({ "warning": warning }),
+        ),
+        QaEvent::Done { mode } => {
+            envelope(sequence, "ask.done", request_id, json!({ "mode": mode }))
+        }
+    }
+}
+
+fn map_qa_error(error: QaError, request_id: &str) -> RestError {
+    match error {
+        QaError::EmptyScope => RestError::empty_scope(request_id),
+        QaError::Retrieval(_) => RestError::internal(request_id),
+    }
+}
+
+fn map_registry_error(error: StreamRegistryError, request_id: &str) -> RestError {
+    match error {
+        StreamRegistryError::TooManyStreams => {
+            RestError::too_many_requests("too many active streams", request_id)
+        }
+        StreamRegistryError::BufferLimitExceeded => RestError::internal(request_id),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qa_events_map_to_stable_sse_event_names() {
+        let request_id = "request";
+        assert_eq!(
+            envelope_from_qa_event(1, request_id, QaEvent::Token("hello".into())).event,
+            "ask.token"
+        );
+        assert_eq!(
+            envelope_from_qa_event(2, request_id, QaEvent::Warning("warn".into())).event,
+            "ask.warning"
+        );
+        assert_eq!(
+            envelope_from_qa_event(
+                3,
+                request_id,
+                QaEvent::Done {
+                    mode: QaAnswerMode::OfflineExtractive
+                }
+            )
+            .event,
+            "ask.done"
+        );
+    }
+}

--- a/crates/server/src/routes/ask.rs
+++ b/crates/server/src/routes/ask.rs
@@ -25,7 +25,9 @@ use crate::auth::context::OrgContext;
 use crate::auth::middleware::AuthenticatedOrg;
 use crate::http::AppState;
 use crate::routes::common::{require_permission_or_403, RestError};
-use crate::routes::search::{narrowed_context, validate_limit, JSON_BODY_LIMIT, MAX_QUERY_CHARS};
+use crate::routes::search::{
+    narrowed_context, validate_collection_ids_len, validate_limit, JSON_BODY_LIMIT, MAX_QUERY_CHARS,
+};
 use crate::services::qa::stream::{DEFAULT_QA_LIMIT, MAX_QA_LIMIT};
 use crate::services::qa::{answer_question, QaAnswerMode, QaCitation, QaError, QaEvent, QaRequest};
 use crate::services::retrieval::VersionMode;
@@ -247,6 +249,7 @@ fn validate_ask_request(
     if question.chars().count() > MAX_QUERY_CHARS {
         return Err(RestError::validation("question is too long", request_id));
     }
+    validate_collection_ids_len(body.collection_ids.as_ref(), request_id)?;
     Ok(ValidAskRequest {
         question,
         limit: validate_limit(
@@ -293,7 +296,9 @@ fn map_registry_error(error: StreamRegistryError, request_id: &str) -> RestError
         StreamRegistryError::TooManyStreams => {
             RestError::too_many_requests("too many active streams", request_id)
         }
-        StreamRegistryError::BufferLimitExceeded => RestError::internal(request_id),
+        StreamRegistryError::BufferLimitExceeded => {
+            RestError::too_many_requests("stream replay buffer limit exceeded", request_id)
+        }
     }
 }
 
@@ -323,5 +328,27 @@ mod tests {
             .event,
             "ask.done"
         );
+    }
+
+    #[test]
+    fn collection_ids_length_is_bounded() {
+        let collection = uuid::Uuid::new_v4();
+        let ctx = OrgContext::try_new(
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+            ["qa.query"],
+            [collection],
+        )
+        .unwrap();
+        let body = AskRequestBody {
+            question: "hello?".into(),
+            limit: None,
+            collection_ids: Some(vec![
+                collection;
+                crate::routes::search::MAX_COLLECTION_IDS + 1
+            ]),
+        };
+
+        assert!(validate_ask_request(body, &ctx, "req").is_err());
     }
 }

--- a/crates/server/src/routes/common.rs
+++ b/crates/server/src/routes/common.rs
@@ -44,6 +44,15 @@ impl RestError {
         }
     }
 
+    pub(crate) fn empty_scope(request_id: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code: "empty_scope",
+            message: "No authorized collections are available".into(),
+            request_id: request_id.into(),
+        }
+    }
+
     pub(crate) fn not_found(request_id: impl Into<String>) -> Self {
         Self {
             status: StatusCode::NOT_FOUND,
@@ -76,6 +85,18 @@ impl RestError {
             status: StatusCode::SERVICE_UNAVAILABLE,
             code: "dependency_unavailable",
             message: "A required service is unavailable".into(),
+            request_id: request_id.into(),
+        }
+    }
+
+    pub(crate) fn too_many_requests(
+        message: impl Into<String>,
+        request_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            code: "rate_limited",
+            message: message.into(),
             request_id: request_id.into(),
         }
     }

--- a/crates/server/src/routes/events.rs
+++ b/crates/server/src/routes/events.rs
@@ -1,0 +1,252 @@
+//! SSE event routes for status streams.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::extract::{Path, State};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use chrono::Utc;
+use futures::stream::{self, BoxStream};
+use futures::StreamExt;
+use serde::Deserialize;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::api::sse::{envelope, event_from_envelope};
+use crate::auth::context::OrgContext;
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::auth::permissions::{require_permission, resolve_org_context_in_txn};
+use crate::db::models::{Job, JobStatus};
+use crate::db::pool::with_org_txn_typed;
+use crate::db::{documents, jobs};
+use crate::http::AppState;
+use crate::routes::common::{
+    parse_uuid, require_collection_or_404, require_permission_or_403, RestError, TxnRestError,
+};
+use crate::routes::jobs::JobResponse;
+
+const JOB_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const JOB_EVENTS_MAX_DURATION: Duration = Duration::from_secs(10 * 60);
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().route("/api/v1/jobs/{jobId}/events", get(job_events))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JobEventsPath {
+    job_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct JobSnapshotKey {
+    status: &'static str,
+    attempts: i32,
+    updated_at: chrono::DateTime<Utc>,
+}
+
+async fn job_events(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(path): Path<JobEventsPath>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let job_id = parse_uuid(&path.job_id, &request_id)?;
+    let initial = load_authorized_job(state.clone(), &auth.context, job_id, &request_id).await?;
+    let stream = job_event_stream(state, auth, job_id, initial);
+    Ok(Sse::new(stream)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("keep-alive"),
+        )
+        .into_response())
+}
+
+fn job_event_stream(
+    state: Arc<AppState>,
+    auth: AuthenticatedOrg,
+    job_id: Uuid,
+    initial: Job,
+) -> BoxStream<'static, Result<Event, Infallible>> {
+    struct State {
+        app: Arc<AppState>,
+        auth: AuthenticatedOrg,
+        job_id: Uuid,
+        request_id: String,
+        stream_id: Uuid,
+        sequence: u64,
+        last: Option<JobSnapshotKey>,
+        initial: Option<Job>,
+        interval: tokio::time::Interval,
+        started_at: Instant,
+        closed: bool,
+    }
+
+    let mut interval = tokio::time::interval(JOB_POLL_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    stream::unfold(
+        State {
+            app: state,
+            request_id: auth.request_id.clone(),
+            auth,
+            job_id,
+            stream_id: Uuid::new_v4(),
+            sequence: 0,
+            last: None,
+            initial: Some(initial),
+            interval,
+            started_at: Instant::now(),
+            closed: false,
+        },
+        |mut state| async move {
+            loop {
+                if state.closed {
+                    return None;
+                }
+
+                let job = if let Some(job) = state.initial.take() {
+                    job
+                } else {
+                    state.interval.tick().await;
+                    if state.started_at.elapsed() > JOB_EVENTS_MAX_DURATION {
+                        state.closed = true;
+                        state.sequence += 1;
+                        let envelope = envelope(
+                            state.sequence,
+                            "job.close",
+                            &state.request_id,
+                            json!({ "reason": "max_duration" }),
+                        );
+                        return Some((event_from_envelope(state.stream_id, &envelope), state));
+                    }
+                    match refresh_and_load_authorized_job(
+                        state.app.clone(),
+                        &state.auth,
+                        state.job_id,
+                        &state.request_id,
+                    )
+                    .await
+                    {
+                        Ok(job) => job,
+                        Err(()) => {
+                            state.closed = true;
+                            state.sequence += 1;
+                            let envelope = envelope(
+                                state.sequence,
+                                "job.close",
+                                &state.request_id,
+                                json!({ "reason": "authorization_changed" }),
+                            );
+                            return Some((event_from_envelope(state.stream_id, &envelope), state));
+                        }
+                    }
+                };
+
+                let key = snapshot_key(&job);
+                if state.last.as_ref() == Some(&key) {
+                    continue;
+                }
+
+                state.last = Some(key);
+                state.sequence += 1;
+                let event_name = if is_terminal(job.status) {
+                    state.closed = true;
+                    "job.done"
+                } else {
+                    "job.status"
+                };
+                let envelope = envelope(
+                    state.sequence,
+                    event_name,
+                    &state.request_id,
+                    serde_json::to_value(JobResponse::from(job))
+                        .expect("job response is serializable"),
+                );
+                return Some((event_from_envelope(state.stream_id, &envelope), state));
+            }
+        },
+    )
+    .boxed()
+}
+
+async fn refresh_and_load_authorized_job(
+    state: Arc<AppState>,
+    auth: &AuthenticatedOrg,
+    job_id: Uuid,
+    request_id: &str,
+) -> Result<Job, ()> {
+    if auth.claims.exp <= Utc::now().timestamp() {
+        return Err(());
+    }
+    let org_id = auth.context.org_id();
+    let user_id = auth.context.user_id();
+    let fresh = resolve_org_context_in_txn(state.pool(), org_id, user_id)
+        .await
+        .map_err(|_| ())?;
+    require_permission(&fresh, "qa.query").map_err(|_| ())?;
+    load_authorized_job(state, &fresh, job_id, request_id)
+        .await
+        .map_err(|_| ())
+}
+
+async fn load_authorized_job(
+    state: Arc<AppState>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    request_id: &str,
+) -> Result<Job, RestError> {
+    with_org_txn_typed(state.pool(), ctx, {
+        let ctx = ctx.clone();
+        let request_id = request_id.to_string();
+        move |txn| {
+            Box::pin(async move {
+                require_permission_or_403(&ctx, "qa.query", &request_id)?;
+                let job = jobs::get_by_id(txn, &ctx, job_id)
+                    .await?
+                    .ok_or_else(|| RestError::not_found(&request_id))?;
+                let document_id = job
+                    .document_id
+                    .ok_or_else(|| RestError::not_found(&request_id))?;
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                require_collection_or_404(&ctx, document.collection_id, &request_id)?;
+                Ok::<_, TxnRestError>(job)
+            })
+        }
+    })
+    .await
+    .map_err(|error: TxnRestError| error.into_rest(request_id))
+}
+
+fn snapshot_key(job: &Job) -> JobSnapshotKey {
+    JobSnapshotKey {
+        status: job.status.as_str(),
+        attempts: job.attempts,
+        updated_at: job.updated_at,
+    }
+}
+
+fn is_terminal(status: JobStatus) -> bool {
+    matches!(
+        status,
+        JobStatus::Succeeded | JobStatus::DeadLetter | JobStatus::Cancelled | JobStatus::Failed
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_jobs_are_terminal_for_sse() {
+        assert!(is_terminal(JobStatus::Succeeded));
+        assert!(is_terminal(JobStatus::DeadLetter));
+        assert!(is_terminal(JobStatus::Cancelled));
+        assert!(is_terminal(JobStatus::Failed));
+        assert!(!is_terminal(JobStatus::Pending));
+    }
+}

--- a/crates/server/src/routes/jobs.rs
+++ b/crates/server/src/routes/jobs.rs
@@ -31,19 +31,19 @@ struct JobPath {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct JobResponse {
-    id: Uuid,
-    job_type: &'static str,
-    status: &'static str,
-    attempts: i32,
-    max_attempts: i32,
-    document_id: Option<Uuid>,
-    version_id: Option<Uuid>,
-    available_at: DateTime<Utc>,
-    started_at: Option<DateTime<Utc>>,
-    finished_at: Option<DateTime<Utc>>,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
+pub(crate) struct JobResponse {
+    pub(crate) id: Uuid,
+    pub(crate) job_type: &'static str,
+    pub(crate) status: &'static str,
+    pub(crate) attempts: i32,
+    pub(crate) max_attempts: i32,
+    pub(crate) document_id: Option<Uuid>,
+    pub(crate) version_id: Option<Uuid>,
+    pub(crate) available_at: DateTime<Utc>,
+    pub(crate) started_at: Option<DateTime<Utc>>,
+    pub(crate) finished_at: Option<DateTime<Utc>>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
 }
 
 impl From<Job> for JobResponse {

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,8 +1,11 @@
 //! HTTP route modules.
 
+pub mod ask;
 pub mod auth;
 pub mod collections;
 pub(crate) mod common;
 pub mod documents;
+pub mod events;
 pub mod jobs;
+pub mod search;
 pub mod uploads;

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -21,6 +21,7 @@ use crate::services::retrieval::{
 
 pub(crate) const JSON_BODY_LIMIT: usize = 16 * 1024;
 pub(crate) const MAX_QUERY_CHARS: usize = 4096;
+pub(crate) const MAX_COLLECTION_IDS: usize = 512;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -118,12 +119,26 @@ pub(crate) fn validate_search_request(
     if query.chars().count() > MAX_QUERY_CHARS {
         return Err(RestError::validation("query is too long", request_id));
     }
+    validate_collection_ids_len(body.collection_ids.as_ref(), request_id)?;
     let limit = validate_limit(body.limit, MAX_RETRIEVAL_LIMIT, request_id)?;
     Ok(ValidSearchRequest {
         query,
         limit,
         ctx: narrowed_context(ctx, body.collection_ids),
     })
+}
+
+pub(crate) fn validate_collection_ids_len(
+    collection_ids: Option<&Vec<Uuid>>,
+    request_id: &str,
+) -> Result<(), RestError> {
+    if collection_ids.is_some_and(|ids| ids.len() > MAX_COLLECTION_IDS) {
+        return Err(RestError::validation(
+            format!("collectionIds must contain at most {MAX_COLLECTION_IDS} entries"),
+            request_id,
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_limit(
@@ -222,6 +237,20 @@ mod tests {
             query: "x".repeat(MAX_QUERY_CHARS + 1),
             limit: None,
             collection_ids: None,
+        };
+
+        assert!(validate_search_request(body, &ctx, "req").is_err());
+    }
+
+    #[test]
+    fn collection_ids_length_is_bounded() {
+        let collection = Uuid::new_v4();
+        let ctx = OrgContext::try_new(Uuid::new_v4(), Uuid::new_v4(), ["qa.query"], [collection])
+            .unwrap();
+        let body = SearchRequestBody {
+            query: "hello".into(),
+            limit: None,
+            collection_ids: Some(vec![collection; MAX_COLLECTION_IDS + 1]),
         };
 
         assert!(validate_search_request(body, &ctx, "req").is_err());

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -1,0 +1,229 @@
+//! Search API routes backed by the tenant-scoped retrieval engine.
+
+use std::sync::Arc;
+
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{DefaultBodyLimit, State};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::http::AppState;
+use crate::routes::common::{require_permission_or_403, RestError};
+use crate::services::retrieval::{
+    retrieve, Degradation, GroundedHit, RetrievalError, RetrievalRequest, VersionMode,
+    MAX_RETRIEVAL_LIMIT,
+};
+
+pub(crate) const JSON_BODY_LIMIT: usize = 16 * 1024;
+pub(crate) const MAX_QUERY_CHARS: usize = 4096;
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/v1/search", post(search))
+        .route_layer(DefaultBodyLimit::max(JSON_BODY_LIMIT))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SearchRequestBody {
+    pub(crate) query: String,
+    pub(crate) limit: Option<u32>,
+    pub(crate) collection_ids: Option<Vec<Uuid>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SearchResponse {
+    hits: Vec<SearchHitResponse>,
+    degraded: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SearchHitResponse {
+    chunk_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    collection_id: Uuid,
+    version_number: i32,
+    snippet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    heading_path: Option<Vec<String>>,
+    lexical_score: f32,
+    vector_score: f32,
+    rerank_score: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    slide: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sheet: Option<String>,
+    is_current: bool,
+}
+
+pub(crate) struct ValidSearchRequest {
+    pub(crate) query: String,
+    pub(crate) limit: usize,
+    pub(crate) ctx: OrgContext,
+}
+
+async fn search(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    body: Result<Json<SearchRequestBody>, JsonRejection>,
+) -> Result<Response, RestError> {
+    let request_id = auth.request_id.clone();
+    let Json(body) =
+        body.map_err(|_| RestError::validation("request body is invalid", &request_id))?;
+    require_permission_or_403(&auth.context, "qa.query", &request_id)?;
+    let input = validate_search_request(body, &auth.context, &request_id)?;
+    let response = retrieve(
+        state.pool(),
+        state.qdrant(),
+        &input.ctx,
+        RetrievalRequest {
+            query: input.query,
+            limit: input.limit,
+            mode: VersionMode::Current,
+        },
+    )
+    .await
+    .map_err(|error| map_retrieval_error(error, &request_id))?;
+
+    Ok(Json(SearchResponse {
+        hits: response
+            .hits
+            .into_iter()
+            .map(SearchHitResponse::from)
+            .collect(),
+        degraded: response.degraded.map(degradation_code),
+    })
+    .into_response())
+}
+
+pub(crate) fn validate_search_request(
+    body: SearchRequestBody,
+    ctx: &OrgContext,
+    request_id: &str,
+) -> Result<ValidSearchRequest, RestError> {
+    let query = body.query.trim().to_string();
+    if query.is_empty() {
+        return Err(RestError::validation("query must not be empty", request_id));
+    }
+    if query.chars().count() > MAX_QUERY_CHARS {
+        return Err(RestError::validation("query is too long", request_id));
+    }
+    let limit = validate_limit(body.limit, MAX_RETRIEVAL_LIMIT, request_id)?;
+    Ok(ValidSearchRequest {
+        query,
+        limit,
+        ctx: narrowed_context(ctx, body.collection_ids),
+    })
+}
+
+pub(crate) fn validate_limit(
+    limit: Option<u32>,
+    max: usize,
+    request_id: &str,
+) -> Result<usize, RestError> {
+    let limit = limit.unwrap_or(max.min(10) as u32);
+    let limit = usize::try_from(limit)
+        .map_err(|_| RestError::validation("limit is invalid", request_id))?;
+    if !(1..=max).contains(&limit) {
+        return Err(RestError::validation(
+            format!("limit must be between 1 and {max}"),
+            request_id,
+        ));
+    }
+    Ok(limit)
+}
+
+pub(crate) fn narrowed_context(
+    ctx: &OrgContext,
+    requested_collection_ids: Option<Vec<Uuid>>,
+) -> OrgContext {
+    match requested_collection_ids {
+        Some(collection_ids) => ctx.with_narrowed_collections(collection_ids),
+        None => ctx.clone(),
+    }
+}
+
+pub(crate) fn map_retrieval_error(error: RetrievalError, request_id: &str) -> RestError {
+    match error {
+        RetrievalError::EmptyScope => RestError::empty_scope(request_id),
+        _ => RestError::internal(request_id),
+    }
+}
+
+fn degradation_code(degradation: Degradation) -> &'static str {
+    match degradation {
+        Degradation::VectorUnavailable => "vector_unavailable",
+        Degradation::LexicalUnavailable => "lexical_unavailable",
+    }
+}
+
+impl From<GroundedHit> for SearchHitResponse {
+    fn from(hit: GroundedHit) -> Self {
+        Self {
+            chunk_id: hit.chunk_id,
+            document_id: hit.document_id,
+            version_id: hit.version_id,
+            collection_id: hit.collection_id,
+            version_number: hit.version_number,
+            snippet: hit.snippet,
+            heading_path: if hit.heading_path.is_empty() {
+                None
+            } else {
+                Some(hit.heading_path)
+            },
+            lexical_score: hit.lexical_score,
+            vector_score: hit.vector_score,
+            rerank_score: hit.rerank_score,
+            page: hit.page,
+            slide: hit.slide,
+            sheet: hit.sheet,
+            is_current: hit.is_current,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collection_filter_is_intersection_only() {
+        let allowed = Uuid::new_v4();
+        let denied = Uuid::new_v4();
+        let ctx =
+            OrgContext::try_new(Uuid::new_v4(), Uuid::new_v4(), ["qa.query"], [allowed]).unwrap();
+
+        let narrowed = narrowed_context(&ctx, Some(vec![allowed, denied]));
+
+        assert!(narrowed.allows_collection(allowed));
+        assert!(!narrowed.allows_collection(denied));
+    }
+
+    #[test]
+    fn query_length_is_bounded() {
+        let ctx = OrgContext::try_new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            ["qa.query"],
+            [Uuid::new_v4()],
+        )
+        .unwrap();
+        let body = SearchRequestBody {
+            query: "x".repeat(MAX_QUERY_CHARS + 1),
+            limit: None,
+            collection_ids: None,
+        };
+
+        assert!(validate_search_request(body, &ctx, "req").is_err());
+    }
+}

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -84,7 +84,7 @@ async fn search(
     let input = validate_search_request(body, &auth.context, &request_id)?;
     let response = retrieve(
         state.pool(),
-        state.qdrant(),
+        state.vector_store(),
         &input.ctx,
         RetrievalRequest {
             query: input.query,

--- a/crates/server/tests/sse_api.rs
+++ b/crates/server/tests/sse_api.rs
@@ -1,0 +1,789 @@
+//! Live HTTP integration tests for P1B-R05 search/ask/SSE APIs.
+//!
+//! These tests self-skip unless PostgreSQL and Qdrant test endpoints are provided.
+//! They are intentionally not run by the normal library test gate.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use deadpool_postgres::Pool;
+use fileconv_knowledge::embedding::{local_vector, LOCAL_VECTOR_DIMENSIONS};
+use fileconv_knowledge::identity::chunk_identity;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::auth::jwt::JwtKeys;
+use fileconv_server::auth::provider::{AuthProvider, AuthRequestMeta, PasswordAuthProvider};
+use fileconv_server::auth::session;
+use fileconv_server::config::{
+    Argon2Config, AuthConfig, JwtAlgorithm, RuntimeEndpoints, SecretString, ServerConfig,
+};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::chunks::{self, NewChunk};
+use fileconv_server::db::collections::{self, NewCollection};
+use fileconv_server::db::index_metadata::{self, EnsureGeneration};
+use fileconv_server::db::models::{CollectionVisibility, EmbeddingRuntimePath};
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::http::{router, AppState};
+use fileconv_server::services::embedding::approved_plan;
+use fileconv_server::state::RuntimeState;
+use fileconv_server::storage::qdrant::{ChunkPointPayload, QdrantClient, UpsertPoint, VectorScope};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn test_qdrant_client() -> Option<(String, QdrantClient)> {
+    let url = match std::env::var("MARKHAND_TEST_QDRANT_URL") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_QDRANT_URL unset");
+            return None;
+        }
+    };
+    let api_key = std::env::var("MARKHAND_TEST_QDRANT_API_KEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(SecretString::new);
+    let client = QdrantClient::with_api_key(url.clone(), api_key).expect("qdrant client");
+    Some((url, client))
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_r05_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+fn test_auth_config() -> AuthConfig {
+    AuthConfig {
+        issuer: Some("https://issuer.r05.markhand.test".into()),
+        audience: Some("markhand-api".into()),
+        signing_key: Some(SecretString::new("r05-integration-signing-key-abcdef")),
+        alg: JwtAlgorithm::Hs256,
+        kid: Some("r05-test-kid".into()),
+        access_token_ttl_secs: 900,
+        refresh_token_ttl_secs: 3_600,
+        argon2: Argon2Config {
+            memory_kib: 8_192,
+            time_cost: 1,
+            parallelism: 1,
+        },
+    }
+}
+
+fn test_runtime(database_url: &str, qdrant_url: String) -> RuntimeState {
+    RuntimeState::from_config(ServerConfig::test_with_endpoints_and_auth(
+        RuntimeEndpoints {
+            database_url: SecretString::new(database_url),
+            qdrant_url,
+            minio_url: "http://127.0.0.1:1".into(),
+        },
+        test_auth_config(),
+    ))
+    .expect("runtime")
+}
+
+struct LiveEnv {
+    db: EphemeralDb,
+    pool: Pool,
+    provider: PasswordAuthProvider,
+    qdrant: QdrantClient,
+    app: axum::Router,
+}
+
+impl LiveEnv {
+    async fn boot() -> Option<Self> {
+        let base_url = test_database_url()?;
+        let (qdrant_url, qdrant) = test_qdrant_client()?;
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("apply migrations");
+        let pool = create_pool(&db.url).expect("pool");
+        let auth = test_auth_config();
+        let provider = PasswordAuthProvider::new(
+            pool.clone(),
+            auth.clone(),
+            JwtKeys::from_auth(&auth).expect("jwt keys"),
+        );
+        let app = router(
+            AppState::from_parts_with_clients(
+                test_runtime(&db.url, qdrant_url),
+                pool.clone(),
+                Some(PasswordAuthProvider::new(
+                    pool.clone(),
+                    auth.clone(),
+                    JwtKeys::from_auth(&auth).expect("jwt keys"),
+                )),
+                None,
+                qdrant.clone(),
+            )
+            .expect("app state"),
+        );
+        Some(Self {
+            db,
+            pool,
+            provider,
+            qdrant,
+            app,
+        })
+    }
+
+    async fn token(&self, email: &str, password: &str) -> String {
+        self.provider
+            .login_password(
+                email,
+                password,
+                &AuthRequestMeta {
+                    request_id: Uuid::new_v4().to_string(),
+                },
+            )
+            .await
+            .expect("login")
+            .tokens
+            .access_token
+            .expose()
+            .to_string()
+    }
+
+    async fn drop(self) {
+        self.db.drop().await;
+    }
+}
+
+#[derive(Clone)]
+struct Seeded {
+    collection_id: Uuid,
+    denied_collection_id: Uuid,
+    allowed_job_id: Uuid,
+    denied_job_id: Uuid,
+}
+
+async fn seed(env: &LiveEnv) -> Seeded {
+    let org_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let other_user_id = Uuid::new_v4();
+    let no_query_id = Uuid::new_v4();
+    let collection_id = Uuid::new_v4();
+    let denied_collection_id = Uuid::new_v4();
+    let ctx = OrgContext::try_new(org_id, owner_id, ["qa.query"], [collection_id])
+        .expect("owner context");
+    let allowed = seed_indexed_document(
+        env,
+        &ctx,
+        collection_id,
+        "Allowed R05",
+        "R05 Heading",
+        "Markhand R05 answers cite this authorized Vietnamese content.",
+    )
+    .await;
+    let denied_document_id = Uuid::new_v4();
+    let denied_job_id = Uuid::new_v4();
+    let allowed_job_id = Uuid::new_v4();
+    with_org_txn(&env.pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                seed_user_and_roles(txn, org_id, owner_id, other_user_id, no_query_id).await?;
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: denied_collection_id,
+                        name: "Denied R05",
+                        slug: "denied-r05",
+                        description: None,
+                        visibility: CollectionVisibility::Private,
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE collections SET owner_user_id = $3 WHERE org_id = $1 AND id = $2",
+                    &[&org_id, &denied_collection_id, &other_user_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO documents (id, org_id, collection_id, title, state, created_by_user_id)
+                     VALUES ($1, $2, $3, 'Denied job doc', 'indexed', $4)",
+                    &[&denied_document_id, &org_id, &denied_collection_id, &other_user_id],
+                )
+                .await?;
+                insert_job(txn, org_id, allowed_job_id, allowed.document_id).await?;
+                insert_job(txn, org_id, denied_job_id, denied_document_id).await
+            })
+        }
+    })
+    .await
+    .expect("seed r05 rows");
+    for (user_id, password) in [
+        (owner_id, "owner-password"),
+        (other_user_id, "other-password"),
+        (no_query_id, "no-query-password"),
+    ] {
+        session::set_password_hash(&env.pool, user_id, password, &test_auth_config().argon2)
+            .await
+            .expect("password hash");
+    }
+    Seeded {
+        collection_id,
+        denied_collection_id,
+        allowed_job_id,
+        denied_job_id,
+    }
+}
+
+struct SeededDocument {
+    document_id: Uuid,
+}
+
+async fn seed_indexed_document(
+    env: &LiveEnv,
+    ctx: &OrgContext,
+    collection_id: Uuid,
+    title: &str,
+    heading: &str,
+    body: &str,
+) -> SeededDocument {
+    let plan = approved_plan();
+    let signature = plan
+        .index_signature(LOCAL_VECTOR_DIMENSIONS)
+        .expect("index signature");
+    let signature_digest = signature.digest();
+    let runtime_path = signature.runtime_path.to_string();
+    let embedding_family = signature.embedding_family.to_string();
+    let embedding_revision = signature.embedding_revision.to_string();
+    let dimensions = signature.dimensions;
+    let normalized = signature.normalized;
+    let chunking_version = signature.chunking_version.to_string();
+    let body_text_version = signature.body_text_version.to_string();
+    let query_normalization_version = signature.query_normalization_version.to_string();
+    let collection_name = env
+        .qdrant
+        .ensure_collection_for_signature(&signature)
+        .await
+        .expect("ensure qdrant collection");
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let chunk_id = Uuid::new_v4();
+    let heading_path = vec![heading.to_string()];
+    let content_sha256 = hex::encode(Sha256::digest(body.as_bytes()));
+    let chunk_identity = chunk_identity(
+        &document_id.to_string(),
+        &version_id.to_string(),
+        0,
+        &heading_path.join(" > "),
+        body,
+        &body_text_version,
+    );
+    let metadata = with_org_txn(&env.pool, ctx, {
+        let ctx = ctx.clone();
+        let title = title.to_string();
+        let heading_path = heading_path.clone();
+        let body = body.to_string();
+        let content_sha256 = content_sha256.clone();
+        let chunk_identity = chunk_identity.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &ctx, "r05-org", "R05 Org").await?;
+                orgs::ensure_user(txn, &ctx, ctx.user_id(), "owner-r05@example.test", "Owner")
+                    .await?;
+                orgs::ensure_membership(txn, &ctx).await?;
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: collection_id,
+                        name: "Allowed R05",
+                        slug: "allowed-r05",
+                        description: None,
+                        visibility: CollectionVisibility::Org,
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO documents (id, org_id, collection_id, title, state, created_by_user_id)
+                     VALUES ($1, $2, $3, $4, 'indexed', $5)",
+                    &[&document_id, &ctx.org_id(), &collection_id, &title, &ctx.user_id()],
+                )
+                .await?;
+                let object_key = format!("r05/{version_id}.md");
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key, markdown_object_key,
+                        source_content_type, byte_size, created_by_user_id
+                     )
+                     VALUES ($1, $2, $3, 1, 'published', true, $4, $5, $5,
+                             'text/markdown', $6, $7)",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &content_sha256,
+                        &object_key,
+                        &(body.len() as i64),
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE documents SET current_version_id = $3 WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id, &version_id],
+                )
+                .await?;
+                let metadata = index_metadata::ensure_active_generation(
+                    txn,
+                    &ctx,
+                    EnsureGeneration {
+                        collection_id: Some(collection_id),
+                        signature_sha256: &signature_digest,
+                        chunking_version: &chunking_version,
+                        body_text_version: &body_text_version,
+                        query_normalization_version: &query_normalization_version,
+                        embedding_family: &embedding_family,
+                        embedding_revision: &embedding_revision,
+                        dimensions: i32::try_from(dimensions).expect("dimensions"),
+                        normalized,
+                        runtime_path: EmbeddingRuntimePath::parse(&runtime_path).expect("runtime"),
+                    },
+                )
+                .await?;
+                chunks::insert(
+                    txn,
+                    &ctx,
+                    NewChunk {
+                        id: chunk_id,
+                        document_id,
+                        version_id,
+                        ordinal: 0,
+                        heading_path: &heading_path,
+                        body: &body,
+                        body_text_version: &body_text_version,
+                        chunk_identity_sha256: &chunk_identity,
+                        index_metadata_id: metadata.id,
+                        index_signature: &signature_digest,
+                    },
+                )
+                .await?;
+                Ok(metadata)
+            })
+        }
+    })
+    .await
+    .expect("seed indexed document");
+    env.qdrant
+        .upsert_points(
+            &collection_name,
+            &VectorScope::new(ctx.org_id(), [collection_id]),
+            &[UpsertPoint {
+                chunk_identity: chunk_identity.clone(),
+                vector: local_vector(body).into_values(),
+                payload: ChunkPointPayload {
+                    org_id: ctx.org_id(),
+                    collection_id,
+                    document_id,
+                    version_id,
+                    chunk_id: chunk_identity,
+                    ordinal: 0,
+                    is_current: true,
+                    is_effective: true,
+                    index_generation: u32::try_from(metadata.generation).expect("generation"),
+                },
+            }],
+        )
+        .await
+        .expect("upsert point");
+    SeededDocument { document_id }
+}
+
+async fn seed_user_and_roles(
+    txn: &tokio_postgres::Transaction<'_>,
+    org_id: Uuid,
+    owner_id: Uuid,
+    other_user_id: Uuid,
+    no_query_id: Uuid,
+) -> Result<(), fileconv_server::db::error::DbError> {
+    for (user_id, email, name) in [
+        (other_user_id, "other-r05@example.test", "Other"),
+        (no_query_id, "no-query-r05@example.test", "No Query"),
+    ] {
+        txn.execute(
+            "INSERT INTO users (id, email, display_name) VALUES ($1, $2, $3)",
+            &[&user_id, &email, &name],
+        )
+        .await?;
+    }
+    txn.execute(
+        "INSERT INTO org_memberships (org_id, user_id, role)
+         VALUES ($1, $2, 'owner'), ($1, $3, 'viewer'), ($1, $4, 'editor')
+         ON CONFLICT DO NOTHING",
+        &[&org_id, &owner_id, &other_user_id, &no_query_id],
+    )
+    .await?;
+    for (role, permission) in [
+        ("owner", "qa.query"),
+        ("viewer", "qa.query"),
+        ("editor", "doc.upload"),
+    ] {
+        grant_permission(txn, org_id, role, permission).await?;
+    }
+    Ok(())
+}
+
+async fn grant_permission(
+    txn: &tokio_postgres::Transaction<'_>,
+    org_id: Uuid,
+    role: &str,
+    permission: &str,
+) -> Result<(), fileconv_server::db::error::DbError> {
+    txn.execute(
+        "INSERT INTO roles (id, org_id, code, name, is_system)
+         VALUES ($1, $2, $3, $3, true)
+         ON CONFLICT (org_id, code) DO NOTHING",
+        &[&Uuid::new_v4(), &org_id, &role],
+    )
+    .await?;
+    txn.execute(
+        "INSERT INTO permissions (id, code, description)
+         VALUES ($1, $2, $2)
+         ON CONFLICT (code) DO NOTHING",
+        &[&Uuid::new_v4(), &permission],
+    )
+    .await?;
+    let role_id: Uuid = txn
+        .query_one(
+            "SELECT id FROM roles WHERE org_id = $1 AND code = $2",
+            &[&org_id, &role],
+        )
+        .await?
+        .get(0);
+    let permission_id: Uuid = txn
+        .query_one("SELECT id FROM permissions WHERE code = $1", &[&permission])
+        .await?
+        .get(0);
+    txn.execute(
+        "INSERT INTO role_permissions (org_id, role_id, permission_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT DO NOTHING",
+        &[&org_id, &role_id, &permission_id],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn insert_job(
+    txn: &tokio_postgres::Transaction<'_>,
+    org_id: Uuid,
+    job_id: Uuid,
+    document_id: Uuid,
+) -> Result<(), fileconv_server::db::error::DbError> {
+    let payload = json!({ "document_id": document_id });
+    txn.execute(
+        "INSERT INTO jobs (
+            id, org_id, job_type, status, payload_version, payload, attempts,
+            max_attempts, idempotency_key, document_id, available_at, finished_at
+         )
+         VALUES ($1, $2, 'convert', 'succeeded', 1, $3, 1, 1, $4, $5,
+                 clock_timestamp(), clock_timestamp())",
+        &[
+            &job_id,
+            &org_id,
+            &payload,
+            &format!("r05-job-{job_id}"),
+            &document_id,
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn post_json(app: axum::Router, token: &str, uri: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body = serde_json::from_slice(&bytes).unwrap_or_else(|_| json!({}));
+    (status, body)
+}
+
+async fn sse_body(
+    app: axum::Router,
+    token: &str,
+    uri: &str,
+    body: Option<Value>,
+    last_event_id: Option<&str>,
+) -> (StatusCode, String) {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"));
+    if let Some(last_event_id) = last_event_id {
+        builder = builder.header("last-event-id", last_event_id);
+    }
+    let body = body.map(|value| value.to_string()).unwrap_or_default();
+    let response = app
+        .oneshot(builder.body(Body::from(body)).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    (status, String::from_utf8(bytes.to_vec()).unwrap())
+}
+
+fn parse_sse(body: &str) -> Vec<(String, Value)> {
+    body.split("\n\n")
+        .filter_map(|frame| {
+            let id = frame
+                .lines()
+                .find_map(|line| line.strip_prefix("id: "))
+                .map(str::to_string)?;
+            let data = frame.lines().find_map(|line| line.strip_prefix("data: "))?;
+            Some((id, serde_json::from_str(data).expect("json envelope")))
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn search_enforces_scope_permission_and_query_bounds() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let seeded = seed(&env).await;
+    let owner = env.token("owner-r05@example.test", "owner-password").await;
+    let no_query = env
+        .token("no-query-r05@example.test", "no-query-password")
+        .await;
+
+    let (status, body) = post_json(
+        env.app.clone(),
+        &owner,
+        "/api/v1/search",
+        json!({ "query": "Markhand R05", "collectionIds": [seeded.collection_id] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["hits"][0]["collectionId"],
+        seeded.collection_id.to_string()
+    );
+
+    let (status, body) = post_json(
+        env.app.clone(),
+        &owner,
+        "/api/v1/search",
+        json!({ "query": "Markhand", "collectionIds": [seeded.denied_collection_id] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["code"], "empty_scope");
+
+    let (status, _) = post_json(
+        env.app.clone(),
+        &no_query,
+        "/api/v1/search",
+        json!({ "query": "Markhand" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    let (status, _) = post_json(
+        env.app.clone(),
+        &owner,
+        "/api/v1/search",
+        json!({ "query": "x".repeat(4097) }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn ask_json_stream_and_resume_are_caller_bound() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let seeded = seed(&env).await;
+    let owner = env.token("owner-r05@example.test", "owner-password").await;
+    let other = env.token("other-r05@example.test", "other-password").await;
+
+    let (status, body) = post_json(
+        env.app.clone(),
+        &owner,
+        "/api/v1/ask",
+        json!({ "question": "What does R05 content say?", "collectionIds": [seeded.collection_id] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["answer"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+
+    let (status, body) = sse_body(
+        env.app.clone(),
+        &owner,
+        "/api/v1/ask/stream",
+        Some(json!({ "question": "What does R05 content say?", "collectionIds": [seeded.collection_id] })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let events = parse_sse(&body);
+    assert!(!events.is_empty());
+    assert_eq!(events.last().unwrap().1["event"].as_str(), Some("ask.done"));
+    for (expected, (id, envelope)) in (1_u64..).zip(events.iter()) {
+        assert!(id.ends_with(&format!(":{expected}")));
+        assert_eq!(envelope["sequence"].as_u64(), Some(expected));
+    }
+
+    let resume_from = &events[0].0;
+    let (status, replay) = sse_body(
+        env.app.clone(),
+        &owner,
+        "/api/v1/ask/stream",
+        None,
+        Some(resume_from),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let replayed = parse_sse(&replay);
+    assert_eq!(replayed.len(), events.len().saturating_sub(1));
+
+    let (status, _) = sse_body(
+        env.app.clone(),
+        &other,
+        "/api/v1/ask/stream",
+        None,
+        Some(resume_from),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn job_events_emit_safe_terminal_snapshot_and_hide_unauthorized_jobs() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let seeded = seed(&env).await;
+    let owner = env.token("owner-r05@example.test", "owner-password").await;
+
+    let response = env
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/jobs/{}/events", seeded.allowed_job_id))
+                .header("authorization", format!("Bearer {owner}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    let events = parse_sse(&body);
+    assert_eq!(events.last().unwrap().1["event"], "job.done");
+    let data = &events.last().unwrap().1["data"];
+    assert_eq!(data["id"], seeded.allowed_job_id.to_string());
+    assert!(data.get("payload").is_none());
+    assert!(data.get("checkpoint").is_none());
+    assert!(data.get("leaseOwner").is_none());
+
+    let response = env
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/jobs/{}/events", seeded.denied_job_id))
+                .header("authorization", format!("Bearer {owner}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    env.drop().await;
+}

--- a/crates/server/tests/sse_api.rs
+++ b/crates/server/tests/sse_api.rs
@@ -216,6 +216,9 @@ impl LiveEnv {
 
 #[derive(Clone)]
 struct Seeded {
+    org_id: Uuid,
+    owner_id: Uuid,
+    other_user_id: Uuid,
     collection_id: Uuid,
     denied_collection_id: Uuid,
     allowed_job_id: Uuid,
@@ -288,6 +291,9 @@ async fn seed(env: &LiveEnv) -> Seeded {
             .expect("password hash");
     }
     Seeded {
+        org_id,
+        owner_id,
+        other_user_id,
         collection_id,
         denied_collection_id,
         allowed_job_id,
@@ -359,7 +365,7 @@ async fn seed_indexed_document(
                         name: "Allowed R05",
                         slug: "allowed-r05",
                         description: None,
-                        visibility: CollectionVisibility::Org,
+                        visibility: CollectionVisibility::Private,
                     },
                 )
                 .await?;
@@ -730,6 +736,64 @@ async fn ask_json_stream_and_resume_are_caller_bound() {
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let revoke_ctx = OrgContext::try_new(
+        seeded.org_id,
+        seeded.owner_id,
+        ["qa.query"],
+        [seeded.collection_id],
+    )
+    .expect("revoke ctx");
+    with_org_txn(&env.pool, &revoke_ctx, {
+        let collection_id = seeded.collection_id;
+        let org_id = seeded.org_id;
+        let other_user_id = seeded.other_user_id;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE collections
+                     SET owner_user_id = $3, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&org_id, &collection_id, &other_user_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("revoke owner access");
+
+    let (status, _) = sse_body(
+        env.app.clone(),
+        &owner,
+        "/api/v1/ask/stream",
+        None,
+        Some(resume_from),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let (status, other_body) = sse_body(
+        env.app.clone(),
+        &other,
+        "/api/v1/ask/stream",
+        Some(json!({ "question": "What does R05 content say?", "collectionIds": [seeded.collection_id] })),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let other_events = parse_sse(&other_body);
+    let other_resume_from = &other_events[0].0;
+    let (status, _) = sse_body(
+        env.app.clone(),
+        &other,
+        "/api/v1/ask/stream",
+        None,
+        Some(other_resume_from),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
     env.drop().await;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-R05 — Search/ask/resumable SSE API

HTTP/SSE adapter wiring R01 `retrieve` + R03 grounded QA to the API. Stacks on F05/I03/R01/R03/R04. Closes #95.

### Endpoints
| Method | Path | Perm | Notes |
|---|---|---|---|
| `POST` | `/api/v1/search` | `qa.query` + ACL | hybrid retrieval hits (JSON) |
| `POST` | `/api/v1/ask` | `qa.query` + ACL | collected grounded answer + citations + mode |
| `POST` | `/api/v1/ask/stream` | `qa.query` + ACL | **resumable** `text/event-stream` of QA events |
| `GET` | `/api/v1/jobs/{jobId}/events` | `qa.query` + ACL | job status SSE (poll-diff) |

### SSE contract
- Versioned envelope `SseEnvelope { version, sequence, event, requestId, data }`.
- Ask events: `ask.token` / `ask.citations` / `ask.warning` / `ask.done`; SSE `id = {streamId}:{seq}`, monotonic sequence from 1.
- **Resumability**: unguessable UUID `streamId` bound to `{orgId, userId}`; `Last-Event-ID: {streamId}:{seq}` replays only buffered `sequence > seq`; replay never re-invokes the LLM.

### Security (review: gpt-5.6-sol-high, 3 rounds → PASS)
- Every route `AuthenticatedOrg` + `qa.query` + collection ACL. `collectionIds` narrows scope by **intersection only** (never widens `allowed_collection_ids`); empty/unauthorized scope → **403 `empty_scope`** (non-disclosing).
- **Resumable-stream isolation**: caller-bound stream ids; a different caller / unknown / expired id → non-disclosing 404. **Replay re-checks collection ACL** — records store their narrowed scope and replay is denied (404) if the caller lost access to any scoped collection.
- **Bounded memory / DoS**: concurrent-stream slot reserved *before* any retrieval/LLM work (over-cap → 429 with zero QA work); replay registry hard-bounded by per-caller-active, per-caller-retained, and global caps, with the stored scope charged to the per-record byte budget (total ≤ `MAX_TOTAL_STREAMS × MAX_BYTES_PER_STREAM` + O(1)/record); `collectionIds` capped at 512; poison-tolerant locks.
- Job-events re-resolves permission + ACL and checks token `exp` each poll (close on revoke/expiry); emits only safe job fields (no payload/lease/checkpoint); terminal `job.done`; bounded poll interval + 10-min max.
- 16 KiB body, query/question length cap, limit clamp, KeepAlive heartbeat. Only `VersionMode::Current` exposed (AsOf/History/Compare deferred).
- Architecture boundary respected: routes reach Qdrant via the neutral `AppState::vector_store()` accessor (`check-architecture-boundaries.py` green).

### Files
- `api/sse.rs` (envelope helper + bounded caller/scope-bound replay registry), `routes/{search,ask,events}.rs`, `routes/{common,jobs,mod}.rs`, `http.rs` (Qdrant client + registry on `AppState`), `auth/context.rs` (`with_narrowed_collections`, intersection-only). `crates/server/tests/sse_api.rs` (self-skipping live HTTP/SSE tests).

### Tests / gates
- Live tests pass (search scope/permission/query-bounds; ask JSON + stream ordering + caller-bound resume + **resume-after-revoke → 404**; job-events safe terminal snapshot + unauthorized-job hiding).
- `cargo fmt`, `clippy -D warnings`, 103 lib tests, `make check-boundaries`, `cargo metadata --locked`, dependency-policy — all green. No new crates/migrations.

### Deferred (non-blocking, tracked)
Process-local replay registry (HA/shared-store follow-up); poll-diff job events (no pub/sub in POC); a disconnected client's accepted producer may run to R03's 120s provider deadline; TTL eviction can drop resumability for a >5-min active stream; AsOf/History/Compare HTTP modes; OpenAPI formalization = R06.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

