### PR TITLE
feat(server): P1B-O01 end-to-end telemetry & safe audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,6 +2142,8 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "tower",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "zip 2.4.2",
 ]
@@ -3733,6 +3735,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,6 +4007,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6047,6 +6067,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7009,6 +7038,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7404,6 +7442,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -7621,6 +7702,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -49,6 +49,8 @@ thiserror.workspace = true
 tokio = { version = "1.53.0", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-postgres = { version = "0.7.18", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-postgres-rustls = "0.14.0"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 uuid = { version = "1.24.0", features = ["serde", "v4", "v8"] }
 zip = "2.2"
 

--- a/crates/server/src/auth/session.rs
+++ b/crates/server/src/auth/session.rs
@@ -14,6 +14,7 @@ use crate::auth::permissions::{resolve_org_context_in_txn, ResolveError};
 use crate::config::{Argon2Config, AuthConfig, SecretString};
 use crate::db::error::DbError;
 use crate::db::pool::{apply_org_context, with_org_txn};
+use crate::telemetry::redacted_json_value;
 
 const REFRESH_PREFIX: &str = "mh1";
 const REFRESH_SECRET_BYTES: usize = 32;
@@ -139,8 +140,9 @@ pub struct AuditEvent<'a> {
 
 /// Append-only audit row (metadata must never contain secrets).
 pub async fn write_audit(txn: &Transaction<'_>, event: AuditEvent<'_>) -> Result<(), DbError> {
+    let metadata = redacted_json_value(event.metadata);
     // Defense-in-depth: refuse metadata / request ids that embed raw secrets.
-    let rendered = event.metadata.to_string();
+    let rendered = metadata.to_string();
     for fragment in [
         "\"password\":",
         "\"refreshToken\":",
@@ -172,7 +174,7 @@ pub async fn write_audit(txn: &Transaction<'_>, event: AuditEvent<'_>) -> Result
             &event.resource_type,
             &event.resource_id,
             &event.outcome,
-            &event.metadata,
+            &metadata,
             &event.request_id,
         ],
     )

--- a/crates/server/src/auth/session.rs
+++ b/crates/server/src/auth/session.rs
@@ -220,20 +220,25 @@ pub async fn login_with_password(
                 .await
             {
                 let org_id: Uuid = row.get(0);
-                let _ = audit_on_client(
-                    &mut client,
-                    AuditEvent {
-                        org_id,
-                        actor_user_id: None,
-                        action: "auth.login",
-                        resource_type: "session",
-                        resource_id: None,
-                        outcome: "deny",
-                        request_id,
-                        metadata: serde_json::json!({ "reason": "unknown_user" }),
-                    },
-                )
-                .await;
+                warn_audit_failure(
+                    audit_on_client(
+                        &mut client,
+                        AuditEvent {
+                            org_id,
+                            actor_user_id: None,
+                            action: "auth.login",
+                            resource_type: "session",
+                            resource_id: None,
+                            outcome: "deny",
+                            request_id,
+                            metadata: serde_json::json!({ "reason": "unknown_user" }),
+                        },
+                    )
+                    .await,
+                    "auth.login",
+                    "deny",
+                    request_id,
+                );
             }
         }
         return Err(SessionError::InvalidCredentials);
@@ -251,20 +256,25 @@ pub async fn login_with_password(
             burn_password_verify_time(password, &auth.argon2);
         }
         if let Some(org_id) = find_user_org(&mut client, user_id).await? {
-            let _ = audit_on_client(
-                &mut client,
-                AuditEvent {
-                    org_id,
-                    actor_user_id: Some(user_id),
-                    action: "auth.login",
-                    resource_type: "session",
-                    resource_id: None,
-                    outcome: "deny",
-                    request_id,
-                    metadata: serde_json::json!({ "reason": "user_disabled" }),
-                },
-            )
-            .await;
+            warn_audit_failure(
+                audit_on_client(
+                    &mut client,
+                    AuditEvent {
+                        org_id,
+                        actor_user_id: Some(user_id),
+                        action: "auth.login",
+                        resource_type: "session",
+                        resource_id: None,
+                        outcome: "deny",
+                        request_id,
+                        metadata: serde_json::json!({ "reason": "user_disabled" }),
+                    },
+                )
+                .await,
+                "auth.login",
+                "deny",
+                request_id,
+            );
         }
         return Err(SessionError::InvalidCredentials);
     }
@@ -275,20 +285,25 @@ pub async fn login_with_password(
     };
     if password::verify_password(password, &password_hash).is_err() {
         if let Some(org_id) = find_user_org(&mut client, user_id).await? {
-            let _ = audit_on_client(
-                &mut client,
-                AuditEvent {
-                    org_id,
-                    actor_user_id: Some(user_id),
-                    action: "auth.login",
-                    resource_type: "session",
-                    resource_id: None,
-                    outcome: "deny",
-                    request_id,
-                    metadata: serde_json::json!({ "reason": "bad_password" }),
-                },
-            )
-            .await;
+            warn_audit_failure(
+                audit_on_client(
+                    &mut client,
+                    AuditEvent {
+                        org_id,
+                        actor_user_id: Some(user_id),
+                        action: "auth.login",
+                        resource_type: "session",
+                        resource_id: None,
+                        outcome: "deny",
+                        request_id,
+                        metadata: serde_json::json!({ "reason": "bad_password" }),
+                    },
+                )
+                .await,
+                "auth.login",
+                "deny",
+                request_id,
+            );
         }
         return Err(SessionError::InvalidCredentials);
     }
@@ -394,6 +409,37 @@ async fn audit_on_client(client: &mut Object, event: AuditEvent<'_>) -> Result<(
     write_audit(&txn, event).await?;
     txn.commit().await.map_err(|_| SessionError::Database)?;
     Ok(())
+}
+
+fn warn_audit_failure(
+    result: Result<(), SessionError>,
+    action: &'static str,
+    outcome: &'static str,
+    request_id: &str,
+) {
+    if let Err(error) = result {
+        tracing::warn!(
+            action = action,
+            outcome = outcome,
+            request_id = %request_id,
+            error_code = session_error_code(error),
+            "audit write failed"
+        );
+    }
+}
+
+fn session_error_code(error: SessionError) -> &'static str {
+    match error {
+        SessionError::InvalidCredentials => "invalid_credentials",
+        SessionError::UserDisabled => "user_disabled",
+        SessionError::MembershipMissing => "membership_missing",
+        SessionError::InvalidRefresh => "invalid_refresh",
+        SessionError::RefreshReuse => "refresh_reuse",
+        SessionError::NotConfigured => "not_configured",
+        SessionError::Database => "database",
+        SessionError::Token => "token",
+        SessionError::Password => "password",
+    }
 }
 
 async fn set_org_guc_txn(txn: &Transaction<'_>, org_id: Uuid) -> Result<(), DbError> {

--- a/crates/server/src/bin/worker.rs
+++ b/crates/server/src/bin/worker.rs
@@ -83,13 +83,21 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
     let metrics = Arc::new(MetricsRegistry::new());
     match kind.as_str() {
         "convert" => {
-            tracing::info!(worker_kind = "convert", "fileconv-worker starting");
+            tracing::info!(
+                target: "fileconv_worker",
+                worker_kind = "convert",
+                "fileconv-worker starting"
+            );
             let storage = MinioClient::from_config(storage_config.minio())
                 .map_err(|error| format!("storage client failed: {}", error.code()))?;
             run_convert_worker(state, pool, storage, worker_id, ctx, metrics).await
         }
         "index" => {
-            tracing::info!(worker_kind = "index", "fileconv-worker starting");
+            tracing::info!(
+                target: "fileconv_worker",
+                worker_kind = "index",
+                "fileconv-worker starting"
+            );
             let storage = MinioClient::from_config(storage_config.minio())
                 .map_err(|error| format!("storage client failed: {}", error.code()))?;
             let qdrant = QdrantClient::with_api_key(
@@ -100,7 +108,11 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
             run_index_worker(state, pool, storage, qdrant, worker_id, ctx, metrics).await
         }
         "delete" => {
-            tracing::info!(worker_kind = "delete", "fileconv-worker starting");
+            tracing::info!(
+                target: "fileconv_worker",
+                worker_kind = "delete",
+                "fileconv-worker starting"
+            );
             let storage = MinioClient::from_config(storage_config.minio())
                 .map_err(|error| format!("storage client failed: {}", error.code()))?;
             let qdrant = QdrantClient::with_api_key(
@@ -111,7 +123,11 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
             run_delete_worker(state, pool, storage, qdrant, worker_id, ctx, metrics).await
         }
         "reconcile" => {
-            tracing::info!(worker_kind = "reconcile", "fileconv-worker starting");
+            tracing::info!(
+                target: "fileconv_worker",
+                worker_kind = "reconcile",
+                "fileconv-worker starting"
+            );
             let storage = MinioClient::from_config(storage_config.minio())
                 .map_err(|error| format!("storage client failed: {}", error.code()))?;
             let qdrant = QdrantClient::with_api_key(
@@ -162,7 +178,7 @@ async fn run_convert_worker(
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                tracing::info!("fileconv-worker shutdown requested");
+                tracing::info!(target: "fileconv_worker", "fileconv-worker shutdown requested");
                 break;
             }
             poll = instrument_worker_once(metrics.clone(), "convert", worker.run_once(&ctx)) => {
@@ -174,6 +190,7 @@ async fn run_convert_worker(
                     Err(error) => {
                         metrics.record_job_processed("convert", "error", poll.duration_seconds);
                         tracing::error!(
+                            target: "fileconv_worker",
                             job_type = "convert",
                             error_code = error.safe_job_error(),
                             "convert worker error"
@@ -222,7 +239,7 @@ async fn run_index_worker(
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                tracing::info!("fileconv-worker shutdown requested");
+                tracing::info!(target: "fileconv_worker", "fileconv-worker shutdown requested");
                 break;
             }
             poll = instrument_worker_once(metrics.clone(), "index", async {
@@ -239,6 +256,7 @@ async fn run_index_worker(
                     Err(error) => {
                         metrics.record_job_processed("index", "error", poll.duration_seconds);
                         tracing::error!(
+                            target: "fileconv_worker",
                             job_type = "index",
                             error_code = %error,
                             "index worker error"
@@ -281,7 +299,7 @@ async fn run_delete_worker(
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                tracing::info!("fileconv-worker shutdown requested");
+                tracing::info!(target: "fileconv_worker", "fileconv-worker shutdown requested");
                 break;
             }
             poll = instrument_worker_once(metrics.clone(), "delete", async {
@@ -298,6 +316,7 @@ async fn run_delete_worker(
                     Err(error) => {
                         metrics.record_job_processed("delete", "error", poll.duration_seconds);
                         tracing::error!(
+                            target: "fileconv_worker",
                             job_type = "delete",
                             error_code = %error,
                             "delete worker error"
@@ -343,7 +362,7 @@ async fn run_reconcile_worker(
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                tracing::info!("fileconv-worker shutdown requested");
+                tracing::info!(target: "fileconv_worker", "fileconv-worker shutdown requested");
                 break;
             }
             poll = instrument_worker_once(metrics.clone(), "reconcile", async {
@@ -360,6 +379,7 @@ async fn run_reconcile_worker(
                     Err(error) => {
                         metrics.record_job_processed("reconcile", "error", poll.duration_seconds);
                         tracing::error!(
+                            target: "fileconv_worker",
                             job_type = "reconcile",
                             error_code = %error,
                             "reconcile worker error"
@@ -383,7 +403,7 @@ async fn instrument_worker_once<T, E>(
     job_type: &'static str,
     future: impl Future<Output = Result<T, E>>,
 ) -> WorkerPoll<T, E> {
-    let span = tracing::info_span!("worker.job", job_type = job_type);
+    let span = tracing::info_span!(target: "fileconv_worker", "worker.job", job_type = job_type);
     let started = std::time::Instant::now();
     metrics.increment_jobs_in_flight();
     let result = {
@@ -410,6 +430,7 @@ fn record_convert_run(
         } => {
             metrics.record_job_processed("convert", "success", duration_seconds);
             tracing::info!(
+                target: "fileconv_worker",
                 job_type = "convert",
                 job_id = %job_id,
                 markdown_bytes = markdown_bytes,
@@ -420,6 +441,7 @@ fn record_convert_run(
         fileconv_server::workers::convert::ConvertWorkerRun::Failed { job_id, terminal } => {
             metrics.record_job_processed("convert", "failed", duration_seconds);
             tracing::warn!(
+                target: "fileconv_worker",
                 job_type = "convert",
                 job_id = %job_id,
                 terminal = terminal,
@@ -430,6 +452,7 @@ fn record_convert_run(
         fileconv_server::workers::convert::ConvertWorkerRun::LeaseLost { job_id } => {
             metrics.record_job_processed("convert", "lease_lost", duration_seconds);
             tracing::warn!(
+                target: "fileconv_worker",
                 job_type = "convert",
                 job_id = %job_id,
                 outcome = "lease_lost",
@@ -445,6 +468,7 @@ fn record_index_run(metrics: &MetricsRegistry, run: IndexWorkerRun, duration_sec
         IndexWorkerRun::Completed { job_id, chunks } => {
             metrics.record_job_processed("index", "success", duration_seconds);
             tracing::info!(
+                target: "fileconv_worker",
                 job_type = "index",
                 job_id = %job_id,
                 chunks = chunks,
@@ -455,6 +479,7 @@ fn record_index_run(metrics: &MetricsRegistry, run: IndexWorkerRun, duration_sec
         IndexWorkerRun::Failed { job_id, terminal } => {
             metrics.record_job_processed("index", "failed", duration_seconds);
             tracing::warn!(
+                target: "fileconv_worker",
                 job_type = "index",
                 job_id = %job_id,
                 terminal = terminal,
@@ -465,6 +490,7 @@ fn record_index_run(metrics: &MetricsRegistry, run: IndexWorkerRun, duration_sec
         IndexWorkerRun::LeaseLost { job_id } => {
             metrics.record_job_processed("index", "lease_lost", duration_seconds);
             tracing::warn!(
+                target: "fileconv_worker",
                 job_type = "index",
                 job_id = %job_id,
                 outcome = "lease_lost",
@@ -483,6 +509,7 @@ fn record_delete_run(metrics: &MetricsRegistry, run: DeleteWorkerRun, duration_s
         } => {
             metrics.record_job_processed("delete", "success", duration_seconds);
             tracing::info!(
+                target: "fileconv_worker",
                 job_type = "delete",
                 job_id = %job_id,
                 deleted_chunks = deleted_chunks,
@@ -493,6 +520,7 @@ fn record_delete_run(metrics: &MetricsRegistry, run: DeleteWorkerRun, duration_s
         DeleteWorkerRun::Failed { job_id, terminal } => {
             metrics.record_job_processed("delete", "failed", duration_seconds);
             tracing::warn!(
+                target: "fileconv_worker",
                 job_type = "delete",
                 job_id = %job_id,
                 terminal = terminal,
@@ -503,6 +531,7 @@ fn record_delete_run(metrics: &MetricsRegistry, run: DeleteWorkerRun, duration_s
         DeleteWorkerRun::LeaseLost { job_id } => {
             metrics.record_job_processed("delete", "lease_lost", duration_seconds);
             tracing::warn!(
+                target: "fileconv_worker",
                 job_type = "delete",
                 job_id = %job_id,
                 outcome = "lease_lost",
@@ -518,6 +547,7 @@ fn record_reconcile_run(metrics: &MetricsRegistry, run: ReconcileWorkerRun, dura
         ReconcileWorkerRun::Completed { job_id, report } => {
             metrics.record_job_processed("reconcile", "success", duration_seconds);
             tracing::info!(
+                target: "fileconv_worker",
                 job_type = "reconcile",
                 job_id = %job_id,
                 orphan_vectors_repaired = report.repaired.orphan_vectors,
@@ -530,6 +560,7 @@ fn record_reconcile_run(metrics: &MetricsRegistry, run: ReconcileWorkerRun, dura
         ReconcileWorkerRun::Failed { job_id, terminal } => {
             metrics.record_job_processed("reconcile", "failed", duration_seconds);
             tracing::warn!(
+                target: "fileconv_worker",
                 job_type = "reconcile",
                 job_id = %job_id,
                 terminal = terminal,
@@ -540,6 +571,7 @@ fn record_reconcile_run(metrics: &MetricsRegistry, run: ReconcileWorkerRun, dura
         ReconcileWorkerRun::LeaseLost { job_id } => {
             metrics.record_job_processed("reconcile", "lease_lost", duration_seconds);
             tracing::warn!(
+                target: "fileconv_worker",
                 job_type = "reconcile",
                 job_id = %job_id,
                 outcome = "lease_lost",

--- a/crates/server/src/bin/worker.rs
+++ b/crates/server/src/bin/worker.rs
@@ -81,14 +81,15 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "convert".into());
     let metrics = Arc::new(MetricsRegistry::new());
-    tracing::info!(worker_id = %worker_id, worker_kind = %kind, "fileconv-worker starting");
     match kind.as_str() {
         "convert" => {
+            tracing::info!(worker_kind = "convert", "fileconv-worker starting");
             let storage = MinioClient::from_config(storage_config.minio())
                 .map_err(|error| format!("storage client failed: {}", error.code()))?;
             run_convert_worker(state, pool, storage, worker_id, ctx, metrics).await
         }
         "index" => {
+            tracing::info!(worker_kind = "index", "fileconv-worker starting");
             let storage = MinioClient::from_config(storage_config.minio())
                 .map_err(|error| format!("storage client failed: {}", error.code()))?;
             let qdrant = QdrantClient::with_api_key(
@@ -99,6 +100,7 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
             run_index_worker(state, pool, storage, qdrant, worker_id, ctx, metrics).await
         }
         "delete" => {
+            tracing::info!(worker_kind = "delete", "fileconv-worker starting");
             let storage = MinioClient::from_config(storage_config.minio())
                 .map_err(|error| format!("storage client failed: {}", error.code()))?;
             let qdrant = QdrantClient::with_api_key(
@@ -109,6 +111,7 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
             run_delete_worker(state, pool, storage, qdrant, worker_id, ctx, metrics).await
         }
         "reconcile" => {
+            tracing::info!(worker_kind = "reconcile", "fileconv-worker starting");
             let storage = MinioClient::from_config(storage_config.minio())
                 .map_err(|error| format!("storage client failed: {}", error.code()))?;
             let qdrant = QdrantClient::with_api_key(
@@ -118,7 +121,9 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
             .map_err(|error| format!("qdrant client failed: {}", error.code()))?;
             run_reconcile_worker(state, pool, storage, qdrant, worker_id, ctx, metrics).await
         }
-        other => Err(format!("unknown MARKHAND_WORKER_KIND: {other}")),
+        _ => Err(
+            "unknown MARKHAND_WORKER_KIND; expected convert, index, delete, or reconcile".into(),
+        ),
     }
 }
 

--- a/crates/server/src/bin/worker.rs
+++ b/crates/server/src/bin/worker.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::time::Duration;
 
 use fileconv_server::auth::context::OrgContext;
@@ -6,6 +7,7 @@ use fileconv_server::jobs;
 use fileconv_server::services::indexing::OutboxJobSink;
 use fileconv_server::services::reconciliation::ReconcileMode;
 use fileconv_server::storage::{MinioClient, QdrantClient};
+use fileconv_server::telemetry::metrics::MetricsRegistry;
 use fileconv_server::workers::convert::{ConvertWorker, ConvertWorkerConfig};
 use fileconv_server::workers::delete::{DeleteWorker, DeleteWorkerConfig, DeleteWorkerRun};
 use fileconv_server::workers::index::{IndexWorker, IndexWorkerConfig, IndexWorkerRun};
@@ -14,6 +16,7 @@ use fileconv_server::workers::reconcile::{
     ReconcileWorker, ReconcileWorkerConfig, ReconcileWorkerRun,
 };
 use fileconv_server::workers::sandbox::SandboxConfig;
+use std::sync::Arc;
 use uuid::Uuid;
 
 #[tokio::main]
@@ -30,6 +33,7 @@ async fn main() {
     }
     match fileconv_server::config::ServerConfig::from_worker_env() {
         Ok(config) if args.iter().any(|argument| argument == "--check-config") => {
+            fileconv_server::telemetry::logging::init_tracing(&config);
             match fileconv_server::state::RuntimeState::from_config(config) {
                 Ok(state) => println!(
                     "configuration valid: profile={:?}, bind={}",
@@ -39,14 +43,17 @@ async fn main() {
                 Err(error) => exit_with_error(format!("invalid worker configuration: {error}")),
             }
         }
-        Ok(config) => match fileconv_server::state::RuntimeState::from_config(config) {
-            Ok(state) => {
-                if let Err(error) = run_worker(state).await {
-                    exit_with_error(error);
+        Ok(config) => {
+            fileconv_server::telemetry::logging::init_tracing(&config);
+            match fileconv_server::state::RuntimeState::from_config(config) {
+                Ok(state) => {
+                    if let Err(error) = run_worker(state).await {
+                        exit_with_error(error);
+                    }
                 }
+                Err(error) => exit_with_error(format!("invalid worker configuration: {error}")),
             }
-            Err(error) => exit_with_error(format!("invalid worker configuration: {error}")),
-        },
+        }
         Err(error) => {
             exit_with_error(format!("invalid worker configuration: {error}"));
         }
@@ -73,11 +80,13 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
         .ok()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "convert".into());
+    let metrics = Arc::new(MetricsRegistry::new());
+    tracing::info!(worker_id = %worker_id, worker_kind = %kind, "fileconv-worker starting");
     match kind.as_str() {
         "convert" => {
             let storage = MinioClient::from_config(storage_config.minio())
                 .map_err(|error| format!("storage client failed: {}", error.code()))?;
-            run_convert_worker(state, pool, storage, worker_id, ctx).await
+            run_convert_worker(state, pool, storage, worker_id, ctx, metrics).await
         }
         "index" => {
             let storage = MinioClient::from_config(storage_config.minio())
@@ -87,7 +96,7 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
                 storage_config.qdrant_api_key().cloned(),
             )
             .map_err(|error| format!("qdrant client failed: {}", error.code()))?;
-            run_index_worker(state, pool, storage, qdrant, worker_id, ctx).await
+            run_index_worker(state, pool, storage, qdrant, worker_id, ctx, metrics).await
         }
         "delete" => {
             let storage = MinioClient::from_config(storage_config.minio())
@@ -97,7 +106,7 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
                 storage_config.qdrant_api_key().cloned(),
             )
             .map_err(|error| format!("qdrant client failed: {}", error.code()))?;
-            run_delete_worker(state, pool, storage, qdrant, worker_id, ctx).await
+            run_delete_worker(state, pool, storage, qdrant, worker_id, ctx, metrics).await
         }
         "reconcile" => {
             let storage = MinioClient::from_config(storage_config.minio())
@@ -107,7 +116,7 @@ async fn run_worker(state: fileconv_server::state::RuntimeState) -> Result<(), S
                 storage_config.qdrant_api_key().cloned(),
             )
             .map_err(|error| format!("qdrant client failed: {}", error.code()))?;
-            run_reconcile_worker(state, pool, storage, qdrant, worker_id, ctx).await
+            run_reconcile_worker(state, pool, storage, qdrant, worker_id, ctx, metrics).await
         }
         other => Err(format!("unknown MARKHAND_WORKER_KIND: {other}")),
     }
@@ -119,6 +128,7 @@ async fn run_convert_worker(
     storage: MinioClient,
     worker_id: String,
     ctx: OrgContext,
+    metrics: Arc<MetricsRegistry>,
 ) -> Result<(), String> {
     let mut config = ConvertWorkerConfig::new(worker_id, sandbox_config_from_env()?);
     config.lease_ttl = Duration::from_secs(state.config().limits().job_lease_seconds);
@@ -147,17 +157,22 @@ async fn run_convert_worker(
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                println!("fileconv-worker: shutdown requested");
+                tracing::info!("fileconv-worker shutdown requested");
                 break;
             }
-            result = worker.run_once(&ctx) => {
-                match result {
+            poll = instrument_worker_once(metrics.clone(), "convert", worker.run_once(&ctx)) => {
+                match poll.result {
                     Ok(fileconv_server::workers::convert::ConvertWorkerRun::NoJob) => {
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
-                    Ok(outcome) => println!("fileconv-worker: {outcome:?}"),
+                    Ok(outcome) => record_convert_run(&metrics, outcome, poll.duration_seconds),
                     Err(error) => {
-                        eprintln!("fileconv-worker: convert worker error: {error}");
+                        metrics.record_job_processed("convert", "error", poll.duration_seconds);
+                        tracing::error!(
+                            job_type = "convert",
+                            error_code = error.safe_job_error(),
+                            "convert worker error"
+                        );
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
                 }
@@ -174,6 +189,7 @@ async fn run_index_worker(
     qdrant: QdrantClient,
     worker_id: String,
     ctx: OrgContext,
+    metrics: Arc<MetricsRegistry>,
 ) -> Result<(), String> {
     let mut config = IndexWorkerConfig::new(worker_id);
     config.lease_ttl = Duration::from_secs(state.config().limits().job_lease_seconds);
@@ -201,22 +217,27 @@ async fn run_index_worker(
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                println!("fileconv-worker: shutdown requested");
+                tracing::info!("fileconv-worker shutdown requested");
                 break;
             }
-            result = async {
+            poll = instrument_worker_once(metrics.clone(), "index", async {
                 jobs::relay_outbox_with_sink(&pool, &ctx, 32, &sink)
                     .await
-                    .map_err(|error| error.to_string())?;
-                worker.run_once(&ctx).await.map_err(|error| error.to_string())
-            } => {
-                match result {
+                    .map_err(|_| "outbox_relay_error")?;
+                worker.run_once(&ctx).await.map_err(|error| error.safe_job_error())
+            }) => {
+                match poll.result {
                     Ok(IndexWorkerRun::NoJob) => {
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
-                    Ok(outcome) => println!("fileconv-worker: {outcome:?}"),
+                    Ok(outcome) => record_index_run(&metrics, outcome, poll.duration_seconds),
                     Err(error) => {
-                        eprintln!("fileconv-worker: index worker error: {error}");
+                        metrics.record_job_processed("index", "error", poll.duration_seconds);
+                        tracing::error!(
+                            job_type = "index",
+                            error_code = %error,
+                            "index worker error"
+                        );
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
                 }
@@ -233,6 +254,7 @@ async fn run_delete_worker(
     qdrant: QdrantClient,
     worker_id: String,
     ctx: OrgContext,
+    metrics: Arc<MetricsRegistry>,
 ) -> Result<(), String> {
     let mut config = DeleteWorkerConfig::new(worker_id);
     config.lease_ttl = Duration::from_secs(state.config().limits().job_lease_seconds);
@@ -254,22 +276,27 @@ async fn run_delete_worker(
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                println!("fileconv-worker: shutdown requested");
+                tracing::info!("fileconv-worker shutdown requested");
                 break;
             }
-            result = async {
+            poll = instrument_worker_once(metrics.clone(), "delete", async {
                 jobs::relay_outbox_with_sink(&pool, &ctx, 32, &sink)
                     .await
-                    .map_err(|error| error.to_string())?;
-                worker.run_once(&ctx).await.map_err(|error| error.to_string())
-            } => {
-                match result {
+                    .map_err(|_| "outbox_relay_error")?;
+                worker.run_once(&ctx).await.map_err(|error| error.safe_job_error())
+            }) => {
+                match poll.result {
                     Ok(DeleteWorkerRun::NoJob) => {
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
-                    Ok(outcome) => println!("fileconv-worker: {outcome:?}"),
+                    Ok(outcome) => record_delete_run(&metrics, outcome, poll.duration_seconds),
                     Err(error) => {
-                        eprintln!("fileconv-worker: delete worker error: {error}");
+                        metrics.record_job_processed("delete", "error", poll.duration_seconds);
+                        tracing::error!(
+                            job_type = "delete",
+                            error_code = %error,
+                            "delete worker error"
+                        );
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
                 }
@@ -286,6 +313,7 @@ async fn run_reconcile_worker(
     qdrant: QdrantClient,
     worker_id: String,
     ctx: OrgContext,
+    metrics: Arc<MetricsRegistry>,
 ) -> Result<(), String> {
     let mut config = ReconcileWorkerConfig::new(worker_id);
     config.lease_ttl = Duration::from_secs(state.config().limits().job_lease_seconds);
@@ -310,22 +338,27 @@ async fn run_reconcile_worker(
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                println!("fileconv-worker: shutdown requested");
+                tracing::info!("fileconv-worker shutdown requested");
                 break;
             }
-            result = async {
+            poll = instrument_worker_once(metrics.clone(), "reconcile", async {
                 jobs::relay_outbox_with_sink(&pool, &ctx, 32, &sink)
                     .await
-                    .map_err(|error| error.to_string())?;
-                worker.run_once(&ctx).await.map_err(|error| error.to_string())
-            } => {
-                match result {
+                    .map_err(|_| "outbox_relay_error")?;
+                worker.run_once(&ctx).await.map_err(|error| error.safe_job_error())
+            }) => {
+                match poll.result {
                     Ok(ReconcileWorkerRun::NoJob) => {
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
-                    Ok(outcome) => println!("fileconv-worker: {outcome:?}"),
+                    Ok(outcome) => record_reconcile_run(&metrics, outcome, poll.duration_seconds),
                     Err(error) => {
-                        eprintln!("fileconv-worker: reconcile worker error: {error}");
+                        metrics.record_job_processed("reconcile", "error", poll.duration_seconds);
+                        tracing::error!(
+                            job_type = "reconcile",
+                            error_code = %error,
+                            "reconcile worker error"
+                        );
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }
                 }
@@ -333,6 +366,182 @@ async fn run_reconcile_worker(
         }
     }
     Ok(())
+}
+
+struct WorkerPoll<T, E> {
+    result: Result<T, E>,
+    duration_seconds: f64,
+}
+
+async fn instrument_worker_once<T, E>(
+    metrics: Arc<MetricsRegistry>,
+    job_type: &'static str,
+    future: impl Future<Output = Result<T, E>>,
+) -> WorkerPoll<T, E> {
+    let span = tracing::info_span!("worker.job", job_type = job_type);
+    let started = std::time::Instant::now();
+    metrics.increment_jobs_in_flight();
+    let result = {
+        use tracing::Instrument;
+        future.instrument(span).await
+    };
+    metrics.decrement_jobs_in_flight();
+    WorkerPoll {
+        result,
+        duration_seconds: started.elapsed().as_secs_f64(),
+    }
+}
+
+fn record_convert_run(
+    metrics: &MetricsRegistry,
+    run: fileconv_server::workers::convert::ConvertWorkerRun,
+    duration_seconds: f64,
+) {
+    match run {
+        fileconv_server::workers::convert::ConvertWorkerRun::NoJob => {}
+        fileconv_server::workers::convert::ConvertWorkerRun::Completed {
+            job_id,
+            markdown_bytes,
+        } => {
+            metrics.record_job_processed("convert", "success", duration_seconds);
+            tracing::info!(
+                job_type = "convert",
+                job_id = %job_id,
+                markdown_bytes = markdown_bytes,
+                outcome = "success",
+                "worker job completed"
+            );
+        }
+        fileconv_server::workers::convert::ConvertWorkerRun::Failed { job_id, terminal } => {
+            metrics.record_job_processed("convert", "failed", duration_seconds);
+            tracing::warn!(
+                job_type = "convert",
+                job_id = %job_id,
+                terminal = terminal,
+                outcome = "failed",
+                "worker job failed"
+            );
+        }
+        fileconv_server::workers::convert::ConvertWorkerRun::LeaseLost { job_id } => {
+            metrics.record_job_processed("convert", "lease_lost", duration_seconds);
+            tracing::warn!(
+                job_type = "convert",
+                job_id = %job_id,
+                outcome = "lease_lost",
+                "worker job lease lost"
+            );
+        }
+    }
+}
+
+fn record_index_run(metrics: &MetricsRegistry, run: IndexWorkerRun, duration_seconds: f64) {
+    match run {
+        IndexWorkerRun::NoJob => {}
+        IndexWorkerRun::Completed { job_id, chunks } => {
+            metrics.record_job_processed("index", "success", duration_seconds);
+            tracing::info!(
+                job_type = "index",
+                job_id = %job_id,
+                chunks = chunks,
+                outcome = "success",
+                "worker job completed"
+            );
+        }
+        IndexWorkerRun::Failed { job_id, terminal } => {
+            metrics.record_job_processed("index", "failed", duration_seconds);
+            tracing::warn!(
+                job_type = "index",
+                job_id = %job_id,
+                terminal = terminal,
+                outcome = "failed",
+                "worker job failed"
+            );
+        }
+        IndexWorkerRun::LeaseLost { job_id } => {
+            metrics.record_job_processed("index", "lease_lost", duration_seconds);
+            tracing::warn!(
+                job_type = "index",
+                job_id = %job_id,
+                outcome = "lease_lost",
+                "worker job lease lost"
+            );
+        }
+    }
+}
+
+fn record_delete_run(metrics: &MetricsRegistry, run: DeleteWorkerRun, duration_seconds: f64) {
+    match run {
+        DeleteWorkerRun::NoJob => {}
+        DeleteWorkerRun::Completed {
+            job_id,
+            deleted_chunks,
+        } => {
+            metrics.record_job_processed("delete", "success", duration_seconds);
+            tracing::info!(
+                job_type = "delete",
+                job_id = %job_id,
+                deleted_chunks = deleted_chunks,
+                outcome = "success",
+                "worker job completed"
+            );
+        }
+        DeleteWorkerRun::Failed { job_id, terminal } => {
+            metrics.record_job_processed("delete", "failed", duration_seconds);
+            tracing::warn!(
+                job_type = "delete",
+                job_id = %job_id,
+                terminal = terminal,
+                outcome = "failed",
+                "worker job failed"
+            );
+        }
+        DeleteWorkerRun::LeaseLost { job_id } => {
+            metrics.record_job_processed("delete", "lease_lost", duration_seconds);
+            tracing::warn!(
+                job_type = "delete",
+                job_id = %job_id,
+                outcome = "lease_lost",
+                "worker job lease lost"
+            );
+        }
+    }
+}
+
+fn record_reconcile_run(metrics: &MetricsRegistry, run: ReconcileWorkerRun, duration_seconds: f64) {
+    match run {
+        ReconcileWorkerRun::NoJob => {}
+        ReconcileWorkerRun::Completed { job_id, report } => {
+            metrics.record_job_processed("reconcile", "success", duration_seconds);
+            tracing::info!(
+                job_type = "reconcile",
+                job_id = %job_id,
+                orphan_vectors_repaired = report.repaired.orphan_vectors,
+                stale_vectors_repaired = report.repaired.stale_vectors,
+                staged_objects_repaired = report.repaired.staged_objects,
+                outcome = "success",
+                "worker job completed"
+            );
+        }
+        ReconcileWorkerRun::Failed { job_id, terminal } => {
+            metrics.record_job_processed("reconcile", "failed", duration_seconds);
+            tracing::warn!(
+                job_type = "reconcile",
+                job_id = %job_id,
+                terminal = terminal,
+                outcome = "failed",
+                "worker job failed"
+            );
+        }
+        ReconcileWorkerRun::LeaseLost { job_id } => {
+            metrics.record_job_processed("reconcile", "lease_lost", duration_seconds);
+            tracing::warn!(
+                job_type = "reconcile",
+                job_id = %job_id,
+                outcome = "lease_lost",
+                "worker job lease lost"
+            );
+        }
+    }
 }
 
 fn sandbox_config_from_env() -> Result<SandboxConfig, String> {

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -25,6 +25,7 @@ const DEFAULT_RATE_LIMIT_LLM_PER_MINUTE: u32 = 60;
 const DEFAULT_RATE_LIMIT_AUTHENTICATED_PER_MINUTE: u32 = 300;
 const DEFAULT_RATE_LIMIT_FALLBACK_PER_MINUTE: u32 = 120;
 const DEFAULT_RATE_LIMIT_MAX_ENTRIES: usize = 8_192;
+const DEFAULT_LOG_LEVEL: &str = "info";
 const PROD_MIN_ARGON2_MEMORY_KIB: u32 = 19_456;
 const PROD_MIN_ARGON2_TIME_COST: u32 = 2;
 const PROD_MAX_ACCESS_TOKEN_TTL_SECS: u64 = 900;
@@ -37,6 +38,22 @@ pub enum Profile {
     Dev,
     Test,
     Prod,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogFormat {
+    Json,
+    Pretty,
+}
+
+impl LogFormat {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "json" => Ok(Self::Json),
+            "pretty" => Ok(Self::Pretty),
+            _ => Err("MARKHAND_LOG_FORMAT must be json or pretty".into()),
+        }
+    }
 }
 
 /// Process role controls which secrets and invariants are applicable.
@@ -100,6 +117,10 @@ pub struct ServerConfig {
     trusted_proxy: bool,
     cors_allowed_origins: Vec<String>,
     index_signature: Option<String>,
+    log_format: LogFormat,
+    log_level: String,
+    metrics_enabled: bool,
+    otlp_endpoint: Option<String>,
 }
 
 impl fmt::Debug for ServerConfig {
@@ -148,6 +169,13 @@ impl fmt::Debug for ServerConfig {
             .field("trusted_proxy", &self.trusted_proxy)
             .field("cors_allowed_origins", &self.cors_allowed_origins)
             .field("index_signature", &self.index_signature)
+            .field("log_format", &self.log_format)
+            .field("log_level", &self.log_level)
+            .field("metrics_enabled", &self.metrics_enabled)
+            .field(
+                "otlp_endpoint",
+                &self.otlp_endpoint.as_ref().map(|_| "[REDACTED_ENDPOINT]"),
+            )
             .finish()
     }
 }
@@ -424,6 +452,10 @@ struct ConfigFile {
     trusted_proxy: Option<bool>,
     cors_allowed_origins: Option<Vec<String>>,
     index_signature: Option<String>,
+    log_format: Option<String>,
+    log_level: Option<String>,
+    metrics_enabled: Option<bool>,
+    otlp_endpoint: Option<String>,
 }
 
 impl ServerConfig {
@@ -755,6 +787,27 @@ impl ServerConfig {
         let index_signature = optional_value(file, env, "MARKHAND_INDEX_SIGNATURE", |value| {
             value.index_signature.as_ref()
         });
+        let log_format = optional_value(file, env, "MARKHAND_LOG_FORMAT", |value| {
+            value.log_format.as_ref()
+        })
+        .as_deref()
+        .map(LogFormat::parse)
+        .transpose()?
+        .unwrap_or(LogFormat::Json);
+        let log_level = optional_value(file, env, "MARKHAND_LOG_LEVEL", |value| {
+            value.log_level.as_ref()
+        })
+        .unwrap_or_else(|| DEFAULT_LOG_LEVEL.into());
+        let metrics_enabled = bool_value(
+            file,
+            env,
+            "MARKHAND_METRICS_ENABLED",
+            |value| value.metrics_enabled,
+            true,
+        )?;
+        let otlp_endpoint = optional_value(file, env, "MARKHAND_OTLP_ENDPOINT", |value| {
+            value.otlp_endpoint.as_ref()
+        });
 
         let config = Self {
             role,
@@ -778,6 +831,10 @@ impl ServerConfig {
             trusted_proxy,
             cors_allowed_origins,
             index_signature,
+            log_format,
+            log_level,
+            metrics_enabled,
+            otlp_endpoint,
         };
         config.validate()?;
         Ok(config)
@@ -824,6 +881,22 @@ impl ServerConfig {
 
     pub fn index_signature(&self) -> Option<&str> {
         self.index_signature.as_deref()
+    }
+
+    pub const fn log_format(&self) -> LogFormat {
+        self.log_format
+    }
+
+    pub fn log_level(&self) -> &str {
+        &self.log_level
+    }
+
+    pub const fn metrics_enabled(&self) -> bool {
+        self.metrics_enabled
+    }
+
+    pub fn otlp_endpoint(&self) -> Option<&str> {
+        self.otlp_endpoint.as_deref()
     }
 
     pub(crate) fn is_api_role(&self) -> bool {
@@ -891,6 +964,10 @@ impl ServerConfig {
             trusted_proxy: false,
             cors_allowed_origins: Vec::new(),
             index_signature: None,
+            log_format: LogFormat::Json,
+            log_level: DEFAULT_LOG_LEVEL.into(),
+            metrics_enabled: true,
+            otlp_endpoint: None,
         }
     }
 
@@ -908,6 +985,11 @@ impl ServerConfig {
     ) -> Self {
         self.trusted_proxy = trusted_proxy;
         self.cors_allowed_origins = cors_allowed_origins;
+        self
+    }
+
+    pub fn with_test_metrics_enabled(mut self, enabled: bool) -> Self {
+        self.metrics_enabled = enabled;
         self
     }
 
@@ -962,6 +1044,11 @@ impl ServerConfig {
         self.validate_limits()?;
         self.upload.validate()?;
         self.validate_index_signature(false)?;
+        validate_log_level(&self.log_level)?;
+        if let Some(endpoint) = self.otlp_endpoint.as_deref() {
+            let _ = required_url(Some(endpoint), "MARKHAND_OTLP_ENDPOINT")?;
+            // TODO(O01/Otel): wire a real OTLP exporter behind this opt-in endpoint.
+        }
         if self.role == RuntimeRole::Api {
             self.validate_auth()?;
         }
@@ -1254,6 +1341,18 @@ fn validate_rate_limit(value: u32, env_name: &str) -> Result<(), String> {
     }
 }
 
+fn validate_log_level(value: &str) -> Result<(), String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.len() > 256
+        || trimmed.bytes().any(|byte| byte.is_ascii_control())
+    {
+        Err("MARKHAND_LOG_LEVEL must be a non-empty visible filter string".into())
+    } else {
+        Ok(())
+    }
+}
+
 fn validate_cors_origin(origin: &str) -> Result<(), String> {
     let trimmed = origin.trim();
     if trimmed == "*" {
@@ -1446,6 +1545,10 @@ mod tests {
             trusted_proxy: None,
             cors_allowed_origins: None,
             index_signature: None,
+            log_format: None,
+            log_level: None,
+            metrics_enabled: None,
+            otlp_endpoint: None,
         };
         let env = BTreeMap::from([
             ("MARKHAND_PROFILE".into(), "dev".into()),
@@ -1459,6 +1562,9 @@ mod tests {
             "postgres://file-secret"
         );
         assert_eq!(config.qdrant_url.as_deref(), Some("http://qdrant.test"));
+        assert_eq!(config.log_format, super::LogFormat::Json);
+        assert_eq!(config.log_level, "info");
+        assert!(config.metrics_enabled);
     }
 
     #[test]
@@ -1505,6 +1611,42 @@ mod tests {
     fn invalid_bind_fails_fast() {
         let env = BTreeMap::from([("MARKHAND_BIND_ADDR".into(), "not-an-address".into())]);
         assert!(ServerConfig::from_sources(None, &env).is_err());
+    }
+
+    #[test]
+    fn observability_configuration_has_safe_defaults_and_overrides() {
+        let defaults = ServerConfig::from_sources(None, &BTreeMap::new()).unwrap();
+        assert_eq!(defaults.log_format, super::LogFormat::Json);
+        assert_eq!(defaults.log_level, "info");
+        assert!(defaults.metrics_enabled);
+        assert_eq!(defaults.otlp_endpoint, None);
+
+        let env = BTreeMap::from([
+            ("MARKHAND_LOG_FORMAT".into(), "pretty".into()),
+            (
+                "MARKHAND_LOG_LEVEL".into(),
+                "fileconv_server=debug,tower_http=info".into(),
+            ),
+            ("MARKHAND_METRICS_ENABLED".into(), "false".into()),
+            (
+                "MARKHAND_OTLP_ENDPOINT".into(),
+                "http://127.0.0.1:4317".into(),
+            ),
+        ]);
+        let config = ServerConfig::from_sources(None, &env).unwrap();
+        assert_eq!(config.log_format, super::LogFormat::Pretty);
+        assert_eq!(config.log_level, "fileconv_server=debug,tower_http=info");
+        assert!(!config.metrics_enabled);
+        assert_eq!(
+            config.otlp_endpoint.as_deref(),
+            Some("http://127.0.0.1:4317")
+        );
+
+        let invalid = BTreeMap::from([("MARKHAND_LOG_FORMAT".into(), "plain".into())]);
+        assert_eq!(
+            ServerConfig::from_sources(None, &invalid).unwrap_err(),
+            "MARKHAND_LOG_FORMAT must be json or pretty"
+        );
     }
 
     #[test]

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -17,6 +17,7 @@ use crate::routes;
 use crate::services::download::{CapabilityKey, ConsumedDownloadNonces};
 use crate::services::quota;
 use crate::state::RuntimeState;
+use crate::telemetry::metrics::MetricsRegistry;
 
 pub(crate) const DEPENDENCY_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -34,6 +35,7 @@ pub struct AppState {
     ask_streams: AskStreamRegistry,
     download_capability_key: Option<CapabilityKey>,
     consumed_download_nonces: ConsumedDownloadNonces,
+    metrics: MetricsRegistry,
 }
 
 impl AppState {
@@ -98,6 +100,7 @@ impl AppState {
             ask_streams: AskStreamRegistry::new(),
             download_capability_key,
             consumed_download_nonces: ConsumedDownloadNonces::new(),
+            metrics: MetricsRegistry::new(),
         })
     }
 
@@ -156,6 +159,7 @@ impl AppState {
             ask_streams: AskStreamRegistry::new(),
             download_capability_key,
             consumed_download_nonces: ConsumedDownloadNonces::new(),
+            metrics: MetricsRegistry::new(),
         })
     }
 
@@ -215,6 +219,10 @@ impl AppState {
     pub fn consumed_download_nonces(&self) -> &ConsumedDownloadNonces {
         &self.consumed_download_nonces
     }
+
+    pub fn metrics(&self) -> &MetricsRegistry {
+        &self.metrics
+    }
 }
 
 fn start_quota_sweep(pool: Pool, config: QuotaSweepConfig) {
@@ -229,14 +237,14 @@ fn start_quota_sweep(pool: Pool, config: QuotaSweepConfig) {
             // showing stale reserved rows.
             match quota::sweep_expired_all_orgs(&pool, config.batch_size).await {
                 Ok(expired) if expired > 0 => {
-                    eprintln!("fileconv-server: quota expiry sweep marked {expired} reservations");
+                    tracing::info!(
+                        expired_reservations = expired,
+                        "quota expiry sweep marked expired reservations"
+                    );
                 }
                 Ok(_) => {}
                 Err(error) => {
-                    eprintln!(
-                        "fileconv-server: quota expiry sweep failed: {}",
-                        error.code()
-                    );
+                    tracing::warn!(error_code = error.code(), "quota expiry sweep failed");
                 }
             }
         }
@@ -255,10 +263,15 @@ pub fn router(state: AppState) -> Router {
         .merge(routes::search::router())
         .merge(routes::ask::router())
         .merge(routes::events::router())
+        .merge(routes::metrics::router())
         .merge(routes::uploads::router(max_upload_bytes))
         .with_state(state.clone())
         .layer(from_fn_with_state(state.clone(), rate_limit::rate_limit))
-        .layer(from_fn_with_state(state, cors::cors))
+        .layer(from_fn_with_state(state.clone(), cors::cors))
+        .layer(from_fn_with_state(
+            state,
+            crate::telemetry::http::record_http_metrics,
+        ))
         .layer(from_fn(request_id::ensure_request_id))
 }
 
@@ -431,6 +444,86 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), axum::http::StatusCode::OK);
         }
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_is_config_gated_and_rate_limit_exempt() {
+        let disabled = test_app(
+            config_for_middleware_tests()
+                .with_test_rate_limits(test_rate_limits(1))
+                .with_test_metrics_enabled(false),
+        );
+        let response = disabled
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+
+        let enabled = test_app(
+            config_for_middleware_tests()
+                .with_test_rate_limits(test_rate_limits(1))
+                .with_test_metrics_enabled(true),
+        );
+        for _ in 0..3 {
+            let response = enabled
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/v1/metrics")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), axum::http::StatusCode::OK);
+            assert_eq!(
+                response
+                    .headers()
+                    .get(axum::http::header::CONTENT_TYPE)
+                    .unwrap(),
+                "text/plain; version=0.0.4"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn metrics_use_route_pattern_not_raw_identifier_path() {
+        let document_id = "d4010000-0000-4000-8000-000000000001";
+        let app = test_app(config_for_middleware_tests());
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/documents/{document_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(response.status(), axum::http::StatusCode::OK);
+
+        let metrics = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let metrics = String::from_utf8(metrics.to_vec()).unwrap();
+        assert!(metrics.contains(r#"route="/api/v1/documents/{documentId}""#));
+        assert!(!metrics.contains(document_id));
     }
 
     #[tokio::test]

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -10,6 +10,7 @@ async fn main() {
     }
     match fileconv_server::config::ServerConfig::from_env() {
         Ok(config) if args.iter().any(|argument| argument == "--check-config") => {
+            fileconv_server::telemetry::logging::init_tracing(&config);
             match config.runtime_endpoints() {
                 Ok(_) => println!(
                     "configuration valid: profile={:?}, bind={}",
@@ -20,6 +21,7 @@ async fn main() {
             }
         }
         Ok(config) => {
+            fileconv_server::telemetry::logging::init_tracing(&config);
             let state = match fileconv_server::state::RuntimeState::from_config(config) {
                 Ok(state) => state,
                 Err(error) => exit_with_error(error.to_string()),
@@ -38,9 +40,9 @@ async fn main() {
                 Ok(listener) => listener,
                 Err(error) => exit_with_error(format!("cannot bind server: {error}")),
             };
-            println!(
-                "fileconv-server listening on http://{}",
-                state.config().bind_addr()
+            tracing::info!(
+                bind_addr = %state.config().bind_addr(),
+                "fileconv-server listening"
             );
             if let Err(error) = axum::serve(
                 listener,
@@ -70,7 +72,7 @@ async fn shutdown_signal() {
                     signal.recv().await;
                 }
                 Err(error) => {
-                    eprintln!("fileconv-server: cannot register SIGTERM handler: {error}");
+                    tracing::warn!(error = %error, "cannot register SIGTERM handler");
                 }
             }
         };

--- a/crates/server/src/middleware/rate_limit.rs
+++ b/crates/server/src/middleware/rate_limit.rs
@@ -167,7 +167,7 @@ pub async fn rate_limit(
     request: Request<Body>,
     next: Next,
 ) -> Response {
-    if is_health_path(request.uri().path()) {
+    if is_exempt_path(request.uri().path()) {
         return next.run(request).await;
     }
 
@@ -181,10 +181,10 @@ pub async fn rate_limit(
     }
 }
 
-fn is_health_path(path: &str) -> bool {
+fn is_exempt_path(path: &str) -> bool {
     matches!(
         path,
-        "/api/v1/health/live" | "/api/v1/health/ready" | "/api/v1/health/start"
+        "/api/v1/health/live" | "/api/v1/health/ready" | "/api/v1/health/start" | "/api/v1/metrics"
     )
 }
 

--- a/crates/server/src/routes/ask.rs
+++ b/crates/server/src/routes/ask.rs
@@ -72,14 +72,18 @@ async fn ask(
     let Json(body) =
         body.map_err(|_| RestError::validation("request body is invalid", &request_id))?;
     if let Err(error) = require_permission_or_403(&auth.context, "qa.query", &request_id) {
-        let _ = audit_qa_query(
-            &state,
-            &auth.context,
+        warn_audit_failure(
+            audit_qa_query(
+                &state,
+                &auth.context,
+                "deny",
+                &request_id,
+                serde_json::json!({ "endpoint": "ask", "reason": "permission_denied" }),
+            )
+            .await,
             "deny",
             &request_id,
-            serde_json::json!({ "endpoint": "ask", "reason": "permission_denied" }),
-        )
-        .await;
+        );
         return Err(error);
     }
     let input = validate_ask_request(body, &auth.context, &request_id)?;
@@ -112,14 +116,18 @@ async fn ask(
                 QaError::EmptyScope => ("deny", "empty_scope"),
                 QaError::Retrieval(_) => ("error", "qa_failed"),
             };
-            let _ = audit_qa_query(
-                &state,
-                &auth.context,
+            warn_audit_failure(
+                audit_qa_query(
+                    &state,
+                    &auth.context,
+                    outcome,
+                    &request_id,
+                    merge_audit_reason(audit_metadata, reason),
+                )
+                .await,
                 outcome,
                 &request_id,
-                merge_audit_reason(audit_metadata, reason),
-            )
-            .await;
+            );
             return Err(map_qa_error(error, &request_id));
         }
     };
@@ -129,14 +137,18 @@ async fn ask(
         retrieval_started.elapsed().as_secs_f64(),
     );
     let response = collect_answer(stream, &request_id).await?;
-    let _ = audit_qa_query(
-        &state,
-        &auth.context,
+    warn_audit_failure(
+        audit_qa_query(
+            &state,
+            &auth.context,
+            "success",
+            &request_id,
+            audit_metadata,
+        )
+        .await,
         "success",
         &request_id,
-        audit_metadata,
-    )
-    .await;
+    );
     Ok(Json(response).into_response())
 }
 
@@ -148,14 +160,18 @@ async fn ask_stream(
 ) -> Result<Response, RestError> {
     let request_id = auth.request_id.clone();
     if let Err(error) = require_permission_or_403(&auth.context, "qa.query", &request_id) {
-        let _ = audit_qa_query(
-            &state,
-            &auth.context,
+        warn_audit_failure(
+            audit_qa_query(
+                &state,
+                &auth.context,
+                "deny",
+                &request_id,
+                serde_json::json!({ "endpoint": "ask_stream", "reason": "permission_denied" }),
+            )
+            .await,
             "deny",
             &request_id,
-            serde_json::json!({ "endpoint": "ask_stream", "reason": "permission_denied" }),
-        )
-        .await;
+        );
         return Err(error);
     }
     let caller = StreamCaller {
@@ -224,14 +240,18 @@ async fn ask_stream(
                 QaError::EmptyScope => ("deny", "empty_scope"),
                 QaError::Retrieval(_) => ("error", "qa_failed"),
             };
-            let _ = audit_qa_query(
-                &state,
-                &auth.context,
+            warn_audit_failure(
+                audit_qa_query(
+                    &state,
+                    &auth.context,
+                    outcome,
+                    &request_id,
+                    merge_audit_reason(audit_metadata, reason),
+                )
+                .await,
                 outcome,
                 &request_id,
-                merge_audit_reason(audit_metadata, reason),
-            )
-            .await;
+            );
             return Err(map_qa_error(error, &request_id));
         }
     };
@@ -240,14 +260,18 @@ async fn ask_stream(
         "success",
         retrieval_started.elapsed().as_secs_f64(),
     );
-    let _ = audit_qa_query(
-        &state,
-        &auth.context,
+    warn_audit_failure(
+        audit_qa_query(
+            &state,
+            &auth.context,
+            "success",
+            &request_id,
+            audit_metadata,
+        )
+        .await,
         "success",
         &request_id,
-        audit_metadata,
-    )
-    .await;
+    );
     let stream = qa_sse_stream(
         stream_id,
         request_id.clone(),
@@ -277,6 +301,22 @@ async fn audit_qa_query(
         },
     )
     .await
+}
+
+fn warn_audit_failure(
+    result: Result<(), crate::db::error::DbError>,
+    outcome: &'static str,
+    request_id: &str,
+) {
+    if let Err(error) = result {
+        tracing::warn!(
+            action = "qa.query",
+            outcome = outcome,
+            request_id = %request_id,
+            error_code = error.code(),
+            "audit write failed"
+        );
+    }
 }
 
 fn merge_audit_reason(mut metadata: serde_json::Value, reason: &'static str) -> serde_json::Value {

--- a/crates/server/src/routes/ask.rs
+++ b/crates/server/src/routes/ask.rs
@@ -2,7 +2,7 @@
 
 use std::convert::Infallible;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::body::Bytes;
 use axum::extract::rejection::JsonRejection;
@@ -28,6 +28,7 @@ use crate::routes::common::{require_permission_or_403, RestError};
 use crate::routes::search::{
     narrowed_context, validate_collection_ids_len, validate_limit, JSON_BODY_LIMIT, MAX_QUERY_CHARS,
 };
+use crate::services::audit::{self, SafeAuditEvent};
 use crate::services::qa::stream::{DEFAULT_QA_LIMIT, MAX_QA_LIMIT};
 use crate::services::qa::{answer_question, QaAnswerMode, QaCitation, QaError, QaEvent, QaRequest};
 use crate::services::retrieval::VersionMode;
@@ -70,9 +71,25 @@ async fn ask(
     let request_id = auth.request_id.clone();
     let Json(body) =
         body.map_err(|_| RestError::validation("request body is invalid", &request_id))?;
-    require_permission_or_403(&auth.context, "qa.query", &request_id)?;
+    if let Err(error) = require_permission_or_403(&auth.context, "qa.query", &request_id) {
+        let _ = audit_qa_query(
+            &state,
+            &auth.context,
+            "deny",
+            &request_id,
+            serde_json::json!({ "endpoint": "ask", "reason": "permission_denied" }),
+        )
+        .await;
+        return Err(error);
+    }
     let input = validate_ask_request(body, &auth.context, &request_id)?;
-    let stream = answer_question(
+    let audit_metadata = serde_json::json!({
+        "endpoint": "ask",
+        "limit": input.limit,
+        "collectionScopeCount": input.ctx.allowed_collection_ids().len()
+    });
+    let retrieval_started = Instant::now();
+    let stream = match answer_question(
         state.pool(),
         state.vector_store(),
         &input.ctx,
@@ -83,8 +100,43 @@ async fn ask(
         },
     )
     .await
-    .map_err(|error| map_qa_error(error, &request_id))?;
+    {
+        Ok(stream) => stream,
+        Err(error) => {
+            state.metrics().observe_retrieval_latency(
+                "ask",
+                "error",
+                retrieval_started.elapsed().as_secs_f64(),
+            );
+            let (outcome, reason) = match &error {
+                QaError::EmptyScope => ("deny", "empty_scope"),
+                QaError::Retrieval(_) => ("error", "qa_failed"),
+            };
+            let _ = audit_qa_query(
+                &state,
+                &auth.context,
+                outcome,
+                &request_id,
+                merge_audit_reason(audit_metadata, reason),
+            )
+            .await;
+            return Err(map_qa_error(error, &request_id));
+        }
+    };
+    state.metrics().observe_retrieval_latency(
+        "ask",
+        "success",
+        retrieval_started.elapsed().as_secs_f64(),
+    );
     let response = collect_answer(stream, &request_id).await?;
+    let _ = audit_qa_query(
+        &state,
+        &auth.context,
+        "success",
+        &request_id,
+        audit_metadata,
+    )
+    .await;
     Ok(Json(response).into_response())
 }
 
@@ -95,7 +147,17 @@ async fn ask_stream(
     body: Bytes,
 ) -> Result<Response, RestError> {
     let request_id = auth.request_id.clone();
-    require_permission_or_403(&auth.context, "qa.query", &request_id)?;
+    if let Err(error) = require_permission_or_403(&auth.context, "qa.query", &request_id) {
+        let _ = audit_qa_query(
+            &state,
+            &auth.context,
+            "deny",
+            &request_id,
+            serde_json::json!({ "endpoint": "ask_stream", "reason": "permission_denied" }),
+        )
+        .await;
+        return Err(error);
+    }
     let caller = StreamCaller {
         org_id: auth.context.org_id(),
         user_id: auth.context.user_id(),
@@ -127,12 +189,18 @@ async fn ask_stream(
     let body: AskRequestBody = serde_json::from_slice(&body)
         .map_err(|_| RestError::validation("request body is invalid", &request_id))?;
     let input = validate_ask_request(body, &auth.context, &request_id)?;
+    let audit_metadata = serde_json::json!({
+        "endpoint": "ask_stream",
+        "limit": input.limit,
+        "collectionScopeCount": input.ctx.allowed_collection_ids().len()
+    });
     let collection_scope = input.ctx.allowed_collection_ids().iter().copied();
     let stream_id = state
         .ask_streams()
         .start_stream(caller, collection_scope)
         .map_err(|error| map_registry_error(error, &request_id))?;
-    let qa_stream = answer_question(
+    let retrieval_started = Instant::now();
+    let qa_stream = match answer_question(
         state.pool(),
         state.vector_store(),
         &input.ctx,
@@ -143,10 +211,43 @@ async fn ask_stream(
         },
     )
     .await
-    .map_err(|error| {
-        state.ask_streams().remove(stream_id);
-        map_qa_error(error, &request_id)
-    })?;
+    {
+        Ok(stream) => stream,
+        Err(error) => {
+            state.ask_streams().remove(stream_id);
+            state.metrics().observe_retrieval_latency(
+                "ask_stream",
+                "error",
+                retrieval_started.elapsed().as_secs_f64(),
+            );
+            let (outcome, reason) = match &error {
+                QaError::EmptyScope => ("deny", "empty_scope"),
+                QaError::Retrieval(_) => ("error", "qa_failed"),
+            };
+            let _ = audit_qa_query(
+                &state,
+                &auth.context,
+                outcome,
+                &request_id,
+                merge_audit_reason(audit_metadata, reason),
+            )
+            .await;
+            return Err(map_qa_error(error, &request_id));
+        }
+    };
+    state.metrics().observe_retrieval_latency(
+        "ask_stream",
+        "success",
+        retrieval_started.elapsed().as_secs_f64(),
+    );
+    let _ = audit_qa_query(
+        &state,
+        &auth.context,
+        "success",
+        &request_id,
+        audit_metadata,
+    )
+    .await;
     let stream = qa_sse_stream(
         stream_id,
         request_id.clone(),
@@ -154,6 +255,35 @@ async fn ask_stream(
         qa_stream,
     );
     Ok(sse_response(stream))
+}
+
+async fn audit_qa_query(
+    state: &Arc<AppState>,
+    ctx: &OrgContext,
+    outcome: &'static str,
+    request_id: &str,
+    metadata: serde_json::Value,
+) -> Result<(), crate::db::error::DbError> {
+    audit::record_audit_event(
+        state.pool(),
+        ctx,
+        SafeAuditEvent {
+            action: "qa.query",
+            resource_type: "qa",
+            resource_id: None,
+            outcome,
+            request_id: request_id.into(),
+            metadata,
+        },
+    )
+    .await
+}
+
+fn merge_audit_reason(mut metadata: serde_json::Value, reason: &'static str) -> serde_json::Value {
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert("reason".into(), serde_json::Value::String(reason.into()));
+    }
+    metadata
 }
 
 fn sse_response<S>(stream: S) -> Response

--- a/crates/server/src/routes/documents.rs
+++ b/crates/server/src/routes/documents.rs
@@ -541,20 +541,26 @@ async fn resolve_citation(
 ) -> Result<Response, DocumentRouteError> {
     let request_id = auth.request_id.clone();
     if require_permission(&auth.context, "qa.query").is_err() {
-        let _ = audit_download(
-            &state,
-            &auth.context,
-            "document.download.mint",
+        let action = "document.citation.resolve";
+        warn_audit_failure(
+            audit_download(
+                &state,
+                &auth.context,
+                action,
+                "deny",
+                Some(path.version_id.to_string()),
+                &request_id,
+                serde_json::json!({
+                    "reason": "permission_denied",
+                    "documentId": path.document_id.to_string(),
+                    "versionId": path.version_id.to_string()
+                }),
+            )
+            .await,
+            action,
             "deny",
-            Some(path.version_id.to_string()),
             &request_id,
-            serde_json::json!({
-                "reason": "permission_denied",
-                "documentId": path.document_id.to_string(),
-                "versionId": path.version_id.to_string()
-            }),
-        )
-        .await;
+        );
         return Err(DocumentRouteError::forbidden(request_id.clone()));
     }
     if path.document_id != pin.document_id || path.version_id != pin.version_id {
@@ -628,37 +634,48 @@ async fn authorize_download(
     {
         Ok(capability) => capability,
         Err(error) => {
-            let _ = audit_download(
-                &state,
-                &auth.context,
+            let outcome = download_audit_outcome(&error);
+            warn_audit_failure(
+                audit_download(
+                    &state,
+                    &auth.context,
+                    "document.download.mint",
+                    outcome,
+                    Some(path.version_id.to_string()),
+                    &request_id,
+                    serde_json::json!({
+                        "reason": download_audit_reason(&error),
+                        "documentId": path.document_id.to_string(),
+                        "versionId": path.version_id.to_string()
+                    }),
+                )
+                .await,
                 "document.download.mint",
-                download_audit_outcome(&error),
-                Some(path.version_id.to_string()),
+                outcome,
                 &request_id,
-                serde_json::json!({
-                    "reason": download_audit_reason(&error),
-                    "documentId": path.document_id.to_string(),
-                    "versionId": path.version_id.to_string()
-                }),
-            )
-            .await;
+            );
             return Err(DocumentRouteError::download(error, request_id.clone()));
         }
     };
-    let _ = audit_download(
-        &state,
-        &auth.context,
+    warn_audit_failure(
+        audit_download(
+            &state,
+            &auth.context,
+            "document.download.mint",
+            "success",
+            Some(path.version_id.to_string()),
+            &request_id,
+            serde_json::json!({
+                "documentId": path.document_id.to_string(),
+                "versionId": path.version_id.to_string(),
+                "byteSize": capability.byte_size
+            }),
+        )
+        .await,
         "document.download.mint",
         "success",
-        Some(path.version_id.to_string()),
         &request_id,
-        serde_json::json!({
-            "documentId": path.document_id.to_string(),
-            "versionId": path.version_id.to_string(),
-            "byteSize": capability.byte_size
-        }),
-    )
-    .await;
+    );
     Ok(Json(capability).into_response())
 }
 
@@ -725,6 +742,23 @@ async fn audit_download(
         },
     )
     .await
+}
+
+fn warn_audit_failure(
+    result: Result<(), crate::db::error::DbError>,
+    action: &'static str,
+    outcome: &'static str,
+    request_id: &str,
+) {
+    if let Err(error) = result {
+        tracing::warn!(
+            action = action,
+            outcome = outcome,
+            request_id = %request_id,
+            error_code = error.code(),
+            "audit write failed"
+        );
+    }
 }
 
 fn download_audit_outcome(error: &DownloadError) -> &'static str {

--- a/crates/server/src/routes/documents.rs
+++ b/crates/server/src/routes/documents.rs
@@ -28,6 +28,7 @@ use crate::routes::common::{
     require_collection_or_404, require_permission_or_403, validate_idempotency_header,
     ListResponse, PageParams, RestError, TxnRestError,
 };
+use crate::services::audit::{self, SafeAuditEvent};
 use crate::services::citation::{self, CitationPin};
 use crate::services::deletion::{self, DeleteRequestOutcome, DeletionError};
 use crate::services::download::{self, DownloadError};
@@ -539,8 +540,23 @@ async fn resolve_citation(
     Json(pin): Json<CitationPin>,
 ) -> Result<Response, DocumentRouteError> {
     let request_id = auth.request_id.clone();
-    require_permission(&auth.context, "qa.query")
-        .map_err(|_| DocumentRouteError::forbidden(request_id.clone()))?;
+    if require_permission(&auth.context, "qa.query").is_err() {
+        let _ = audit_download(
+            &state,
+            &auth.context,
+            "document.download.mint",
+            "deny",
+            Some(path.version_id.to_string()),
+            &request_id,
+            serde_json::json!({
+                "reason": "permission_denied",
+                "documentId": path.document_id.to_string(),
+                "versionId": path.version_id.to_string()
+            }),
+        )
+        .await;
+        return Err(DocumentRouteError::forbidden(request_id.clone()));
+    }
     if path.document_id != pin.document_id || path.version_id != pin.version_id {
         return Err(DocumentRouteError::validation(
             "Citation pin does not match the requested document version",
@@ -599,7 +615,7 @@ async fn authorize_download(
     let key = state
         .download_capability_key()
         .ok_or_else(|| DocumentRouteError::service_unavailable(request_id.clone()))?;
-    let capability = download::authorize_download(
+    let capability = match download::authorize_download(
         state.pool(),
         storage,
         &auth.context,
@@ -609,7 +625,40 @@ async fn authorize_download(
         Utc::now(),
     )
     .await
-    .map_err(|error| DocumentRouteError::download(error, request_id.clone()))?;
+    {
+        Ok(capability) => capability,
+        Err(error) => {
+            let _ = audit_download(
+                &state,
+                &auth.context,
+                "document.download.mint",
+                download_audit_outcome(&error),
+                Some(path.version_id.to_string()),
+                &request_id,
+                serde_json::json!({
+                    "reason": download_audit_reason(&error),
+                    "documentId": path.document_id.to_string(),
+                    "versionId": path.version_id.to_string()
+                }),
+            )
+            .await;
+            return Err(DocumentRouteError::download(error, request_id.clone()));
+        }
+    };
+    let _ = audit_download(
+        &state,
+        &auth.context,
+        "document.download.mint",
+        "success",
+        Some(path.version_id.to_string()),
+        &request_id,
+        serde_json::json!({
+            "documentId": path.document_id.to_string(),
+            "versionId": path.version_id.to_string(),
+            "byteSize": capability.byte_size
+        }),
+    )
+    .await;
     Ok(Json(capability).into_response())
 }
 
@@ -630,6 +679,7 @@ async fn redeem_download(
         key,
         state.consumed_download_nonces(),
         &path.token,
+        &request_id,
         Utc::now(),
     )
     .await
@@ -651,6 +701,56 @@ async fn redeem_download(
         HeaderValue::from_static("nosniff"),
     );
     Ok((headers, Body::from(stream.bytes)).into_response())
+}
+
+async fn audit_download(
+    state: &Arc<AppState>,
+    ctx: &OrgContext,
+    action: &'static str,
+    outcome: &'static str,
+    resource_id: Option<String>,
+    request_id: &str,
+    metadata: serde_json::Value,
+) -> Result<(), crate::db::error::DbError> {
+    audit::record_audit_event(
+        state.pool(),
+        ctx,
+        SafeAuditEvent {
+            action,
+            resource_type: "document_version",
+            resource_id,
+            outcome,
+            request_id: request_id.into(),
+            metadata,
+        },
+    )
+    .await
+}
+
+fn download_audit_outcome(error: &DownloadError) -> &'static str {
+    match error {
+        DownloadError::NotFound
+        | DownloadError::InvalidToken
+        | DownloadError::Expired
+        | DownloadError::Replay => "deny",
+        DownloadError::CapabilityUnavailable
+        | DownloadError::Db(_)
+        | DownloadError::Storage(_)
+        | DownloadError::Integrity => "error",
+    }
+}
+
+fn download_audit_reason(error: &DownloadError) -> &'static str {
+    match error {
+        DownloadError::NotFound => "source_not_found",
+        DownloadError::CapabilityUnavailable => "capability_unavailable",
+        DownloadError::InvalidToken => "invalid_token",
+        DownloadError::Expired => "expired",
+        DownloadError::Replay => "replay",
+        DownloadError::Db(_) => "database_error",
+        DownloadError::Storage(_) => "storage_error",
+        DownloadError::Integrity => "integrity_failed",
+    }
 }
 
 async fn load_visible_document(

--- a/crates/server/src/routes/metrics.rs
+++ b/crates/server/src/routes/metrics.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::header::CONTENT_TYPE;
+use axum::http::{HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+
+use crate::http::AppState;
+
+const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4";
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().route("/api/v1/metrics", get(metrics))
+}
+
+async fn metrics(State(state): State<Arc<AppState>>) -> Response {
+    if !state.runtime().config().metrics_enabled() {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    // Production deployments must network-restrict this unauthenticated scrape endpoint.
+    let mut response = state.metrics().render_prometheus().into_response();
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static(PROMETHEUS_CONTENT_TYPE),
+    );
+    response
+}

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -8,5 +8,6 @@ pub mod documents;
 pub mod events;
 pub mod health;
 pub mod jobs;
+pub mod metrics;
 pub mod search;
 pub mod uploads;

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -1,6 +1,7 @@
 //! Search API routes backed by the tenant-scoped retrieval engine.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{DefaultBodyLimit, State};
@@ -14,6 +15,7 @@ use crate::auth::context::OrgContext;
 use crate::auth::middleware::AuthenticatedOrg;
 use crate::http::AppState;
 use crate::routes::common::{require_permission_or_403, RestError};
+use crate::services::audit::{self, SafeAuditEvent};
 use crate::services::retrieval::{
     retrieve, Degradation, GroundedHit, RetrievalError, RetrievalRequest, VersionMode,
     MAX_RETRIEVAL_LIMIT,
@@ -81,9 +83,25 @@ async fn search(
     let request_id = auth.request_id.clone();
     let Json(body) =
         body.map_err(|_| RestError::validation("request body is invalid", &request_id))?;
-    require_permission_or_403(&auth.context, "qa.query", &request_id)?;
+    if let Err(error) = require_permission_or_403(&auth.context, "qa.query", &request_id) {
+        let _ = audit_qa_query(
+            &state,
+            &auth.context,
+            "deny",
+            &request_id,
+            serde_json::json!({ "endpoint": "search", "reason": "permission_denied" }),
+        )
+        .await;
+        return Err(error);
+    }
     let input = validate_search_request(body, &auth.context, &request_id)?;
-    let response = retrieve(
+    let audit_metadata = serde_json::json!({
+        "endpoint": "search",
+        "limit": input.limit,
+        "collectionScopeCount": input.ctx.allowed_collection_ids().len()
+    });
+    let retrieval_started = Instant::now();
+    let response = match retrieve(
         state.pool(),
         state.vector_store(),
         &input.ctx,
@@ -94,7 +112,42 @@ async fn search(
         },
     )
     .await
-    .map_err(|error| map_retrieval_error(error, &request_id))?;
+    {
+        Ok(response) => response,
+        Err(error) => {
+            state.metrics().observe_retrieval_latency(
+                "search",
+                "error",
+                retrieval_started.elapsed().as_secs_f64(),
+            );
+            let (outcome, reason) = match &error {
+                RetrievalError::EmptyScope => ("deny", "empty_scope"),
+                _ => ("error", "retrieval_failed"),
+            };
+            let _ = audit_qa_query(
+                &state,
+                &auth.context,
+                outcome,
+                &request_id,
+                merge_audit_reason(audit_metadata, reason),
+            )
+            .await;
+            return Err(map_retrieval_error(error, &request_id));
+        }
+    };
+    state.metrics().observe_retrieval_latency(
+        "search",
+        "success",
+        retrieval_started.elapsed().as_secs_f64(),
+    );
+    let _ = audit_qa_query(
+        &state,
+        &auth.context,
+        "success",
+        &request_id,
+        audit_metadata,
+    )
+    .await;
 
     Ok(Json(SearchResponse {
         hits: response
@@ -105,6 +158,35 @@ async fn search(
         degraded: response.degraded.map(degradation_code),
     })
     .into_response())
+}
+
+async fn audit_qa_query(
+    state: &Arc<AppState>,
+    ctx: &OrgContext,
+    outcome: &'static str,
+    request_id: &str,
+    metadata: serde_json::Value,
+) -> Result<(), crate::db::error::DbError> {
+    audit::record_audit_event(
+        state.pool(),
+        ctx,
+        SafeAuditEvent {
+            action: "qa.query",
+            resource_type: "qa",
+            resource_id: None,
+            outcome,
+            request_id: request_id.into(),
+            metadata,
+        },
+    )
+    .await
+}
+
+fn merge_audit_reason(mut metadata: serde_json::Value, reason: &'static str) -> serde_json::Value {
+    if let Some(object) = metadata.as_object_mut() {
+        object.insert("reason".into(), serde_json::Value::String(reason.into()));
+    }
+    metadata
 }
 
 pub(crate) fn validate_search_request(

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -84,14 +84,18 @@ async fn search(
     let Json(body) =
         body.map_err(|_| RestError::validation("request body is invalid", &request_id))?;
     if let Err(error) = require_permission_or_403(&auth.context, "qa.query", &request_id) {
-        let _ = audit_qa_query(
-            &state,
-            &auth.context,
+        warn_audit_failure(
+            audit_qa_query(
+                &state,
+                &auth.context,
+                "deny",
+                &request_id,
+                serde_json::json!({ "endpoint": "search", "reason": "permission_denied" }),
+            )
+            .await,
             "deny",
             &request_id,
-            serde_json::json!({ "endpoint": "search", "reason": "permission_denied" }),
-        )
-        .await;
+        );
         return Err(error);
     }
     let input = validate_search_request(body, &auth.context, &request_id)?;
@@ -124,14 +128,18 @@ async fn search(
                 RetrievalError::EmptyScope => ("deny", "empty_scope"),
                 _ => ("error", "retrieval_failed"),
             };
-            let _ = audit_qa_query(
-                &state,
-                &auth.context,
+            warn_audit_failure(
+                audit_qa_query(
+                    &state,
+                    &auth.context,
+                    outcome,
+                    &request_id,
+                    merge_audit_reason(audit_metadata, reason),
+                )
+                .await,
                 outcome,
                 &request_id,
-                merge_audit_reason(audit_metadata, reason),
-            )
-            .await;
+            );
             return Err(map_retrieval_error(error, &request_id));
         }
     };
@@ -140,14 +148,18 @@ async fn search(
         "success",
         retrieval_started.elapsed().as_secs_f64(),
     );
-    let _ = audit_qa_query(
-        &state,
-        &auth.context,
+    warn_audit_failure(
+        audit_qa_query(
+            &state,
+            &auth.context,
+            "success",
+            &request_id,
+            audit_metadata,
+        )
+        .await,
         "success",
         &request_id,
-        audit_metadata,
-    )
-    .await;
+    );
 
     Ok(Json(SearchResponse {
         hits: response
@@ -180,6 +192,22 @@ async fn audit_qa_query(
         },
     )
     .await
+}
+
+fn warn_audit_failure(
+    result: Result<(), crate::db::error::DbError>,
+    outcome: &'static str,
+    request_id: &str,
+) {
+    if let Err(error) = result {
+        tracing::warn!(
+            action = "qa.query",
+            outcome = outcome,
+            request_id = %request_id,
+            error_code = error.code(),
+            "audit write failed"
+        );
+    }
 }
 
 fn merge_audit_reason(mut metadata: serde_json::Value, reason: &'static str) -> serde_json::Value {

--- a/crates/server/src/services/audit.rs
+++ b/crates/server/src/services/audit.rs
@@ -1,0 +1,56 @@
+//! Safe append-only audit helpers built on the durable auth/session writer.
+
+use serde_json::Value;
+
+use crate::auth::context::OrgContext;
+use crate::auth::session::{write_audit, AuditEvent};
+use crate::db::error::DbError;
+use crate::db::pool::with_org_txn;
+use crate::telemetry::redacted_json_value;
+
+pub struct SafeAuditEvent {
+    pub action: &'static str,
+    pub resource_type: &'static str,
+    pub resource_id: Option<String>,
+    pub outcome: &'static str,
+    pub request_id: String,
+    pub metadata: Value,
+}
+
+pub async fn record_audit_event(
+    pool: &deadpool_postgres::Pool,
+    ctx: &OrgContext,
+    event: SafeAuditEvent,
+) -> Result<(), DbError> {
+    let txn_ctx = ctx.clone();
+    let event_ctx = ctx.clone();
+    let request_id = event.request_id;
+    let resource_id = event.resource_id.filter(|value| !value.trim().is_empty());
+    let metadata = redacted_json_value(event.metadata);
+    with_org_txn(pool, &txn_ctx, move |txn| {
+        let ctx = event_ctx.clone();
+        let request_id = request_id.clone();
+        let resource_id = resource_id.clone();
+        let metadata = metadata.clone();
+        let action = event.action;
+        let resource_type = event.resource_type;
+        let outcome = event.outcome;
+        Box::pin(async move {
+            write_audit(
+                txn,
+                AuditEvent {
+                    org_id: ctx.org_id(),
+                    actor_user_id: Some(ctx.user_id()),
+                    action,
+                    resource_type,
+                    resource_id: resource_id.as_deref(),
+                    outcome,
+                    request_id: &request_id,
+                    metadata,
+                },
+            )
+            .await
+        })
+    })
+    .await
+}

--- a/crates/server/src/services/download.rs
+++ b/crates/server/src/services/download.rs
@@ -238,31 +238,39 @@ pub async fn redeem_download(
             if let Ok(ctx) =
                 OrgContext::try_new(verified.org_id, verified.user_id, [] as [&str; 0], [])
             {
-                let _ = audit_redeem(
-                    pool,
-                    &ctx,
-                    &verified,
+                warn_audit_failure(
+                    audit_redeem(
+                        pool,
+                        &ctx,
+                        &verified,
+                        "deny",
+                        Some("identity_not_authorized"),
+                        request_id,
+                        None,
+                    )
+                    .await,
                     "deny",
-                    Some("identity_not_authorized"),
                     request_id,
-                    None,
-                )
-                .await;
+                );
             }
             return Err(DownloadError::NotFound);
         }
     };
     if require_permission(&ctx, "qa.query").is_err() {
-        let _ = audit_redeem(
-            pool,
-            &ctx,
-            &verified,
+        warn_audit_failure(
+            audit_redeem(
+                pool,
+                &ctx,
+                &verified,
+                "deny",
+                Some("permission_denied"),
+                request_id,
+                None,
+            )
+            .await,
             "deny",
-            Some("permission_denied"),
             request_id,
-            None,
-        )
-        .await;
+        );
         return Err(DownloadError::NotFound);
     }
     let source = match authorize_original_source(
@@ -275,31 +283,40 @@ pub async fn redeem_download(
     {
         Ok(source) => source,
         Err(error) => {
-            let _ = audit_redeem(
-                pool,
-                &ctx,
-                &verified,
-                download_audit_outcome(&error),
-                Some(download_audit_reason(&error)),
+            let outcome = download_audit_outcome(&error);
+            warn_audit_failure(
+                audit_redeem(
+                    pool,
+                    &ctx,
+                    &verified,
+                    outcome,
+                    Some(download_audit_reason(&error)),
+                    request_id,
+                    None,
+                )
+                .await,
+                outcome,
                 request_id,
-                None,
-            )
-            .await;
+            );
             return Err(error);
         }
     };
     let key = parse_key_for_org(&source.original_object_key, ctx.org_id())?;
     if key.namespace() != ObjectNamespace::Quarantine {
-        let _ = audit_redeem(
-            pool,
-            &ctx,
-            &verified,
+        warn_audit_failure(
+            audit_redeem(
+                pool,
+                &ctx,
+                &verified,
+                "deny",
+                Some("source_not_found"),
+                request_id,
+                None,
+            )
+            .await,
             "deny",
-            Some("source_not_found"),
             request_id,
-            None,
-        )
-        .await;
+        );
         return Err(DownloadError::NotFound);
     }
     let metadata = storage.head_metadata(ctx.org_id(), &key).await?;
@@ -311,29 +328,37 @@ pub async fn redeem_download(
     let bytes = storage.get_object(ctx.org_id(), &key).await?;
     let actual_sha256 = hex::encode(Sha256::digest(&bytes));
     if actual_sha256 != expected_sha256 {
-        let _ = audit_redeem(
-            pool,
-            &ctx,
-            &verified,
+        warn_audit_failure(
+            audit_redeem(
+                pool,
+                &ctx,
+                &verified,
+                "error",
+                Some("integrity_failed"),
+                request_id,
+                None,
+            )
+            .await,
             "error",
-            Some("integrity_failed"),
             request_id,
-            None,
-        )
-        .await;
+        );
         return Err(DownloadError::Integrity);
     }
     let byte_size = bytes.len() as u64;
-    let _ = audit_redeem(
-        pool,
-        &ctx,
-        &verified,
+    warn_audit_failure(
+        audit_redeem(
+            pool,
+            &ctx,
+            &verified,
+            "success",
+            None,
+            request_id,
+            Some(byte_size),
+        )
+        .await,
         "success",
-        None,
         request_id,
-        Some(byte_size),
-    )
-    .await;
+    );
     Ok(DownloadStream {
         byte_size,
         bytes,
@@ -375,6 +400,18 @@ async fn audit_redeem(
         },
     )
     .await
+}
+
+fn warn_audit_failure(result: Result<(), DbError>, outcome: &'static str, request_id: &str) {
+    if let Err(error) = result {
+        tracing::warn!(
+            action = "document.download.redeem",
+            outcome = outcome,
+            request_id = %request_id,
+            error_code = error.code(),
+            "audit write failed"
+        );
+    }
 }
 
 fn download_audit_outcome(error: &DownloadError) -> &'static str {

--- a/crates/server/src/services/download.rs
+++ b/crates/server/src/services/download.rs
@@ -21,6 +21,7 @@ use crate::auth::permissions::{require_permission, resolve_org_context_in_txn};
 use crate::config::SecretString;
 use crate::db::error::DbError;
 use crate::db::pool::with_org_txn_typed;
+use crate::services::audit::{record_audit_event, SafeAuditEvent};
 use crate::storage::keys::parse_key_for_org;
 use crate::storage::minio::MinioClient;
 use crate::storage::{ObjectNamespace, StorageError};
@@ -224,20 +225,81 @@ pub async fn redeem_download(
     capability_key: &CapabilityKey,
     consumed_nonces: &ConsumedDownloadNonces,
     token: &str,
+    request_id: &str,
     now: DateTime<Utc>,
 ) -> Result<DownloadStream, DownloadError> {
     let verified = verify_token(capability_key, token, now)?;
     consumed_nonces
         .consume_once(verified.nonce, verified.expires_at, now)
         .await?;
-    let ctx = resolve_org_context_in_txn(pool, verified.org_id, verified.user_id)
-        .await
-        .map_err(|_| DownloadError::NotFound)?;
-    require_permission(&ctx, "qa.query").map_err(|_| DownloadError::NotFound)?;
-    let source =
-        authorize_original_source(pool, &ctx, verified.document_id, verified.version_id).await?;
+    let ctx = match resolve_org_context_in_txn(pool, verified.org_id, verified.user_id).await {
+        Ok(ctx) => ctx,
+        Err(_) => {
+            if let Ok(ctx) =
+                OrgContext::try_new(verified.org_id, verified.user_id, [] as [&str; 0], [])
+            {
+                let _ = audit_redeem(
+                    pool,
+                    &ctx,
+                    &verified,
+                    "deny",
+                    Some("identity_not_authorized"),
+                    request_id,
+                    None,
+                )
+                .await;
+            }
+            return Err(DownloadError::NotFound);
+        }
+    };
+    if require_permission(&ctx, "qa.query").is_err() {
+        let _ = audit_redeem(
+            pool,
+            &ctx,
+            &verified,
+            "deny",
+            Some("permission_denied"),
+            request_id,
+            None,
+        )
+        .await;
+        return Err(DownloadError::NotFound);
+    }
+    let source = match authorize_original_source(
+        pool,
+        &ctx,
+        verified.document_id,
+        verified.version_id,
+    )
+    .await
+    {
+        Ok(source) => source,
+        Err(error) => {
+            let _ = audit_redeem(
+                pool,
+                &ctx,
+                &verified,
+                download_audit_outcome(&error),
+                Some(download_audit_reason(&error)),
+                request_id,
+                None,
+            )
+            .await;
+            return Err(error);
+        }
+    };
     let key = parse_key_for_org(&source.original_object_key, ctx.org_id())?;
     if key.namespace() != ObjectNamespace::Quarantine {
+        let _ = audit_redeem(
+            pool,
+            &ctx,
+            &verified,
+            "deny",
+            Some("source_not_found"),
+            request_id,
+            None,
+        )
+        .await;
         return Err(DownloadError::NotFound);
     }
     let metadata = storage.head_metadata(ctx.org_id(), &key).await?;
@@ -249,15 +311,96 @@ pub async fn redeem_download(
     let bytes = storage.get_object(ctx.org_id(), &key).await?;
     let actual_sha256 = hex::encode(Sha256::digest(&bytes));
     if actual_sha256 != expected_sha256 {
+        let _ = audit_redeem(
+            pool,
+            &ctx,
+            &verified,
+            "error",
+            Some("integrity_failed"),
+            request_id,
+            None,
+        )
+        .await;
         return Err(DownloadError::Integrity);
     }
+    let byte_size = bytes.len() as u64;
+    let _ = audit_redeem(
+        pool,
+        &ctx,
+        &verified,
+        "success",
+        None,
+        request_id,
+        Some(byte_size),
+    )
+    .await;
     Ok(DownloadStream {
-        byte_size: bytes.len() as u64,
+        byte_size,
         bytes,
         content_type,
         filename,
         content_sha256: actual_sha256,
     })
+}
+
+async fn audit_redeem(
+    pool: &Pool,
+    ctx: &OrgContext,
+    verified: &VerifiedToken,
+    outcome: &'static str,
+    reason: Option<&'static str>,
+    request_id: &str,
+    byte_size: Option<u64>,
+) -> Result<(), DbError> {
+    let mut metadata = serde_json::json!({
+        "documentId": verified.document_id.to_string(),
+        "versionId": verified.version_id.to_string()
+    });
+    if let Some(reason) = reason {
+        metadata["reason"] = serde_json::Value::String(reason.into());
+    }
+    if let Some(byte_size) = byte_size {
+        metadata["byteSize"] = serde_json::Value::Number(byte_size.into());
+    }
+    record_audit_event(
+        pool,
+        ctx,
+        SafeAuditEvent {
+            action: "document.download.redeem",
+            resource_type: "document_version",
+            resource_id: Some(verified.version_id.to_string()),
+            outcome,
+            request_id: request_id.into(),
+            metadata,
+        },
+    )
+    .await
+}
+
+fn download_audit_outcome(error: &DownloadError) -> &'static str {
+    match error {
+        DownloadError::NotFound
+        | DownloadError::InvalidToken
+        | DownloadError::Expired
+        | DownloadError::Replay => "deny",
+        DownloadError::CapabilityUnavailable
+        | DownloadError::Db(_)
+        | DownloadError::Storage(_)
+        | DownloadError::Integrity => "error",
+    }
+}
+
+fn download_audit_reason(error: &DownloadError) -> &'static str {
+    match error {
+        DownloadError::NotFound => "source_not_found",
+        DownloadError::CapabilityUnavailable => "capability_unavailable",
+        DownloadError::InvalidToken => "invalid_token",
+        DownloadError::Expired => "expired",
+        DownloadError::Replay => "replay",
+        DownloadError::Db(_) => "database_error",
+        DownloadError::Storage(_) => "storage_error",
+        DownloadError::Integrity => "integrity_failed",
+    }
 }
 
 async fn authorize_original_source(

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -1,6 +1,7 @@
 //! Application services (use cases over repositories).
 
 pub mod artifacts;
+pub mod audit;
 pub mod chunking;
 pub mod citation;
 pub mod conversion;

--- a/crates/server/src/telemetry.rs
+++ b/crates/server/src/telemetry.rs
@@ -1,10 +1,14 @@
-//! In-memory observability and audit contracts; no exporter or durable storage.
+//! In-memory observability and audit contracts.
 
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-const SENSITIVE_FRAGMENTS: &[&str] = &[
+pub mod http;
+pub mod logging;
+pub mod metrics;
+
+pub const SENSITIVE_FRAGMENTS: &[&str] = &[
     "authorization",
     "cookie",
     "database_url",
@@ -17,7 +21,7 @@ const SENSITIVE_FRAGMENTS: &[&str] = &[
     "token",
 ];
 
-const FORBIDDEN_METRIC_LABELS: &[&str] = &[
+pub const FORBIDDEN_METRIC_LABELS: &[&str] = &[
     "actor_id",
     "document_id",
     "filename",
@@ -64,11 +68,7 @@ pub fn redacted_fields(fields: &BTreeMap<String, String>) -> BTreeMap<String, St
     fields
         .iter()
         .map(|(key, value)| {
-            let normalized = key.to_ascii_lowercase();
-            let value = if SENSITIVE_FRAGMENTS
-                .iter()
-                .any(|fragment| normalized.contains(fragment))
-            {
+            let value = if is_sensitive_field_name(key) {
                 "[REDACTED]".to_string()
             } else {
                 value.clone()
@@ -76,6 +76,54 @@ pub fn redacted_fields(fields: &BTreeMap<String, String>) -> BTreeMap<String, St
             (key.clone(), value)
         })
         .collect()
+}
+
+pub fn redacted_json_value(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(object) => serde_json::Value::Object(
+            object
+                .into_iter()
+                .map(|(key, value)| {
+                    let value = if is_sensitive_field_name(&key) {
+                        serde_json::Value::String("[REDACTED]".into())
+                    } else {
+                        redacted_json_value(value)
+                    };
+                    (key, value)
+                })
+                .collect(),
+        ),
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(redacted_json_value).collect())
+        }
+        other => other,
+    }
+}
+
+pub fn redacted_field_value(key: &str, value: impl Into<String>) -> String {
+    if is_sensitive_field_name(key) {
+        "[REDACTED]".into()
+    } else {
+        value.into()
+    }
+}
+
+fn is_sensitive_field_name(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase();
+    let compact = normalized
+        .bytes()
+        .filter(|byte| byte.is_ascii_alphanumeric())
+        .collect::<Vec<_>>();
+    SENSITIVE_FRAGMENTS.iter().any(|fragment| {
+        let fragment_compact = fragment
+            .bytes()
+            .filter(|byte| byte.is_ascii_alphanumeric())
+            .collect::<Vec<_>>();
+        normalized.contains(fragment)
+            || compact
+                .windows(fragment_compact.len())
+                .any(|window| window == fragment_compact.as_slice())
+    })
 }
 
 pub fn validate_metric(name: &str, labels: &[&str]) -> Result<(), String> {
@@ -98,7 +146,9 @@ pub fn validate_metric(name: &str, labels: &[&str]) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{redacted_fields, validate_metric, AuditEvent, CorrelationContext};
+    use super::{
+        redacted_fields, redacted_json_value, validate_metric, AuditEvent, CorrelationContext,
+    };
     use std::collections::BTreeMap;
 
     #[test]
@@ -142,6 +192,21 @@ mod tests {
         assert!(validate_metric("markhand_job_duration_seconds", &["job_type", "outcome"]).is_ok());
         assert!(validate_metric("markhand_job_total", &["org_id"]).is_err());
         assert!(validate_metric("Bad-Metric", &[]).is_err());
+    }
+
+    #[test]
+    fn redacts_camel_case_sensitive_metadata() {
+        let metadata = serde_json::json!({
+            "documentContent": "never expose this private text",
+            "safeId": "safe",
+            "nested": { "signedUrl": "https://example.test/token" }
+        });
+        let redacted = redacted_json_value(metadata);
+        let rendered = redacted.to_string();
+        assert!(!rendered.contains("private text"));
+        assert!(!rendered.contains("example.test/token"));
+        assert!(rendered.contains("safe"));
+        assert!(rendered.contains("[REDACTED]"));
     }
 
     #[test]

--- a/crates/server/src/telemetry/http.rs
+++ b/crates/server/src/telemetry/http.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::body::Body;
+use axum::extract::{MatchedPath, State};
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use tracing::{info_span, Instrument};
+
+use crate::http::AppState;
+use crate::middleware::request_id::RequestId;
+
+const UNMATCHED_ROUTE: &str = "unmatched";
+
+pub async fn record_http_metrics(
+    State(state): State<Arc<AppState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let method = request.method().as_str().to_string();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|matched| matched.as_str().to_string())
+        .unwrap_or_else(|| UNMATCHED_ROUTE.into());
+    let request_id = request
+        .extensions()
+        .get::<RequestId>()
+        .map(|value| value.0.clone())
+        .unwrap_or_default();
+    let span = info_span!(
+        "http.request",
+        request_id = %request_id,
+        http.method = %method,
+        http.route = %route
+    );
+    async move {
+        let started = Instant::now();
+        let response = next.run(request).await;
+        let status = response.status().as_u16();
+        let elapsed = started.elapsed().as_secs_f64();
+        state
+            .metrics()
+            .record_http_request(&route, &method, status, elapsed);
+        tracing::info!(
+            request_id = %request_id,
+            http.method = %method,
+            http.route = %route,
+            http.status = status,
+            duration_ms = (elapsed * 1000.0).round() as u64,
+            "http request completed"
+        );
+        response
+    }
+    .instrument(span)
+    .await
+}

--- a/crates/server/src/telemetry/logging.rs
+++ b/crates/server/src/telemetry/logging.rs
@@ -1,0 +1,23 @@
+use tracing_subscriber::EnvFilter;
+
+use crate::config::{LogFormat, ServerConfig};
+
+pub fn init_tracing(config: &ServerConfig) {
+    let filter = EnvFilter::try_from_env("RUST_LOG")
+        .or_else(|_| EnvFilter::try_new(config.log_level()))
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let result = match config.log_format() {
+        LogFormat::Json => tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(true)
+            .json()
+            .try_init(),
+        LogFormat::Pretty => tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(true)
+            .pretty()
+            .try_init(),
+    };
+    let _ = result;
+}

--- a/crates/server/src/telemetry/logging.rs
+++ b/crates/server/src/telemetry/logging.rs
@@ -2,10 +2,29 @@ use tracing_subscriber::EnvFilter;
 
 use crate::config::{LogFormat, ServerConfig};
 
+const DEFAULT_DEPENDENCY_LEVEL: &str = "warn";
+const APPLICATION_TARGETS: &[&str] = &["fileconv_server", "fileconv_core", "fileconv_knowledge"];
+const SENSITIVE_DEPENDENCY_TARGETS: &[&str] = &[
+    "tokio_postgres",
+    "postgres",
+    "postgres_protocol",
+    "postgres_types",
+    "deadpool",
+    "deadpool_postgres",
+    "hyper",
+    "hyper_util",
+    "h2",
+    "reqwest",
+    "rustls",
+    "rust_s3",
+    "s3",
+    "tower",
+    "tower_http",
+];
+
 pub fn init_tracing(config: &ServerConfig) {
-    let filter = EnvFilter::try_from_env("RUST_LOG")
-        .or_else(|_| EnvFilter::try_new(config.log_level()))
-        .unwrap_or_else(|_| EnvFilter::new("info"));
+    let rust_log = std::env::var("RUST_LOG").ok();
+    let filter = env_filter(config.log_level(), rust_log.as_deref());
 
     let result = match config.log_format() {
         LogFormat::Json => tracing_subscriber::fmt()
@@ -20,4 +39,165 @@ pub fn init_tracing(config: &ServerConfig) {
             .try_init(),
     };
     let _ = result;
+}
+
+fn env_filter(configured: &str, rust_log: Option<&str>) -> EnvFilter {
+    let directives = filter_directives(configured, rust_log);
+    EnvFilter::try_new(&directives).unwrap_or_else(|_| EnvFilter::new(DEFAULT_DEPENDENCY_LEVEL))
+}
+
+fn filter_directives(configured: &str, rust_log: Option<&str>) -> String {
+    let configured_level = level_directive(configured).unwrap_or("info");
+    let source = rust_log
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(configured);
+    let mut app_level = level_directive(source).unwrap_or(configured_level);
+    let mut directives = vec![DEFAULT_DEPENDENCY_LEVEL.to_string()];
+    let mut app_specific = Vec::new();
+
+    for directive in source
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if let Some(level) = level_directive(directive) {
+            app_level = level;
+            continue;
+        }
+        let Some((target, level)) = directive.rsplit_once('=') else {
+            continue;
+        };
+        let target = target.trim();
+        let Some(level) = normalize_level(level.trim()) else {
+            continue;
+        };
+        if APPLICATION_TARGETS
+            .iter()
+            .any(|app| target == *app || target.starts_with(&format!("{app}::")))
+        {
+            app_specific.push(format!("{target}={level}"));
+        }
+    }
+
+    directives.extend(
+        APPLICATION_TARGETS
+            .iter()
+            .map(|target| format!("{target}={app_level}")),
+    );
+    directives.extend(app_specific);
+    // Keep these caps last: EnvFilter gives equal-specificity directives last-wins
+    // precedence, and earlier env/config dependency directives are ignored anyway.
+    directives.extend(
+        SENSITIVE_DEPENDENCY_TARGETS
+            .iter()
+            .map(|target| format!("{target}=warn")),
+    );
+    directives.join(",")
+}
+
+fn level_directive(value: &str) -> Option<&'static str> {
+    let trimmed = value.trim();
+    if trimmed.contains('=') || trimmed.contains('[') {
+        return None;
+    }
+    normalize_level(trimmed)
+}
+
+fn normalize_level(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "trace" => Some("trace"),
+        "debug" => Some("debug"),
+        "info" => Some("info"),
+        "warn" => Some("warn"),
+        "error" => Some("error"),
+        "off" => Some("off"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    use super::{env_filter, filter_directives};
+
+    #[derive(Clone, Default)]
+    struct Capture {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    struct CaptureWriter {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl<'a> MakeWriter<'a> for Capture {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            CaptureWriter {
+                bytes: self.bytes.clone(),
+            }
+        }
+    }
+
+    impl Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.bytes
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn sensitive_dependencies_are_capped_while_app_targets_follow_filter() {
+        let capture = Capture::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(env_filter(
+                "info",
+                Some("tokio_postgres=debug,reqwest=trace,fileconv_server=debug"),
+            ))
+            .with_writer(capture.clone())
+            .with_ansi(false)
+            .without_time()
+            .finish();
+
+        with_default(subscriber, || {
+            tracing::debug!(target: "tokio_postgres", "postgres debug canary");
+            tracing::trace!(target: "reqwest", "reqwest trace canary");
+            tracing::debug!(target: "fileconv_server", "app debug canary");
+            tracing::warn!(target: "tokio_postgres", "postgres warn canary");
+        });
+
+        let output = String::from_utf8(
+            capture
+                .bytes
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone(),
+        )
+        .expect("utf8 logs");
+        assert!(output.contains("app debug canary"));
+        assert!(output.contains("postgres warn canary"));
+        assert!(!output.contains("postgres debug canary"));
+        assert!(!output.contains("reqwest trace canary"));
+
+        let directives = filter_directives(
+            "info",
+            Some("tokio_postgres=debug,reqwest=trace,fileconv_server=debug"),
+        );
+        assert!(directives.ends_with("tower_http=warn"));
+        assert!(directives.contains("fileconv_server=debug"));
+        assert!(directives.contains("tokio_postgres=warn"));
+        assert!(directives.contains("reqwest=warn"));
+    }
 }

--- a/crates/server/src/telemetry/logging.rs
+++ b/crates/server/src/telemetry/logging.rs
@@ -3,7 +3,12 @@ use tracing_subscriber::EnvFilter;
 use crate::config::{LogFormat, ServerConfig};
 
 const DEFAULT_DEPENDENCY_LEVEL: &str = "warn";
-const APPLICATION_TARGETS: &[&str] = &["fileconv_server", "fileconv_core", "fileconv_knowledge"];
+const APPLICATION_TARGETS: &[&str] = &[
+    "fileconv_server",
+    "fileconv_worker",
+    "fileconv_core",
+    "fileconv_knowledge",
+];
 const SENSITIVE_DEPENDENCY_TARGETS: &[&str] = &[
     "tokio_postgres",
     "postgres",
@@ -167,6 +172,7 @@ mod tests {
                 Some("tokio_postgres=debug,reqwest=trace,fileconv_server=debug"),
             ))
             .with_writer(capture.clone())
+            .with_target(true)
             .with_ansi(false)
             .without_time()
             .finish();
@@ -175,6 +181,7 @@ mod tests {
             tracing::debug!(target: "tokio_postgres", "postgres debug canary");
             tracing::trace!(target: "reqwest", "reqwest trace canary");
             tracing::debug!(target: "fileconv_server", "app debug canary");
+            tracing::info!(target: "fileconv_worker", "worker startup canary");
             tracing::warn!(target: "tokio_postgres", "postgres warn canary");
         });
 
@@ -187,6 +194,8 @@ mod tests {
         )
         .expect("utf8 logs");
         assert!(output.contains("app debug canary"));
+        assert!(output.contains("worker startup canary"));
+        assert!(output.contains("fileconv_worker"));
         assert!(output.contains("postgres warn canary"));
         assert!(!output.contains("postgres debug canary"));
         assert!(!output.contains("reqwest trace canary"));
@@ -197,6 +206,7 @@ mod tests {
         );
         assert!(directives.ends_with("tower_http=warn"));
         assert!(directives.contains("fileconv_server=debug"));
+        assert!(directives.contains("fileconv_worker=info"));
         assert!(directives.contains("tokio_postgres=warn"));
         assert!(directives.contains("reqwest=warn"));
     }

--- a/crates/server/src/telemetry/metrics.rs
+++ b/crates/server/src/telemetry/metrics.rs
@@ -1,0 +1,482 @@
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::telemetry::validate_metric;
+
+const LABEL_SET_CAP: usize = 128;
+const HTTP_DURATION_BUCKETS: &[f64] = &[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0];
+const JOB_DURATION_BUCKETS: &[f64] = &[0.1, 0.5, 1.0, 2.5, 5.0, 15.0, 30.0, 60.0, 300.0];
+const LATENCY_BUCKETS: &[f64] = &[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0];
+
+#[derive(Debug)]
+pub struct MetricsRegistry {
+    http_requests: CounterFamily,
+    http_request_duration: HistogramFamily,
+    jobs_processed: CounterFamily,
+    jobs_duration: HistogramFamily,
+    jobs_in_flight: AtomicI64,
+    jobs_queue_depth: AtomicI64,
+    retrieval_latency: HistogramFamily,
+    embedding_latency: HistogramFamily,
+}
+
+impl Default for MetricsRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MetricsRegistry {
+    pub fn new() -> Self {
+        Self::with_label_set_cap(LABEL_SET_CAP)
+    }
+
+    fn with_label_set_cap(label_set_cap: usize) -> Self {
+        Self {
+            http_requests: CounterFamily::new(
+                "markhand_http_requests_total",
+                "HTTP requests served by the Markhand API.",
+                &["route", "method", "status"],
+                label_set_cap,
+            ),
+            http_request_duration: HistogramFamily::new(
+                "markhand_http_request_duration_seconds",
+                "HTTP request duration in seconds.",
+                &["route", "method", "status"],
+                HTTP_DURATION_BUCKETS,
+                label_set_cap,
+            ),
+            jobs_processed: CounterFamily::new(
+                "markhand_jobs_processed_total",
+                "Background jobs processed by workers.",
+                &["job_type", "outcome"],
+                label_set_cap,
+            ),
+            jobs_duration: HistogramFamily::new(
+                "markhand_job_duration_seconds",
+                "Background job processing duration in seconds.",
+                &["job_type", "outcome"],
+                JOB_DURATION_BUCKETS,
+                label_set_cap,
+            ),
+            jobs_in_flight: AtomicI64::new(0),
+            jobs_queue_depth: AtomicI64::new(0),
+            retrieval_latency: HistogramFamily::new(
+                "markhand_retrieval_latency_seconds",
+                "Retrieval service latency in seconds.",
+                &["stage", "outcome"],
+                LATENCY_BUCKETS,
+                label_set_cap,
+            ),
+            embedding_latency: HistogramFamily::new(
+                "markhand_embedding_latency_seconds",
+                "Embedding computation latency in seconds.",
+                &["stage", "outcome"],
+                LATENCY_BUCKETS,
+                label_set_cap,
+            ),
+        }
+    }
+
+    pub fn record_http_request(
+        &self,
+        route: &str,
+        method: &str,
+        status: u16,
+        duration_seconds: f64,
+    ) {
+        let status = status.to_string();
+        let labels = [
+            ("route", route),
+            ("method", method),
+            ("status", status.as_str()),
+        ];
+        let _ = self.http_requests.increment(&labels);
+        let _ = self
+            .http_request_duration
+            .observe(&labels, duration_seconds);
+    }
+
+    pub fn record_job_processed(&self, job_type: &str, outcome: &str, duration_seconds: f64) {
+        let labels = [("job_type", job_type), ("outcome", outcome)];
+        let _ = self.jobs_processed.increment(&labels);
+        let _ = self.jobs_duration.observe(&labels, duration_seconds);
+    }
+
+    pub fn increment_jobs_in_flight(&self) {
+        self.jobs_in_flight.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn decrement_jobs_in_flight(&self) {
+        self.jobs_in_flight.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    pub fn set_jobs_queue_depth(&self, value: i64) {
+        self.jobs_queue_depth.store(value.max(0), Ordering::Relaxed);
+    }
+
+    pub fn observe_retrieval_latency(&self, stage: &str, outcome: &str, duration_seconds: f64) {
+        let labels = [("stage", stage), ("outcome", outcome)];
+        let _ = self.retrieval_latency.observe(&labels, duration_seconds);
+    }
+
+    pub fn observe_embedding_latency(&self, stage: &str, outcome: &str, duration_seconds: f64) {
+        let labels = [("stage", stage), ("outcome", outcome)];
+        let _ = self.embedding_latency.observe(&labels, duration_seconds);
+    }
+
+    pub fn render_prometheus(&self) -> String {
+        let mut output = String::new();
+        self.http_requests.render(&mut output);
+        self.http_request_duration.render(&mut output);
+        self.jobs_processed.render(&mut output);
+        self.jobs_duration.render(&mut output);
+        render_gauge(
+            &mut output,
+            "markhand_jobs_in_flight",
+            "Background jobs currently being processed.",
+            self.jobs_in_flight.load(Ordering::Relaxed),
+        );
+        render_gauge(
+            &mut output,
+            "markhand_jobs_queue_depth",
+            "Background jobs waiting to be processed.",
+            self.jobs_queue_depth.load(Ordering::Relaxed),
+        );
+        self.retrieval_latency.render(&mut output);
+        self.embedding_latency.render(&mut output);
+        output
+    }
+}
+
+#[derive(Debug)]
+struct CounterFamily {
+    name: &'static str,
+    help: &'static str,
+    label_names: &'static [&'static str],
+    label_set_cap: usize,
+    entries: Mutex<BTreeMap<LabelSet, Arc<CounterEntry>>>,
+}
+
+impl CounterFamily {
+    fn new(
+        name: &'static str,
+        help: &'static str,
+        label_names: &'static [&'static str],
+        label_set_cap: usize,
+    ) -> Self {
+        validate_metric(name, label_names).expect("static metric definition is valid");
+        Self {
+            name,
+            help,
+            label_names,
+            label_set_cap,
+            entries: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    fn increment(&self, labels: &[(&str, &str)]) -> Result<(), String> {
+        let entry = self.entry(labels)?;
+        entry.value.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn entry(&self, labels: &[(&str, &str)]) -> Result<Arc<CounterEntry>, String> {
+        let labels = self.label_set(labels)?;
+        let mut entries = self.lock_entries();
+        let key = bounded_key(&mut entries, labels, self.label_set_cap);
+        Ok(entries
+            .entry(key)
+            .or_insert_with(|| Arc::new(CounterEntry::default()))
+            .clone())
+    }
+
+    fn label_set(&self, labels: &[(&str, &str)]) -> Result<LabelSet, String> {
+        label_set(self.name, self.label_names, labels)
+    }
+
+    fn lock_entries(&self) -> std::sync::MutexGuard<'_, BTreeMap<LabelSet, Arc<CounterEntry>>> {
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn render(&self, output: &mut String) {
+        render_header(output, self.name, self.help, "counter");
+        for (labels, entry) in self.lock_entries().iter() {
+            let _ = writeln!(
+                output,
+                "{}{} {}",
+                self.name,
+                render_labels(labels),
+                entry.value.load(Ordering::Relaxed)
+            );
+        }
+    }
+}
+
+#[derive(Debug)]
+struct HistogramFamily {
+    name: &'static str,
+    help: &'static str,
+    label_names: &'static [&'static str],
+    buckets: &'static [f64],
+    label_set_cap: usize,
+    entries: Mutex<BTreeMap<LabelSet, Arc<HistogramEntry>>>,
+}
+
+impl HistogramFamily {
+    fn new(
+        name: &'static str,
+        help: &'static str,
+        label_names: &'static [&'static str],
+        buckets: &'static [f64],
+        label_set_cap: usize,
+    ) -> Self {
+        validate_metric(name, label_names).expect("static metric definition is valid");
+        Self {
+            name,
+            help,
+            label_names,
+            buckets,
+            label_set_cap,
+            entries: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    fn observe(&self, labels: &[(&str, &str)], value: f64) -> Result<(), String> {
+        if !value.is_finite() || value < 0.0 {
+            return Ok(());
+        }
+        let entry = self.entry(labels)?;
+        if let Some(index) = self.buckets.iter().position(|bucket| value <= *bucket) {
+            entry.buckets[index].fetch_add(1, Ordering::Relaxed);
+        }
+        entry.count.fetch_add(1, Ordering::Relaxed);
+        entry
+            .sum_micros
+            .fetch_add((value * 1_000_000.0).round() as u64, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn entry(&self, labels: &[(&str, &str)]) -> Result<Arc<HistogramEntry>, String> {
+        let labels = label_set(self.name, self.label_names, labels)?;
+        let mut entries = self.lock_entries();
+        let key = bounded_key(&mut entries, labels, self.label_set_cap);
+        Ok(entries
+            .entry(key)
+            .or_insert_with(|| Arc::new(HistogramEntry::new(self.buckets.len())))
+            .clone())
+    }
+
+    fn lock_entries(&self) -> std::sync::MutexGuard<'_, BTreeMap<LabelSet, Arc<HistogramEntry>>> {
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn render(&self, output: &mut String) {
+        render_header(output, self.name, self.help, "histogram");
+        for (labels, entry) in self.lock_entries().iter() {
+            let mut cumulative = 0;
+            for (index, bucket) in self.buckets.iter().enumerate() {
+                cumulative += entry.buckets[index].load(Ordering::Relaxed);
+                let mut bucket_labels = labels.clone();
+                bucket_labels.push(("le".into(), format_float(*bucket)));
+                let _ = writeln!(
+                    output,
+                    "{}_bucket{} {}",
+                    self.name,
+                    render_labels(&bucket_labels),
+                    cumulative
+                );
+            }
+            let count = entry.count.load(Ordering::Relaxed);
+            let mut infinity_labels = labels.clone();
+            infinity_labels.push(("le".into(), "+Inf".into()));
+            let _ = writeln!(
+                output,
+                "{}_bucket{} {}",
+                self.name,
+                render_labels(&infinity_labels),
+                count
+            );
+            let _ = writeln!(
+                output,
+                "{}_sum{} {:.6}",
+                self.name,
+                render_labels(labels),
+                entry.sum_micros.load(Ordering::Relaxed) as f64 / 1_000_000.0
+            );
+            let _ = writeln!(
+                output,
+                "{}_count{} {}",
+                self.name,
+                render_labels(labels),
+                count
+            );
+        }
+    }
+}
+
+type LabelSet = Vec<(String, String)>;
+
+#[derive(Debug, Default)]
+struct CounterEntry {
+    value: AtomicU64,
+}
+
+#[derive(Debug)]
+struct HistogramEntry {
+    buckets: Vec<AtomicU64>,
+    count: AtomicU64,
+    sum_micros: AtomicU64,
+}
+
+impl HistogramEntry {
+    fn new(bucket_count: usize) -> Self {
+        Self {
+            buckets: (0..bucket_count).map(|_| AtomicU64::new(0)).collect(),
+            count: AtomicU64::new(0),
+            sum_micros: AtomicU64::new(0),
+        }
+    }
+}
+
+fn label_set(
+    metric_name: &str,
+    expected_names: &[&str],
+    labels: &[(&str, &str)],
+) -> Result<LabelSet, String> {
+    let names = labels.iter().map(|(name, _)| *name).collect::<Vec<_>>();
+    validate_metric(metric_name, &names)?;
+    if names != expected_names {
+        return Err(format!(
+            "metric labels for {metric_name} do not match allowlist"
+        ));
+    }
+    Ok(labels
+        .iter()
+        .map(|(name, value)| ((*name).to_string(), bounded_label_value(value)))
+        .collect())
+}
+
+fn bounded_label_value(value: &str) -> String {
+    if value.is_empty()
+        || value.len() > 128
+        || value
+            .bytes()
+            .any(|byte| byte.is_ascii_control() || byte == b'"' || byte == b'\\')
+    {
+        "other".into()
+    } else {
+        value.into()
+    }
+}
+
+fn bounded_key<T>(
+    entries: &mut BTreeMap<LabelSet, Arc<T>>,
+    labels: LabelSet,
+    label_set_cap: usize,
+) -> LabelSet {
+    if entries.contains_key(&labels) || entries.len() < label_set_cap.saturating_sub(1) {
+        return labels;
+    }
+    labels
+        .into_iter()
+        .map(|(name, _)| (name, "other".into()))
+        .collect()
+}
+
+fn render_header(output: &mut String, name: &str, help: &str, metric_type: &str) {
+    let _ = writeln!(output, "# HELP {name} {help}");
+    let _ = writeln!(output, "# TYPE {name} {metric_type}");
+}
+
+fn render_gauge(output: &mut String, name: &str, help: &str, value: i64) {
+    validate_metric(name, &[]).expect("static metric definition is valid");
+    render_header(output, name, help, "gauge");
+    let _ = writeln!(output, "{name} {value}");
+}
+
+fn render_labels(labels: &LabelSet) -> String {
+    if labels.is_empty() {
+        return String::new();
+    }
+    let pairs = labels
+        .iter()
+        .map(|(name, value)| format!(r#"{name}="{}""#, escape_label_value(value)))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{{{pairs}}}")
+}
+
+fn escape_label_value(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|character| match character {
+            '\\' => "\\\\".chars().collect::<Vec<_>>(),
+            '"' => "\\\"".chars().collect(),
+            '\n' => "\\n".chars().collect(),
+            other => vec![other],
+        })
+        .collect()
+}
+
+fn format_float(value: f64) -> String {
+    let rendered = format!("{value:.3}");
+    rendered.trim_end_matches('0').trim_end_matches('.').into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MetricsRegistry;
+
+    #[test]
+    fn prometheus_output_uses_expected_text_format() {
+        let registry = MetricsRegistry::new();
+        registry.record_http_request("/api/v1/health/live", "GET", 200, 0.012);
+        let output = registry.render_prometheus();
+        assert!(output.contains("# HELP markhand_http_requests_total"));
+        assert!(output.contains(
+            r#"markhand_http_requests_total{route="/api/v1/health/live",method="GET",status="200"} 1"#
+        ));
+        assert!(output.contains("markhand_http_request_duration_seconds_bucket"));
+        assert!(output.contains("markhand_jobs_in_flight 0"));
+    }
+
+    #[test]
+    fn label_cardinality_is_capped_with_other_bucket() {
+        let registry = MetricsRegistry::with_label_set_cap(3);
+        for index in 0..10 {
+            registry.record_http_request(&format!("/route/{index}"), "GET", 200, 0.001);
+        }
+        let output = registry.render_prometheus();
+        assert!(output.contains(r#"route="other",method="other",status="other""#));
+        assert!(output.matches("markhand_http_requests_total{").count() <= 3);
+    }
+
+    #[test]
+    fn forbidden_metric_labels_are_rejected_and_not_rendered() {
+        let registry = MetricsRegistry::new();
+        assert!(registry
+            .http_requests
+            .increment(&[("route", "/safe"), ("method", "GET"), ("org_id", "tenant")])
+            .is_err());
+        let output = registry.render_prometheus();
+        assert!(!output.contains("tenant"));
+        assert!(!output.contains("org_id"));
+    }
+
+    #[test]
+    fn metric_names_keep_markhand_prefix_contract() {
+        assert!(crate::telemetry::validate_metric(
+            "markhand_http_requests_total",
+            &["route", "method", "status"]
+        )
+        .is_ok());
+        assert!(crate::telemetry::validate_metric("http_requests_total", &[]).is_err());
+    }
+}

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -1127,7 +1127,7 @@ impl ConvertWorkerError {
         )
     }
 
-    fn safe_job_error(&self) -> &'static str {
+    pub fn safe_job_error(&self) -> &'static str {
         match self {
             Self::Db(_) => "convert database error",
             Self::Storage(_) => "convert storage error",

--- a/crates/server/tests/citation_preview_download.rs
+++ b/crates/server/tests/citation_preview_download.rs
@@ -512,6 +512,7 @@ async fn live_citation_preview_download_authorization() {
         &env.capability_key,
         &consumed,
         &capability.token,
+        "req-download-live-1",
         Utc::now(),
     )
     .await
@@ -525,6 +526,7 @@ async fn live_citation_preview_download_authorization() {
             &env.capability_key,
             &consumed,
             &capability.token,
+            "req-download-live-2",
             Utc::now(),
         )
         .await,
@@ -549,6 +551,7 @@ async fn live_citation_preview_download_authorization() {
             &env.capability_key,
             &ConsumedDownloadNonces::new(),
             &expired.token,
+            "req-download-live-3",
             Utc::now(),
         )
         .await,
@@ -568,6 +571,7 @@ async fn live_citation_preview_download_authorization() {
             &env.capability_key,
             &ConsumedDownloadNonces::new(),
             &tampered,
+            "req-download-live-4",
             Utc::now(),
         )
         .await,

--- a/crates/server/tests/telemetry.rs
+++ b/crates/server/tests/telemetry.rs
@@ -1,0 +1,267 @@
+//! Live telemetry/audit tests. They self-skip unless `MARKHAND_TEST_DATABASE_URL` is set.
+
+use axum::body::Body;
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::config::{RuntimeEndpoints, SecretString, ServerConfig};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::orgs;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::http::{router, AppState};
+use fileconv_server::services::audit::{record_audit_event, SafeAuditEvent};
+use fileconv_server::state::RuntimeState;
+use http_body_util::BodyExt;
+use serde_json::json;
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_telemetry_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+struct LiveEnv {
+    db: EphemeralDb,
+    pool: Pool,
+    app: axum::Router,
+}
+
+impl LiveEnv {
+    async fn boot() -> Option<Self> {
+        let base_url = test_database_url()?;
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("apply migrations");
+        let pool = create_pool(&db.url).expect("pool");
+        let runtime =
+            RuntimeState::from_config(ServerConfig::test_with_endpoints(RuntimeEndpoints {
+                database_url: SecretString::new(&db.url),
+                qdrant_url: "http://127.0.0.1:1".into(),
+                minio_url: "http://127.0.0.1:1".into(),
+            }))
+            .expect("runtime");
+        let app = router(AppState::from_parts(runtime, pool.clone(), None).expect("app state"));
+        Some(Self { db, pool, app })
+    }
+
+    async fn shutdown(self) {
+        self.db.drop().await;
+    }
+}
+
+async fn seed_context(pool: &Pool, permission: bool) -> OrgContext {
+    let org_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let collection_id = Uuid::new_v4();
+    let permissions = if permission {
+        vec!["qa.query"]
+    } else {
+        Vec::new()
+    };
+    let ctx = OrgContext::try_new(org_id, user_id, permissions, [collection_id]).unwrap();
+    with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(
+                    txn,
+                    &ctx,
+                    &format!("telemetry-{}", org_id.simple()),
+                    "Telemetry",
+                )
+                .await?;
+                orgs::ensure_user(
+                    txn,
+                    &ctx,
+                    user_id,
+                    &format!("telemetry-{}@example.test", user_id.simple()),
+                    "Telemetry",
+                )
+                .await?;
+                orgs::ensure_membership(txn, &ctx).await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed context");
+    ctx
+}
+
+async fn audit_rows(pool: &Pool, ctx: &OrgContext) -> Vec<(String, String, serde_json::Value)> {
+    let org_id = ctx.org_id();
+    with_org_txn(pool, ctx, move |txn| {
+        Box::pin(async move {
+            let rows = txn
+                .query(
+                    "SELECT action, outcome, metadata FROM audit_log WHERE org_id = $1 ORDER BY seq",
+                    &[&org_id],
+                )
+                .await?;
+            Ok(rows
+                .into_iter()
+                .map(|row| (row.get(0), row.get(1), row.get(2)))
+                .collect())
+        })
+    })
+    .await
+    .expect("audit rows")
+}
+
+#[tokio::test]
+async fn live_audit_redacts_metadata_and_metrics_reflect_requests() {
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+
+    let allowed = seed_context(&env.pool, true).await;
+    record_audit_event(
+        &env.pool,
+        &allowed,
+        SafeAuditEvent {
+            action: "qa.query",
+            resource_type: "qa",
+            resource_id: None,
+            outcome: "success",
+            request_id: "req-live-telemetry-1".into(),
+            metadata: json!({
+                "endpoint": "search",
+                "documentContent": "CANARY_DOCUMENT_CONTENT",
+                "token": "CANARY_TOKEN"
+            }),
+        },
+    )
+    .await
+    .expect("allowed audit");
+
+    let denied = seed_context(&env.pool, false).await;
+    record_audit_event(
+        &env.pool,
+        &denied,
+        SafeAuditEvent {
+            action: "qa.query",
+            resource_type: "qa",
+            resource_id: None,
+            outcome: "deny",
+            request_id: "req-live-telemetry-2".into(),
+            metadata: json!({ "reason": "permission_denied" }),
+        },
+    )
+    .await
+    .expect("deny audit");
+
+    let response = env
+        .app
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/v1/health/live")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let metrics = env
+        .app
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/api/v1/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let metrics = String::from_utf8(metrics.to_vec()).unwrap();
+    assert!(metrics.contains("markhand_http_requests_total"));
+    assert!(metrics.contains(r#"route="/api/v1/health/live""#));
+    assert!(!metrics.contains(allowed.org_id().to_string().as_str()));
+    assert!(!metrics.contains("CANARY_TOKEN"));
+
+    let rows = audit_rows(&env.pool, &allowed).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "qa.query");
+    assert_eq!(rows[0].1, "success");
+    let rendered = rows[0].2.to_string();
+    assert!(!rendered.contains("CANARY_DOCUMENT_CONTENT"));
+    assert!(!rendered.contains("CANARY_TOKEN"));
+    assert!(rendered.contains("[REDACTED]"));
+
+    let rows = audit_rows(&env.pool, &denied).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1, "deny");
+    assert_eq!(rows[0].2["reason"], "permission_denied");
+
+    env.shutdown().await;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-O01 — End-to-end telemetry & safe audit

Structured tracing/logging, a bounded Prometheus metrics registry + `/metrics`, HTTP/worker instrumentation, and safe append-only audit coverage — honoring the F-11 `telemetry` contract. Stacks on R01–R06. Closes #97. **No R01–R06 route semantics changed.**

### Observability
- **Logging**: `tracing` + `tracing-subscriber` (MIT) JSON/pretty subscriber with a **hardened `EnvFilter`** — only application targets (`fileconv_*`) are honored from `RUST_LOG`/config, and data/secret-carrying dependencies (`tokio_postgres`, `deadpool`, `hyper`, `h2`, `reqwest`, `rustls`, `tower`…) are force-capped at `warn`, so **no env value can enable SQL-bind-parameter logging** (email PII / chunk content). Correlation fields (request/job/doc ids) on spans; hot-path `println!`→`tracing` in `main.rs` + worker (worker events emit under `fileconv_worker`).
- **Metrics** (`telemetry/` hand-rolled, bounded): `markhand_http_requests_total{route,method,status}` + duration histogram, `markhand_jobs_processed_total{job_type,outcome}` + duration + in-flight/queue gauges, retrieval/embedding latency histograms. Enforces the `markhand_` prefix + `FORBIDDEN_METRIC_LABELS` allowlist (no tenant/user/doc/request ids), uses **route patterns not raw paths**, and caps label-sets/family (128 → `other`) so cardinality/memory is bounded.
- **`GET /api/v1/metrics`**: Prometheus `text/plain; version=0.0.4`, aggregate-only, config-gated (`MARKHAND_METRICS_ENABLED`, default on → 404 when off), rate-limit-exempt (exact path); documented prod network-restriction.

### Safe audit
- Reuses the append-only `audit_log` writer (org/actor from authenticated `OrgContext`, forced RLS). Added coverage for `qa.query` (search/ask/ask-stream success/deny/error) and download mint/redeem. Metadata is **redacted** — never query/question text, document content, tokens, filenames, or signed URLs. Audit-write failures emit a redacted `tracing::warn` and remain **non-fatal** (never flip a security decision).

### Config
`MARKHAND_LOG_FORMAT` (json default), `MARKHAND_LOG_LEVEL`/`RUST_LOG`, `MARKHAND_METRICS_ENABLED`, optional `MARKHAND_OTLP_ENDPOINT` (validation-only stub, no export). Conservative defaults; existing config tests intact.

### Tests / gates
- Unit: metric name/label validation, forbidden-label drop, cardinality cap, Prometheus format, route-pattern labels, `/metrics` enabled/disabled/rate-limit-exempt, **redaction canary**, **log-filter suppression** (`tokio_postgres=debug`/`reqwest=trace` stay capped while app debug emits), worker-target emission.
- Live self-skipping `tests/telemetry.rs`: audited success/deny rows with redacted metadata + `/metrics` counter reflects a served request.
- `make check-boundaries`, `cargo fmt`, `clippy -D warnings`, **129 lib tests**, `cargo metadata --locked`, dependency-policy — green. Live regression (auth/rest_api/sse_api/citation/deletion/telemetry) passes under the new middleware.

### Security review
`gpt-5.6-sol-high`, 2 rounds → **PASS**. Round 1 caught 2 HIGH (env log filter could enable `tokio_postgres` param logging → PII/content; worker logged raw `MARKHAND_WORKER_ID`/unvalidated kind) — both fixed and re-verified.

### Deferred (non-blocking, tracked)
Live OTLP exporter wiring (collector exists in dev compose; export is a later concern); broader audit coverage (validation/replay/storage errors); metric label APIs are stringly-typed but hard-cap-bounded. Formal G0-SLO numeric evidence needs load/DR infra (O05).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

