### PR TITLE
feat(server): P1B-O04 vertical-slice/security e2e release suite (+ fixes a real convert bug)

### DIFF
--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -1240,6 +1240,13 @@ mod tests {
         ));
 
         metadata.insert("version-id".into(), source_version_id.to_string());
+        metadata.insert("document-id".into(), Uuid::new_v4().to_string());
+        assert!(matches!(
+            ConvertWorker::verify_quarantine_metadata(&source, &metadata),
+            Err(ConvertWorkerError::InvalidQuarantineMetadata)
+        ));
+
+        metadata.insert("document-id".into(), document_id.to_string());
         metadata.insert("content-sha256".into(), "b".repeat(64));
         assert!(matches!(
             ConvertWorker::verify_quarantine_metadata(&source, &metadata),

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -481,7 +481,7 @@ impl ConvertWorker {
                 self.storage.head_metadata(ctx.org_id(), &quarantine_key),
             )
             .await?;
-        self.verify_quarantine_metadata(&source, &metadata)?;
+        Self::verify_quarantine_metadata(&source, &metadata)?;
         let format = metadata
             .get("canonical-format")
             .or_else(|| metadata.get("x-amz-meta-canonical-format"))
@@ -567,7 +567,6 @@ impl ConvertWorker {
     }
 
     fn verify_quarantine_metadata(
-        &self,
         source: &ConversionSourceVersion,
         metadata: &HashMap<String, String>,
     ) -> Result<(), ConvertWorkerError> {
@@ -580,13 +579,23 @@ impl ConvertWorker {
         {
             return Err(ConvertWorkerError::InvalidQuarantineMetadata);
         }
-        let version_id = source.source_version_id.to_string();
-        if metadata.get("version-id").map(String::as_str) != Some(version_id.as_str()) {
-            return Err(ConvertWorkerError::InvalidQuarantineMetadata);
+        // I01 uploads quarantine objects before a document/version exists, so real
+        // upload metadata legitimately has no document-id/version-id. If an older
+        // seeded or future bound object carries those ids, they remain authoritative
+        // and must match. Isolation/integrity still comes from the org-scoped key,
+        // quarantine namespace, accepted disposition, and content SHA recorded on
+        // the source version.
+        if let Some(version_id) = metadata.get("version-id") {
+            let source_version_id = source.source_version_id.to_string();
+            if version_id.as_str() != source_version_id.as_str() {
+                return Err(ConvertWorkerError::InvalidQuarantineMetadata);
+            }
         }
-        let document_id = source.document_id.to_string();
-        if metadata.get("document-id").map(String::as_str) != Some(document_id.as_str()) {
-            return Err(ConvertWorkerError::InvalidQuarantineMetadata);
+        if let Some(document_id) = metadata.get("document-id") {
+            let source_document_id = source.document_id.to_string();
+            if document_id.as_str() != source_document_id.as_str() {
+                return Err(ConvertWorkerError::InvalidQuarantineMetadata);
+            }
         }
         Ok(())
     }
@@ -1196,5 +1205,45 @@ mod tests {
         assert_eq!(canonical_extension("../../etc/passwd"), None);
         assert_eq!(canonical_extension("txt"), Some("txt"));
         assert_eq!(canonical_extension("mp3"), None);
+    }
+
+    #[test]
+    fn quarantine_metadata_allows_absent_ids_but_rejects_mismatch_and_wrong_sha() {
+        let document_id = Uuid::new_v4();
+        let source_version_id = Uuid::new_v4();
+        let content_sha256 = "a".repeat(64);
+        let source = ConversionSourceVersion {
+            document_id,
+            source_version_id,
+            original_object_key: "quarantine/test/object".into(),
+            content_sha256: content_sha256.clone(),
+            source_filename: None,
+            source_content_type: Some("text/plain".into()),
+            byte_size: Some(12),
+        };
+        let mut metadata = HashMap::from([
+            ("disposition".to_string(), "accepted".to_string()),
+            ("content-sha256".to_string(), content_sha256),
+            ("canonical-format".to_string(), "txt".to_string()),
+        ]);
+
+        assert!(ConvertWorker::verify_quarantine_metadata(&source, &metadata).is_ok());
+
+        metadata.insert("document-id".into(), document_id.to_string());
+        metadata.insert("version-id".into(), source_version_id.to_string());
+        assert!(ConvertWorker::verify_quarantine_metadata(&source, &metadata).is_ok());
+
+        metadata.insert("version-id".into(), Uuid::new_v4().to_string());
+        assert!(matches!(
+            ConvertWorker::verify_quarantine_metadata(&source, &metadata),
+            Err(ConvertWorkerError::InvalidQuarantineMetadata)
+        ));
+
+        metadata.insert("version-id".into(), source_version_id.to_string());
+        metadata.insert("content-sha256".into(), "b".repeat(64));
+        assert!(matches!(
+            ConvertWorker::verify_quarantine_metadata(&source, &metadata),
+            Err(ConvertWorkerError::InvalidQuarantineMetadata)
+        ));
     }
 }

--- a/crates/server/tests/e2e/README.md
+++ b/crates/server/tests/e2e/README.md
@@ -1,0 +1,21 @@
+# P1B-O04 vertical-slice/security e2e suite
+
+Target: `e2e_suite` (`crates/server/tests/e2e_suite.rs`).
+
+Live run:
+
+```bash
+cargo build -p fileconv
+set -a; source /tmp/live-test.env; set +a
+CC=gcc CXX=g++ cargo test -p fileconv-server --test e2e_suite -- --test-threads=1 --nocapture
+```
+
+Scenarios:
+
+- `live_full_vertical_slice_multi_format`: upload txt/csv/html/markdown fixtures, create documents, run real convert and index workers, then verify search, ask, preview, download, and citation resolution.
+- `live_authorization_e2e_unauthorized_gets_no_text`: no-ACL, no-`qa.query`, and cross-tenant users cannot obtain indexed text through search/ask/citation/preview/download/document/job routes.
+- `live_lifecycle_delete_purge_and_revocation`: delete tombstones and purge through workers; search/ask/preview/citation no longer expose text; ACL revocation is honored on the next request.
+- `live_adversarial_malicious_input_rejected_or_contained`: malformed multipart, spoofed content, cross-tenant object keys, traversal keys, and citation pin mismatches fail closed without partial ingest or content leak.
+- `live_fault_injection_worker_kill_retry_consistency`: a convert worker loses its lease after staging, a second worker completes, and indexing finishes with one consistent chunk/vector set.
+
+The target self-skips without PostgreSQL, MinIO, Qdrant, sandbox support, or a built `fileconv` binary. The simple-format vertical slice is expected to pass in the live test environment after `cargo build -p fileconv`.

--- a/crates/server/tests/e2e/harness.rs
+++ b/crates/server/tests/e2e/harness.rs
@@ -7,7 +7,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use bytes::Bytes;
 use deadpool_postgres::Pool;
-use fileconv_knowledge::embedding::LOCAL_VECTOR_DIMENSIONS;
+use fileconv_knowledge::embedding::{local_vector, LOCAL_VECTOR_DIMENSIONS};
 use fileconv_server::auth::context::OrgContext;
 use fileconv_server::auth::jwt::JwtKeys;
 use fileconv_server::auth::provider::{AuthProvider, AuthRequestMeta, PasswordAuthProvider};
@@ -1130,13 +1130,12 @@ pub async fn qdrant_points_for_doc(
         .len()
 }
 
-pub async fn assert_chunk_point_identity(
+pub async fn chunk_identities_for_doc(
     env: &LiveEnv,
     ctx: &OrgContext,
-    collection_id: Uuid,
     document_id: Uuid,
-) {
-    let chunk_identities: Vec<String> = with_org_txn(&env.pool, ctx, {
+) -> Vec<String> {
+    with_org_txn(&env.pool, ctx, {
         let ctx = ctx.clone();
         move |txn| {
             Box::pin(async move {
@@ -1154,7 +1153,91 @@ pub async fn assert_chunk_point_identity(
         }
     })
     .await
-    .expect("chunk identities");
+    .expect("chunk identities")
+}
+
+pub struct DirectQdrantDoc<'a> {
+    pub ctx: &'a OrgContext,
+    pub collection_id: Uuid,
+    pub doc: &'a IngestedDoc,
+}
+
+pub async fn assert_direct_qdrant_tenant_filter(
+    env: &LiveEnv,
+    org_a: DirectQdrantDoc<'_>,
+    org_b: DirectQdrantDoc<'_>,
+    shared_query: &str,
+) {
+    let query_vector = local_vector(shared_query);
+    let org_a_signature = active_signature(env, org_a.ctx, org_a.collection_id).await;
+    let org_a_collection = collection_name_for_digest(&org_a_signature).expect("collection name");
+    let org_a_hits = env
+        .qdrant
+        .search(
+            &org_a_collection,
+            &VectorScope::new(org_a.ctx.org_id(), [org_a.collection_id]),
+            query_vector.values(),
+            100,
+        )
+        .await
+        .expect("direct qdrant org-a search");
+    assert!(
+        org_a_hits.iter().any(|hit| {
+            hit.payload.org_id == org_a.ctx.org_id()
+                && hit.payload.collection_id == org_a.collection_id
+                && hit.payload.document_id == org_a.doc.document_id
+        }),
+        "direct Qdrant org-A control search did not return indexed org-A content"
+    );
+
+    let org_b_signature = active_signature(env, org_b.ctx, org_b.collection_id).await;
+    let org_b_collection = collection_name_for_digest(&org_b_signature).expect("collection name");
+    let org_b_hits = env
+        .qdrant
+        .search(
+            &org_b_collection,
+            &VectorScope::new(org_b.ctx.org_id(), [org_b.collection_id]),
+            query_vector.values(),
+            100,
+        )
+        .await
+        .expect("direct qdrant org-b search");
+    assert!(
+        org_b_hits.iter().any(|hit| {
+            hit.payload.org_id == org_b.ctx.org_id()
+                && hit.payload.collection_id == org_b.collection_id
+                && hit.payload.document_id == org_b.doc.document_id
+        }),
+        "direct Qdrant org-B search did not return indexed org-B control content"
+    );
+    assert!(
+        org_b_hits.iter().all(|hit| {
+            hit.payload.org_id != org_a.ctx.org_id()
+                && hit.payload.collection_id != org_a.collection_id
+                && hit.payload.document_id != org_a.doc.document_id
+        }),
+        "direct Qdrant org-B search leaked org-A payloads"
+    );
+
+    let org_a_chunks = chunk_identities_for_doc(env, org_a.ctx, org_a.doc.document_id).await;
+    assert!(!org_a_chunks.is_empty(), "org-A control doc has no chunks");
+    for chunk_identity in org_a_chunks {
+        assert!(
+            org_b_hits
+                .iter()
+                .all(|hit| hit.payload.chunk_id != chunk_identity),
+            "direct Qdrant org-B search leaked org-A chunk identity {chunk_identity}"
+        );
+    }
+}
+
+pub async fn assert_chunk_point_identity(
+    env: &LiveEnv,
+    ctx: &OrgContext,
+    collection_id: Uuid,
+    document_id: Uuid,
+) {
+    let chunk_identities = chunk_identities_for_doc(env, ctx, document_id).await;
     assert!(
         !chunk_identities.is_empty(),
         "document must have at least one PG chunk"

--- a/crates/server/tests/e2e/harness.rs
+++ b/crates/server/tests/e2e/harness.rs
@@ -1189,6 +1189,23 @@ pub async fn assert_direct_qdrant_tenant_filter(
         }),
         "direct Qdrant org-A control search did not return indexed org-A content"
     );
+    let org_a_chunks = chunk_identities_for_doc(env, org_a.ctx, org_a.doc.document_id).await;
+    assert!(!org_a_chunks.is_empty(), "org-A control doc has no chunks");
+
+    let org_filter_only_hits = env
+        .qdrant
+        .search(
+            &org_a_collection,
+            &VectorScope::new(org_b.ctx.org_id(), [org_a.collection_id]),
+            query_vector.values(),
+            100,
+        )
+        .await
+        .expect("direct qdrant org-filter-only search");
+    assert!(
+        org_filter_only_hits.is_empty(),
+        "direct Qdrant org-B/org-A-collection search returned points"
+    );
 
     let org_b_signature = active_signature(env, org_b.ctx, org_b.collection_id).await;
     let org_b_collection = collection_name_for_digest(&org_b_signature).expect("collection name");
@@ -1219,13 +1236,11 @@ pub async fn assert_direct_qdrant_tenant_filter(
         "direct Qdrant org-B search leaked org-A payloads"
     );
 
-    let org_a_chunks = chunk_identities_for_doc(env, org_a.ctx, org_a.doc.document_id).await;
-    assert!(!org_a_chunks.is_empty(), "org-A control doc has no chunks");
-    for chunk_identity in org_a_chunks {
+    for chunk_identity in &org_a_chunks {
         assert!(
             org_b_hits
                 .iter()
-                .all(|hit| hit.payload.chunk_id != chunk_identity),
+                .all(|hit| hit.payload.chunk_id.as_str() != chunk_identity.as_str()),
             "direct Qdrant org-B search leaked org-A chunk identity {chunk_identity}"
         );
     }

--- a/crates/server/tests/e2e/harness.rs
+++ b/crates/server/tests/e2e/harness.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -25,7 +26,9 @@ use fileconv_server::services::index_signature::collection_name_for_digest;
 use fileconv_server::services::indexing::OutboxJobSink;
 use fileconv_server::state::RuntimeState;
 use fileconv_server::storage::minio::MinioClient;
-use fileconv_server::storage::qdrant::{QdrantClient, VectorScope};
+use fileconv_server::storage::qdrant::{
+    point_id_from_org_collection_and_chunk, QdrantClient, VectorScope,
+};
 use fileconv_server::workers::convert::{ConvertWorker, ConvertWorkerConfig, ConvertWorkerRun};
 use fileconv_server::workers::delete::{DeleteWorker, DeleteWorkerConfig, DeleteWorkerRun};
 use fileconv_server::workers::index::{IndexWorker, IndexWorkerConfig, IndexWorkerRun};
@@ -297,6 +300,16 @@ impl SeededOrg {
             [self.collection_id, self.other_collection_id],
         )
         .expect("worker context")
+    }
+
+    pub fn cross_worker_ctx(&self) -> OrgContext {
+        OrgContext::try_new(
+            self.other_org_id,
+            self.other_user_id,
+            ["doc.upload", "doc.delete", "doc.publish", "qa.query"],
+            [self.cross_collection_id],
+        )
+        .expect("cross worker context")
     }
 }
 
@@ -737,30 +750,40 @@ pub async fn ingest_document(
     token: &str,
     case: FixtureCase,
 ) -> Option<IngestedDoc> {
+    let ctx = seeded.worker_ctx();
+    ingest_document_in_collection(env, token, seeded.collection_id, &ctx, case).await
+}
+
+pub async fn ingest_document_in_collection(
+    env: &LiveEnv,
+    token: &str,
+    collection_id: Uuid,
+    ctx: &OrgContext,
+    case: FixtureCase,
+) -> Option<IngestedDoc> {
     let (status, uploaded) = upload(env, token, case.filename, case.content_type, case.bytes).await;
     assert_eq!(status, StatusCode::CREATED, "{uploaded}");
     assert_eq!(uploaded["disposition"], "accepted");
     let object_key = uploaded["objectKey"].as_str().expect("object key");
     let (document_id, source_version_id, convert_job_id) =
-        create_document(env, token, seeded.collection_id, case.title, object_key).await;
-    let ctx = seeded.worker_ctx();
-    let convert = run_convert_once(env, &ctx).await?;
+        create_document(env, token, collection_id, case.title, object_key).await;
+    let convert = run_convert_once(env, ctx).await?;
     if !matches!(
         convert,
         ConvertWorkerRun::Completed { job_id, .. } if job_id == convert_job_id
     ) {
-        let (status, last_error) = job_status_and_error(env, &ctx, convert_job_id).await;
+        let (status, last_error) = job_status_and_error(env, ctx, convert_job_id).await;
         panic!(
             "unexpected convert outcome for {}: {convert:?}; job_status={status}; last_error={last_error:?}",
             case.name
         );
     }
-    relay_outbox(env, &ctx).await;
-    let index = run_index_once(env, &ctx)
+    relay_outbox(env, ctx).await;
+    let index = run_index_once(env, ctx)
         .await
         .expect("index worker available");
     assert!(matches!(index, IndexWorkerRun::Completed { chunks, .. } if chunks > 0));
-    let current_version_id = current_version(env, &ctx, document_id)
+    let current_version_id = current_version(env, ctx, document_id)
         .await
         .expect("current version");
     assert_ne!(current_version_id, source_version_id);
@@ -768,7 +791,7 @@ pub async fn ingest_document(
         document_id,
         version_id: current_version_id,
         convert_job_id,
-        collection_id: seeded.collection_id,
+        collection_id,
         marker: case.marker.to_string(),
         title: case.title.to_string(),
     })
@@ -1105,6 +1128,121 @@ pub async fn qdrant_points_for_doc(
         .await
         .expect("scroll points")
         .len()
+}
+
+pub async fn assert_chunk_point_identity(
+    env: &LiveEnv,
+    ctx: &OrgContext,
+    collection_id: Uuid,
+    document_id: Uuid,
+) {
+    let chunk_identities: Vec<String> = with_org_txn(&env.pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let rows = txn
+                    .query(
+                        "SELECT chunk_identity_sha256
+                         FROM chunks
+                         WHERE org_id = $1 AND document_id = $2
+                         ORDER BY ordinal, id",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(rows.into_iter().map(|row| row.get(0)).collect())
+            })
+        }
+    })
+    .await
+    .expect("chunk identities");
+    assert!(
+        !chunk_identities.is_empty(),
+        "document must have at least one PG chunk"
+    );
+
+    let mut unique_chunks = HashSet::with_capacity(chunk_identities.len());
+    for identity in &chunk_identities {
+        assert!(
+            unique_chunks.insert(identity.clone()),
+            "duplicated PG logical chunk identity {identity}"
+        );
+    }
+
+    let expected_by_identity: HashMap<String, Uuid> = chunk_identities
+        .iter()
+        .map(|identity| {
+            (
+                identity.clone(),
+                point_id_from_org_collection_and_chunk(ctx.org_id(), collection_id, identity)
+                    .expect("deterministic point id"),
+            )
+        })
+        .collect();
+    let expected_ids = expected_by_identity.values().copied().collect::<Vec<_>>();
+    let signature = active_signature(env, ctx, collection_id).await;
+    let collection = collection_name_for_digest(&signature).expect("collection name");
+    let scope = VectorScope::new(ctx.org_id(), [collection_id]);
+
+    let fetched = env
+        .qdrant
+        .get_points(&collection, &scope, &expected_ids)
+        .await
+        .expect("fetch expected qdrant points");
+    assert_eq!(
+        fetched.len(),
+        expected_ids.len(),
+        "missing Qdrant point for at least one PG chunk"
+    );
+    let fetched_by_id = fetched.iter().cloned().collect::<HashMap<_, _>>();
+    for (identity, expected_id) in &expected_by_identity {
+        let payload = fetched_by_id
+            .get(expected_id)
+            .unwrap_or_else(|| panic!("missing Qdrant point for chunk {identity}"));
+        assert_eq!(
+            payload.chunk_id, *identity,
+            "Qdrant point payload chunk identity diverged from PG"
+        );
+        assert_eq!(payload.document_id, document_id);
+        assert_eq!(payload.collection_id, collection_id);
+        assert_eq!(payload.org_id, ctx.org_id());
+    }
+
+    let scrolled = env
+        .qdrant
+        .scroll_points(
+            &collection,
+            &scope,
+            &[json!({
+                "key": "document_id",
+                "match": { "value": document_id.to_string() }
+            })],
+            1000,
+        )
+        .await
+        .expect("scroll document qdrant points");
+    assert_eq!(
+        scrolled.len(),
+        expected_ids.len(),
+        "document has orphan or duplicate Qdrant points"
+    );
+    let expected_id_set = expected_ids.iter().copied().collect::<HashSet<_>>();
+    let mut seen_payload_chunks = HashSet::with_capacity(scrolled.len());
+    for (point_id, payload) in scrolled {
+        assert!(
+            expected_id_set.contains(&point_id),
+            "orphan Qdrant point {point_id} has no matching PG chunk"
+        );
+        assert!(
+            seen_payload_chunks.insert(payload.chunk_id.clone()),
+            "duplicated Qdrant logical chunk identity {}",
+            payload.chunk_id
+        );
+        assert!(
+            unique_chunks.contains(&payload.chunk_id),
+            "Qdrant payload chunk {} has no matching PG chunk",
+            payload.chunk_id
+        );
+    }
 }
 
 pub async fn revoke_collection_access(env: &LiveEnv, seeded: &SeededOrg, user_id: Uuid) {

--- a/crates/server/tests/e2e/harness.rs
+++ b/crates/server/tests/e2e/harness.rs
@@ -1,0 +1,1168 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use bytes::Bytes;
+use deadpool_postgres::Pool;
+use fileconv_knowledge::embedding::LOCAL_VECTOR_DIMENSIONS;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::auth::jwt::JwtKeys;
+use fileconv_server::auth::provider::{AuthProvider, AuthRequestMeta, PasswordAuthProvider};
+use fileconv_server::auth::session;
+use fileconv_server::config::{
+    Argon2Config, AuthConfig, JwtAlgorithm, MinioConfig, RuntimeEndpoints, SecretString,
+    ServerConfig,
+};
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::models::JobStatus;
+use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::http::{router, AppState};
+use fileconv_server::jobs;
+use fileconv_server::services::embedding::approved_plan;
+use fileconv_server::services::index_signature::collection_name_for_digest;
+use fileconv_server::services::indexing::OutboxJobSink;
+use fileconv_server::state::RuntimeState;
+use fileconv_server::storage::minio::MinioClient;
+use fileconv_server::storage::qdrant::{QdrantClient, VectorScope};
+use fileconv_server::workers::convert::{ConvertWorker, ConvertWorkerConfig, ConvertWorkerRun};
+use fileconv_server::workers::delete::{DeleteWorker, DeleteWorkerConfig, DeleteWorkerRun};
+use fileconv_server::workers::index::{IndexWorker, IndexWorkerConfig, IndexWorkerRun};
+use fileconv_server::workers::limits::ResourceLimits;
+use fileconv_server::workers::sandbox::{self, SandboxConfig};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+pub const BOUNDARY: &str = "----markhandE2eBoundary7MA4YWxk";
+pub const PASSWORD: &str = "correct-e2e-password-1";
+
+const LLM_ENV_KEYS: &[&str] = &[
+    "FILECONV_LLM_PROVIDER",
+    "FILECONV_LLM_API_KEY",
+    "FILECONV_LLM_MODEL",
+    "FILECONV_LLM_BASE_URL",
+];
+
+pub fn test_auth_config() -> AuthConfig {
+    AuthConfig {
+        issuer: Some("https://issuer.e2e.markhand.test".into()),
+        audience: Some("markhand-api".into()),
+        signing_key: Some(SecretString::new("e2e-integration-signing-key-32b!")),
+        alg: JwtAlgorithm::Hs256,
+        kid: Some("e2e-test-kid".into()),
+        access_token_ttl_secs: 900,
+        refresh_token_ttl_secs: 3_600,
+        argon2: Argon2Config {
+            memory_kib: 8_192,
+            time_cost: 1,
+            parallelism: 1,
+        },
+    }
+}
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+            None
+        }
+    }
+}
+
+fn test_minio_client() -> Option<MinioClient> {
+    let endpoint = match std::env::var("MARKHAND_TEST_MINIO_ENDPOINT") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ENDPOINT unset");
+            return None;
+        }
+    };
+    let access_key = match std::env::var("MARKHAND_TEST_MINIO_ACCESS_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_ACCESS_KEY unset");
+            return None;
+        }
+    };
+    let secret_key = match std::env::var("MARKHAND_TEST_MINIO_SECRET_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_MINIO_SECRET_KEY unset");
+            return None;
+        }
+    };
+    let region = std::env::var("MARKHAND_TEST_MINIO_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let bucket = format!("markhand-e2e-{}", Uuid::new_v4().simple());
+    std::env::set_var("RUST_S3_SKIP_LOCATION_CONSTRAINT", "true");
+    let config = MinioConfig::new(
+        endpoint,
+        SecretString::new(access_key),
+        SecretString::new(secret_key),
+        bucket,
+        region,
+        true,
+    )
+    .expect("minio config");
+    Some(MinioClient::from_config(&config).expect("minio client"))
+}
+
+fn test_qdrant_client() -> Option<QdrantClient> {
+    let url = match std::env::var("MARKHAND_TEST_QDRANT_URL") {
+        Ok(url) if !url.trim().is_empty() => url,
+        _ => {
+            eprintln!("skipped: MARKHAND_TEST_QDRANT_URL unset");
+            return None;
+        }
+    };
+    let api_key = std::env::var("MARKHAND_TEST_QDRANT_API_KEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(SecretString::new);
+    Some(QdrantClient::with_api_key(url, api_key).expect("qdrant client"))
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+pub struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_e2e_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect_raw(&self.admin_url).await;
+        let _ = admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
+                 DROP DATABASE IF EXISTS \"{}\"",
+                self.db_name, self.db_name
+            ))
+            .await;
+    }
+}
+
+pub struct LiveEnv {
+    db: EphemeralDb,
+    pub pool: Pool,
+    pub storage: MinioClient,
+    pub qdrant: QdrantClient,
+    provider: PasswordAuthProvider,
+    pub app: axum::Router,
+}
+
+impl LiveEnv {
+    pub async fn boot() -> Option<Self> {
+        let base_url = test_database_url()?;
+        let storage = test_minio_client()?;
+        let qdrant = test_qdrant_client()?;
+        storage.ensure_bucket().await.expect("ensure bucket");
+        let db = EphemeralDb::create(&base_url).await;
+        apply_migrations(&db.url).await.expect("apply migrations");
+        let pool = create_pool(&db.url).expect("pool");
+        let auth = test_auth_config();
+        let provider = PasswordAuthProvider::new(
+            pool.clone(),
+            auth.clone(),
+            JwtKeys::from_auth(&auth).expect("jwt keys"),
+        );
+        let runtime = RuntimeState::from_config(ServerConfig::test_with_endpoints_and_auth(
+            RuntimeEndpoints {
+                database_url: SecretString::new(&db.url),
+                qdrant_url: std::env::var("MARKHAND_TEST_QDRANT_URL")
+                    .unwrap_or_else(|_| "http://127.0.0.1:1".into()),
+                minio_url: std::env::var("MARKHAND_TEST_MINIO_ENDPOINT")
+                    .unwrap_or_else(|_| "http://127.0.0.1:1".into()),
+            },
+            auth.clone(),
+        ))
+        .expect("runtime");
+        let app = router(
+            AppState::from_parts_with_clients(
+                runtime,
+                pool.clone(),
+                Some(PasswordAuthProvider::new(
+                    pool.clone(),
+                    auth.clone(),
+                    JwtKeys::from_auth(&auth).expect("jwt keys"),
+                )),
+                Some(storage.clone()),
+                qdrant.clone(),
+            )
+            .expect("app state"),
+        );
+        Some(Self {
+            db,
+            pool,
+            storage,
+            qdrant,
+            provider,
+            app,
+        })
+    }
+
+    pub async fn token(&self, email: &str) -> String {
+        self.provider
+            .login_password(
+                email,
+                PASSWORD,
+                &AuthRequestMeta {
+                    request_id: Uuid::new_v4().to_string(),
+                },
+            )
+            .await
+            .expect("login")
+            .tokens
+            .access_token
+            .expose()
+            .to_string()
+    }
+
+    pub async fn drop(self) {
+        self.db.drop().await;
+    }
+}
+
+#[derive(Clone)]
+pub struct SeededOrg {
+    pub org_id: Uuid,
+    pub owner_id: Uuid,
+    pub editor_id: Uuid,
+    pub viewer_id: Uuid,
+    pub no_acl_id: Uuid,
+    pub no_query_id: Uuid,
+    pub other_org_id: Uuid,
+    pub other_user_id: Uuid,
+    pub collection_id: Uuid,
+    pub other_collection_id: Uuid,
+    pub cross_collection_id: Uuid,
+    pub owner_email: String,
+    pub editor_email: String,
+    pub viewer_email: String,
+    pub no_acl_email: String,
+    pub no_query_email: String,
+    pub cross_email: String,
+}
+
+impl SeededOrg {
+    pub fn worker_ctx(&self) -> OrgContext {
+        OrgContext::try_new(
+            self.org_id,
+            self.owner_id,
+            ["doc.upload", "doc.delete", "doc.publish", "qa.query"],
+            [self.collection_id, self.other_collection_id],
+        )
+        .expect("worker context")
+    }
+}
+
+pub async fn seed_org(env: &LiveEnv) -> SeededOrg {
+    let seeded = SeededOrg {
+        org_id: Uuid::new_v4(),
+        owner_id: Uuid::new_v4(),
+        editor_id: Uuid::new_v4(),
+        viewer_id: Uuid::new_v4(),
+        no_acl_id: Uuid::new_v4(),
+        no_query_id: Uuid::new_v4(),
+        other_org_id: Uuid::new_v4(),
+        other_user_id: Uuid::new_v4(),
+        collection_id: Uuid::new_v4(),
+        other_collection_id: Uuid::new_v4(),
+        cross_collection_id: Uuid::new_v4(),
+        owner_email: String::new(),
+        editor_email: String::new(),
+        viewer_email: String::new(),
+        no_acl_email: String::new(),
+        no_query_email: String::new(),
+        cross_email: String::new(),
+    };
+    let seeded = SeededOrg {
+        owner_email: format!("owner-{}@e2e.example.test", seeded.owner_id.simple()),
+        editor_email: format!("editor-{}@e2e.example.test", seeded.editor_id.simple()),
+        viewer_email: format!("viewer-{}@e2e.example.test", seeded.viewer_id.simple()),
+        no_acl_email: format!("no-acl-{}@e2e.example.test", seeded.no_acl_id.simple()),
+        no_query_email: format!("no-query-{}@e2e.example.test", seeded.no_query_id.simple()),
+        cross_email: format!("cross-{}@e2e.example.test", seeded.other_user_id.simple()),
+        ..seeded
+    };
+
+    let ctx = seeded.worker_ctx();
+    with_org_txn(&env.pool, &ctx, {
+        let s = seeded.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO orgs (id, slug, name)
+                     VALUES ($1, $2, 'E2E Org')",
+                    &[&s.org_id, &format!("e2e-{}", s.org_id.simple())],
+                )
+                .await?;
+                for (user_id, email, name) in [
+                    (s.owner_id, s.owner_email.as_str(), "Owner E2E"),
+                    (s.editor_id, s.editor_email.as_str(), "Editor E2E"),
+                    (s.viewer_id, s.viewer_email.as_str(), "Viewer E2E"),
+                    (s.no_acl_id, s.no_acl_email.as_str(), "No ACL E2E"),
+                    (s.no_query_id, s.no_query_email.as_str(), "No Query E2E"),
+                ] {
+                    txn.execute(
+                        "INSERT INTO users (id, email, display_name)
+                         VALUES ($1, $2, $3)",
+                        &[&user_id, &email, &name],
+                    )
+                    .await?;
+                }
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES
+                       ($1, $2, 'owner'),
+                       ($1, $3, 'editor'),
+                       ($1, $4, 'viewer'),
+                       ($1, $5, 'viewer'),
+                       ($1, $6, 'editor')",
+                    &[
+                        &s.org_id,
+                        &s.owner_id,
+                        &s.editor_id,
+                        &s.viewer_id,
+                        &s.no_acl_id,
+                        &s.no_query_id,
+                    ],
+                )
+                .await?;
+                seed_roles(txn, s.org_id).await?;
+                txn.execute(
+                    "INSERT INTO org_quotas (
+                        org_id, max_storage_bytes, max_documents,
+                        max_concurrent_jobs, max_monthly_tokens
+                     )
+                     VALUES ($1, 1000000000, 100000, 100, 1000000000)",
+                    &[&s.org_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO collections (id, org_id, name, slug, owner_user_id, visibility)
+                     VALUES
+                       ($1, $2, 'Primary E2E', $3, $4, 'private'),
+                       ($5, $2, 'Other E2E', $6, $7, 'private')",
+                    &[
+                        &s.collection_id,
+                        &s.org_id,
+                        &format!("primary-{}", s.collection_id.simple()),
+                        &s.owner_id,
+                        &s.other_collection_id,
+                        &format!("other-{}", s.other_collection_id.simple()),
+                        &s.editor_id,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO collection_user_access
+                        (id, org_id, collection_id, user_id, access_level)
+                     VALUES
+                        ($1, $2, $3, $4, 'read'),
+                        ($5, $2, $3, $6, 'read')",
+                    &[
+                        &Uuid::new_v4(),
+                        &s.org_id,
+                        &s.collection_id,
+                        &s.viewer_id,
+                        &Uuid::new_v4(),
+                        &s.no_query_id,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed primary org");
+
+    let cross_ctx = OrgContext::try_new(
+        seeded.other_org_id,
+        seeded.other_user_id,
+        ["doc.upload", "doc.delete", "doc.publish", "qa.query"],
+        [seeded.cross_collection_id],
+    )
+    .expect("cross ctx");
+    with_org_txn(&env.pool, &cross_ctx, {
+        let s = seeded.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO orgs (id, slug, name)
+                     VALUES ($1, $2, 'Cross E2E Org')",
+                    &[
+                        &s.other_org_id,
+                        &format!("cross-{}", s.other_org_id.simple()),
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO users (id, email, display_name)
+                     VALUES ($1, $2, 'Cross E2E')",
+                    &[&s.other_user_id, &s.cross_email],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'owner')",
+                    &[&s.other_org_id, &s.other_user_id],
+                )
+                .await?;
+                seed_roles(txn, s.other_org_id).await?;
+                txn.execute(
+                    "INSERT INTO org_quotas (
+                        org_id, max_storage_bytes, max_documents,
+                        max_concurrent_jobs, max_monthly_tokens
+                     )
+                     VALUES ($1, 1000000000, 100000, 100, 1000000000)",
+                    &[&s.other_org_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO collections (id, org_id, name, slug, owner_user_id, visibility)
+                     VALUES ($1, $2, 'Cross Collection', $3, $4, 'private')",
+                    &[
+                        &s.cross_collection_id,
+                        &s.other_org_id,
+                        &format!("cross-{}", s.cross_collection_id.simple()),
+                        &s.other_user_id,
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed cross org");
+
+    for (user_id, password) in [
+        (seeded.owner_id, PASSWORD),
+        (seeded.editor_id, PASSWORD),
+        (seeded.viewer_id, PASSWORD),
+        (seeded.no_acl_id, PASSWORD),
+        (seeded.no_query_id, PASSWORD),
+        (seeded.other_user_id, PASSWORD),
+    ] {
+        session::set_password_hash(&env.pool, user_id, password, &test_auth_config().argon2)
+            .await
+            .expect("set password");
+    }
+
+    seeded
+}
+
+async fn seed_roles(
+    txn: &tokio_postgres::Transaction<'_>,
+    org_id: Uuid,
+) -> Result<(), fileconv_server::db::error::DbError> {
+    for permission in ["doc.upload", "doc.delete", "doc.publish", "qa.query"] {
+        txn.execute(
+            "INSERT INTO permissions (id, code, description)
+             VALUES ($1, $2, $2)
+             ON CONFLICT (code) DO NOTHING",
+            &[&Uuid::new_v4(), &permission],
+        )
+        .await?;
+    }
+    for (code, name) in [
+        ("owner", "Owner"),
+        ("admin", "Admin"),
+        ("editor", "Editor"),
+        ("viewer", "Viewer"),
+    ] {
+        txn.execute(
+            "INSERT INTO roles (id, org_id, code, name, is_system)
+             VALUES ($1, $2, $3, $4, true)
+             ON CONFLICT (org_id, code) DO NOTHING",
+            &[&Uuid::new_v4(), &org_id, &code, &name],
+        )
+        .await?;
+    }
+    for permission in ["doc.upload", "doc.delete", "doc.publish", "qa.query"] {
+        grant_permission(txn, org_id, "owner", permission).await?;
+    }
+    grant_permission(txn, org_id, "admin", "qa.query").await?;
+    grant_permission(txn, org_id, "admin", "doc.delete").await?;
+    grant_permission(txn, org_id, "editor", "doc.upload").await?;
+    grant_permission(txn, org_id, "viewer", "qa.query").await?;
+    Ok(())
+}
+
+async fn grant_permission(
+    txn: &tokio_postgres::Transaction<'_>,
+    org_id: Uuid,
+    role_code: &str,
+    permission: &str,
+) -> Result<(), fileconv_server::db::error::DbError> {
+    let role_id: Uuid = txn
+        .query_one(
+            "SELECT id FROM roles WHERE org_id = $1 AND code = $2",
+            &[&org_id, &role_code],
+        )
+        .await?
+        .get(0);
+    let permission_id: Uuid = txn
+        .query_one("SELECT id FROM permissions WHERE code = $1", &[&permission])
+        .await?
+        .get(0);
+    txn.execute(
+        "INSERT INTO role_permissions (org_id, role_id, permission_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT DO NOTHING",
+        &[&org_id, &role_id, &permission_id],
+    )
+    .await?;
+    Ok(())
+}
+
+pub struct LlmEnvGuard {
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl LlmEnvGuard {
+    pub fn unset_all() -> Self {
+        let saved = LLM_ENV_KEYS
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect::<Vec<_>>();
+        for key in LLM_ENV_KEYS {
+            std::env::remove_var(key);
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for LlmEnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.saved {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
+pub struct HttpResponse {
+    pub status: StatusCode,
+    pub bytes: Bytes,
+}
+
+pub async fn send_request(
+    app: axum::Router,
+    method: &str,
+    uri: &str,
+    body: Body,
+    bearer: Option<&str>,
+    content_type: Option<String>,
+) -> HttpResponse {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("x-request-id", Uuid::new_v4().to_string());
+    if let Some(token) = bearer {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if let Some(content_type) = content_type {
+        builder = builder.header("content-type", content_type);
+    }
+    let response = app
+        .oneshot(builder.body(body).expect("request"))
+        .await
+        .expect("response");
+    let status = response.status();
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("response body")
+        .to_bytes();
+    HttpResponse { status, bytes }
+}
+
+pub async fn json_request(
+    app: axum::Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+    bearer: &str,
+) -> (StatusCode, Value) {
+    let body = body.map(|value| serde_json::to_vec(&value).expect("serialize body"));
+    let response = send_request(
+        app,
+        method,
+        uri,
+        body.map(Body::from).unwrap_or_else(Body::empty),
+        Some(bearer),
+        Some("application/json".into()),
+    )
+    .await;
+    let value = if response.bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&response.bytes).unwrap_or_else(|_| {
+            Value::String(String::from_utf8_lossy(&response.bytes).into_owned())
+        })
+    };
+    (response.status, value)
+}
+
+pub async fn upload(
+    env: &LiveEnv,
+    bearer: &str,
+    filename: &str,
+    content_type: &str,
+    content: &[u8],
+) -> (StatusCode, Value) {
+    let response = send_request(
+        env.app.clone(),
+        "POST",
+        "/api/v1/uploads",
+        Body::from(multipart_body(filename, content_type, content)),
+        Some(bearer),
+        Some(format!("multipart/form-data; boundary={BOUNDARY}")),
+    )
+    .await;
+    let value = if response.bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&response.bytes).unwrap_or_else(|_| {
+            Value::String(String::from_utf8_lossy(&response.bytes).into_owned())
+        })
+    };
+    (response.status, value)
+}
+
+pub fn multipart_body(filename: &str, content_type: &str, content: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"file\"; \
+             filename=\"{filename}\"\r\nContent-Type: {content_type}\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(content);
+    body.extend_from_slice(format!("\r\n--{BOUNDARY}--\r\n").as_bytes());
+    body
+}
+
+pub fn many_part_body(parts: usize) -> Vec<u8> {
+    let mut body = Vec::new();
+    for index in 0..parts {
+        body.extend_from_slice(
+            format!(
+                "--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"field{index}\"\r\n\r\nx\r\n"
+            )
+            .as_bytes(),
+        );
+    }
+    body.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
+    body
+}
+
+pub async fn create_document(
+    env: &LiveEnv,
+    token: &str,
+    collection_id: Uuid,
+    title: &str,
+    object_key: &str,
+) -> (Uuid, Uuid, Uuid) {
+    let (status, created) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/collections/{collection_id}/documents"),
+        Some(json!({ "objectKey": object_key, "title": title })),
+        token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{created}");
+    (
+        parse_uuid_value(&created["document"]["id"]),
+        parse_uuid_value(&created["version"]["id"]),
+        parse_uuid_value(&created["jobId"]),
+    )
+}
+
+pub async fn ingest_document(
+    env: &LiveEnv,
+    seeded: &SeededOrg,
+    token: &str,
+    case: FixtureCase,
+) -> Option<IngestedDoc> {
+    let (status, uploaded) = upload(env, token, case.filename, case.content_type, case.bytes).await;
+    assert_eq!(status, StatusCode::CREATED, "{uploaded}");
+    assert_eq!(uploaded["disposition"], "accepted");
+    let object_key = uploaded["objectKey"].as_str().expect("object key");
+    let (document_id, source_version_id, convert_job_id) =
+        create_document(env, token, seeded.collection_id, case.title, object_key).await;
+    let ctx = seeded.worker_ctx();
+    let convert = run_convert_once(env, &ctx).await?;
+    if !matches!(
+        convert,
+        ConvertWorkerRun::Completed { job_id, .. } if job_id == convert_job_id
+    ) {
+        let (status, last_error) = job_status_and_error(env, &ctx, convert_job_id).await;
+        panic!(
+            "unexpected convert outcome for {}: {convert:?}; job_status={status}; last_error={last_error:?}",
+            case.name
+        );
+    }
+    relay_outbox(env, &ctx).await;
+    let index = run_index_once(env, &ctx)
+        .await
+        .expect("index worker available");
+    assert!(matches!(index, IndexWorkerRun::Completed { chunks, .. } if chunks > 0));
+    let current_version_id = current_version(env, &ctx, document_id)
+        .await
+        .expect("current version");
+    assert_ne!(current_version_id, source_version_id);
+    Some(IngestedDoc {
+        document_id,
+        version_id: current_version_id,
+        convert_job_id,
+        collection_id: seeded.collection_id,
+        marker: case.marker.to_string(),
+        title: case.title.to_string(),
+    })
+}
+
+#[derive(Clone, Copy)]
+pub struct FixtureCase {
+    pub name: &'static str,
+    pub filename: &'static str,
+    pub content_type: &'static str,
+    pub title: &'static str,
+    pub bytes: &'static [u8],
+    pub marker: &'static str,
+}
+
+#[derive(Clone)]
+pub struct IngestedDoc {
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub convert_job_id: Uuid,
+    pub collection_id: Uuid,
+    pub marker: String,
+    pub title: String,
+}
+
+pub fn fixture_cases() -> Vec<FixtureCase> {
+    vec![
+        FixtureCase {
+            name: "txt",
+            filename: "e2e-alpha.txt",
+            content_type: "text/plain",
+            title: "E2E TXT",
+            bytes: b"E2E-TXT-ALPHA-2026 is the unique text marker.\n",
+            marker: "E2E-TXT-ALPHA-2026",
+        },
+        FixtureCase {
+            name: "csv",
+            filename: "e2e-beta.csv",
+            content_type: "text/csv",
+            title: "E2E CSV",
+            bytes: b"name,value\nmarker,E2E-CSV-BETA-2026\n",
+            marker: "E2E-CSV-BETA-2026",
+        },
+        FixtureCase {
+            name: "html",
+            filename: "e2e-gamma.html",
+            content_type: "text/html",
+            title: "E2E HTML",
+            bytes: b"<!doctype html><html><body><h1>Policy</h1><p>E2E-HTML-GAMMA-2026 appears here.</p></body></html>",
+            marker: "E2E-HTML-GAMMA-2026",
+        },
+        FixtureCase {
+            name: "markdown",
+            filename: "e2e-delta.md",
+            content_type: "text/markdown",
+            title: "E2E Markdown",
+            bytes: b"# Markdown\n\nE2E-MD-DELTA-2026 appears in markdown body.\n",
+            marker: "E2E-MD-DELTA-2026",
+        },
+    ]
+}
+
+pub async fn relay_outbox(env: &LiveEnv, ctx: &OrgContext) {
+    let sink = Arc::new(OutboxJobSink::new());
+    jobs::relay_outbox_with_sink(&env.pool, ctx, 64, &sink)
+        .await
+        .expect("relay outbox");
+}
+
+pub fn real_convert_config(worker_id: impl Into<String>) -> Option<ConvertWorkerConfig> {
+    let Some(binary) = fileconv_binary() else {
+        eprintln!("skipped: fileconv binary is not built");
+        return None;
+    };
+    if let Err(error) = sandbox::preflight() {
+        eprintln!("skipped: sandbox isolation unavailable: {error}");
+        return None;
+    }
+    let mut config = ConvertWorkerConfig::new(
+        worker_id,
+        SandboxConfig {
+            argv_template: vec![binary.display().to_string(), "one".into(), "{input}".into()],
+            limits: ResourceLimits {
+                wall_timeout: Duration::from_secs(20),
+                memory_bytes: 512 * 1024 * 1024,
+                cpu_seconds: 10,
+                file_size_bytes: 16 * 1024 * 1024,
+                max_processes: 512,
+                max_open_files: 256,
+                stdout_stderr_bytes: 8 * 1024 * 1024,
+            },
+        },
+    );
+    config.heartbeat_interval = Duration::from_millis(100);
+    config.lease_ttl = Duration::from_secs(5);
+    Some(config)
+}
+
+pub async fn run_convert_once(env: &LiveEnv, ctx: &OrgContext) -> Option<ConvertWorkerRun> {
+    let config = real_convert_config(format!("e2e-convert-{}", Uuid::new_v4()))?;
+    Some(
+        ConvertWorker::new(env.pool.clone(), env.storage.clone(), config)
+            .expect("convert worker")
+            .run_once(ctx)
+            .await
+            .expect("convert run"),
+    )
+}
+
+pub fn fileconv_binary() -> Option<PathBuf> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    [
+        manifest.join("../../target/debug/fileconv"),
+        manifest.join("../../target/release/fileconv"),
+        PathBuf::from("/usr/local/bin/fileconv"),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+}
+
+pub fn index_worker(env: &LiveEnv) -> IndexWorker {
+    let mut config = IndexWorkerConfig::new(format!("e2e-index-{}", Uuid::new_v4()));
+    config.lease_ttl = Duration::from_secs(30);
+    config.heartbeat_interval = Duration::from_secs(5);
+    config.max_job_duration = Duration::from_secs(60);
+    config.embedding_batch_size = 2;
+    IndexWorker::new(
+        env.pool.clone(),
+        env.storage.clone(),
+        env.qdrant.clone(),
+        config,
+        None,
+    )
+    .expect("index worker")
+}
+
+pub async fn run_index_once(env: &LiveEnv, ctx: &OrgContext) -> Option<IndexWorkerRun> {
+    Some(
+        index_worker(env)
+            .run_once(ctx)
+            .await
+            .expect("index worker run"),
+    )
+}
+
+pub async fn run_delete_once(env: &LiveEnv, ctx: &OrgContext) -> DeleteWorkerRun {
+    let mut config = DeleteWorkerConfig::new(format!("e2e-delete-{}", Uuid::new_v4()));
+    config.lease_ttl = Duration::from_secs(30);
+    config.heartbeat_interval = Duration::from_secs(5);
+    config.max_job_duration = Duration::from_secs(60);
+    DeleteWorker::new(
+        env.pool.clone(),
+        env.storage.clone(),
+        env.qdrant.clone(),
+        config,
+    )
+    .expect("delete worker")
+    .run_once(ctx)
+    .await
+    .expect("delete worker run")
+}
+
+pub async fn current_version(env: &LiveEnv, ctx: &OrgContext, document_id: Uuid) -> Option<Uuid> {
+    with_org_txn(&env.pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT current_version_id
+                         FROM documents
+                         WHERE org_id = $1 AND id = $2",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("current version")
+}
+
+pub async fn get_job_status(env: &LiveEnv, ctx: &OrgContext, job_id: Uuid) -> JobStatus {
+    with_org_txn(&env.pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let status: String = txn
+                    .query_one(
+                        "SELECT status FROM jobs WHERE org_id = $1 AND id = $2",
+                        &[&ctx.org_id(), &job_id],
+                    )
+                    .await?
+                    .get(0);
+                JobStatus::parse(&status).map_err(fileconv_server::db::error::DbError::Config)
+            })
+        }
+    })
+    .await
+    .expect("job status")
+}
+
+pub async fn job_status_and_error(
+    env: &LiveEnv,
+    ctx: &OrgContext,
+    job_id: Uuid,
+) -> (String, Option<String>) {
+    with_org_txn(&env.pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT status, last_error FROM jobs WHERE org_id = $1 AND id = $2",
+                        &[&ctx.org_id(), &job_id],
+                    )
+                    .await?;
+                Ok((row.get(0), row.get(1)))
+            })
+        }
+    })
+    .await
+    .expect("job status and error")
+}
+
+pub async fn make_job_available(env: &LiveEnv, ctx: &OrgContext, job_id: Uuid) {
+    with_org_txn(&env.pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE jobs
+                     SET status = 'pending', lease_owner = NULL, lease_expires_at = NULL,
+                         heartbeat_at = NULL, available_at = clock_timestamp(),
+                         updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &job_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("make job available");
+}
+
+pub async fn expire_leases(env: &LiveEnv, ctx: &OrgContext) {
+    jobs::reclaim_expired(&env.pool, ctx, 10, Duration::from_secs(1))
+        .await
+        .expect("reclaim expired");
+}
+
+pub async fn chunk_count(env: &LiveEnv, ctx: &OrgContext, document_id: Uuid) -> i64 {
+    with_org_txn(&env.pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM chunks
+                         WHERE org_id = $1 AND document_id = $2",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("chunk count")
+}
+
+pub async fn document_count(env: &LiveEnv, ctx: &OrgContext) -> i64 {
+    with_org_txn(&env.pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint FROM documents WHERE org_id = $1",
+                        &[&ctx.org_id()],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("document count")
+}
+
+pub async fn active_signature(env: &LiveEnv, ctx: &OrgContext, collection_id: Uuid) -> String {
+    with_org_txn(&env.pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let metadata = fileconv_server::db::index_metadata::find_active(
+                    txn,
+                    &ctx,
+                    Some(collection_id),
+                )
+                .await?;
+                metadata
+                    .map(|value| value.index_signature_sha256)
+                    .ok_or(fileconv_server::db::error::DbError::NotFound)
+            })
+        }
+    })
+    .await
+    .expect("active signature")
+}
+
+pub async fn qdrant_points_for_doc(
+    env: &LiveEnv,
+    ctx: &OrgContext,
+    collection_id: Uuid,
+    document_id: Uuid,
+) -> usize {
+    let signature = active_signature(env, ctx, collection_id).await;
+    let collection = collection_name_for_digest(&signature).expect("collection name");
+    env.qdrant
+        .scroll_points(
+            &collection,
+            &VectorScope::new(ctx.org_id(), [collection_id]),
+            &[json!({
+                "key": "document_id",
+                "match": { "value": document_id.to_string() }
+            })],
+            1000,
+        )
+        .await
+        .expect("scroll points")
+        .len()
+}
+
+pub async fn revoke_collection_access(env: &LiveEnv, seeded: &SeededOrg, user_id: Uuid) {
+    let ctx = seeded.worker_ctx();
+    with_org_txn(&env.pool, &ctx, {
+        let s = seeded.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "DELETE FROM collection_user_access
+                     WHERE org_id = $1 AND collection_id = $2 AND user_id = $3",
+                    &[&s.org_id, &s.collection_id, &user_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("revoke collection access");
+}
+
+pub fn parse_uuid_value(value: &Value) -> Uuid {
+    Uuid::parse_str(value.as_str().expect("uuid string")).expect("uuid")
+}
+
+pub fn citation_pin_from(citation: &Value, quote: &str) -> Value {
+    json!({
+        "documentId": citation["documentId"],
+        "versionId": citation["versionId"],
+        "versionNumber": citation["versionNumber"],
+        "contentSha256": citation["contentSha256"],
+        "chunkId": citation["chunkId"],
+        "spanStart": Value::Null,
+        "spanEnd": Value::Null,
+        "quote": quote,
+    })
+}
+
+pub fn assert_body_lacks(bytes: &[u8], forbidden: &str) {
+    let rendered = String::from_utf8_lossy(bytes);
+    assert!(
+        !rendered.contains(forbidden),
+        "response body leaked forbidden marker"
+    );
+}
+
+pub fn assert_value_lacks(value: &Value, forbidden: &str) {
+    assert!(
+        !value.to_string().contains(forbidden),
+        "response body leaked forbidden marker"
+    );
+}
+
+#[allow(dead_code)]
+pub fn approved_signature() -> String {
+    approved_plan()
+        .index_signature(LOCAL_VECTOR_DIMENSIONS)
+        .expect("approved signature")
+        .digest()
+}

--- a/crates/server/tests/e2e/scenarios.rs
+++ b/crates/server/tests/e2e/scenarios.rs
@@ -47,6 +47,8 @@ async fn live_authorization_e2e_unauthorized_gets_no_text() {
     let no_query = env.token(&seeded.no_query_email).await;
     let cross = env.token(&seeded.cross_email).await;
     let marker = "E2E-AUTH-SECRET-2026";
+    let cross_query = "E2E-CROSS-TENANT-SHARED-2026";
+    let cross_visible_marker = "E2E-CROSS-TENANT-ORG-B-2026";
     let Some(doc) = ingest_document(
         &env,
         &seeded,
@@ -56,7 +58,7 @@ async fn live_authorization_e2e_unauthorized_gets_no_text() {
             filename: "auth-secret.txt",
             content_type: "text/plain",
             title: "Authorization Secret",
-            bytes: b"E2E-AUTH-SECRET-2026 must not leak to unauthorized users.\n",
+            bytes: b"E2E-CROSS-TENANT-SHARED-2026 names an org-A document. E2E-AUTH-SECRET-2026 must not leak to unauthorized users.\n",
             marker,
         },
     )
@@ -67,6 +69,63 @@ async fn live_authorization_e2e_unauthorized_gets_no_text() {
     };
     let citation = first_citation(&env, &owner, &doc).await;
     let pin = citation_pin_from(&citation, marker);
+    let cross_ctx = seeded.cross_worker_ctx();
+    let Some(cross_doc) = ingest_document_in_collection(
+        &env,
+        &cross,
+        seeded.cross_collection_id,
+        &cross_ctx,
+        FixtureCase {
+            name: "cross-tenant-visible",
+            filename: "cross-visible.txt",
+            content_type: "text/plain",
+            title: "Cross Tenant Visible",
+            bytes: b"E2E-CROSS-TENANT-SHARED-2026 names only org-B readable content. E2E-CROSS-TENANT-ORG-B-2026 is allowed.\n",
+            marker: cross_visible_marker,
+        },
+    )
+    .await
+    else {
+        env.drop().await;
+        return;
+    };
+
+    let (status, cross_search) = search(&env, &cross, cross_query, None).await;
+    assert_eq!(status, StatusCode::OK, "{cross_search}");
+    let cross_hits = cross_search["hits"].as_array().expect("cross search hits");
+    assert!(
+        cross_hits
+            .iter()
+            .any(|hit| hit["documentId"] == cross_doc.document_id.to_string()),
+        "cross-tenant control search did not retrieve org-B content"
+    );
+    assert!(
+        cross_hits
+            .iter()
+            .all(|hit| hit["documentId"] != doc.document_id.to_string()
+                && hit["collectionId"] != doc.collection_id.to_string()),
+        "cross-tenant search leaked org-A identifiers: {cross_search}"
+    );
+    assert_value_lacks(&cross_search, marker);
+
+    let (status, cross_ask) = ask(&env, &cross, cross_query, None).await;
+    assert_eq!(status, StatusCode::OK, "{cross_ask}");
+    let cross_citations = cross_ask["citations"]
+        .as_array()
+        .expect("cross ask citations");
+    assert!(
+        cross_citations
+            .iter()
+            .any(|citation| citation["documentId"] == cross_doc.document_id.to_string()),
+        "cross-tenant control ask did not cite org-B content"
+    );
+    assert!(
+        cross_citations.iter().all(|citation| citation["documentId"]
+            != doc.document_id.to_string()
+            && citation["collectionId"] != doc.collection_id.to_string()),
+        "cross-tenant ask leaked org-A identifiers: {cross_ask}"
+    );
+    assert_value_lacks(&cross_ask, marker);
 
     let (status, no_acl_search) = search(&env, &no_acl, marker, Some(doc.collection_id)).await;
     assert_eq!(status, StatusCode::FORBIDDEN, "{no_acl_search}");
@@ -189,6 +248,19 @@ async fn live_lifecycle_delete_purge_and_revocation() {
     };
     assert_grounded_http_roundtrip(&env, &viewer, &doc).await;
     let pin = citation_pin_from(&first_citation(&env, &owner, &doc).await, marker);
+    let stale_download_path = mint_download_path(&env, &owner, &doc).await;
+    let proof_download_path = mint_download_path(&env, &owner, &doc).await;
+    let proof_downloaded = send_request(
+        env.app.clone(),
+        "GET",
+        &proof_download_path,
+        Body::empty(),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(proof_downloaded.status, StatusCode::OK);
+    assert!(String::from_utf8_lossy(&proof_downloaded.bytes).contains(marker));
 
     let (status, deleted) = json_request(
         env.app.clone(),
@@ -200,6 +272,7 @@ async fn live_lifecycle_delete_purge_and_revocation() {
     .await;
     assert_eq!(status, StatusCode::ACCEPTED, "{deleted}");
     assert_eq!(deleted["document"]["state"], "tombstoned");
+    assert_deleted_egress_denied(&env, &owner, &doc, &pin, "after tombstone before purge").await;
 
     let ctx = seeded.worker_ctx();
     relay_outbox(&env, &ctx).await;
@@ -212,40 +285,15 @@ async fn live_lifecycle_delete_purge_and_revocation() {
         qdrant_points_for_doc(&env, &ctx, doc.collection_id, doc.document_id).await,
         0
     );
-
-    let (status, search_after) = search(&env, &owner, marker, Some(doc.collection_id)).await;
-    assert_eq!(status, StatusCode::OK, "{search_after}");
-    assert!(search_after["hits"].as_array().unwrap().is_empty());
-    assert_value_lacks(&search_after, marker);
-    let (status, ask_after) = ask(&env, &owner, marker, Some(doc.collection_id)).await;
-    assert_eq!(status, StatusCode::OK, "{ask_after}");
-    assert_value_lacks(&ask_after, marker);
-    assert!(ask_after["citations"].as_array().unwrap().is_empty());
+    assert_deleted_egress_denied(&env, &owner, &doc, &pin, "after purge").await;
     assert_not_found_raw(
         send_request(
             env.app.clone(),
             "GET",
-            &format!(
-                "/api/v1/documents/{}/versions/{}/preview",
-                doc.document_id, doc.version_id
-            ),
+            &stale_download_path,
             Body::empty(),
-            Some(&owner),
             None,
-        )
-        .await,
-        marker,
-    );
-    assert_not_found_json(
-        json_request(
-            env.app.clone(),
-            "POST",
-            &format!(
-                "/api/v1/documents/{}/versions/{}/citations:resolve",
-                doc.document_id, doc.version_id
-            ),
-            Some(pin),
-            &owner,
+            None,
         )
         .await,
         marker,
@@ -308,6 +356,14 @@ async fn live_adversarial_malicious_input_rejected_or_contained() {
     )
     .await;
     assert_eq!(too_many_parts.status, StatusCode::BAD_REQUEST);
+    let too_many_body: Value =
+        serde_json::from_slice(&too_many_parts.bytes).expect("structured multipart error");
+    assert_eq!(too_many_body["code"], "multipart_invalid");
+    assert_eq!(too_many_body["details"]["threatClass"], "multipart_invalid");
+    assert_eq!(
+        too_many_body["details"]["reasonCode"],
+        "multipart_too_many_parts"
+    );
     assert_body_lacks(&too_many_parts.bytes, "E2E-MALICIOUS");
 
     let (status, spoofed) = upload(
@@ -501,10 +557,7 @@ async fn live_fault_injection_worker_kill_retry_consistency() {
     assert_grounded_http_roundtrip(&env, &owner, &doc).await;
     let chunks = chunk_count(&env, &ctx, document_id).await;
     assert!(chunks > 0);
-    assert_eq!(
-        qdrant_points_for_doc(&env, &ctx, seeded.collection_id, document_id).await as i64,
-        chunks
-    );
+    assert_chunk_point_identity(&env, &ctx, seeded.collection_id, document_id).await;
 
     env.drop().await;
 }
@@ -634,6 +687,93 @@ async fn ask(
         body["collectionIds"] = json!([collection_id]);
     }
     json_request(env.app.clone(), "POST", "/api/v1/ask", Some(body), token).await
+}
+
+async fn mint_download_path(env: &LiveEnv, token: &str, doc: &IngestedDoc) -> String {
+    let (status, capability) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!(
+            "/api/v1/documents/{}/versions/{}/download",
+            doc.document_id, doc.version_id
+        ),
+        None,
+        token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{capability}");
+    capability["downloadPath"]
+        .as_str()
+        .expect("download path")
+        .to_string()
+}
+
+async fn assert_deleted_egress_denied(
+    env: &LiveEnv,
+    token: &str,
+    doc: &IngestedDoc,
+    pin: &Value,
+    phase: &str,
+) {
+    let (status, search_after) = search(env, token, &doc.marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::OK, "{phase}: {search_after}");
+    assert!(
+        search_after["hits"].as_array().unwrap().is_empty(),
+        "{phase}: search still returned deleted document"
+    );
+    assert_value_lacks(&search_after, &doc.marker);
+
+    let (status, ask_after) = ask(env, token, &doc.marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::OK, "{phase}: {ask_after}");
+    assert_value_lacks(&ask_after, &doc.marker);
+    assert!(
+        ask_after["citations"].as_array().unwrap().is_empty(),
+        "{phase}: ask still cited deleted document"
+    );
+
+    assert_not_found_raw(
+        send_request(
+            env.app.clone(),
+            "GET",
+            &format!(
+                "/api/v1/documents/{}/versions/{}/preview",
+                doc.document_id, doc.version_id
+            ),
+            Body::empty(),
+            Some(token),
+            None,
+        )
+        .await,
+        &doc.marker,
+    );
+    assert_not_found_json(
+        json_request(
+            env.app.clone(),
+            "POST",
+            &format!(
+                "/api/v1/documents/{}/versions/{}/citations:resolve",
+                doc.document_id, doc.version_id
+            ),
+            Some(pin.clone()),
+            token,
+        )
+        .await,
+        &doc.marker,
+    );
+    assert_not_found_json(
+        json_request(
+            env.app.clone(),
+            "POST",
+            &format!(
+                "/api/v1/documents/{}/versions/{}/download",
+                doc.document_id, doc.version_id
+            ),
+            None,
+            token,
+        )
+        .await,
+        &doc.marker,
+    );
 }
 
 fn assert_not_found_json((status, body): (StatusCode, Value), marker: &str) {

--- a/crates/server/tests/e2e/scenarios.rs
+++ b/crates/server/tests/e2e/scenarios.rs
@@ -1,0 +1,648 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::StatusCode;
+use fileconv_server::db::models::JobStatus;
+use fileconv_server::services::promotion::PromotionFault;
+use fileconv_server::workers::convert::{ConvertWorker, ConvertWorkerPause, ConvertWorkerRun};
+use fileconv_server::workers::delete::DeleteWorkerRun;
+use fileconv_server::workers::index::IndexWorkerRun;
+use serde_json::{json, Value};
+use tokio::sync::Notify;
+use uuid::Uuid;
+
+use super::harness::*;
+
+#[tokio::test]
+async fn live_full_vertical_slice_multi_format() {
+    let _llm = LlmEnvGuard::unset_all();
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let seeded = seed_org(&env).await;
+    let owner = env.token(&seeded.owner_email).await;
+
+    for case in fixture_cases() {
+        let Some(doc) = ingest_document(&env, &seeded, &owner, case).await else {
+            env.drop().await;
+            return;
+        };
+        assert_grounded_http_roundtrip(&env, &owner, &doc).await;
+        eprintln!("e2e format passed: {}", case.name);
+    }
+
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_authorization_e2e_unauthorized_gets_no_text() {
+    let _llm = LlmEnvGuard::unset_all();
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let seeded = seed_org(&env).await;
+    let owner = env.token(&seeded.owner_email).await;
+    let no_acl = env.token(&seeded.no_acl_email).await;
+    let no_query = env.token(&seeded.no_query_email).await;
+    let cross = env.token(&seeded.cross_email).await;
+    let marker = "E2E-AUTH-SECRET-2026";
+    let Some(doc) = ingest_document(
+        &env,
+        &seeded,
+        &owner,
+        FixtureCase {
+            name: "auth",
+            filename: "auth-secret.txt",
+            content_type: "text/plain",
+            title: "Authorization Secret",
+            bytes: b"E2E-AUTH-SECRET-2026 must not leak to unauthorized users.\n",
+            marker,
+        },
+    )
+    .await
+    else {
+        env.drop().await;
+        return;
+    };
+    let citation = first_citation(&env, &owner, &doc).await;
+    let pin = citation_pin_from(&citation, marker);
+
+    let (status, no_acl_search) = search(&env, &no_acl, marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{no_acl_search}");
+    assert_eq!(no_acl_search["code"], "empty_scope");
+    assert_value_lacks(&no_acl_search, marker);
+
+    let (status, no_acl_ask) = ask(&env, &no_acl, marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{no_acl_ask}");
+    assert_eq!(no_acl_ask["code"], "empty_scope");
+    assert_value_lacks(&no_acl_ask, marker);
+
+    let (status, denied_search) = search(&env, &no_query, marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{denied_search}");
+    assert_eq!(denied_search["code"], "permission_denied");
+    assert_value_lacks(&denied_search, marker);
+
+    let (status, denied_ask) = ask(&env, &no_query, marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{denied_ask}");
+    assert_eq!(denied_ask["code"], "permission_denied");
+    assert_value_lacks(&denied_ask, marker);
+
+    for token in [&no_acl, &cross] {
+        assert_not_found_json(
+            json_request(
+                env.app.clone(),
+                "GET",
+                &format!("/api/v1/documents/{}", doc.document_id),
+                None,
+                token,
+            )
+            .await,
+            marker,
+        );
+        assert_not_found_json(
+            json_request(
+                env.app.clone(),
+                "GET",
+                &format!("/api/v1/jobs/{}", doc.convert_job_id),
+                None,
+                token,
+            )
+            .await,
+            marker,
+        );
+        assert_not_found_raw(
+            send_request(
+                env.app.clone(),
+                "GET",
+                &format!(
+                    "/api/v1/documents/{}/versions/{}/preview",
+                    doc.document_id, doc.version_id
+                ),
+                Body::empty(),
+                Some(token),
+                None,
+            )
+            .await,
+            marker,
+        );
+        assert_not_found_json(
+            json_request(
+                env.app.clone(),
+                "POST",
+                &format!(
+                    "/api/v1/documents/{}/versions/{}/citations:resolve",
+                    doc.document_id, doc.version_id
+                ),
+                Some(pin.clone()),
+                token,
+            )
+            .await,
+            marker,
+        );
+        assert_not_found_json(
+            json_request(
+                env.app.clone(),
+                "POST",
+                &format!(
+                    "/api/v1/documents/{}/versions/{}/download",
+                    doc.document_id, doc.version_id
+                ),
+                None,
+                token,
+            )
+            .await,
+            marker,
+        );
+    }
+
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_lifecycle_delete_purge_and_revocation() {
+    let _llm = LlmEnvGuard::unset_all();
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let seeded = seed_org(&env).await;
+    let owner = env.token(&seeded.owner_email).await;
+    let viewer = env.token(&seeded.viewer_email).await;
+    let marker = "E2E-LIFECYCLE-PURGE-2026";
+    let Some(doc) = ingest_document(
+        &env,
+        &seeded,
+        &owner,
+        FixtureCase {
+            name: "lifecycle",
+            filename: "lifecycle.txt",
+            content_type: "text/plain",
+            title: "Lifecycle Purge",
+            bytes: b"E2E-LIFECYCLE-PURGE-2026 should disappear after purge.\n",
+            marker,
+        },
+    )
+    .await
+    else {
+        env.drop().await;
+        return;
+    };
+    assert_grounded_http_roundtrip(&env, &viewer, &doc).await;
+    let pin = citation_pin_from(&first_citation(&env, &owner, &doc).await, marker);
+
+    let (status, deleted) = json_request(
+        env.app.clone(),
+        "DELETE",
+        &format!("/api/v1/documents/{}", doc.document_id),
+        None,
+        &owner,
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED, "{deleted}");
+    assert_eq!(deleted["document"]["state"], "tombstoned");
+
+    let ctx = seeded.worker_ctx();
+    relay_outbox(&env, &ctx).await;
+    assert!(matches!(
+        run_delete_once(&env, &ctx).await,
+        DeleteWorkerRun::Completed { .. }
+    ));
+    assert_eq!(chunk_count(&env, &ctx, doc.document_id).await, 0);
+    assert_eq!(
+        qdrant_points_for_doc(&env, &ctx, doc.collection_id, doc.document_id).await,
+        0
+    );
+
+    let (status, search_after) = search(&env, &owner, marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::OK, "{search_after}");
+    assert!(search_after["hits"].as_array().unwrap().is_empty());
+    assert_value_lacks(&search_after, marker);
+    let (status, ask_after) = ask(&env, &owner, marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::OK, "{ask_after}");
+    assert_value_lacks(&ask_after, marker);
+    assert!(ask_after["citations"].as_array().unwrap().is_empty());
+    assert_not_found_raw(
+        send_request(
+            env.app.clone(),
+            "GET",
+            &format!(
+                "/api/v1/documents/{}/versions/{}/preview",
+                doc.document_id, doc.version_id
+            ),
+            Body::empty(),
+            Some(&owner),
+            None,
+        )
+        .await,
+        marker,
+    );
+    assert_not_found_json(
+        json_request(
+            env.app.clone(),
+            "POST",
+            &format!(
+                "/api/v1/documents/{}/versions/{}/citations:resolve",
+                doc.document_id, doc.version_id
+            ),
+            Some(pin),
+            &owner,
+        )
+        .await,
+        marker,
+    );
+
+    let revoke_marker = "E2E-REVOKE-FRESH-ACL-2026";
+    let Some(revoke_doc) = ingest_document(
+        &env,
+        &seeded,
+        &owner,
+        FixtureCase {
+            name: "revocation",
+            filename: "revocation.txt",
+            content_type: "text/plain",
+            title: "Revocation Fresh ACL",
+            bytes: b"E2E-REVOKE-FRESH-ACL-2026 is visible until ACL revocation.\n",
+            marker: revoke_marker,
+        },
+    )
+    .await
+    else {
+        env.drop().await;
+        return;
+    };
+    assert_grounded_http_roundtrip(&env, &viewer, &revoke_doc).await;
+    revoke_collection_access(&env, &seeded, seeded.viewer_id).await;
+    let (status, revoked_search) =
+        search(&env, &viewer, revoke_marker, Some(revoke_doc.collection_id)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{revoked_search}");
+    assert_eq!(revoked_search["code"], "empty_scope");
+    assert_value_lacks(&revoked_search, revoke_marker);
+    let (status, revoked_ask) =
+        ask(&env, &viewer, revoke_marker, Some(revoke_doc.collection_id)).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{revoked_ask}");
+    assert_eq!(revoked_ask["code"], "empty_scope");
+    assert_value_lacks(&revoked_ask, revoke_marker);
+
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_adversarial_malicious_input_rejected_or_contained() {
+    let _llm = LlmEnvGuard::unset_all();
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let seeded = seed_org(&env).await;
+    let owner = env.token(&seeded.owner_email).await;
+    let cross = env.token(&seeded.cross_email).await;
+    let ctx = seeded.worker_ctx();
+    let before = document_count(&env, &ctx).await;
+
+    let too_many_parts = send_request(
+        env.app.clone(),
+        "POST",
+        "/api/v1/uploads",
+        Body::from(many_part_body(10)),
+        Some(&owner),
+        Some(format!("multipart/form-data; boundary={BOUNDARY}")),
+    )
+    .await;
+    assert_eq!(too_many_parts.status, StatusCode::BAD_REQUEST);
+    assert_body_lacks(&too_many_parts.bytes, "E2E-MALICIOUS");
+
+    let (status, spoofed) = upload(
+        &env,
+        &owner,
+        "spoofed.pdf",
+        "application/pdf",
+        b"E2E-MALICIOUS-SPOOFED-PDF is actually plain text.\n",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{spoofed}");
+    assert_eq!(spoofed["code"], "upload_rejected");
+    assert_value_lacks(&spoofed, "E2E-MALICIOUS-SPOOFED-PDF");
+    assert!(spoofed.get("objectKey").is_none());
+
+    let (status, cross_upload) = upload(
+        &env,
+        &cross,
+        "cross.txt",
+        "text/plain",
+        b"cross tenant object",
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{cross_upload}");
+    let cross_key = cross_upload["objectKey"].as_str().unwrap();
+    let (status, cross_create) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/collections/{}/documents", seeded.collection_id),
+        Some(json!({ "objectKey": cross_key, "title": "cross key" })),
+        &owner,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{cross_create}");
+
+    let (status, traversal_create) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!("/api/v1/collections/{}/documents", seeded.collection_id),
+        Some(json!({ "objectKey": "../quarantine/evil", "title": "traversal" })),
+        &owner,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{traversal_create}");
+
+    let marker = "E2E-CITATION-PIN-MISMATCH-2026";
+    let Some(doc) = ingest_document(
+        &env,
+        &seeded,
+        &owner,
+        FixtureCase {
+            name: "pin",
+            filename: "pin.txt",
+            content_type: "text/plain",
+            title: "Citation Pin",
+            bytes: b"E2E-CITATION-PIN-MISMATCH-2026 proves pin mismatch is non-disclosing.\n",
+            marker,
+        },
+    )
+    .await
+    else {
+        env.drop().await;
+        return;
+    };
+    let mut pin = citation_pin_from(&first_citation(&env, &owner, &doc).await, marker);
+    pin["contentSha256"] = Value::String("b".repeat(64));
+    assert_not_found_json(
+        json_request(
+            env.app.clone(),
+            "POST",
+            &format!(
+                "/api/v1/documents/{}/versions/{}/citations:resolve",
+                doc.document_id, doc.version_id
+            ),
+            Some(pin),
+            &owner,
+        )
+        .await,
+        marker,
+    );
+
+    assert_eq!(document_count(&env, &ctx).await, before + 1);
+    env.drop().await;
+}
+
+#[tokio::test]
+async fn live_fault_injection_worker_kill_retry_consistency() {
+    let _llm = LlmEnvGuard::unset_all();
+    let Some(env) = LiveEnv::boot().await else {
+        return;
+    };
+    let seeded = seed_org(&env).await;
+    let owner = env.token(&seeded.owner_email).await;
+    let marker = "E2E-FAULT-RETRY-CONSISTENT-2026";
+    let (status, uploaded) = upload(
+        &env,
+        &owner,
+        "fault.txt",
+        "text/plain",
+        b"E2E-FAULT-RETRY-CONSISTENT-2026 survives worker retry exactly once.\n",
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{uploaded}");
+    let (document_id, _source_version_id, job_id) = create_document(
+        &env,
+        &owner,
+        seeded.collection_id,
+        "Fault Retry",
+        uploaded["objectKey"].as_str().unwrap(),
+    )
+    .await;
+
+    let ctx = seeded.worker_ctx();
+    let pause = ConvertWorkerPause {
+        staged: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+    };
+    let Some(mut first_config) =
+        real_convert_config(format!("e2e-convert-crash-{}", Uuid::new_v4()))
+    else {
+        env.drop().await;
+        return;
+    };
+    first_config.lease_ttl = Duration::from_secs(1);
+    first_config.heartbeat_interval = Duration::from_millis(100);
+    first_config.promotion_fault = Some(PromotionFault::AfterStagingPut);
+    first_config.pause_after_staging = Some(pause.clone());
+    let first_worker =
+        ConvertWorker::new(env.pool.clone(), env.storage.clone(), first_config).expect("worker");
+    let first_ctx = ctx.clone();
+    let first_handle = tokio::spawn(async move { first_worker.run_once(&first_ctx).await });
+
+    if tokio::time::timeout(Duration::from_secs(5), pause.staged.notified())
+        .await
+        .is_err()
+    {
+        let first_result = first_handle.await.expect("first join");
+        let (status, last_error) = job_status_and_error(&env, &ctx, job_id).await;
+        panic!(
+            "first worker did not reach staging: {first_result:?}; job_status={status}; last_error={last_error:?}"
+        );
+    }
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    expire_leases(&env, &ctx).await;
+    make_job_available(&env, &ctx, job_id).await;
+
+    let Some(retry_run) = run_convert_once(&env, &ctx).await else {
+        pause.release.notify_waiters();
+        let _ = first_handle.await;
+        env.drop().await;
+        return;
+    };
+    assert!(matches!(
+        retry_run,
+        ConvertWorkerRun::Completed { job_id: completed, .. } if completed == job_id
+    ));
+    pause.release.notify_waiters();
+    let first_result = first_handle.await.expect("first join");
+    assert!(
+        matches!(
+            first_result,
+            Ok(ConvertWorkerRun::LeaseLost { job_id: lost }) if lost == job_id
+        ) || matches!(
+            first_result,
+            Ok(ConvertWorkerRun::Failed {
+                job_id: failed,
+                terminal: false
+            }) if failed == job_id
+        ) || first_result.is_err(),
+        "unexpected first worker result: {first_result:?}"
+    );
+    assert_eq!(
+        get_job_status(&env, &ctx, job_id).await,
+        JobStatus::Succeeded
+    );
+
+    relay_outbox(&env, &ctx).await;
+    let index = run_index_once(&env, &ctx).await.expect("index run");
+    assert!(matches!(index, IndexWorkerRun::Completed { chunks, .. } if chunks > 0));
+    let version_id = current_version(&env, &ctx, document_id)
+        .await
+        .expect("current version");
+    let doc = IngestedDoc {
+        document_id,
+        version_id,
+        convert_job_id: job_id,
+        collection_id: seeded.collection_id,
+        marker: marker.to_string(),
+        title: "Fault Retry".into(),
+    };
+    assert_grounded_http_roundtrip(&env, &owner, &doc).await;
+    let chunks = chunk_count(&env, &ctx, document_id).await;
+    assert!(chunks > 0);
+    assert_eq!(
+        qdrant_points_for_doc(&env, &ctx, seeded.collection_id, document_id).await as i64,
+        chunks
+    );
+
+    env.drop().await;
+}
+
+async fn assert_grounded_http_roundtrip(env: &LiveEnv, token: &str, doc: &IngestedDoc) {
+    let (status, search_response) = search(env, token, &doc.marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::OK, "{search_response}");
+    let hits = search_response["hits"].as_array().expect("search hits");
+    assert!(
+        !hits.is_empty(),
+        "search returned no hits for {}",
+        doc.title
+    );
+    assert!(
+        hits.iter().any(|hit| hit["snippet"]
+            .as_str()
+            .is_some_and(|snippet| snippet.contains(&doc.marker))),
+        "search snippet did not include expected marker"
+    );
+
+    let (status, ask_response) = ask(env, token, &doc.marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::OK, "{ask_response}");
+    assert!(ask_response["answer"]
+        .as_str()
+        .unwrap_or_default()
+        .contains(&doc.marker));
+    let citations = ask_response["citations"].as_array().expect("citations");
+    let citation = citations
+        .iter()
+        .find(|citation| citation["documentId"] == doc.document_id.to_string())
+        .expect("citation for ingested document");
+    assert!(citation["snippet"]
+        .as_str()
+        .unwrap_or_default()
+        .contains(&doc.marker));
+    let pin = citation_pin_from(citation, &doc.marker);
+    let (status, resolved) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!(
+            "/api/v1/documents/{}/versions/{}/citations:resolve",
+            doc.document_id, doc.version_id
+        ),
+        Some(pin),
+        token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{resolved}");
+    assert!(resolved["snippet"]
+        .as_str()
+        .unwrap_or_default()
+        .contains(&doc.marker));
+
+    let preview = send_request(
+        env.app.clone(),
+        "GET",
+        &format!(
+            "/api/v1/documents/{}/versions/{}/preview",
+            doc.document_id, doc.version_id
+        ),
+        Body::empty(),
+        Some(token),
+        None,
+    )
+    .await;
+    assert_eq!(preview.status, StatusCode::OK);
+    assert!(String::from_utf8_lossy(&preview.bytes).contains(&doc.marker));
+
+    let (status, capability) = json_request(
+        env.app.clone(),
+        "POST",
+        &format!(
+            "/api/v1/documents/{}/versions/{}/download",
+            doc.document_id, doc.version_id
+        ),
+        None,
+        token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{capability}");
+    let download_path = capability["downloadPath"].as_str().expect("download path");
+    let downloaded = send_request(
+        env.app.clone(),
+        "GET",
+        download_path,
+        Body::empty(),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(downloaded.status, StatusCode::OK);
+    assert!(String::from_utf8_lossy(&downloaded.bytes).contains(&doc.marker));
+}
+
+async fn first_citation(env: &LiveEnv, token: &str, doc: &IngestedDoc) -> Value {
+    let (status, ask_response) = ask(env, token, &doc.marker, Some(doc.collection_id)).await;
+    assert_eq!(status, StatusCode::OK, "{ask_response}");
+    ask_response["citations"]
+        .as_array()
+        .expect("citations")
+        .first()
+        .expect("first citation")
+        .clone()
+}
+
+async fn search(
+    env: &LiveEnv,
+    token: &str,
+    query: &str,
+    collection_id: Option<Uuid>,
+) -> (StatusCode, Value) {
+    let mut body = json!({ "query": query, "limit": 5 });
+    if let Some(collection_id) = collection_id {
+        body["collectionIds"] = json!([collection_id]);
+    }
+    json_request(env.app.clone(), "POST", "/api/v1/search", Some(body), token).await
+}
+
+async fn ask(
+    env: &LiveEnv,
+    token: &str,
+    question: &str,
+    collection_id: Option<Uuid>,
+) -> (StatusCode, Value) {
+    let mut body = json!({ "question": question, "limit": 5 });
+    if let Some(collection_id) = collection_id {
+        body["collectionIds"] = json!([collection_id]);
+    }
+    json_request(env.app.clone(), "POST", "/api/v1/ask", Some(body), token).await
+}
+
+fn assert_not_found_json((status, body): (StatusCode, Value), marker: &str) {
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    assert_eq!(body["code"], "not_found");
+    assert_value_lacks(&body, marker);
+}
+
+fn assert_not_found_raw(response: HttpResponse, marker: &str) {
+    assert_eq!(response.status, StatusCode::NOT_FOUND);
+    assert_body_lacks(&response.bytes, marker);
+}

--- a/crates/server/tests/e2e/scenarios.rs
+++ b/crates/server/tests/e2e/scenarios.rs
@@ -89,6 +89,27 @@ async fn live_authorization_e2e_unauthorized_gets_no_text() {
         env.drop().await;
         return;
     };
+    let org_a_ctx = seeded.worker_ctx();
+    assert_direct_qdrant_tenant_filter(
+        &env,
+        DirectQdrantDoc {
+            ctx: &org_a_ctx,
+            collection_id: doc.collection_id,
+            doc: &doc,
+        },
+        DirectQdrantDoc {
+            ctx: &cross_ctx,
+            collection_id: cross_doc.collection_id,
+            doc: &cross_doc,
+        },
+        cross_query,
+    )
+    .await;
+    let org_a_chunk_identities = chunk_identities_for_doc(&env, &org_a_ctx, doc.document_id).await;
+    assert!(
+        !org_a_chunk_identities.is_empty(),
+        "org-A control doc has no chunk identities"
+    );
 
     let (status, cross_search) = search(&env, &cross, cross_query, None).await;
     assert_eq!(status, StatusCode::OK, "{cross_search}");
@@ -107,6 +128,13 @@ async fn live_authorization_e2e_unauthorized_gets_no_text() {
         "cross-tenant search leaked org-A identifiers: {cross_search}"
     );
     assert_value_lacks(&cross_search, marker);
+    for chunk_identity in &org_a_chunk_identities {
+        assert_value_lacks(&cross_search, chunk_identity);
+    }
+    assert!(
+        cross_search.to_string().contains(cross_visible_marker),
+        "cross-tenant control search did not include org-B marker: {cross_search}"
+    );
 
     let (status, cross_ask) = ask(&env, &cross, cross_query, None).await;
     assert_eq!(status, StatusCode::OK, "{cross_ask}");
@@ -126,6 +154,13 @@ async fn live_authorization_e2e_unauthorized_gets_no_text() {
         "cross-tenant ask leaked org-A identifiers: {cross_ask}"
     );
     assert_value_lacks(&cross_ask, marker);
+    for chunk_identity in &org_a_chunk_identities {
+        assert_value_lacks(&cross_ask, chunk_identity);
+    }
+    assert!(
+        cross_ask.to_string().contains(cross_visible_marker),
+        "cross-tenant control ask did not include org-B marker: {cross_ask}"
+    );
 
     let (status, no_acl_search) = search(&env, &no_acl, marker, Some(doc.collection_id)).await;
     assert_eq!(status, StatusCode::FORBIDDEN, "{no_acl_search}");
@@ -248,7 +283,8 @@ async fn live_lifecycle_delete_purge_and_revocation() {
     };
     assert_grounded_http_roundtrip(&env, &viewer, &doc).await;
     let pin = citation_pin_from(&first_citation(&env, &owner, &doc).await, marker);
-    let stale_download_path = mint_download_path(&env, &owner, &doc).await;
+    let tombstone_stale_download_path = mint_download_path(&env, &owner, &doc).await;
+    let purge_stale_download_path = mint_download_path(&env, &owner, &doc).await;
     let proof_download_path = mint_download_path(&env, &owner, &doc).await;
     let proof_downloaded = send_request(
         env.app.clone(),
@@ -273,6 +309,18 @@ async fn live_lifecycle_delete_purge_and_revocation() {
     assert_eq!(status, StatusCode::ACCEPTED, "{deleted}");
     assert_eq!(deleted["document"]["state"], "tombstoned");
     assert_deleted_egress_denied(&env, &owner, &doc, &pin, "after tombstone before purge").await;
+    assert_not_found_raw(
+        send_request(
+            env.app.clone(),
+            "GET",
+            &tombstone_stale_download_path,
+            Body::empty(),
+            None,
+            None,
+        )
+        .await,
+        marker,
+    );
 
     let ctx = seeded.worker_ctx();
     relay_outbox(&env, &ctx).await;
@@ -290,7 +338,7 @@ async fn live_lifecycle_delete_purge_and_revocation() {
         send_request(
             env.app.clone(),
             "GET",
-            &stale_download_path,
+            &purge_stale_download_path,
             Body::empty(),
             None,
             None,

--- a/crates/server/tests/e2e_suite.rs
+++ b/crates/server/tests/e2e_suite.rs
@@ -1,0 +1,10 @@
+//! P1B-O04 live end-to-end release/security suite.
+//!
+//! The tests skip cleanly unless `MARKHAND_TEST_DATABASE_URL`,
+//! `MARKHAND_TEST_QDRANT_URL`, and `MARKHAND_TEST_MINIO_*` are set.
+
+#[path = "e2e/harness.rs"]
+mod harness;
+
+#[path = "e2e/scenarios.rs"]
+mod scenarios;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-O04 — Vertical-slice/security release suite

An end-to-end integration/security suite (`crates/server/tests/e2e/**`) exercising the whole pipeline through the **real** converters/workers/services, plus the production bug it surfaced. Stacks on O01. Closes #100.

### 🐛 Real defect found & fixed
The suite exposed that the entire **HTTP `upload → create-document → convert` path was broken** in production: I01 quarantines an object *before* a document exists (metadata `document-id`/`version-id` are `None`), but `workers/convert.rs::verify_quarantine_metadata` **required** those ids to equal the source version → every real upload failed with `InvalidQuarantineMetadata`. Per-issue tests missed it because they seed the object with matching ids. **Fix**: verify `document-id`/`version-id` only when present; isolation/integrity stay enforced by the org-scoped quarantine key + `accepted` disposition + `content-sha256 == source version` (the PG `original_object_key` is the authoritative version↔object binding). Security review confirmed **no tenant/integrity regression**; added a unit test (absent-ok / id-mismatch-fail / wrong-sha-fail).

### e2e scenarios (live, self-skipping)
1. **Full vertical slice** — txt/csv/html/markdown: upload → create → **sandboxed convert** → index → `search` → `ask` → **citation resolves** to ingested content (round-trips).
2. **Authorization** — no-ACL / no-`qa.query` / cross-tenant users get **no text** via search/ask/preview/citation/download/jobs (non-disclosing 404, no snippet leak). Includes a **direct Qdrant probe** `VectorScope(orgB,[orgA_collection])` proving the org filter is load-bearing (a Qdrant tenant-filter regression fails the test), plus org-A chunk-id absence and org-B marker presence.
3. **Lifecycle/revocation** — egress denial asserted **after tombstone** *and* **after purge** (search/ask/preview/citation/download); a pre-minted, proven-working **download capability is revoked** in both states; collection-access revocation cuts access on the next request.
4. **Adversarial** — oversized/disallowed-type upload, spoofed/cross-tenant/traversal object key, citation-pin IDOR rejected/contained (asserts structured reason codes; no partial ingest).
5. **Fault injection** — convert lease-loss → another worker resumes → **chunk↔Qdrant-point identity bijection** verified (no orphan/missing points, no duplicate chunks — not just equal counts).

Plus a POC run manifest (`tests/e2e/README.md`).

### Tests / gates
- Live e2e (5 scenarios) + regression (worker 20, uploads 27, index_worker 5, deletion_reconcile 10) pass against native PG/Qdrant/MinIO; `cargo fmt`, `clippy -D warnings`, **130 lib tests**, `make check-boundaries` green. No new crates/migrations.

### Security review
`gpt-5.6-sol-high`, **4 rounds** → **PASS**. Confirmed the convert fix is regression-free; rounds 2–4 eliminated e2e *false-assurance* gaps (cross-tenant search/ask + Qdrant-filter isolation, tombstone-time capability revocation, chunk↔point identity).

### Note
Tests-only besides the reviewed convert fix. Catalog's container/SBOM "release" packaging is **F02** (separate); this issue is the vertical-slice/security suite. Formal G0-SEC/G1A sign-off references this suite as evidence.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

