### PR TITLE
feat(server): P1B-R06 OpenAPI, rate limit & readiness

### DIFF
--- a/crates/server/openapi/fixtures/ask_response.json
+++ b/crates/server/openapi/fixtures/ask_response.json
@@ -1,0 +1,23 @@
+{
+  "answer": "Payment is due within 30 days. [1]",
+  "citations": [
+    {
+      "documentId": "d4010000-0000-4000-8000-000000000001",
+      "versionId": "e5010000-0000-4000-8000-000000000001",
+      "versionNumber": 3,
+      "contentSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "chunkId": "c3010000-0000-4000-8000-000000000001",
+      "headingPath": [
+        "Contract",
+        "Payment"
+      ],
+      "snippet": "Payment is due within 30 days.",
+      "page": 4,
+      "slide": null,
+      "sheet": null,
+      "isCurrent": true
+    }
+  ],
+  "warnings": [],
+  "mode": "offline_extractive"
+}

--- a/crates/server/openapi/fixtures/job_response.json
+++ b/crates/server/openapi/fixtures/job_response.json
@@ -1,0 +1,14 @@
+{
+  "id": "b2010000-0000-4000-8000-000000000001",
+  "jobType": "convert",
+  "status": "running",
+  "attempts": 1,
+  "maxAttempts": 3,
+  "documentId": "d4010000-0000-4000-8000-000000000001",
+  "versionId": "e5010000-0000-4000-8000-000000000001",
+  "availableAt": "2026-07-19T22:40:00Z",
+  "startedAt": "2026-07-19T22:41:00Z",
+  "finishedAt": null,
+  "createdAt": "2026-07-19T22:39:00Z",
+  "updatedAt": "2026-07-19T22:41:30Z"
+}

--- a/crates/server/openapi/fixtures/rate_limited.json
+++ b/crates/server/openapi/fixtures/rate_limited.json
@@ -1,0 +1,5 @@
+{
+  "code": "rate_limited",
+  "message": "Too many requests; please retry later",
+  "requestId": "a1010000-0000-4000-8000-000000000003"
+}

--- a/crates/server/openapi/fixtures/search_response.json
+++ b/crates/server/openapi/fixtures/search_response.json
@@ -1,0 +1,22 @@
+{
+  "hits": [
+    {
+      "chunkId": "c3010000-0000-4000-8000-000000000001",
+      "documentId": "d4010000-0000-4000-8000-000000000001",
+      "versionId": "e5010000-0000-4000-8000-000000000001",
+      "collectionId": "f6010000-0000-4000-8000-000000000001",
+      "versionNumber": 3,
+      "snippet": "Payment is due within 30 days.",
+      "headingPath": [
+        "Contract",
+        "Payment"
+      ],
+      "lexicalScore": 0.75,
+      "vectorScore": 0.5,
+      "rerankScore": 0.25,
+      "page": 4,
+      "isCurrent": true
+    }
+  ],
+  "degraded": null
+}

--- a/crates/server/openapi/openapi.yaml
+++ b/crates/server/openapi/openapi.yaml
@@ -2,12 +2,22 @@ openapi: 3.1.0
 info:
   title: Markhand Web API
   version: 0.1.0
-  description: Phase 1B POC API contract.
+  description: Phase 1B POC API contract for shipped `/api/v1` routes.
 servers:
   - url: /api/v1
+tags:
+  - name: Health
+  - name: Auth
+  - name: Uploads
+  - name: Collections
+  - name: Documents
+  - name: Jobs
+  - name: Search
+  - name: Ask
 paths:
   /health/live:
     get:
+      tags: [Health]
       operationId: healthLive
       responses:
         "200":
@@ -18,6 +28,7 @@ paths:
                 $ref: "#/components/schemas/Health"
   /health/ready:
     get:
+      tags: [Health]
       operationId: healthReady
       responses:
         "200":
@@ -28,10 +39,847 @@ paths:
                 $ref: "#/components/schemas/Health"
         "503":
           $ref: "#/components/responses/ApiError"
+  /health/start:
+    get:
+      tags: [Health]
+      operationId: healthStart
+      responses:
+        "200":
+          description: Startup has completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Health"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /auth/login:
+    post:
+      tags: [Auth]
+      operationId: authLogin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        "200":
+          description: Password login succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /auth/refresh:
+    post:
+      tags: [Auth]
+      operationId: authRefresh
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RefreshRequest"
+      responses:
+        "200":
+          description: Refresh token rotation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /auth/logout:
+    post:
+      tags: [Auth]
+      operationId: authLogout
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LogoutRequest"
+      responses:
+        "204":
+          description: Refresh token family logout accepted.
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /auth/me:
+    get:
+      tags: [Auth]
+      operationId: authMe
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Current authenticated principal and authorization context.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MeResponse"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /uploads:
+    post:
+      tags: [Uploads]
+      operationId: createUpload
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: Upload accepted or quarantined.
+          headers:
+            x-quota-resource:
+              $ref: "#/components/headers/QuotaResource"
+            x-quota-limit:
+              $ref: "#/components/headers/QuotaLimit"
+            x-quota-used:
+              $ref: "#/components/headers/QuotaUsed"
+            x-quota-reserved:
+              $ref: "#/components/headers/QuotaReserved"
+            x-quota-remaining:
+              $ref: "#/components/headers/QuotaRemaining"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "413":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/QuotaOrRateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /collections:
+    get:
+      tags: [Collections]
+      operationId: listCollections
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: Authorized collections page.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CollectionListResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+    post:
+      tags: [Collections]
+      operationId: createCollection
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCollectionRequest"
+      responses:
+        "201":
+          description: Collection created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Collection"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+  /collections/{collectionId}:
+    get:
+      tags: [Collections]
+      operationId: getCollection
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CollectionId"
+      responses:
+        "200":
+          description: Collection metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Collection"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+  /collections/{collectionId}/documents:
+    get:
+      tags: [Documents]
+      operationId: listCollectionDocuments
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CollectionId"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: Documents in the collection.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentListResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+    post:
+      tags: [Documents]
+      operationId: createDocumentFromUpload
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CollectionId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateDocumentRequest"
+      responses:
+        "201":
+          description: Document and source version created; conversion job enqueued.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateDocumentResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /documents/{documentId}:
+    get:
+      tags: [Documents]
+      operationId: getDocument
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/DocumentId"
+      responses:
+        "200":
+          description: Document metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Document"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+    delete:
+      tags: [Documents]
+      operationId: deleteDocument
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/DocumentId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      responses:
+        "200":
+          description: Delete was already requested.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteDocumentResponse"
+        "202":
+          description: Delete requested and job enqueued.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteDocumentResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "409":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /documents/{documentId}:reindex:
+    post:
+      tags: [Documents]
+      operationId: reindexDocument
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/DocumentId"
+      responses:
+        "202":
+          description: Index job enqueued.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JobSummary"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "409":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+  /documents/{documentId}/versions:
+    get:
+      tags: [Documents]
+      operationId: listDocumentVersions
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/DocumentId"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
+      responses:
+        "200":
+          description: Document versions page.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentVersionListResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /documents/{documentId}/versions/{versionId}/citations:resolve:
+    post:
+      tags: [Documents]
+      operationId: resolveCitation
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/DocumentId"
+        - $ref: "#/components/parameters/VersionId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CitationPin"
+      responses:
+        "200":
+          description: Citation resolved against live authorization and source content.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResolvedCitation"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+  /documents/{documentId}/versions/{versionId}/preview:
+    get:
+      tags: [Documents]
+      operationId: getMarkdownPreview
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/DocumentId"
+        - $ref: "#/components/parameters/VersionId"
+      responses:
+        "200":
+          description: Markdown preview bytes.
+          headers:
+            x-content-type-options:
+              schema:
+                type: string
+                enum: [nosniff]
+          content:
+            text/markdown; charset=utf-8:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /documents/{documentId}/versions/{versionId}/download:
+    post:
+      tags: [Documents]
+      operationId: authorizeDownload
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/DocumentId"
+        - $ref: "#/components/parameters/VersionId"
+      responses:
+        "200":
+          description: Short-lived, one-time download capability.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadCapability"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /documents/download/{token}:
+    get:
+      tags: [Documents]
+      operationId: redeemDownload
+      parameters:
+        - $ref: "#/components/parameters/DownloadToken"
+      responses:
+        "200":
+          description: Original uploaded object bytes.
+          headers:
+            content-disposition:
+              schema:
+                type: string
+            x-content-type-options:
+              schema:
+                type: string
+                enum: [nosniff]
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+        "503":
+          $ref: "#/components/responses/ApiError"
+  /jobs/{jobId}:
+    get:
+      tags: [Jobs]
+      operationId: getJob
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/JobId"
+      responses:
+        "200":
+          description: Job snapshot.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Job"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+  /jobs/{jobId}/events:
+    get:
+      tags: [Jobs]
+      operationId: streamJobEvents
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/JobId"
+      responses:
+        "200":
+          description: Server-sent job status events. Event names are `job.status`, `job.done`, and `job.close`.
+          content:
+            text/event-stream:
+              schema:
+                $ref: "#/components/schemas/SseEnvelope"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+  /search:
+    post:
+      tags: [Search]
+      operationId: search
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SearchRequest"
+      responses:
+        "200":
+          description: Grounded retrieval hits.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+  /ask:
+    post:
+      tags: [Ask]
+      operationId: ask
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AskRequest"
+      responses:
+        "200":
+          description: Grounded answer collected from the QA stream.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AskResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
+  /ask/stream:
+    post:
+      tags: [Ask]
+      operationId: streamAsk
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/LastEventId"
+      requestBody:
+        required: false
+        description: Required when starting a stream. Omitted on replay requests that provide `Last-Event-ID`.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AskRequest"
+      responses:
+        "200":
+          description: Server-sent QA events. Event names are `ask.token`, `ask.citations`, `ask.warning`, and `ask.done`.
+          content:
+            text/event-stream:
+              schema:
+                $ref: "#/components/schemas/SseEnvelope"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/ApiError"
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    CollectionId:
+      name: collectionId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    DocumentId:
+      name: documentId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    VersionId:
+      name: versionId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    JobId:
+      name: jobId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    DownloadToken:
+      name: token
+      in: path
+      required: true
+      schema:
+        type: string
+        maxLength: 256
+    Limit:
+      name: limit
+      in: query
+      required: false
+      description: Page size; defaults to 25 and must be between 1 and 100.
+      schema:
+        type: string
+    Cursor:
+      name: cursor
+      in: query
+      required: false
+      description: Opaque cursor returned as `pageInfo.nextCursor`.
+      schema:
+        type: string
+        maxLength: 512
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: Optional visible-ASCII idempotency key, 1-128 bytes, using alphanumeric characters plus `.`, `_`, `-`, and `:`.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 128
+    LastEventId:
+      name: Last-Event-ID
+      in: header
+      required: false
+      description: SSE replay cursor formatted as `{streamUuid}:{sequence}`.
+      schema:
+        type: string
+  headers:
+    RetryAfter:
+      description: Seconds to wait before retrying.
+      schema:
+        type: string
+    QuotaResource:
+      description: Quota resource kind that was checked.
+      schema:
+        type: string
+        enum: [storage_bytes, documents]
+    QuotaLimit:
+      description: Resource limit.
+      schema:
+        type: string
+    QuotaUsed:
+      description: Committed resource usage.
+      schema:
+        type: string
+    QuotaReserved:
+      description: Currently reserved resource usage.
+      schema:
+        type: string
+    QuotaRemaining:
+      description: Remaining resource budget.
+      schema:
+        type: string
   responses:
     ApiError:
-      description: Canonical API error
+      description: Canonical API error.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    RateLimited:
+      description: Request rate limit exceeded. `ApiError.code` is `rate_limited`.
+      headers:
+        Retry-After:
+          $ref: "#/components/headers/RetryAfter"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    QuotaOrRateLimited:
+      description: Request rate limit exceeded (`rate_limited`) or upload quota exceeded (`quota_exceeded`).
+      headers:
+        Retry-After:
+          $ref: "#/components/headers/RetryAfter"
+        x-quota-resource:
+          $ref: "#/components/headers/QuotaResource"
+        x-quota-limit:
+          $ref: "#/components/headers/QuotaLimit"
+        x-quota-used:
+          $ref: "#/components/headers/QuotaUsed"
+        x-quota-reserved:
+          $ref: "#/components/headers/QuotaReserved"
+        x-quota-remaining:
+          $ref: "#/components/headers/QuotaRemaining"
       content:
         application/json:
           schema:
@@ -49,6 +897,19 @@ components:
           format: uuid
     ApiError:
       type: object
+      description: |
+        Canonical API error. Stable `code` values currently returned by shipped routes include
+        `validation_failed`, `unauthorized`, `invalid_credentials`, `invalid_refresh`,
+        `refresh_reuse`, `user_disabled`, `membership_missing`, `auth_unavailable`,
+        `permission_denied`, `collection_denied`, `empty_scope`, `not_found`,
+        `state_conflict`, `rate_limited`, `dependency_unavailable`,
+        `configuration_invalid`, `storage_unavailable`, `multipart_invalid`,
+        `upload_rejected`, `upload_too_large`, `quota_exceeded`,
+        `quota_not_configured`, `quota_invalid_key`, `quota_invalid_amount`,
+        `quota_arithmetic_overflow`, `quota_reservation_not_found`,
+        `quota_reservation_resource_mismatch`, `quota_reservation_conflict`,
+        `quota_refunded_cannot_finalize`, `quota_expired_cannot_finalize`,
+        `quota_finalized_cannot_refund`, `quota_database_error`, and `internal_error`.
       required: [code, message, requestId]
       properties:
         code:
@@ -64,6 +925,764 @@ components:
       required: [hasMore]
       properties:
         nextCursor:
-          type: [string, "null"]
+          type: string
         hasMore:
           type: boolean
+    SseEnvelope:
+      type: object
+      required: [version, sequence, event, requestId, data]
+      properties:
+        version:
+          type: integer
+          format: int32
+          enum: [1]
+        sequence:
+          type: integer
+          format: int64
+          minimum: 0
+        event:
+          type: string
+          description: Stable event name, for example `job.status`, `job.done`, `job.close`, `ask.token`, `ask.citations`, `ask.warning`, or `ask.done`.
+        requestId:
+          type: string
+        data: {}
+    LoginRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email:
+          type: string
+          maxLength: 320
+        password:
+          type: string
+          maxLength: 1024
+    RefreshRequest:
+      type: object
+      required: [refreshToken]
+      properties:
+        refreshToken:
+          type: string
+          maxLength: 512
+    LogoutRequest:
+      type: object
+      required: [refreshToken]
+      properties:
+        refreshToken:
+          type: string
+          maxLength: 512
+    TokenResponse:
+      type: object
+      required: [accessToken, refreshToken, tokenType, expiresIn, orgId, userId]
+      properties:
+        accessToken:
+          type: string
+        refreshToken:
+          type: string
+        tokenType:
+          type: string
+          enum: [Bearer]
+        expiresIn:
+          type: integer
+          format: int64
+          minimum: 0
+        orgId:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+    MeResponse:
+      type: object
+      required: [userId, orgId, email, displayName, permissions, allowedCollectionIds, sessionId]
+      properties:
+        userId:
+          type: string
+          format: uuid
+        orgId:
+          type: string
+          format: uuid
+        email:
+          type: string
+        displayName:
+          type: string
+        permissions:
+          type: array
+          items:
+            type: string
+        allowedCollectionIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        sessionId:
+          type: string
+          format: uuid
+    UploadResponse:
+      type: object
+      required: [disposition, objectKey, objectId, sha256, sizeBytes, canonicalFormat, requestId]
+      properties:
+        disposition:
+          type: string
+          enum: [accepted, quarantined, rejected]
+        threatClass:
+          type: string
+          enum:
+            - extension_spoof
+            - mime_mismatch
+            - unsupported_format
+            - archive_bomb
+            - archive_path_traversal
+            - nested_archive
+            - malformed_ooxml
+            - parser_corruption
+            - oversize
+            - truncated_upload
+            - pdf_page_bomb
+            - image_pixel_bomb
+            - audio_duration_limit
+            - csv_formula
+            - prompt_injection
+            - active_content
+            - permission_denied
+            - storage_failure
+            - multipart_invalid
+            - internal
+        reasonCode:
+          type: string
+          enum:
+            - extension_magic_mismatch
+            - magic_unrecognized
+            - upload_too_large
+            - stream_interrupted
+            - archive_entry_limit
+            - archive_uncompressed_limit
+            - archive_compression_ratio
+            - archive_path_traversal
+            - nested_archive_entry
+            - missing_content_types
+            - missing_format_paths
+            - malformed_archive
+            - malformed_xml
+            - pdf_missing_eof
+            - pdf_page_limit
+            - image_pixel_limit
+            - audio_duration_review
+            - csv_formula_review
+            - prompt_injection_review
+            - html_active_content
+            - permission_denied
+            - storage_unavailable
+            - multipart_missing_file
+            - multipart_too_many_files
+            - multipart_too_many_parts
+            - multipart_header_too_large
+            - multipart_timeout
+            - fail_closed
+        objectKey:
+          type: string
+        objectId:
+          type: string
+          format: uuid
+        sha256:
+          type: string
+        sizeBytes:
+          type: integer
+          format: int64
+          minimum: 0
+        canonicalFormat:
+          type: string
+        originalFilename:
+          type: string
+        requestId:
+          type: string
+          format: uuid
+    CreateCollectionRequest:
+      type: object
+      required: [name, slug, visibility]
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type: [string, "null"]
+        visibility:
+          type: string
+          enum: [private, org]
+    Collection:
+      type: object
+      required: [id, name, slug, description, ownerUserId, visibility, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type: [string, "null"]
+        ownerUserId:
+          type: string
+          format: uuid
+        visibility:
+          type: string
+          enum: [private, org, groups]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    CollectionListResponse:
+      type: object
+      required: [items, pageInfo]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Collection"
+        pageInfo:
+          $ref: "#/components/schemas/PageInfo"
+    CreateDocumentRequest:
+      type: object
+      required: [title]
+      properties:
+        objectKey:
+          type: [string, "null"]
+        objectId:
+          type: [string, "null"]
+          format: uuid
+        title:
+          type: string
+    Document:
+      type: object
+      required: [id, collectionId, title, state, currentVersionId, createdByUserId, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        collectionId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        state:
+          $ref: "#/components/schemas/DocumentState"
+        currentVersionId:
+          type: [string, "null"]
+          format: uuid
+        createdByUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    DocumentState:
+      type: string
+      enum: [uploaded, converting, converted, indexing, indexed, failed, tombstoned, purged]
+    DocumentListResponse:
+      type: object
+      required: [items, pageInfo]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Document"
+        pageInfo:
+          $ref: "#/components/schemas/PageInfo"
+    DocumentVersion:
+      type: object
+      required:
+        - id
+        - documentId
+        - versionNumber
+        - parentVersionId
+        - publicationState
+        - isCurrent
+        - contentSha256
+        - sourceFilename
+        - sourceContentType
+        - byteSize
+        - effectiveFrom
+        - effectiveTo
+        - changeSummary
+        - createdByUserId
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        documentId:
+          type: string
+          format: uuid
+        versionNumber:
+          type: integer
+          format: int32
+        parentVersionId:
+          type: [string, "null"]
+          format: uuid
+        publicationState:
+          type: string
+          enum: [draft, published]
+        isCurrent:
+          type: boolean
+        contentSha256:
+          type: string
+        sourceFilename:
+          type: [string, "null"]
+        sourceContentType:
+          type: [string, "null"]
+        byteSize:
+          type: [integer, "null"]
+          format: int64
+        effectiveFrom:
+          type: string
+          format: date-time
+        effectiveTo:
+          type: [string, "null"]
+          format: date-time
+        changeSummary:
+          type: [string, "null"]
+        createdByUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+    DocumentVersionListResponse:
+      type: object
+      required: [items, pageInfo]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentVersion"
+        pageInfo:
+          $ref: "#/components/schemas/PageInfo"
+    CreateDocumentResponse:
+      type: object
+      required: [document, version, jobId, jobStatus]
+      properties:
+        document:
+          $ref: "#/components/schemas/Document"
+        version:
+          $ref: "#/components/schemas/DocumentVersion"
+        jobId:
+          type: string
+          format: uuid
+        jobStatus:
+          $ref: "#/components/schemas/JobStatus"
+    DeleteDocumentResponse:
+      type: object
+      required: [document, deleteRequested]
+      properties:
+        document:
+          $ref: "#/components/schemas/Document"
+        deleteRequested:
+          type: boolean
+    JobSummary:
+      type: object
+      required: [id, status]
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          $ref: "#/components/schemas/JobStatus"
+    Job:
+      type: object
+      required:
+        - id
+        - jobType
+        - status
+        - attempts
+        - maxAttempts
+        - documentId
+        - versionId
+        - availableAt
+        - startedAt
+        - finishedAt
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        jobType:
+          $ref: "#/components/schemas/JobType"
+        status:
+          $ref: "#/components/schemas/JobStatus"
+        attempts:
+          type: integer
+          format: int32
+        maxAttempts:
+          type: integer
+          format: int32
+        documentId:
+          type: [string, "null"]
+          format: uuid
+        versionId:
+          type: [string, "null"]
+          format: uuid
+        availableAt:
+          type: string
+          format: date-time
+        startedAt:
+          type: [string, "null"]
+          format: date-time
+        finishedAt:
+          type: [string, "null"]
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    JobType:
+      type: string
+      enum: [convert, index, delete, reconcile, embedding_batch]
+    JobStatus:
+      type: string
+      enum: [pending, leased, running, succeeded, failed, cancelled, dead_letter]
+    CitationPin:
+      type: object
+      required: [documentId, versionId, versionNumber, contentSha256, chunkId]
+      properties:
+        documentId:
+          type: string
+          format: uuid
+        versionId:
+          type: string
+          format: uuid
+        versionNumber:
+          type: integer
+          format: int32
+        contentSha256:
+          type: string
+        chunkId:
+          type: string
+          format: uuid
+        spanStart:
+          type: [integer, "null"]
+          format: int32
+        spanEnd:
+          type: [integer, "null"]
+          format: int32
+        quote:
+          type: [string, "null"]
+    ResolvedCitation:
+      type: object
+      required:
+        - orgId
+        - documentId
+        - versionId
+        - versionNumber
+        - contentSha256
+        - chunkId
+        - collectionId
+        - headingPath
+        - snippet
+        - page
+        - slide
+        - sheet
+        - spanStart
+        - spanEnd
+        - quote
+        - effectiveFrom
+        - effectiveTo
+        - isCurrent
+      properties:
+        orgId:
+          type: string
+          format: uuid
+        documentId:
+          type: string
+          format: uuid
+        versionId:
+          type: string
+          format: uuid
+        versionNumber:
+          type: integer
+          format: int32
+        contentSha256:
+          type: string
+        chunkId:
+          type: string
+          format: uuid
+        collectionId:
+          type: string
+          format: uuid
+        headingPath:
+          type: array
+          items:
+            type: string
+        snippet:
+          type: string
+        page:
+          type: [integer, "null"]
+          format: int32
+        slide:
+          type: [integer, "null"]
+          format: int32
+        sheet:
+          type: [string, "null"]
+        spanStart:
+          type: [integer, "null"]
+          format: int32
+        spanEnd:
+          type: [integer, "null"]
+          format: int32
+        quote:
+          type: [string, "null"]
+        effectiveFrom:
+          type: string
+          format: date-time
+        effectiveTo:
+          type: [string, "null"]
+          format: date-time
+        isCurrent:
+          type: boolean
+    DownloadCapability:
+      type: object
+      required: [token, downloadPath, expiresAt, filename, contentType, byteSize, contentSha256]
+      properties:
+        token:
+          type: string
+        downloadPath:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+        filename:
+          type: string
+        contentType:
+          type: string
+        byteSize:
+          type: integer
+          format: int64
+          minimum: 0
+        contentSha256:
+          type: string
+    SearchRequest:
+      type: object
+      required: [query]
+      properties:
+        query:
+          type: string
+          maxLength: 4096
+        limit:
+          type: [integer, "null"]
+          format: int32
+          minimum: 1
+        collectionIds:
+          type: [array, "null"]
+          maxItems: 512
+          items:
+            type: string
+            format: uuid
+    SearchResponse:
+      type: object
+      required: [hits, degraded]
+      properties:
+        hits:
+          type: array
+          items:
+            $ref: "#/components/schemas/SearchHit"
+        degraded:
+          type: [string, "null"]
+          enum: [vector_unavailable, lexical_unavailable, null]
+    SearchHit:
+      type: object
+      required:
+        - chunkId
+        - documentId
+        - versionId
+        - collectionId
+        - versionNumber
+        - snippet
+        - lexicalScore
+        - vectorScore
+        - rerankScore
+        - isCurrent
+      properties:
+        chunkId:
+          type: string
+          format: uuid
+        documentId:
+          type: string
+          format: uuid
+        versionId:
+          type: string
+          format: uuid
+        collectionId:
+          type: string
+          format: uuid
+        versionNumber:
+          type: integer
+          format: int32
+        snippet:
+          type: string
+        headingPath:
+          type: array
+          items:
+            type: string
+        lexicalScore:
+          type: number
+          format: float
+        vectorScore:
+          type: number
+          format: float
+        rerankScore:
+          type: number
+          format: float
+        page:
+          type: integer
+          format: int32
+        slide:
+          type: integer
+          format: int32
+        sheet:
+          type: string
+        isCurrent:
+          type: boolean
+    AskRequest:
+      type: object
+      required: [question]
+      properties:
+        question:
+          type: string
+          maxLength: 4096
+        limit:
+          type: [integer, "null"]
+          format: int32
+          minimum: 1
+          maximum: 20
+        collectionIds:
+          type: [array, "null"]
+          maxItems: 512
+          items:
+            type: string
+            format: uuid
+    AskResponse:
+      type: object
+      required: [answer, citations, warnings, mode]
+      properties:
+        answer:
+          type: string
+        citations:
+          type: array
+          items:
+            $ref: "#/components/schemas/QaCitation"
+        warnings:
+          type: array
+          items:
+            type: string
+        mode:
+          $ref: "#/components/schemas/QaAnswerMode"
+    QaAnswerMode:
+      type: string
+      enum: [cloud_llm, fallback_extractive, offline_extractive]
+    QaCitation:
+      type: object
+      required:
+        - documentId
+        - versionId
+        - versionNumber
+        - contentSha256
+        - chunkId
+        - headingPath
+        - snippet
+        - page
+        - slide
+        - sheet
+        - isCurrent
+      properties:
+        documentId:
+          type: string
+          format: uuid
+        versionId:
+          type: string
+          format: uuid
+        versionNumber:
+          type: integer
+          format: int32
+        contentSha256:
+          type: string
+        chunkId:
+          type: string
+          format: uuid
+        headingPath:
+          type: array
+          items:
+            type: string
+        snippet:
+          type: string
+        page:
+          type: [integer, "null"]
+          format: int32
+        slide:
+          type: [integer, "null"]
+          format: int32
+        sheet:
+          type: [string, "null"]
+        isCurrent:
+          type: boolean
+    QaEvent:
+      description: Direct serde representation of the QA service event enum (`snake_case` variant names). `/ask/stream` wraps mapped event data in `SseEnvelope`.
+      oneOf:
+        - type: object
+          required: [token]
+          properties:
+            token:
+              type: string
+        - type: object
+          required: [citations]
+          properties:
+            citations:
+              type: array
+              items:
+                $ref: "#/components/schemas/QaCitation"
+        - type: object
+          required: [warning]
+          properties:
+            warning:
+              type: string
+        - type: object
+          required: [done]
+          properties:
+            done:
+              type: object
+              required: [mode]
+              properties:
+                mode:
+                  $ref: "#/components/schemas/QaAnswerMode"
+    AskSseData:
+      description: Data payloads emitted inside `SseEnvelope.data` by `/ask/stream`.
+      oneOf:
+        - type: object
+          required: [token]
+          properties:
+            token:
+              type: string
+        - type: object
+          required: [citations]
+          properties:
+            citations:
+              type: array
+              items:
+                $ref: "#/components/schemas/QaCitation"
+        - type: object
+          required: [warning]
+          properties:
+            warning:
+              type: string
+        - type: object
+          required: [mode]
+          properties:
+            mode:
+              $ref: "#/components/schemas/QaAnswerMode"

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -58,5 +58,10 @@ mod tests {
             serde_json::from_str(include_str!("../openapi/fixtures/sse.json")).unwrap();
         assert_eq!(event.version, 1);
         assert_eq!(event.sequence, 42);
+
+        let rate_limited: ApiError =
+            serde_json::from_str(include_str!("../openapi/fixtures/rate_limited.json")).unwrap();
+        assert_eq!(rate_limited.code, "rate_limited");
+        assert!(rate_limited.details.is_none());
     }
 }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -29,7 +29,7 @@ const PROD_MIN_ARGON2_MEMORY_KIB: u32 = 19_456;
 const PROD_MIN_ARGON2_TIME_COST: u32 = 2;
 const PROD_MAX_ACCESS_TOKEN_TTL_SECS: u64 = 900;
 const MAX_RATE_LIMIT_PER_MINUTE: u32 = 100_000;
-const MAX_RATE_LIMIT_ENTRIES: usize = 1_000_000;
+const MAX_RATE_LIMIT_ENTRIES: usize = 65_536;
 
 /// Deployment profile with explicitly different safety requirements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1631,6 +1631,13 @@ mod tests {
         assert_eq!(
             ServerConfig::from_sources(None, &invalid_signature).unwrap_err(),
             "MARKHAND_INDEX_SIGNATURE must be a 64-character hex digest"
+        );
+
+        let oversized_rate_limit_map =
+            BTreeMap::from([("MARKHAND_RATE_LIMIT_MAX_ENTRIES".into(), "65537".into())]);
+        assert_eq!(
+            ServerConfig::from_sources(None, &oversized_rate_limit_map).unwrap_err(),
+            "MARKHAND_RATE_LIMIT_MAX_ENTRIES must be between 1 and 65536"
         );
     }
 

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -20,9 +20,16 @@ const DEFAULT_QUOTA_SWEEP_BATCH_SIZE: u32 = 500;
 const DEFAULT_ARGON2_MEMORY_KIB: u32 = 19_456;
 const DEFAULT_ARGON2_TIME_COST: u32 = 2;
 const DEFAULT_ARGON2_PARALLELISM: u32 = 1;
+const DEFAULT_RATE_LIMIT_AUTH_PER_MINUTE: u32 = 20;
+const DEFAULT_RATE_LIMIT_LLM_PER_MINUTE: u32 = 60;
+const DEFAULT_RATE_LIMIT_AUTHENTICATED_PER_MINUTE: u32 = 300;
+const DEFAULT_RATE_LIMIT_FALLBACK_PER_MINUTE: u32 = 120;
+const DEFAULT_RATE_LIMIT_MAX_ENTRIES: usize = 8_192;
 const PROD_MIN_ARGON2_MEMORY_KIB: u32 = 19_456;
 const PROD_MIN_ARGON2_TIME_COST: u32 = 2;
 const PROD_MAX_ACCESS_TOKEN_TTL_SECS: u64 = 900;
+const MAX_RATE_LIMIT_PER_MINUTE: u32 = 100_000;
+const MAX_RATE_LIMIT_ENTRIES: usize = 1_000_000;
 
 /// Deployment profile with explicitly different safety requirements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -89,6 +96,9 @@ pub struct ServerConfig {
     limits: RuntimeLimits,
     upload: UploadConfig,
     quota_sweep: QuotaSweepConfig,
+    rate_limits: RateLimitConfig,
+    trusted_proxy: bool,
+    cors_allowed_origins: Vec<String>,
     index_signature: Option<String>,
 }
 
@@ -134,6 +144,9 @@ impl fmt::Debug for ServerConfig {
             .field("limits", &self.limits)
             .field("upload", &self.upload)
             .field("quota_sweep", &self.quota_sweep)
+            .field("rate_limits", &self.rate_limits)
+            .field("trusted_proxy", &self.trusted_proxy)
+            .field("cors_allowed_origins", &self.cors_allowed_origins)
             .field("index_signature", &self.index_signature)
             .finish()
     }
@@ -355,6 +368,15 @@ pub struct QuotaSweepConfig {
     pub batch_size: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RateLimitConfig {
+    pub auth_per_ip_per_minute: u32,
+    pub llm_per_user_per_minute: u32,
+    pub authenticated_per_user_per_minute: u32,
+    pub fallback_per_ip_per_minute: u32,
+    pub max_entries: usize,
+}
+
 #[derive(Default, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ConfigFile {
@@ -394,6 +416,13 @@ struct ConfigFile {
     upload_idle_timeout_secs: Option<u64>,
     quota_sweep_interval_secs: Option<u64>,
     quota_sweep_batch_size: Option<u64>,
+    rate_limit_auth_per_minute: Option<u64>,
+    rate_limit_llm_per_minute: Option<u64>,
+    rate_limit_authenticated_per_minute: Option<u64>,
+    rate_limit_fallback_per_minute: Option<u64>,
+    rate_limit_max_entries: Option<u64>,
+    trusted_proxy: Option<bool>,
+    cors_allowed_origins: Option<Vec<String>>,
     index_signature: Option<String>,
 }
 
@@ -678,6 +707,51 @@ impl ServerConfig {
                 DEFAULT_QUOTA_SWEEP_BATCH_SIZE,
             )?,
         };
+        let rate_limits = RateLimitConfig {
+            auth_per_ip_per_minute: u32_value(
+                file,
+                env,
+                "MARKHAND_RATE_LIMIT_AUTH_PER_MINUTE",
+                |value| value.rate_limit_auth_per_minute,
+                DEFAULT_RATE_LIMIT_AUTH_PER_MINUTE,
+            )?,
+            llm_per_user_per_minute: u32_value(
+                file,
+                env,
+                "MARKHAND_RATE_LIMIT_LLM_PER_MINUTE",
+                |value| value.rate_limit_llm_per_minute,
+                DEFAULT_RATE_LIMIT_LLM_PER_MINUTE,
+            )?,
+            authenticated_per_user_per_minute: u32_value(
+                file,
+                env,
+                "MARKHAND_RATE_LIMIT_AUTHENTICATED_PER_MINUTE",
+                |value| value.rate_limit_authenticated_per_minute,
+                DEFAULT_RATE_LIMIT_AUTHENTICATED_PER_MINUTE,
+            )?,
+            fallback_per_ip_per_minute: u32_value(
+                file,
+                env,
+                "MARKHAND_RATE_LIMIT_FALLBACK_PER_MINUTE",
+                |value| value.rate_limit_fallback_per_minute,
+                DEFAULT_RATE_LIMIT_FALLBACK_PER_MINUTE,
+            )?,
+            max_entries: usize_value(
+                file,
+                env,
+                "MARKHAND_RATE_LIMIT_MAX_ENTRIES",
+                |value| value.rate_limit_max_entries,
+                DEFAULT_RATE_LIMIT_MAX_ENTRIES,
+            )?,
+        };
+        let trusted_proxy = bool_value(
+            file,
+            env,
+            "MARKHAND_TRUSTED_PROXY",
+            |value| value.trusted_proxy,
+            false,
+        )?;
+        let cors_allowed_origins = cors_origins_value(file, env)?;
         let index_signature = optional_value(file, env, "MARKHAND_INDEX_SIGNATURE", |value| {
             value.index_signature.as_ref()
         });
@@ -700,6 +774,9 @@ impl ServerConfig {
             limits,
             upload,
             quota_sweep,
+            rate_limits,
+            trusted_proxy,
+            cors_allowed_origins,
             index_signature,
         };
         config.validate()?;
@@ -726,6 +803,18 @@ impl ServerConfig {
 
     pub const fn quota_sweep(&self) -> QuotaSweepConfig {
         self.quota_sweep
+    }
+
+    pub const fn rate_limits(&self) -> RateLimitConfig {
+        self.rate_limits
+    }
+
+    pub const fn trusted_proxy(&self) -> bool {
+        self.trusted_proxy
+    }
+
+    pub fn cors_allowed_origins(&self) -> &[String] {
+        &self.cors_allowed_origins
     }
 
     /// Legacy runtime limits (max upload + job lease).
@@ -792,8 +881,34 @@ impl ServerConfig {
                 interval_secs: DEFAULT_QUOTA_SWEEP_INTERVAL_SECS,
                 batch_size: DEFAULT_QUOTA_SWEEP_BATCH_SIZE,
             },
+            rate_limits: RateLimitConfig {
+                auth_per_ip_per_minute: DEFAULT_RATE_LIMIT_AUTH_PER_MINUTE,
+                llm_per_user_per_minute: DEFAULT_RATE_LIMIT_LLM_PER_MINUTE,
+                authenticated_per_user_per_minute: DEFAULT_RATE_LIMIT_AUTHENTICATED_PER_MINUTE,
+                fallback_per_ip_per_minute: DEFAULT_RATE_LIMIT_FALLBACK_PER_MINUTE,
+                max_entries: DEFAULT_RATE_LIMIT_MAX_ENTRIES,
+            },
+            trusted_proxy: false,
+            cors_allowed_origins: Vec::new(),
             index_signature: None,
         }
+    }
+
+    /// Test helper for middleware-focused HTTP tests.
+    pub fn with_test_rate_limits(mut self, rate_limits: RateLimitConfig) -> Self {
+        self.rate_limits = rate_limits;
+        self
+    }
+
+    /// Test helper for proxy/CORS middleware-focused HTTP tests.
+    pub fn with_test_http_hardening(
+        mut self,
+        trusted_proxy: bool,
+        cors_allowed_origins: Vec<String>,
+    ) -> Self {
+        self.trusted_proxy = trusted_proxy;
+        self.cors_allowed_origins = cors_allowed_origins;
+        self
     }
 
     /// Returns the service endpoints required to start the real POC server.
@@ -965,6 +1080,32 @@ impl ServerConfig {
         if self.quota_sweep.batch_size == 0 || self.quota_sweep.batch_size > 10_000 {
             return Err("MARKHAND_QUOTA_SWEEP_BATCH_SIZE must be between 1 and 10000".into());
         }
+        validate_rate_limit(
+            self.rate_limits.auth_per_ip_per_minute,
+            "MARKHAND_RATE_LIMIT_AUTH_PER_MINUTE",
+        )?;
+        validate_rate_limit(
+            self.rate_limits.llm_per_user_per_minute,
+            "MARKHAND_RATE_LIMIT_LLM_PER_MINUTE",
+        )?;
+        validate_rate_limit(
+            self.rate_limits.authenticated_per_user_per_minute,
+            "MARKHAND_RATE_LIMIT_AUTHENTICATED_PER_MINUTE",
+        )?;
+        validate_rate_limit(
+            self.rate_limits.fallback_per_ip_per_minute,
+            "MARKHAND_RATE_LIMIT_FALLBACK_PER_MINUTE",
+        )?;
+        if self.rate_limits.max_entries == 0
+            || self.rate_limits.max_entries > MAX_RATE_LIMIT_ENTRIES
+        {
+            return Err(format!(
+                "MARKHAND_RATE_LIMIT_MAX_ENTRIES must be between 1 and {MAX_RATE_LIMIT_ENTRIES}"
+            ));
+        }
+        for origin in &self.cors_allowed_origins {
+            validate_cors_origin(origin)?;
+        }
         Ok(())
     }
 
@@ -1075,6 +1216,70 @@ fn bool_value(
         },
         None => Ok(file.and_then(from_file).unwrap_or(default)),
     }
+}
+
+fn cors_origins_value(
+    file: Option<&ConfigFile>,
+    env: &BTreeMap<String, String>,
+) -> Result<Vec<String>, String> {
+    let origins = match env.get("MARKHAND_CORS_ALLOWED_ORIGINS") {
+        Some(value) => value
+            .split(',')
+            .map(str::trim)
+            .filter(|origin| !origin.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>(),
+        None => file
+            .and_then(|value| value.cors_allowed_origins.clone())
+            .unwrap_or_default(),
+    };
+    origins
+        .into_iter()
+        .map(|origin| normalize_cors_origin(&origin))
+        .collect()
+}
+
+fn normalize_cors_origin(origin: &str) -> Result<String, String> {
+    validate_cors_origin(origin)?;
+    Ok(origin.trim().trim_end_matches('/').to_string())
+}
+
+fn validate_rate_limit(value: u32, env_name: &str) -> Result<(), String> {
+    if value == 0 || value > MAX_RATE_LIMIT_PER_MINUTE {
+        Err(format!(
+            "{env_name} must be between 1 and {MAX_RATE_LIMIT_PER_MINUTE}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_cors_origin(origin: &str) -> Result<(), String> {
+    let trimmed = origin.trim();
+    if trimmed == "*" {
+        return Err("MARKHAND_CORS_ALLOWED_ORIGINS must not contain *".into());
+    }
+    let parsed = reqwest::Url::parse(trimmed)
+        .map_err(|_| "MARKHAND_CORS_ALLOWED_ORIGINS must contain absolute origins".to_string())?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err("MARKHAND_CORS_ALLOWED_ORIGINS origins must use http or https".into());
+    }
+    if parsed.host_str().is_none() {
+        return Err("MARKHAND_CORS_ALLOWED_ORIGINS origins must include a host".into());
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("MARKHAND_CORS_ALLOWED_ORIGINS origins must not embed credentials".into());
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err(
+            "MARKHAND_CORS_ALLOWED_ORIGINS origins must not include query or fragment".into(),
+        );
+    }
+    let path = parsed.path();
+    if path != "/" && !path.is_empty() {
+        return Err("MARKHAND_CORS_ALLOWED_ORIGINS origins must not include a path".into());
+    }
+    Ok(())
 }
 
 fn required_url(value: Option<&str>, name: &str) -> Result<String, String> {
@@ -1233,6 +1438,13 @@ mod tests {
             upload_idle_timeout_secs: None,
             quota_sweep_interval_secs: None,
             quota_sweep_batch_size: None,
+            rate_limit_auth_per_minute: None,
+            rate_limit_llm_per_minute: None,
+            rate_limit_authenticated_per_minute: None,
+            rate_limit_fallback_per_minute: None,
+            rate_limit_max_entries: None,
+            trusted_proxy: None,
+            cors_allowed_origins: None,
             index_signature: None,
         };
         let env = BTreeMap::from([

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -64,11 +64,25 @@ pub fn migration_checksum(source: &str) -> String {
         .collect()
 }
 
-pub fn latest_migration() -> (&'static str, String) {
-    let (name, source) = MIGRATIONS
-        .last()
-        .expect("embedded migration manifest must not be empty");
-    (*name, migration_checksum(source))
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedMigrationChecksum {
+    pub version: &'static str,
+    pub name: &'static str,
+    pub checksum: String,
+}
+
+pub fn embedded_migration_checksums() -> Vec<EmbeddedMigrationChecksum> {
+    MIGRATIONS
+        .iter()
+        .map(|&(name, source)| EmbeddedMigrationChecksum {
+            version: name
+                .split_once('_')
+                .map(|(version, _)| version)
+                .unwrap_or(name),
+            name,
+            checksum: migration_checksum(source),
+        })
+        .collect()
 }
 
 pub async fn apply_migrations(database_url: &str) -> Result<(), String> {

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -63,6 +63,14 @@ pub fn migration_checksum(source: &str) -> String {
         .map(|byte| format!("{byte:02x}"))
         .collect()
 }
+
+pub fn latest_migration() -> (&'static str, String) {
+    let (name, source) = MIGRATIONS
+        .last()
+        .expect("embedded migration manifest must not be empty");
+    (*name, migration_checksum(source))
+}
+
 pub async fn apply_migrations(database_url: &str) -> Result<(), String> {
     let mut client = connect(database_url).await?;
     client

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -3,35 +3,29 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::State;
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::routing::get;
-use axum::{Json, Router};
+use axum::middleware::{from_fn, from_fn_with_state};
+use axum::Router;
 use deadpool_postgres::Pool;
-use serde::Serialize;
-use tokio::time::timeout;
-use uuid::Uuid;
 
 use crate::api::sse::AskStreamRegistry;
-use crate::api::ApiError;
 use crate::auth::jwt::JwtKeys;
 use crate::auth::provider::PasswordAuthProvider;
 use crate::config::QuotaSweepConfig;
-use crate::database;
 use crate::db::pool::create_pool;
+use crate::middleware::{cors, rate_limit, request_id};
 use crate::routes;
 use crate::services::download::{CapabilityKey, ConsumedDownloadNonces};
 use crate::services::quota;
 use crate::state::RuntimeState;
 
-const DEPENDENCY_TIMEOUT: Duration = Duration::from_secs(3);
-const READINESS_CACHE_TTL: Duration = Duration::from_secs(1);
+pub(crate) const DEPENDENCY_TIMEOUT: Duration = Duration::from_secs(3);
 
 pub struct AppState {
     runtime: RuntimeState,
     http_client: reqwest::Client,
-    readiness: tokio::sync::Mutex<Option<CachedReadiness>>,
+    readiness: tokio::sync::Mutex<Option<crate::services::health::CachedReadiness>>,
+    startup_complete: std::sync::atomic::AtomicBool,
+    rate_limiter: rate_limit::RateLimiter,
     pool: Pool,
     auth_provider: Option<PasswordAuthProvider>,
     /// Object store adapter (optional when credentials are absent in tests).
@@ -40,11 +34,6 @@ pub struct AppState {
     ask_streams: AskStreamRegistry,
     download_capability_key: Option<CapabilityKey>,
     consumed_download_nonces: ConsumedDownloadNonces,
-}
-
-struct CachedReadiness {
-    checked_at: tokio::time::Instant,
-    result: Result<(), ()>,
 }
 
 impl AppState {
@@ -97,9 +86,11 @@ impl AppState {
             .as_ref()
             .map(CapabilityKey::derive_from_auth_signing_key);
         Ok(Self {
+            rate_limiter: rate_limit::RateLimiter::new(runtime.config().rate_limits()),
             runtime,
             http_client,
             readiness: tokio::sync::Mutex::new(None),
+            startup_complete: std::sync::atomic::AtomicBool::new(true),
             pool,
             auth_provider,
             object_store,
@@ -153,9 +144,11 @@ impl AppState {
             .as_ref()
             .map(CapabilityKey::derive_from_auth_signing_key);
         Ok(Self {
+            rate_limiter: rate_limit::RateLimiter::new(runtime.config().rate_limits()),
             runtime,
             http_client,
             readiness: tokio::sync::Mutex::new(None),
+            startup_complete: std::sync::atomic::AtomicBool::new(true),
             pool,
             auth_provider,
             object_store,
@@ -176,6 +169,31 @@ impl AppState {
 
     pub fn runtime(&self) -> &RuntimeState {
         &self.runtime
+    }
+
+    pub(crate) fn http_client(&self) -> &reqwest::Client {
+        &self.http_client
+    }
+
+    pub(crate) fn readiness_cache(
+        &self,
+    ) -> &tokio::sync::Mutex<Option<crate::services::health::CachedReadiness>> {
+        &self.readiness
+    }
+
+    pub(crate) fn startup_complete(&self) -> bool {
+        self.startup_complete
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    pub(crate) fn rate_limiter(&self) -> &rate_limit::RateLimiter {
+        &self.rate_limiter
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_startup_complete_for_test(&self, value: bool) {
+        self.startup_complete
+            .store(value, std::sync::atomic::Ordering::Release);
     }
 
     pub fn object_store(&self) -> Option<&crate::storage::MinioClient> {
@@ -225,18 +243,11 @@ fn start_quota_sweep(pool: Pool, config: QuotaSweepConfig) {
     });
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct Health {
-    status: &'static str,
-    request_id: String,
-}
-
 pub fn router(state: AppState) -> Router {
     let max_upload_bytes = state.runtime.config().upload().limits.max_upload_bytes as usize;
+    let state = Arc::new(state);
     Router::new()
-        .route("/api/v1/health/live", get(liveness))
-        .route("/api/v1/health/ready", get(readiness))
+        .merge(routes::health::router())
         .merge(routes::auth::router())
         .merge(routes::collections::router())
         .merge(routes::documents::router())
@@ -245,107 +256,73 @@ pub fn router(state: AppState) -> Router {
         .merge(routes::ask::router())
         .merge(routes::events::router())
         .merge(routes::uploads::router(max_upload_bytes))
-        .with_state(Arc::new(state))
-}
-
-async fn liveness() -> Json<Health> {
-    Json(healthy())
-}
-
-async fn readiness(State(state): State<Arc<AppState>>) -> Result<Json<Health>, ReadinessError> {
-    check_dependencies(state).await?;
-    Ok(Json(healthy()))
-}
-
-async fn check_dependencies(state: Arc<AppState>) -> Result<(), ReadinessError> {
-    let mut cached = state.readiness.lock().await;
-    if let Some(previous) = cached.as_ref() {
-        if previous.checked_at.elapsed() < READINESS_CACHE_TTL {
-            return previous
-                .result
-                .as_ref()
-                .map(|_| ())
-                .map_err(|_| ReadinessError);
-        }
-    }
-
-    let result = check_dependencies_uncached(&state).await;
-    *cached = Some(CachedReadiness {
-        checked_at: tokio::time::Instant::now(),
-        result: result.as_ref().map(|_| ()).map_err(|_| ()),
-    });
-    result.map_err(|_| ReadinessError)
-}
-
-async fn check_dependencies_uncached(state: &AppState) -> Result<(), String> {
-    let database = timeout(
-        DEPENDENCY_TIMEOUT,
-        database::check_connection(state.runtime.endpoints().database_url.expose()),
-    );
-    let qdrant = state
-        .http_client
-        .get(format!("{}/healthz", state.runtime.endpoints().qdrant_url))
-        .send();
-    let minio = state
-        .http_client
-        .get(format!(
-            "{}/minio/health/live",
-            state.runtime.endpoints().minio_url
-        ))
-        .send();
-
-    let (database, qdrant, minio) = tokio::join!(database, qdrant, minio);
-    database.map_err(|_| "PostgreSQL readiness timed out".to_string())??;
-    ensure_success(qdrant, "Qdrant").await?;
-    ensure_success(minio, "MinIO").await
-}
-
-async fn ensure_success(
-    response: Result<reqwest::Response, reqwest::Error>,
-    dependency: &str,
-) -> Result<(), String> {
-    let response = response.map_err(|_| format!("{dependency} readiness request failed"))?;
-    if response.status().is_success() {
-        Ok(())
-    } else {
-        Err(format!("{dependency} returned {}", response.status()))
-    }
-}
-
-fn healthy() -> Health {
-    Health {
-        status: "ok",
-        request_id: Uuid::new_v4().to_string(),
-    }
-}
-
-struct ReadinessError;
-
-impl IntoResponse for ReadinessError {
-    fn into_response(self) -> Response {
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(ApiError {
-                code: "dependency_unavailable".into(),
-                message: "A required service is unavailable".into(),
-                request_id: Uuid::new_v4().to_string(),
-                details: None,
-            }),
-        )
-            .into_response()
-    }
+        .with_state(state.clone())
+        .layer(from_fn_with_state(state.clone(), rate_limit::rate_limit))
+        .layer(from_fn_with_state(state, cors::cors))
+        .layer(from_fn(request_id::ensure_request_id))
 }
 
 #[cfg(test)]
 mod tests {
     use axum::body::Body;
+    use axum::extract::ConnectInfo;
+    use axum::http::header::{ACCESS_CONTROL_ALLOW_ORIGIN, ORIGIN, RETRY_AFTER, VARY};
+    use axum::http::{Method, Request};
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
     use super::{router, AppState};
-    use crate::config::{RuntimeEndpoints, SecretString, ServerConfig};
+    use crate::api::ApiError;
+    use crate::config::{RateLimitConfig, RuntimeEndpoints, SecretString, ServerConfig};
     use crate::db::pool::create_pool;
+    use crate::middleware::request_id::X_REQUEST_ID;
     use crate::state::RuntimeState;
+
+    fn test_rate_limits(limit: u32) -> RateLimitConfig {
+        RateLimitConfig {
+            auth_per_ip_per_minute: limit,
+            llm_per_user_per_minute: limit,
+            authenticated_per_user_per_minute: limit,
+            fallback_per_ip_per_minute: limit,
+            max_entries: 64,
+        }
+    }
+
+    fn test_app(config: ServerConfig) -> axum::Router {
+        let runtime = RuntimeState::from_config(config).unwrap();
+        let pool = create_pool("postgres://markhand_app:markhand_app@127.0.0.1:5432/markhand_test")
+            .expect("pool");
+        router(AppState::from_parts(runtime, pool, None).unwrap())
+    }
+
+    fn config_for_middleware_tests() -> ServerConfig {
+        ServerConfig::test_with_endpoints(RuntimeEndpoints {
+            database_url: SecretString::new("postgres://unused"),
+            qdrant_url: "http://127.0.0.1:1".into(),
+            minio_url: "http://127.0.0.1:1".into(),
+        })
+    }
+
+    fn login_request(ip: &str, forwarded_for: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method(Method::POST)
+            .uri("/api/v1/auth/login")
+            .header("content-type", "application/json");
+        if let Some(forwarded_for) = forwarded_for {
+            builder = builder.header("x-forwarded-for", forwarded_for);
+        }
+        let mut request = builder
+            .body(Body::from(
+                r#"{"email":"a@example.com","password":"secret"}"#,
+            ))
+            .unwrap();
+        request.extensions_mut().insert(ConnectInfo(
+            format!("{ip}:12345")
+                .parse::<std::net::SocketAddr>()
+                .unwrap(),
+        ));
+        request
+    }
 
     #[tokio::test]
     async fn liveness_has_a_contract_compliant_body() {
@@ -391,5 +368,194 @@ mod tests {
             AppState::from_parts(state, pool, None).err().as_deref(),
             Some("HTTP application requires API runtime configuration")
         );
+    }
+
+    #[tokio::test]
+    async fn rate_limit_returns_429_with_retry_after_and_api_error() {
+        let app =
+            test_app(config_for_middleware_tests().with_test_rate_limits(test_rate_limits(2)));
+        for _ in 0..2 {
+            let response = app
+                .clone()
+                .oneshot(login_request("192.0.2.10", None))
+                .await
+                .unwrap();
+            assert_ne!(response.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        }
+        let response = app
+            .oneshot(login_request("192.0.2.10", None))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        assert!(response.headers().contains_key(RETRY_AFTER));
+        assert!(response.headers().contains_key(&X_REQUEST_ID));
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let error: ApiError = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error.code, "rate_limited");
+        assert!(!error.request_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rate_limit_keys_are_isolated_and_health_is_exempt() {
+        let app =
+            test_app(config_for_middleware_tests().with_test_rate_limits(test_rate_limits(1)));
+        let first = app
+            .clone()
+            .oneshot(login_request("192.0.2.10", None))
+            .await
+            .unwrap();
+        assert_ne!(first.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        let limited = app
+            .clone()
+            .oneshot(login_request("192.0.2.10", None))
+            .await
+            .unwrap();
+        assert_eq!(limited.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        let isolated = app
+            .clone()
+            .oneshot(login_request("192.0.2.11", None))
+            .await
+            .unwrap();
+        assert_ne!(isolated.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+
+        for _ in 0..3 {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/v1/health/live")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), axum::http::StatusCode::OK);
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_connect_info_falls_back_without_panicking() {
+        let app =
+            test_app(config_for_middleware_tests().with_test_rate_limits(test_rate_limits(1)));
+        for expected in [
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            axum::http::StatusCode::TOO_MANY_REQUESTS,
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/api/v1/auth/login")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            r#"{"email":"a@example.com","password":"secret"}"#,
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn forwarded_for_is_ignored_unless_trusted_proxy_is_enabled() {
+        let untrusted = test_app(
+            config_for_middleware_tests()
+                .with_test_rate_limits(test_rate_limits(1))
+                .with_test_http_hardening(false, Vec::new()),
+        );
+        let first = untrusted
+            .clone()
+            .oneshot(login_request("192.0.2.1", Some("198.51.100.1")))
+            .await
+            .unwrap();
+        assert_ne!(first.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        let limited = untrusted
+            .oneshot(login_request("192.0.2.1", Some("198.51.100.2")))
+            .await
+            .unwrap();
+        assert_eq!(limited.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+
+        let trusted = test_app(
+            config_for_middleware_tests()
+                .with_test_rate_limits(test_rate_limits(1))
+                .with_test_http_hardening(true, Vec::new()),
+        );
+        let first = trusted
+            .clone()
+            .oneshot(login_request("192.0.2.1", Some("198.51.100.1")))
+            .await
+            .unwrap();
+        assert_ne!(first.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        let isolated = trusted
+            .oneshot(login_request("192.0.2.1", Some("198.51.100.2")))
+            .await
+            .unwrap();
+        assert_ne!(isolated.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn cors_preflight_and_request_id_headers_are_conservative() {
+        let app = test_app(
+            config_for_middleware_tests()
+                .with_test_http_hardening(false, vec!["https://app.example.test".into()]),
+        );
+        let allowed = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/health/live")
+                    .header(ORIGIN, "https://app.example.test")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(allowed.status(), axum::http::StatusCode::OK);
+        assert_eq!(
+            allowed.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).unwrap(),
+            "https://app.example.test"
+        );
+        assert!(allowed.headers().contains_key(VARY));
+        assert!(allowed.headers().contains_key(&X_REQUEST_ID));
+
+        let disallowed = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/health/live")
+                    .header(ORIGIN, "https://evil.example")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(!disallowed
+            .headers()
+            .contains_key(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assert!(disallowed.headers().contains_key(&X_REQUEST_ID));
+
+        let preflight = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/api/v1/health/live")
+                    .header(ORIGIN, "https://app.example.test")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(preflight.status(), axum::http::StatusCode::NO_CONTENT);
+        assert_eq!(
+            preflight
+                .headers()
+                .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+                .unwrap(),
+            "https://app.example.test"
+        );
+        assert!(preflight.headers().contains_key(&X_REQUEST_ID));
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod db;
 pub mod error;
 pub mod http;
 pub mod jobs;
+pub mod middleware;
 pub mod routes;
 pub mod services;
 pub mod state;

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -42,9 +42,12 @@ async fn main() {
                 "fileconv-server listening on http://{}",
                 state.config().bind_addr()
             );
-            if let Err(error) = axum::serve(listener, app)
-                .with_graceful_shutdown(shutdown_signal())
-                .await
+            if let Err(error) = axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .with_graceful_shutdown(shutdown_signal())
+            .await
             {
                 exit_with_error(format!("server failed: {error}"));
             }

--- a/crates/server/src/middleware/cors.rs
+++ b/crates/server/src/middleware/cors.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::header::{
+    ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
+    ORIGIN, VARY,
+};
+use axum::http::{HeaderValue, Method, Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use crate::http::AppState;
+
+const ALLOWED_METHODS: &str = "GET,POST,PUT,PATCH,DELETE,OPTIONS";
+const ALLOWED_HEADERS: &str = "Authorization,Content-Type,Idempotency-Key,Last-Event-ID";
+
+pub async fn cors(
+    State(state): State<Arc<AppState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let allowed_origin = request
+        .headers()
+        .get(ORIGIN)
+        .and_then(|value| value.to_str().ok())
+        .filter(|origin| {
+            state
+                .runtime()
+                .config()
+                .cors_allowed_origins()
+                .iter()
+                .any(|allowed| allowed == origin)
+        })
+        .map(str::to_string);
+
+    if request.method() == Method::OPTIONS {
+        let mut response = StatusCode::NO_CONTENT.into_response();
+        if let Some(origin) = allowed_origin.as_deref() {
+            apply_cors_headers(response.headers_mut(), origin);
+        }
+        return response;
+    }
+
+    let mut response = next.run(request).await;
+    if let Some(origin) = allowed_origin.as_deref() {
+        apply_cors_headers(response.headers_mut(), origin);
+    }
+    response
+}
+
+fn apply_cors_headers(headers: &mut axum::http::HeaderMap, origin: &str) {
+    if let Ok(origin) = HeaderValue::from_str(origin) {
+        headers.insert(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+        headers.insert(
+            ACCESS_CONTROL_ALLOW_METHODS,
+            HeaderValue::from_static(ALLOWED_METHODS),
+        );
+        headers.insert(
+            ACCESS_CONTROL_ALLOW_HEADERS,
+            HeaderValue::from_static(ALLOWED_HEADERS),
+        );
+        headers.append(VARY, HeaderValue::from_static("Origin"));
+    }
+}

--- a/crates/server/src/middleware/mod.rs
+++ b/crates/server/src/middleware/mod.rs
@@ -1,0 +1,5 @@
+//! Cross-cutting HTTP middleware.
+
+pub mod cors;
+pub mod rate_limit;
+pub mod request_id;

--- a/crates/server/src/middleware/rate_limit.rs
+++ b/crates/server/src/middleware/rate_limit.rs
@@ -1,0 +1,344 @@
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::extract::{ConnectInfo, State};
+use axum::http::header::{AUTHORIZATION, RETRY_AFTER};
+use axum::http::{HeaderMap, HeaderValue, Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use uuid::Uuid;
+
+use crate::api::ApiError;
+use crate::config::RateLimitConfig;
+use crate::http::AppState;
+use crate::middleware::request_id::{RequestId, X_REQUEST_ID};
+
+const WINDOW: Duration = Duration::from_secs(60);
+const IDLE_TTL: Duration = Duration::from_secs(10 * 60);
+const FALLBACK_PEER: &str = "unknown-peer";
+
+#[derive(Debug)]
+pub(crate) struct RateLimiter {
+    buckets: Mutex<RateLimitStore>,
+    max_entries: usize,
+}
+
+#[derive(Debug)]
+struct RateLimitStore {
+    buckets: HashMap<BucketKey, Bucket>,
+    last_eviction: tokio::time::Instant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BucketKey {
+    class: RateClass,
+    identity: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum RateClass {
+    Auth,
+    Llm,
+    Authenticated,
+    Fallback,
+}
+
+#[derive(Debug, Clone)]
+struct Bucket {
+    tokens: f64,
+    refilled_at: tokio::time::Instant,
+    last_seen: tokio::time::Instant,
+}
+
+#[derive(Debug)]
+struct RateDecision {
+    key: BucketKey,
+    limit_per_minute: u32,
+}
+
+impl RateLimiter {
+    pub(crate) fn new(config: RateLimitConfig) -> Self {
+        Self {
+            buckets: Mutex::new(RateLimitStore {
+                buckets: HashMap::new(),
+                last_eviction: tokio::time::Instant::now(),
+            }),
+            max_entries: config.max_entries,
+        }
+    }
+
+    fn check(&self, key: BucketKey, limit_per_minute: u32) -> Result<(), Duration> {
+        self.check_at(key, limit_per_minute, tokio::time::Instant::now())
+    }
+
+    fn check_at(
+        &self,
+        key: BucketKey,
+        limit_per_minute: u32,
+        now: tokio::time::Instant,
+    ) -> Result<(), Duration> {
+        let mut store = self
+            .buckets
+            .lock()
+            .expect("rate limiter mutex must not be poisoned");
+        store.evict_if_due(now, self.max_entries);
+        if !store.buckets.contains_key(&key) && store.buckets.len() >= self.max_entries {
+            store.evict_oldest();
+        }
+
+        let capacity = f64::from(limit_per_minute);
+        let refill_per_second = capacity / WINDOW.as_secs_f64();
+        let bucket = store.buckets.entry(key).or_insert_with(|| Bucket {
+            tokens: capacity,
+            refilled_at: now,
+            last_seen: now,
+        });
+        let elapsed = now.duration_since(bucket.refilled_at).as_secs_f64();
+        bucket.tokens = (bucket.tokens + elapsed * refill_per_second).min(capacity);
+        bucket.refilled_at = now;
+        bucket.last_seen = now;
+
+        if bucket.tokens >= 1.0 {
+            bucket.tokens -= 1.0;
+            Ok(())
+        } else {
+            let retry = ((1.0 - bucket.tokens) / refill_per_second).ceil().max(1.0) as u64;
+            Err(Duration::from_secs(retry))
+        }
+    }
+
+    #[cfg(test)]
+    fn bucket_count(&self) -> usize {
+        self.buckets
+            .lock()
+            .expect("rate limiter mutex must not be poisoned")
+            .buckets
+            .len()
+    }
+}
+
+impl RateLimitStore {
+    fn evict_if_due(&mut self, now: tokio::time::Instant, max_entries: usize) {
+        if self.buckets.len() < max_entries && now.duration_since(self.last_eviction) < IDLE_TTL {
+            return;
+        }
+        self.last_eviction = now;
+        self.buckets
+            .retain(|_, bucket| now.duration_since(bucket.last_seen) < IDLE_TTL);
+    }
+
+    fn evict_oldest(&mut self) {
+        if let Some(oldest) = self
+            .buckets
+            .iter()
+            .min_by_key(|(_, bucket)| bucket.last_seen)
+            .map(|(key, _)| key.clone())
+        {
+            self.buckets.remove(&oldest);
+        }
+    }
+}
+
+pub async fn rate_limit(
+    State(state): State<std::sync::Arc<AppState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    if is_health_path(request.uri().path()) {
+        return next.run(request).await;
+    }
+
+    let decision = rate_decision(&state, &request);
+    match state
+        .rate_limiter()
+        .check(decision.key, decision.limit_per_minute)
+    {
+        Ok(()) => next.run(request).await,
+        Err(retry_after) => rate_limited_response(&request, retry_after),
+    }
+}
+
+fn is_health_path(path: &str) -> bool {
+    path.starts_with("/api/v1/health/")
+}
+
+fn rate_decision(state: &AppState, request: &Request<Body>) -> RateDecision {
+    let config = state.runtime().config().rate_limits();
+    let path = request.uri().path();
+    let user_key = verified_user_key(state, request.headers());
+    if matches!(path, "/api/v1/auth/login" | "/api/v1/auth/refresh") {
+        return RateDecision {
+            key: BucketKey {
+                class: RateClass::Auth,
+                identity: ip_key(state, request),
+            },
+            limit_per_minute: config.auth_per_ip_per_minute,
+        };
+    }
+    if matches!(
+        path,
+        "/api/v1/search" | "/api/v1/ask" | "/api/v1/ask/stream"
+    ) {
+        if let Some(identity) = user_key {
+            return RateDecision {
+                key: BucketKey {
+                    class: RateClass::Llm,
+                    identity,
+                },
+                limit_per_minute: config.llm_per_user_per_minute,
+            };
+        }
+        return fallback_decision(state, request, config);
+    }
+    if let Some(identity) = user_key {
+        RateDecision {
+            key: BucketKey {
+                class: RateClass::Authenticated,
+                identity,
+            },
+            limit_per_minute: config.authenticated_per_user_per_minute,
+        }
+    } else {
+        fallback_decision(state, request, config)
+    }
+}
+
+fn fallback_decision(
+    state: &AppState,
+    request: &Request<Body>,
+    config: RateLimitConfig,
+) -> RateDecision {
+    RateDecision {
+        key: BucketKey {
+            class: RateClass::Fallback,
+            identity: ip_key(state, request),
+        },
+        limit_per_minute: config.fallback_per_ip_per_minute,
+    }
+}
+
+fn verified_user_key(state: &AppState, headers: &HeaderMap) -> Option<String> {
+    let token = bearer_token(headers)?;
+    let claims = state
+        .auth_provider()
+        .and_then(|provider| provider.keys().verify_access_token(token).ok())?;
+    Some(format!("org:{}:user:{}", claims.org_id, claims.sub))
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let header = headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())?;
+    let token = header
+        .strip_prefix("Bearer ")
+        .or_else(|| header.strip_prefix("bearer "))?;
+    (!token.is_empty() && token.len() <= 4096).then_some(token)
+}
+
+fn ip_key(state: &AppState, request: &Request<Body>) -> String {
+    if state.runtime().config().trusted_proxy() {
+        if let Some(ip) = forwarded_ip(request.headers()) {
+            return format!("ip:{ip}");
+        }
+    }
+    request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(addr)| format!("ip:{}", addr.ip()))
+        .unwrap_or_else(|| format!("ip:{FALLBACK_PEER}"))
+}
+
+fn forwarded_ip(headers: &HeaderMap) -> Option<IpAddr> {
+    headers
+        .get("x-forwarded-for")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(',').next())
+        .map(str::trim)
+        .and_then(|value| value.parse::<IpAddr>().ok())
+        .or_else(|| {
+            headers
+                .get("x-real-ip")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.trim().parse::<IpAddr>().ok())
+        })
+}
+
+fn rate_limited_response(request: &Request<Body>, retry_after: Duration) -> Response {
+    let request_id = request
+        .extensions()
+        .get::<RequestId>()
+        .map(|request_id| request_id.0.clone())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+    let retry_seconds = retry_after.as_secs().max(1).to_string();
+    let mut response = (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(ApiError {
+            code: "rate_limited".into(),
+            message: "Too many requests; please retry later".into(),
+            request_id: request_id.clone(),
+            details: None,
+        }),
+    )
+        .into_response();
+    response.headers_mut().insert(
+        RETRY_AFTER,
+        HeaderValue::from_str(&retry_seconds).expect("retry seconds are a valid header value"),
+    );
+    response.headers_mut().insert(
+        X_REQUEST_ID.clone(),
+        HeaderValue::from_str(&request_id).expect("UUID is a valid header value"),
+    );
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(max_entries: usize) -> RateLimitConfig {
+        RateLimitConfig {
+            auth_per_ip_per_minute: 2,
+            llm_per_user_per_minute: 2,
+            authenticated_per_user_per_minute: 2,
+            fallback_per_ip_per_minute: 2,
+            max_entries,
+        }
+    }
+
+    #[test]
+    fn token_bucket_refills_and_reports_retry_after() {
+        let limiter = RateLimiter::new(test_config(16));
+        let key = BucketKey {
+            class: RateClass::Fallback,
+            identity: "ip:127.0.0.1".into(),
+        };
+        let now = tokio::time::Instant::now();
+        assert!(limiter.check_at(key.clone(), 2, now).is_ok());
+        assert!(limiter.check_at(key.clone(), 2, now).is_ok());
+        assert_eq!(
+            limiter.check_at(key.clone(), 2, now).unwrap_err(),
+            Duration::from_secs(30)
+        );
+        assert!(limiter
+            .check_at(key, 2, now + Duration::from_secs(30))
+            .is_ok());
+    }
+
+    #[test]
+    fn bucket_map_is_capped() {
+        let limiter = RateLimiter::new(test_config(2));
+        let now = tokio::time::Instant::now();
+        for index in 0..10 {
+            let key = BucketKey {
+                class: RateClass::Fallback,
+                identity: format!("ip:192.0.2.{index}"),
+            };
+            assert!(limiter.check_at(key, 2, now).is_ok());
+        }
+        assert_eq!(limiter.bucket_count(), 2);
+    }
+}

--- a/crates/server/src/middleware/rate_limit.rs
+++ b/crates/server/src/middleware/rate_limit.rs
@@ -18,7 +18,7 @@ use crate::http::AppState;
 use crate::middleware::request_id::{RequestId, X_REQUEST_ID};
 
 const WINDOW: Duration = Duration::from_secs(60);
-const IDLE_TTL: Duration = Duration::from_secs(10 * 60);
+const SWEEP_INTERVAL: Duration = Duration::from_secs(10);
 const FALLBACK_PEER: &str = "unknown-peer";
 
 #[derive(Debug)]
@@ -30,7 +30,9 @@ pub(crate) struct RateLimiter {
 #[derive(Debug)]
 struct RateLimitStore {
     buckets: HashMap<BucketKey, Bucket>,
-    last_eviction: tokio::time::Instant,
+    last_sweep: tokio::time::Instant,
+    #[cfg(test)]
+    sweep_count: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -65,7 +67,9 @@ impl RateLimiter {
         Self {
             buckets: Mutex::new(RateLimitStore {
                 buckets: HashMap::new(),
-                last_eviction: tokio::time::Instant::now(),
+                last_sweep: tokio::time::Instant::now(),
+                #[cfg(test)]
+                sweep_count: 0,
             }),
             max_entries: config.max_entries,
         }
@@ -81,65 +85,80 @@ impl RateLimiter {
         limit_per_minute: u32,
         now: tokio::time::Instant,
     ) -> Result<(), Duration> {
-        let mut store = self
-            .buckets
-            .lock()
-            .expect("rate limiter mutex must not be poisoned");
-        store.evict_if_due(now, self.max_entries);
-        if !store.buckets.contains_key(&key) && store.buckets.len() >= self.max_entries {
-            store.evict_oldest();
+        let mut store = self.lock_store();
+        store.sweep_expired_if_due(now);
+        if let Some(bucket) = store.buckets.get_mut(&key) {
+            return check_bucket(bucket, limit_per_minute, now);
         }
 
+        if store.buckets.len() >= self.max_entries {
+            // Fail open at hard capacity. The table is already memory-bounded, and
+            // scanning for an eviction victim here would make novel attacker keys
+            // impose O(N) work under the global mutex.
+            return Ok(());
+        }
         let capacity = f64::from(limit_per_minute);
-        let refill_per_second = capacity / WINDOW.as_secs_f64();
-        let bucket = store.buckets.entry(key).or_insert_with(|| Bucket {
-            tokens: capacity,
-            refilled_at: now,
-            last_seen: now,
-        });
-        let elapsed = now.duration_since(bucket.refilled_at).as_secs_f64();
-        bucket.tokens = (bucket.tokens + elapsed * refill_per_second).min(capacity);
-        bucket.refilled_at = now;
-        bucket.last_seen = now;
+        store.buckets.insert(
+            key,
+            Bucket {
+                tokens: capacity - 1.0,
+                refilled_at: now,
+                last_seen: now,
+            },
+        );
+        Ok(())
+    }
 
-        if bucket.tokens >= 1.0 {
-            bucket.tokens -= 1.0;
-            Ok(())
-        } else {
-            let retry = ((1.0 - bucket.tokens) / refill_per_second).ceil().max(1.0) as u64;
-            Err(Duration::from_secs(retry))
-        }
+    fn lock_store(&self) -> std::sync::MutexGuard<'_, RateLimitStore> {
+        self.buckets
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     #[cfg(test)]
     fn bucket_count(&self) -> usize {
-        self.buckets
-            .lock()
-            .expect("rate limiter mutex must not be poisoned")
-            .buckets
-            .len()
+        self.lock_store().buckets.len()
+    }
+
+    #[cfg(test)]
+    fn sweep_count(&self) -> usize {
+        self.lock_store().sweep_count
+    }
+}
+
+fn check_bucket(
+    bucket: &mut Bucket,
+    limit_per_minute: u32,
+    now: tokio::time::Instant,
+) -> Result<(), Duration> {
+    let capacity = f64::from(limit_per_minute);
+    let refill_per_second = capacity / WINDOW.as_secs_f64();
+    let elapsed = now.duration_since(bucket.refilled_at).as_secs_f64();
+    bucket.tokens = (bucket.tokens + elapsed * refill_per_second).min(capacity);
+    bucket.refilled_at = now;
+    bucket.last_seen = now;
+
+    if bucket.tokens >= 1.0 {
+        bucket.tokens -= 1.0;
+        Ok(())
+    } else {
+        let retry = ((1.0 - bucket.tokens) / refill_per_second).ceil().max(1.0) as u64;
+        Err(Duration::from_secs(retry))
     }
 }
 
 impl RateLimitStore {
-    fn evict_if_due(&mut self, now: tokio::time::Instant, max_entries: usize) {
-        if self.buckets.len() < max_entries && now.duration_since(self.last_eviction) < IDLE_TTL {
+    fn sweep_expired_if_due(&mut self, now: tokio::time::Instant) {
+        if now.duration_since(self.last_sweep) < SWEEP_INTERVAL {
             return;
         }
-        self.last_eviction = now;
-        self.buckets
-            .retain(|_, bucket| now.duration_since(bucket.last_seen) < IDLE_TTL);
-    }
-
-    fn evict_oldest(&mut self) {
-        if let Some(oldest) = self
-            .buckets
-            .iter()
-            .min_by_key(|(_, bucket)| bucket.last_seen)
-            .map(|(key, _)| key.clone())
+        self.last_sweep = now;
+        #[cfg(test)]
         {
-            self.buckets.remove(&oldest);
+            self.sweep_count += 1;
         }
+        self.buckets
+            .retain(|_, bucket| now.duration_since(bucket.last_seen) <= WINDOW);
     }
 }
 
@@ -163,7 +182,10 @@ pub async fn rate_limit(
 }
 
 fn is_health_path(path: &str) -> bool {
-    path.starts_with("/api/v1/health/")
+    matches!(
+        path,
+        "/api/v1/health/live" | "/api/v1/health/ready" | "/api/v1/health/start"
+    )
 }
 
 fn rate_decision(state: &AppState, request: &Request<Body>) -> RateDecision {
@@ -340,5 +362,101 @@ mod tests {
             assert!(limiter.check_at(key, 2, now).is_ok());
         }
         assert_eq!(limiter.bucket_count(), 2);
+    }
+
+    #[test]
+    fn saturated_map_fails_open_for_novel_keys_without_losing_existing_limits() {
+        let limiter = RateLimiter::new(test_config(2));
+        let now = tokio::time::Instant::now();
+        let first = BucketKey {
+            class: RateClass::Fallback,
+            identity: "ip:192.0.2.1".into(),
+        };
+        let second = BucketKey {
+            class: RateClass::Fallback,
+            identity: "ip:192.0.2.2".into(),
+        };
+        let novel = BucketKey {
+            class: RateClass::Fallback,
+            identity: "ip:192.0.2.3".into(),
+        };
+
+        assert!(limiter.check_at(first.clone(), 1, now).is_ok());
+        assert!(limiter.check_at(second, 1, now).is_ok());
+        assert!(limiter.check_at(novel, 1, now).is_ok());
+        assert_eq!(limiter.bucket_count(), 2);
+        assert_eq!(
+            limiter.check_at(first, 1, now).unwrap_err(),
+            Duration::from_secs(60)
+        );
+    }
+
+    #[test]
+    fn flood_is_bounded_and_sweeps_only_on_interval() {
+        let limiter = RateLimiter::new(test_config(4));
+        let now = tokio::time::Instant::now();
+        for index in 0..100 {
+            let key = BucketKey {
+                class: RateClass::Fallback,
+                identity: format!("ip:198.51.100.{index}"),
+            };
+            assert!(limiter.check_at(key, 2, now).is_ok());
+        }
+        assert_eq!(limiter.bucket_count(), 4);
+        assert_eq!(limiter.sweep_count(), 0);
+
+        let before_sweep = BucketKey {
+            class: RateClass::Fallback,
+            identity: "ip:203.0.113.1".into(),
+        };
+        assert!(limiter
+            .check_at(
+                before_sweep,
+                2,
+                now + SWEEP_INTERVAL - Duration::from_secs(1)
+            )
+            .is_ok());
+        assert_eq!(limiter.bucket_count(), 4);
+        assert_eq!(limiter.sweep_count(), 0);
+
+        let first_due = BucketKey {
+            class: RateClass::Fallback,
+            identity: "ip:203.0.113.2".into(),
+        };
+        assert!(limiter.check_at(first_due, 2, now + SWEEP_INTERVAL).is_ok());
+        assert_eq!(limiter.bucket_count(), 4);
+        assert_eq!(limiter.sweep_count(), 1);
+
+        let after_expiry = BucketKey {
+            class: RateClass::Fallback,
+            identity: "ip:203.0.113.3".into(),
+        };
+        assert!(limiter
+            .check_at(
+                after_expiry,
+                2,
+                now + WINDOW + SWEEP_INTERVAL + Duration::from_secs(1),
+            )
+            .is_ok());
+        assert_eq!(limiter.bucket_count(), 1);
+        assert_eq!(limiter.sweep_count(), 2);
+    }
+
+    #[test]
+    fn poisoned_mutex_recovers_for_future_requests() {
+        let limiter = RateLimiter::new(test_config(2));
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = limiter.lock_store();
+            panic!("intentional poison");
+        }));
+        assert!(poisoned.is_err());
+
+        let key = BucketKey {
+            class: RateClass::Fallback,
+            identity: "ip:192.0.2.44".into(),
+        };
+        assert!(limiter
+            .check_at(key, 2, tokio::time::Instant::now())
+            .is_ok());
     }
 }

--- a/crates/server/src/middleware/request_id.rs
+++ b/crates/server/src/middleware/request_id.rs
@@ -1,0 +1,26 @@
+use axum::body::Body;
+use axum::http::header::HeaderName;
+use axum::http::{HeaderValue, Request};
+use axum::middleware::Next;
+use axum::response::Response;
+use uuid::Uuid;
+
+pub(crate) static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+
+#[derive(Debug, Clone)]
+pub(crate) struct RequestId(pub(crate) String);
+
+pub async fn ensure_request_id(mut request: Request<Body>, next: Next) -> Response {
+    let request_id = Uuid::new_v4().to_string();
+    request
+        .extensions_mut()
+        .insert(RequestId(request_id.clone()));
+    let mut response = next.run(request).await;
+    if !response.headers().contains_key(&X_REQUEST_ID) {
+        response.headers_mut().insert(
+            X_REQUEST_ID.clone(),
+            HeaderValue::from_str(&request_id).expect("UUID is a valid header value"),
+        );
+    }
+    response
+}

--- a/crates/server/src/routes/ask.rs
+++ b/crates/server/src/routes/ask.rs
@@ -351,4 +351,31 @@ mod tests {
 
         assert!(validate_ask_request(body, &ctx, "req").is_err());
     }
+
+    #[test]
+    fn ask_response_fixture_matches_wire_dto() {
+        let response = AskResponse {
+            answer: "Payment is due within 30 days. [1]".into(),
+            citations: vec![QaCitation {
+                document_id: uuid::Uuid::parse_str("d4010000-0000-4000-8000-000000000001").unwrap(),
+                version_id: uuid::Uuid::parse_str("e5010000-0000-4000-8000-000000000001").unwrap(),
+                version_number: 3,
+                content_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .into(),
+                chunk_id: uuid::Uuid::parse_str("c3010000-0000-4000-8000-000000000001").unwrap(),
+                heading_path: vec!["Contract".into(), "Payment".into()],
+                snippet: "Payment is due within 30 days.".into(),
+                page: Some(4),
+                slide: None,
+                sheet: None,
+                is_current: true,
+            }],
+            warnings: Vec::new(),
+            mode: QaAnswerMode::OfflineExtractive,
+        };
+        let expected: serde_json::Value =
+            serde_json::from_str(include_str!("../../openapi/fixtures/ask_response.json")).unwrap();
+
+        assert_eq!(serde_json::to_value(response).unwrap(), expected);
+    }
 }

--- a/crates/server/src/routes/health.rs
+++ b/crates/server/src/routes/health.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::api::ApiError;
+use crate::http::AppState;
+use crate::services::health::{check_dependencies, HealthErrorKind};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Health {
+    status: &'static str,
+    request_id: String,
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/v1/health/live", get(liveness))
+        .route("/api/v1/health/ready", get(readiness))
+        .route("/api/v1/health/start", get(startup))
+}
+
+async fn liveness() -> Json<Health> {
+    Json(healthy())
+}
+
+async fn startup(State(state): State<Arc<AppState>>) -> Result<Json<Health>, HealthError> {
+    if state.startup_complete() {
+        Ok(Json(healthy()))
+    } else {
+        Err(HealthError::dependency_unavailable())
+    }
+}
+
+async fn readiness(State(state): State<Arc<AppState>>) -> Result<Json<Health>, HealthError> {
+    check_dependencies(state).await.map_err(HealthError::from)?;
+    Ok(Json(healthy()))
+}
+
+fn healthy() -> Health {
+    Health {
+        status: "ok",
+        request_id: Uuid::new_v4().to_string(),
+    }
+}
+
+struct HealthError {
+    code: &'static str,
+    message: &'static str,
+}
+
+impl HealthError {
+    fn dependency_unavailable() -> Self {
+        Self {
+            code: "dependency_unavailable",
+            message: "A required service is unavailable",
+        }
+    }
+}
+
+impl From<HealthErrorKind> for HealthError {
+    fn from(value: HealthErrorKind) -> Self {
+        match value {
+            HealthErrorKind::DependencyUnavailable => Self::dependency_unavailable(),
+            HealthErrorKind::ConfigurationInvalid => Self {
+                code: "configuration_invalid",
+                message: "Server configuration is invalid",
+            },
+        }
+    }
+}
+
+impl IntoResponse for HealthError {
+    fn into_response(self) -> Response {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ApiError {
+                code: self.code.into(),
+                message: self.message.into(),
+                request_id: Uuid::new_v4().to_string(),
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}

--- a/crates/server/src/routes/jobs.rs
+++ b/crates/server/src/routes/jobs.rs
@@ -94,3 +94,36 @@ async fn get_job(
     .map_err(|error: TxnRestError| error.into_rest(&request_id))?;
     Ok(Json(JobResponse::from(job)).into_response())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dt(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn job_response_fixture_matches_wire_dto() {
+        let response = JobResponse {
+            id: Uuid::parse_str("b2010000-0000-4000-8000-000000000001").unwrap(),
+            job_type: "convert",
+            status: "running",
+            attempts: 1,
+            max_attempts: 3,
+            document_id: Some(Uuid::parse_str("d4010000-0000-4000-8000-000000000001").unwrap()),
+            version_id: Some(Uuid::parse_str("e5010000-0000-4000-8000-000000000001").unwrap()),
+            available_at: dt("2026-07-19T22:40:00Z"),
+            started_at: Some(dt("2026-07-19T22:41:00Z")),
+            finished_at: None,
+            created_at: dt("2026-07-19T22:39:00Z"),
+            updated_at: dt("2026-07-19T22:41:30Z"),
+        };
+        let expected: serde_json::Value =
+            serde_json::from_str(include_str!("../../openapi/fixtures/job_response.json")).unwrap();
+
+        assert_eq!(serde_json::to_value(response).unwrap(), expected);
+    }
+}

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -6,6 +6,7 @@ pub mod collections;
 pub(crate) mod common;
 pub mod documents;
 pub mod events;
+pub mod health;
 pub mod jobs;
 pub mod search;
 pub mod uploads;

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -255,4 +255,32 @@ mod tests {
 
         assert!(validate_search_request(body, &ctx, "req").is_err());
     }
+
+    #[test]
+    fn search_response_fixture_matches_wire_dto() {
+        let response = SearchResponse {
+            hits: vec![SearchHitResponse {
+                chunk_id: Uuid::parse_str("c3010000-0000-4000-8000-000000000001").unwrap(),
+                document_id: Uuid::parse_str("d4010000-0000-4000-8000-000000000001").unwrap(),
+                version_id: Uuid::parse_str("e5010000-0000-4000-8000-000000000001").unwrap(),
+                collection_id: Uuid::parse_str("f6010000-0000-4000-8000-000000000001").unwrap(),
+                version_number: 3,
+                snippet: "Payment is due within 30 days.".into(),
+                heading_path: Some(vec!["Contract".into(), "Payment".into()]),
+                lexical_score: 0.75,
+                vector_score: 0.5,
+                rerank_score: 0.25,
+                page: Some(4),
+                slide: None,
+                sheet: None,
+                is_current: true,
+            }],
+            degraded: None,
+        };
+        let expected: serde_json::Value =
+            serde_json::from_str(include_str!("../../openapi/fixtures/search_response.json"))
+                .unwrap();
+
+        assert_eq!(serde_json::to_value(response).unwrap(), expected);
+    }
 }

--- a/crates/server/src/services/health.rs
+++ b/crates/server/src/services/health.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -81,23 +82,35 @@ fn validate_index_signature_config(state: &AppState) -> Result<(), HealthErrorKi
 }
 
 async fn check_migrations_applied(pool: &Pool) -> Result<(), String> {
-    let (expected_name, expected_checksum) = database::latest_migration();
+    let expected = database::embedded_migration_checksums();
     let client = pool
         .get()
         .await
         .map_err(|error| format!("PostgreSQL pool checkout failed: {error}"))?;
-    let row = client
-        .query_opt(
-            "SELECT checksum FROM markhand_schema_migrations WHERE name = $1",
-            &[&expected_name],
-        )
+    let rows = client
+        .query("SELECT name, checksum FROM markhand_schema_migrations", &[])
         .await
         .map_err(|error| format!("cannot inspect migration history: {error}"))?;
-    match row {
-        Some(row) if row.get::<_, String>(0) == expected_checksum => Ok(()),
-        Some(_) => Err(format!("migration checksum mismatch for {expected_name}")),
-        None => Err(format!("migration {expected_name} has not been applied")),
+    if rows.len() != expected.len() {
+        return Err("migration history count mismatch".into());
     }
+    let actual = rows
+        .into_iter()
+        .map(|row| (row.get::<_, String>(0), row.get::<_, String>(1)))
+        .collect::<HashMap<_, _>>();
+    for migration in expected {
+        match actual.get(migration.name) {
+            Some(checksum) if checksum == &migration.checksum => {}
+            Some(_) => {
+                return Err(format!(
+                    "migration checksum mismatch for {}",
+                    migration.name
+                ))
+            }
+            None => return Err(format!("migration {} has not been applied", migration.name)),
+        }
+    }
+    Ok(())
 }
 
 async fn ensure_success(
@@ -122,6 +135,7 @@ mod tests {
 
     use crate::api::ApiError;
     use crate::config::{RuntimeEndpoints, SecretString, ServerConfig};
+    use crate::database::apply_migrations;
     use crate::db::pool::create_pool;
     use crate::http::{router, AppState};
     use crate::state::RuntimeState;
@@ -264,5 +278,28 @@ mod tests {
         assert!(result
             .unwrap_err()
             .contains("cannot inspect migration history"));
+    }
+
+    #[tokio::test]
+    async fn missing_earlier_migration_history_fails_closed() {
+        let Some(base_url) = test_database_url() else {
+            return;
+        };
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("migrations");
+        let client = connect_raw(&db.url).await;
+        client
+            .execute(
+                "DELETE FROM markhand_schema_migrations WHERE name = $1",
+                &[&"0001_expand_orgs_users.sql"],
+            )
+            .await
+            .expect("delete migration history row");
+        let pool = create_pool(&db.url).expect("pool");
+        let result = super::check_migrations_applied(&pool).await;
+        db.drop().await;
+        assert!(result
+            .unwrap_err()
+            .contains("migration history count mismatch"));
     }
 }

--- a/crates/server/src/services/health.rs
+++ b/crates/server/src/services/health.rs
@@ -1,0 +1,268 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use deadpool_postgres::Pool;
+use tokio::time::timeout;
+
+use crate::database;
+use crate::http::{AppState, DEPENDENCY_TIMEOUT};
+use crate::services::index_signature::validate_signature_digest;
+
+const READINESS_CACHE_TTL: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone)]
+pub(crate) struct CachedReadiness {
+    pub(crate) checked_at: tokio::time::Instant,
+    pub(crate) result: Result<(), HealthErrorKind>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum HealthErrorKind {
+    DependencyUnavailable,
+    ConfigurationInvalid,
+}
+
+pub(crate) async fn check_dependencies(state: Arc<AppState>) -> Result<(), HealthErrorKind> {
+    let mut cached = state.readiness_cache().lock().await;
+    if let Some(previous) = cached.as_ref() {
+        if previous.checked_at.elapsed() < READINESS_CACHE_TTL {
+            return previous.result;
+        }
+    }
+
+    let result = check_dependencies_uncached(&state).await;
+    *cached = Some(CachedReadiness {
+        checked_at: tokio::time::Instant::now(),
+        result,
+    });
+    result
+}
+
+async fn check_dependencies_uncached(state: &AppState) -> Result<(), HealthErrorKind> {
+    validate_index_signature_config(state)?;
+    // TODO(O03): reconciliation-backlog readiness.
+    let database = timeout(
+        DEPENDENCY_TIMEOUT,
+        database::check_connection(state.runtime().endpoints().database_url.expose()),
+    );
+    let migrations = timeout(DEPENDENCY_TIMEOUT, check_migrations_applied(state.pool()));
+    let qdrant = state
+        .http_client()
+        .get(format!(
+            "{}/healthz",
+            state.runtime().endpoints().qdrant_url
+        ))
+        .send();
+    let minio = state
+        .http_client()
+        .get(format!(
+            "{}/minio/health/live",
+            state.runtime().endpoints().minio_url
+        ))
+        .send();
+
+    let (database, migrations, qdrant, minio) = tokio::join!(database, migrations, qdrant, minio);
+    database
+        .map_err(|_| HealthErrorKind::DependencyUnavailable)?
+        .map_err(|_| HealthErrorKind::DependencyUnavailable)?;
+    migrations
+        .map_err(|_| HealthErrorKind::DependencyUnavailable)?
+        .map_err(|_| HealthErrorKind::DependencyUnavailable)?;
+    ensure_success(qdrant).await?;
+    ensure_success(minio).await
+}
+
+fn validate_index_signature_config(state: &AppState) -> Result<(), HealthErrorKind> {
+    let Some(signature) = state.runtime().config().index_signature() else {
+        return Ok(());
+    };
+    let normalized = signature.trim().to_ascii_lowercase();
+    validate_signature_digest(&normalized).map_err(|_| HealthErrorKind::ConfigurationInvalid)
+}
+
+async fn check_migrations_applied(pool: &Pool) -> Result<(), String> {
+    let (expected_name, expected_checksum) = database::latest_migration();
+    let client = pool
+        .get()
+        .await
+        .map_err(|error| format!("PostgreSQL pool checkout failed: {error}"))?;
+    let row = client
+        .query_opt(
+            "SELECT checksum FROM markhand_schema_migrations WHERE name = $1",
+            &[&expected_name],
+        )
+        .await
+        .map_err(|error| format!("cannot inspect migration history: {error}"))?;
+    match row {
+        Some(row) if row.get::<_, String>(0) == expected_checksum => Ok(()),
+        Some(_) => Err(format!("migration checksum mismatch for {expected_name}")),
+        None => Err(format!("migration {expected_name} has not been applied")),
+    }
+}
+
+async fn ensure_success(
+    response: Result<reqwest::Response, reqwest::Error>,
+) -> Result<(), HealthErrorKind> {
+    let response = response.map_err(|_| HealthErrorKind::DependencyUnavailable)?;
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(HealthErrorKind::DependencyUnavailable)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tokio_postgres::NoTls;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use crate::api::ApiError;
+    use crate::config::{RuntimeEndpoints, SecretString, ServerConfig};
+    use crate::db::pool::create_pool;
+    use crate::http::{router, AppState};
+    use crate::state::RuntimeState;
+
+    fn app_with_unreachable_dependencies() -> axum::Router {
+        let runtime =
+            RuntimeState::from_config(ServerConfig::test_with_endpoints(RuntimeEndpoints {
+                database_url: SecretString::new("postgres://unused"),
+                qdrant_url: "http://127.0.0.1:1".into(),
+                minio_url: "http://127.0.0.1:1".into(),
+            }))
+            .unwrap();
+        let pool = create_pool("postgres://markhand_app:markhand_app@127.0.0.1:5432/markhand_test")
+            .expect("pool");
+        router(AppState::from_parts(runtime, pool, None).unwrap())
+    }
+
+    fn test_database_url() -> Option<String> {
+        match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+            Ok(url) if !url.trim().is_empty() => Some(url),
+            _ => {
+                eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+                None
+            }
+        }
+    }
+
+    fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+        let (without_query, query) = match base_url.split_once('?') {
+            Some((head, tail)) => (head, Some(tail)),
+            None => (base_url, None),
+        };
+        let prefix = without_query
+            .rsplit_once('/')
+            .map(|(head, _)| head)
+            .expect("database URL must include a path");
+        match query {
+            Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+            None => format!("{prefix}/{database_name}"),
+        }
+    }
+
+    async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+        let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+            .await
+            .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+        client
+    }
+
+    struct EphemeralDb {
+        admin_url: String,
+        db_name: String,
+        url: String,
+    }
+
+    impl EphemeralDb {
+        async fn create(base_url: &str) -> Self {
+            let db_name = format!("markhand_health_{}", Uuid::new_v4().simple());
+            let admin_url = rewrite_database_url(base_url, "postgres");
+            let admin = connect_raw(&admin_url).await;
+            admin
+                .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+                .await
+                .expect("CREATE DATABASE");
+            Self {
+                admin_url,
+                db_name: db_name.clone(),
+                url: rewrite_database_url(base_url, &db_name),
+            }
+        }
+
+        async fn drop(self) {
+            let admin = connect_raw(&self.admin_url).await;
+            let _ = admin
+                .batch_execute(&format!(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                     WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                     DROP DATABASE IF EXISTS \"{}\"",
+                    self.db_name, self.db_name
+                ))
+                .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn readiness_fails_closed_when_dependencies_are_unreachable() {
+        let response = app_with_unreachable_dependencies()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/health/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let error: ApiError = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error.code, "dependency_unavailable");
+    }
+
+    #[tokio::test]
+    async fn startup_probe_reflects_initialization_flag() {
+        let runtime =
+            RuntimeState::from_config(ServerConfig::test_with_endpoints(RuntimeEndpoints {
+                database_url: SecretString::new("postgres://unused"),
+                qdrant_url: "http://127.0.0.1:1".into(),
+                minio_url: "http://127.0.0.1:1".into(),
+            }))
+            .unwrap();
+        let pool = create_pool("postgres://markhand_app:markhand_app@127.0.0.1:5432/markhand_test")
+            .expect("pool");
+        let state = AppState::from_parts(runtime, pool, None).unwrap();
+        state.set_startup_complete_for_test(false);
+        let app = router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/health/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn migration_history_missing_fails_closed_when_database_is_available() {
+        let Some(base_url) = test_database_url() else {
+            return;
+        };
+        let db = EphemeralDb::create(&base_url).await;
+        let pool = create_pool(&db.url).expect("pool");
+        let result = super::check_migrations_applied(&pool).await;
+        db.drop().await;
+        assert!(result
+            .unwrap_err()
+            .contains("cannot inspect migration history"));
+    }
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -8,6 +8,7 @@ pub mod deletion;
 pub mod document_state;
 pub mod download;
 pub mod embedding;
+pub mod health;
 pub mod index_signature;
 pub mod indexing;
 pub mod preview;

--- a/web/src/api/generated/contract.ts
+++ b/web/src/api/generated/contract.ts
@@ -36,6 +36,342 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/health/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["healthStart"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["authLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["authRefresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["authLogout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["authMe"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/uploads": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["createUpload"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/collections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["listCollections"];
+        put?: never;
+        post: operations["createCollection"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/collections/{collectionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getCollection"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/collections/{collectionId}/documents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["listCollectionDocuments"];
+        put?: never;
+        post: operations["createDocumentFromUpload"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{documentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getDocument"];
+        put?: never;
+        post?: never;
+        delete: operations["deleteDocument"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{documentId}:reindex": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["reindexDocument"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{documentId}/versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["listDocumentVersions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{documentId}/versions/{versionId}/citations:resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["resolveCitation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{documentId}/versions/{versionId}/preview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getMarkdownPreview"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/{documentId}/versions/{versionId}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["authorizeDownload"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/documents/download/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["redeemDownload"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/jobs/{jobId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getJob"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/jobs/{jobId}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["streamJobEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["search"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ask": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["ask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ask/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["streamAsk"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -46,6 +382,20 @@ export interface components {
             /** Format: uuid */
             requestId: string;
         };
+        /**
+         * @description Canonical API error. Stable `code` values currently returned by shipped routes include
+         *     `validation_failed`, `unauthorized`, `invalid_credentials`, `invalid_refresh`,
+         *     `refresh_reuse`, `user_disabled`, `membership_missing`, `auth_unavailable`,
+         *     `permission_denied`, `collection_denied`, `empty_scope`, `not_found`,
+         *     `state_conflict`, `rate_limited`, `dependency_unavailable`,
+         *     `configuration_invalid`, `storage_unavailable`, `multipart_invalid`,
+         *     `upload_rejected`, `upload_too_large`, `quota_exceeded`,
+         *     `quota_not_configured`, `quota_invalid_key`, `quota_invalid_amount`,
+         *     `quota_arithmetic_overflow`, `quota_reservation_not_found`,
+         *     `quota_reservation_resource_mismatch`, `quota_reservation_conflict`,
+         *     `quota_refunded_cannot_finalize`, `quota_expired_cannot_finalize`,
+         *     `quota_finalized_cannot_refund`, `quota_database_error`, and `internal_error`.
+         */
         ApiError: {
             code: string;
             message: string;
@@ -54,12 +404,357 @@ export interface components {
             details?: unknown;
         };
         PageInfo: {
-            nextCursor?: string | null;
+            nextCursor?: string;
             hasMore: boolean;
+        };
+        SseEnvelope: {
+            /**
+             * Format: int32
+             * @enum {integer}
+             */
+            version: 1;
+            /** Format: int64 */
+            sequence: number;
+            /** @description Stable event name, for example `job.status`, `job.done`, `job.close`, `ask.token`, `ask.citations`, `ask.warning`, or `ask.done`. */
+            event: string;
+            requestId: string;
+            data: unknown;
+        };
+        LoginRequest: {
+            email: string;
+            password: string;
+        };
+        RefreshRequest: {
+            refreshToken: string;
+        };
+        LogoutRequest: {
+            refreshToken: string;
+        };
+        TokenResponse: {
+            accessToken: string;
+            refreshToken: string;
+            /** @enum {string} */
+            tokenType: "Bearer";
+            /** Format: int64 */
+            expiresIn: number;
+            /** Format: uuid */
+            orgId: string;
+            /** Format: uuid */
+            userId: string;
+        };
+        MeResponse: {
+            /** Format: uuid */
+            userId: string;
+            /** Format: uuid */
+            orgId: string;
+            email: string;
+            displayName: string;
+            permissions: string[];
+            allowedCollectionIds: string[];
+            /** Format: uuid */
+            sessionId: string;
+        };
+        UploadResponse: {
+            /** @enum {string} */
+            disposition: "accepted" | "quarantined" | "rejected";
+            /** @enum {string} */
+            threatClass?: "extension_spoof" | "mime_mismatch" | "unsupported_format" | "archive_bomb" | "archive_path_traversal" | "nested_archive" | "malformed_ooxml" | "parser_corruption" | "oversize" | "truncated_upload" | "pdf_page_bomb" | "image_pixel_bomb" | "audio_duration_limit" | "csv_formula" | "prompt_injection" | "active_content" | "permission_denied" | "storage_failure" | "multipart_invalid" | "internal";
+            /** @enum {string} */
+            reasonCode?: "extension_magic_mismatch" | "magic_unrecognized" | "upload_too_large" | "stream_interrupted" | "archive_entry_limit" | "archive_uncompressed_limit" | "archive_compression_ratio" | "archive_path_traversal" | "nested_archive_entry" | "missing_content_types" | "missing_format_paths" | "malformed_archive" | "malformed_xml" | "pdf_missing_eof" | "pdf_page_limit" | "image_pixel_limit" | "audio_duration_review" | "csv_formula_review" | "prompt_injection_review" | "html_active_content" | "permission_denied" | "storage_unavailable" | "multipart_missing_file" | "multipart_too_many_files" | "multipart_too_many_parts" | "multipart_header_too_large" | "multipart_timeout" | "fail_closed";
+            objectKey: string;
+            /** Format: uuid */
+            objectId: string;
+            sha256: string;
+            /** Format: int64 */
+            sizeBytes: number;
+            canonicalFormat: string;
+            originalFilename?: string;
+            /** Format: uuid */
+            requestId: string;
+        };
+        CreateCollectionRequest: {
+            name: string;
+            slug: string;
+            description?: string | null;
+            /** @enum {string} */
+            visibility: "private" | "org";
+        };
+        Collection: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            slug: string;
+            description: string | null;
+            /** Format: uuid */
+            ownerUserId: string;
+            /** @enum {string} */
+            visibility: "private" | "org" | "groups";
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        CollectionListResponse: {
+            items: components["schemas"]["Collection"][];
+            pageInfo: components["schemas"]["PageInfo"];
+        };
+        CreateDocumentRequest: {
+            objectKey?: string | null;
+            /** Format: uuid */
+            objectId?: string | null;
+            title: string;
+        };
+        Document: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            collectionId: string;
+            title: string;
+            state: components["schemas"]["DocumentState"];
+            /** Format: uuid */
+            currentVersionId: string | null;
+            /** Format: uuid */
+            createdByUserId: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        /** @enum {string} */
+        DocumentState: "uploaded" | "converting" | "converted" | "indexing" | "indexed" | "failed" | "tombstoned" | "purged";
+        DocumentListResponse: {
+            items: components["schemas"]["Document"][];
+            pageInfo: components["schemas"]["PageInfo"];
+        };
+        DocumentVersion: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            documentId: string;
+            /** Format: int32 */
+            versionNumber: number;
+            /** Format: uuid */
+            parentVersionId: string | null;
+            /** @enum {string} */
+            publicationState: "draft" | "published";
+            isCurrent: boolean;
+            contentSha256: string;
+            sourceFilename: string | null;
+            sourceContentType: string | null;
+            /** Format: int64 */
+            byteSize: number | null;
+            /** Format: date-time */
+            effectiveFrom: string;
+            /** Format: date-time */
+            effectiveTo: string | null;
+            changeSummary: string | null;
+            /** Format: uuid */
+            createdByUserId: string;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        DocumentVersionListResponse: {
+            items: components["schemas"]["DocumentVersion"][];
+            pageInfo: components["schemas"]["PageInfo"];
+        };
+        CreateDocumentResponse: {
+            document: components["schemas"]["Document"];
+            version: components["schemas"]["DocumentVersion"];
+            /** Format: uuid */
+            jobId: string;
+            jobStatus: components["schemas"]["JobStatus"];
+        };
+        DeleteDocumentResponse: {
+            document: components["schemas"]["Document"];
+            deleteRequested: boolean;
+        };
+        JobSummary: {
+            /** Format: uuid */
+            id: string;
+            status: components["schemas"]["JobStatus"];
+        };
+        Job: {
+            /** Format: uuid */
+            id: string;
+            jobType: components["schemas"]["JobType"];
+            status: components["schemas"]["JobStatus"];
+            /** Format: int32 */
+            attempts: number;
+            /** Format: int32 */
+            maxAttempts: number;
+            /** Format: uuid */
+            documentId: string | null;
+            /** Format: uuid */
+            versionId: string | null;
+            /** Format: date-time */
+            availableAt: string;
+            /** Format: date-time */
+            startedAt: string | null;
+            /** Format: date-time */
+            finishedAt: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        /** @enum {string} */
+        JobType: "convert" | "index" | "delete" | "reconcile" | "embedding_batch";
+        /** @enum {string} */
+        JobStatus: "pending" | "leased" | "running" | "succeeded" | "failed" | "cancelled" | "dead_letter";
+        CitationPin: {
+            /** Format: uuid */
+            documentId: string;
+            /** Format: uuid */
+            versionId: string;
+            /** Format: int32 */
+            versionNumber: number;
+            contentSha256: string;
+            /** Format: uuid */
+            chunkId: string;
+            /** Format: int32 */
+            spanStart?: number | null;
+            /** Format: int32 */
+            spanEnd?: number | null;
+            quote?: string | null;
+        };
+        ResolvedCitation: {
+            /** Format: uuid */
+            orgId: string;
+            /** Format: uuid */
+            documentId: string;
+            /** Format: uuid */
+            versionId: string;
+            /** Format: int32 */
+            versionNumber: number;
+            contentSha256: string;
+            /** Format: uuid */
+            chunkId: string;
+            /** Format: uuid */
+            collectionId: string;
+            headingPath: string[];
+            snippet: string;
+            /** Format: int32 */
+            page: number | null;
+            /** Format: int32 */
+            slide: number | null;
+            sheet: string | null;
+            /** Format: int32 */
+            spanStart: number | null;
+            /** Format: int32 */
+            spanEnd: number | null;
+            quote: string | null;
+            /** Format: date-time */
+            effectiveFrom: string;
+            /** Format: date-time */
+            effectiveTo: string | null;
+            isCurrent: boolean;
+        };
+        DownloadCapability: {
+            token: string;
+            downloadPath: string;
+            /** Format: date-time */
+            expiresAt: string;
+            filename: string;
+            contentType: string;
+            /** Format: int64 */
+            byteSize: number;
+            contentSha256: string;
+        };
+        SearchRequest: {
+            query: string;
+            /** Format: int32 */
+            limit?: number | null;
+            collectionIds?: string[] | null;
+        };
+        SearchResponse: {
+            hits: components["schemas"]["SearchHit"][];
+            /** @enum {string|null} */
+            degraded: "vector_unavailable" | "lexical_unavailable" | null;
+        };
+        SearchHit: {
+            /** Format: uuid */
+            chunkId: string;
+            /** Format: uuid */
+            documentId: string;
+            /** Format: uuid */
+            versionId: string;
+            /** Format: uuid */
+            collectionId: string;
+            /** Format: int32 */
+            versionNumber: number;
+            snippet: string;
+            headingPath?: string[];
+            /** Format: float */
+            lexicalScore: number;
+            /** Format: float */
+            vectorScore: number;
+            /** Format: float */
+            rerankScore: number;
+            /** Format: int32 */
+            page?: number;
+            /** Format: int32 */
+            slide?: number;
+            sheet?: string;
+            isCurrent: boolean;
+        };
+        AskRequest: {
+            question: string;
+            /** Format: int32 */
+            limit?: number | null;
+            collectionIds?: string[] | null;
+        };
+        AskResponse: {
+            answer: string;
+            citations: components["schemas"]["QaCitation"][];
+            warnings: string[];
+            mode: components["schemas"]["QaAnswerMode"];
+        };
+        /** @enum {string} */
+        QaAnswerMode: "cloud_llm" | "fallback_extractive" | "offline_extractive";
+        QaCitation: {
+            /** Format: uuid */
+            documentId: string;
+            /** Format: uuid */
+            versionId: string;
+            /** Format: int32 */
+            versionNumber: number;
+            contentSha256: string;
+            /** Format: uuid */
+            chunkId: string;
+            headingPath: string[];
+            snippet: string;
+            /** Format: int32 */
+            page: number | null;
+            /** Format: int32 */
+            slide: number | null;
+            sheet: string | null;
+            isCurrent: boolean;
+        };
+        /** @description Direct serde representation of the QA service event enum (`snake_case` variant names). `/ask/stream` wraps mapped event data in `SseEnvelope`. */
+        QaEvent: {
+            token: string;
+        } | {
+            citations: components["schemas"]["QaCitation"][];
+        } | {
+            warning: string;
+        } | {
+            done: {
+                mode: components["schemas"]["QaAnswerMode"];
+            };
+        };
+        /** @description Data payloads emitted inside `SseEnvelope.data` by `/ask/stream`. */
+        AskSseData: {
+            token: string;
+        } | {
+            citations: components["schemas"]["QaCitation"][];
+        } | {
+            warning: string;
+        } | {
+            mode: components["schemas"]["QaAnswerMode"];
         };
     };
     responses: {
-        /** @description Canonical API error */
+        /** @description Canonical API error. */
         ApiError: {
             headers: {
                 [name: string]: unknown;
@@ -68,10 +763,62 @@ export interface components {
                 "application/json": components["schemas"]["ApiError"];
             };
         };
+        /** @description Request rate limit exceeded. `ApiError.code` is `rate_limited`. */
+        RateLimited: {
+            headers: {
+                "Retry-After": components["headers"]["RetryAfter"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ApiError"];
+            };
+        };
+        /** @description Request rate limit exceeded (`rate_limited`) or upload quota exceeded (`quota_exceeded`). */
+        QuotaOrRateLimited: {
+            headers: {
+                "Retry-After": components["headers"]["RetryAfter"];
+                "x-quota-resource": components["headers"]["QuotaResource"];
+                "x-quota-limit": components["headers"]["QuotaLimit"];
+                "x-quota-used": components["headers"]["QuotaUsed"];
+                "x-quota-reserved": components["headers"]["QuotaReserved"];
+                "x-quota-remaining": components["headers"]["QuotaRemaining"];
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ApiError"];
+            };
+        };
     };
-    parameters: never;
+    parameters: {
+        CollectionId: string;
+        DocumentId: string;
+        VersionId: string;
+        JobId: string;
+        DownloadToken: string;
+        /** @description Page size; defaults to 25 and must be between 1 and 100. */
+        Limit: string;
+        /** @description Opaque cursor returned as `pageInfo.nextCursor`. */
+        Cursor: string;
+        /** @description Optional visible-ASCII idempotency key, 1-128 bytes, using alphanumeric characters plus `.`, `_`, `-`, and `:`. */
+        IdempotencyKey: string;
+        /** @description SSE replay cursor formatted as `{streamUuid}:{sequence}`. */
+        LastEventId: string;
+    };
     requestBodies: never;
-    headers: never;
+    headers: {
+        /** @description Seconds to wait before retrying. */
+        RetryAfter: string;
+        /** @description Quota resource kind that was checked. */
+        QuotaResource: "storage_bytes" | "documents";
+        /** @description Resource limit. */
+        QuotaLimit: string;
+        /** @description Committed resource usage. */
+        QuotaUsed: string;
+        /** @description Currently reserved resource usage. */
+        QuotaReserved: string;
+        /** @description Remaining resource budget. */
+        QuotaRemaining: string;
+    };
     pathItems: never;
 }
 export type $defs = Record<string, never>;
@@ -115,6 +862,737 @@ export interface operations {
                 };
             };
             503: components["responses"]["ApiError"];
+        };
+    };
+    healthStart: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Startup has completed. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Health"];
+                };
+            };
+            503: components["responses"]["ApiError"];
+        };
+    };
+    authLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LoginRequest"];
+            };
+        };
+        responses: {
+            /** @description Password login succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    authRefresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RefreshRequest"];
+            };
+        };
+        responses: {
+            /** @description Refresh token rotation succeeded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    authLogout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LogoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Refresh token family logout accepted. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    authMe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current authenticated principal and authorization context. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MeResponse"];
+                };
+            };
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    createUpload: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description Optional visible-ASCII idempotency key, 1-128 bytes, using alphanumeric characters plus `.`, `_`, `-`, and `:`. */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /** Format: binary */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Upload accepted or quarantined. */
+            201: {
+                headers: {
+                    "x-quota-resource": components["headers"]["QuotaResource"];
+                    "x-quota-limit": components["headers"]["QuotaLimit"];
+                    "x-quota-used": components["headers"]["QuotaUsed"];
+                    "x-quota-reserved": components["headers"]["QuotaReserved"];
+                    "x-quota-remaining": components["headers"]["QuotaRemaining"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UploadResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            413: components["responses"]["ApiError"];
+            429: components["responses"]["QuotaOrRateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    listCollections: {
+        parameters: {
+            query?: {
+                /** @description Page size; defaults to 25 and must be between 1 and 100. */
+                limit?: components["parameters"]["Limit"];
+                /** @description Opaque cursor returned as `pageInfo.nextCursor`. */
+                cursor?: components["parameters"]["Cursor"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Authorized collections page. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CollectionListResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    createCollection: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateCollectionRequest"];
+            };
+        };
+        responses: {
+            /** @description Collection created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Collection"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+        };
+    };
+    getCollection: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                collectionId: components["parameters"]["CollectionId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Collection metadata. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Collection"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+        };
+    };
+    listCollectionDocuments: {
+        parameters: {
+            query?: {
+                /** @description Page size; defaults to 25 and must be between 1 and 100. */
+                limit?: components["parameters"]["Limit"];
+                /** @description Opaque cursor returned as `pageInfo.nextCursor`. */
+                cursor?: components["parameters"]["Cursor"];
+            };
+            header?: never;
+            path: {
+                collectionId: components["parameters"]["CollectionId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Documents in the collection. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentListResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    createDocumentFromUpload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                collectionId: components["parameters"]["CollectionId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDocumentRequest"];
+            };
+        };
+        responses: {
+            /** @description Document and source version created; conversion job enqueued. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateDocumentResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    getDocument: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                documentId: components["parameters"]["DocumentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Document metadata. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Document"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+        };
+    };
+    deleteDocument: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description Optional visible-ASCII idempotency key, 1-128 bytes, using alphanumeric characters plus `.`, `_`, `-`, and `:`. */
+                "Idempotency-Key"?: components["parameters"]["IdempotencyKey"];
+            };
+            path: {
+                documentId: components["parameters"]["DocumentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Delete was already requested. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteDocumentResponse"];
+                };
+            };
+            /** @description Delete requested and job enqueued. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteDocumentResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            409: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    reindexDocument: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                documentId: components["parameters"]["DocumentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Index job enqueued. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobSummary"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            409: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+        };
+    };
+    listDocumentVersions: {
+        parameters: {
+            query?: {
+                /** @description Page size; defaults to 25 and must be between 1 and 100. */
+                limit?: components["parameters"]["Limit"];
+                /** @description Opaque cursor returned as `pageInfo.nextCursor`. */
+                cursor?: components["parameters"]["Cursor"];
+            };
+            header?: never;
+            path: {
+                documentId: components["parameters"]["DocumentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Document versions page. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DocumentVersionListResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    resolveCitation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                documentId: components["parameters"]["DocumentId"];
+                versionId: components["parameters"]["VersionId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CitationPin"];
+            };
+        };
+        responses: {
+            /** @description Citation resolved against live authorization and source content. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResolvedCitation"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+        };
+    };
+    getMarkdownPreview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                documentId: components["parameters"]["DocumentId"];
+                versionId: components["parameters"]["VersionId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Markdown preview bytes. */
+            200: {
+                headers: {
+                    "x-content-type-options"?: "nosniff";
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/markdown; charset=utf-8": string;
+                };
+            };
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    authorizeDownload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                documentId: components["parameters"]["DocumentId"];
+                versionId: components["parameters"]["VersionId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Short-lived, one-time download capability. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DownloadCapability"];
+                };
+            };
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    redeemDownload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: components["parameters"]["DownloadToken"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Original uploaded object bytes. */
+            200: {
+                headers: {
+                    "content-disposition"?: string;
+                    "x-content-type-options"?: "nosniff";
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/octet-stream": string;
+                };
+            };
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+            503: components["responses"]["ApiError"];
+        };
+    };
+    getJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                jobId: components["parameters"]["JobId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Job snapshot. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Job"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+        };
+    };
+    streamJobEvents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                jobId: components["parameters"]["JobId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Server-sent job status events. Event names are `job.status`, `job.done`, and `job.close`. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": components["schemas"]["SseEnvelope"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+        };
+    };
+    search: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SearchRequest"];
+            };
+        };
+        responses: {
+            /** @description Grounded retrieval hits. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+        };
+    };
+    ask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AskRequest"];
+            };
+        };
+        responses: {
+            /** @description Grounded answer collected from the QA stream. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AskResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
+        };
+    };
+    streamAsk: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description SSE replay cursor formatted as `{streamUuid}:{sequence}`. */
+                "Last-Event-ID"?: components["parameters"]["LastEventId"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Required when starting a stream. Omitted on replay requests that provide `Last-Event-ID`. */
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["AskRequest"];
+            };
+        };
+        responses: {
+            /** @description Server-sent QA events. Event names are `ask.token`, `ask.citations`, `ask.warning`, and `ask.done`. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": components["schemas"]["SseEnvelope"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+            500: components["responses"]["ApiError"];
         };
     };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-R06 — OpenAPI, rate limit & readiness

Final API-hardening issue of Phase 1B. Cross-cutting middleware + full contract; **no R04/R05 route semantics changed**. Stacks on R04/R05. Closes #96.

### Part 1 — hardening middleware & health (no new crates, hand-rolled)
- **Rate limit** (`middleware/rate_limit.rs`): bounded in-memory token bucket keyed by a **signature-verified** JWT `org:user` when a valid bearer is present, else client IP. Per-class limits (auth-login/refresh per-IP for brute-force; LLM `search`/`ask`/`ask/stream` per-user; general authenticated per-user; global fallback). `X-Forwarded-For`/`X-Real-IP` trusted **only** when `MARKHAND_TRUSTED_PROXY=true` (default off → socket peer). `/health/*` exempt. Limit → **429 + `Retry-After` + `ApiError{code:"rate_limited"}`**. O(1)-amortized per request (time-based 10s sweep, no per-request full scan, no O(N) oldest-key scan), map hard-capped (≤ 65 536, default 8 192), poison-tolerant lock.
- **CORS** (`middleware/cors.rs`): conservative allow-list only — echoes a matched `Origin`, never `*`+credentials, never reflects untrusted origins, preflight `204`; default empty allow-list = same-origin only.
- **Request-id** (`middleware/request_id.rs`): server-minted `x-request-id` on every response; inbound ids never trusted.
- **Health** (`routes/health.rs` + `services/health.rs`): `live`/`ready`/**`start`**; readiness is **fail-closed 503** on any dep (PG/Qdrant/MinIO), the **full embedded migration set** (count + per-migration checksum), or an invalid index-signature config; 1s cache.
- **Config** (`config.rs`): rate-limit/trusted-proxy/CORS settings with conservative valid defaults + env overrides (absurd values rejected). `main.rs` serves with `ConnectInfo<SocketAddr>`.

### Part 2 — OpenAPI contract
- `crates/server/openapi/openapi.yaml` expanded to cover **every shipped `/api/v1` route** (health/auth/uploads/collections/documents/citations/preview/download/jobs/jobs-events/search/ask/ask-stream) with camelCase DTO schemas, `bearerAuth`, `ApiError`/`PageInfo`/`SseEnvelope`, pagination query + `Idempotency-Key`/`Last-Event-Id` headers + `Retry-After` + stable error codes.
- Regenerated `web/src/api/generated/contract.ts` (`openapi-typescript`); `make check-web` (format/lint/test/api:check/build) green.
- Added search/ask/job/`rate_limited` fixtures + Rust serde round-trip coverage.

### Tests / gates
- `make check-boundaries`, `cargo fmt`, `clippy -D warnings`, **120 lib tests**, `cargo metadata --locked`, dependency-policy, **`make check-web`** — all green. Live integration (auth/quota/rest_api/sse_api/uploads/schema_migrations) pass under the new middleware; offline tests cover limiter boundedness/poison/fail-open, CORS, request-id, readiness fail-closed, and the missing-earlier-migration → 503 path. No new crates/migrations.

### Security review
`gpt-5.6-sol-high`, 2 rounds → **PASS**. Round 1 caught 3 HIGH (limiter O(N)-under-lock DoS at capacity; mutex-poison wedges all traffic; readiness only checked the latest migration) — all fixed and re-verified.

### Deferred (non-blocking, tracked)
New identities are unlimited only while the local map is saturated (bounded fail-open); `Vary: Origin` emitted on allowed origins; process-local limiter (per-replica; distributed limiter is out-of-scope per catalog); reconciliation-backlog readiness → O03.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

