### PR TITLE
feat(deploy): P1B-F02 POC deployment & isolation scaffold

### DIFF
--- a/deploy/Dockerfile.server
+++ b/deploy/Dockerfile.server
@@ -1,0 +1,45 @@
+ARG RUST_IMAGE=rust:1.88.0-bookworm
+ARG RUNTIME_IMAGE=debian:bookworm-slim
+
+FROM ${RUST_IMAGE} AS builder
+
+ENV CC=cc \
+    CXX=c++
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        clang \
+        cmake \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY . .
+
+RUN cargo build --release -p fileconv-server --bin fileconv-server
+
+FROM ${RUNTIME_IMAGE} AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libssl3 \
+        libstdc++6 \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system markhand \
+    && useradd --system --gid markhand --create-home --home-dir /var/lib/markhand --shell /usr/sbin/nologin markhand
+
+COPY --from=builder /workspace/target/release/fileconv-server /usr/local/bin/fileconv-server
+
+USER markhand
+WORKDIR /var/lib/markhand
+
+EXPOSE 8787
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8787/api/v1/health/live >/dev/null || exit 1
+
+ENTRYPOINT ["/usr/local/bin/fileconv-server"]

--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -1,0 +1,53 @@
+ARG RUST_IMAGE=rust:1.88.0-bookworm
+ARG RUNTIME_IMAGE=debian:bookworm-slim
+
+FROM ${RUST_IMAGE} AS builder
+
+ENV CC=cc \
+    CXX=c++
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        clang \
+        cmake \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+COPY . .
+
+RUN cargo build --release -p fileconv-server --bin fileconv-worker \
+    && cargo build --release -p fileconv-cli --bin fileconv
+
+FROM ${RUNTIME_IMAGE} AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        libstdc++6 \
+        tesseract-ocr \
+        tesseract-ocr-eng \
+        tesseract-ocr-vie \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system markhand \
+    && useradd --system --gid markhand --create-home --home-dir /var/lib/markhand --shell /usr/sbin/nologin markhand \
+    && mkdir -p /opt/fileconv/pdfium/lib /opt/fileconv/tessdata_best /opt/fileconv/models \
+    && chown -R markhand:markhand /var/lib/markhand /opt/fileconv
+
+COPY --from=builder /workspace/target/release/fileconv-worker /usr/local/bin/fileconv-worker
+COPY --from=builder /workspace/target/release/fileconv /usr/local/bin/fileconv
+
+ENV FILECONV_PDFIUM_LIB=/opt/fileconv/pdfium/lib
+
+USER markhand
+WORKDIR /var/lib/markhand
+VOLUME ["/opt/fileconv/pdfium/lib", "/opt/fileconv/tessdata_best", "/opt/fileconv/models"]
+
+# Workers are long-running pollers without an HTTP listener; health is process supervision.
+HEALTHCHECK NONE
+
+ENTRYPOINT ["/usr/local/bin/fileconv-worker"]

--- a/deploy/compose.poc.yml
+++ b/deploy/compose.poc.yml
@@ -1,0 +1,279 @@
+name: ${MARKHAND_POC_COMPOSE_PROJECT:-markhand-poc}
+
+x-server-environment: &server-environment
+  MARKHAND_PROFILE: "${MARKHAND_PROFILE:-dev}"
+  MARKHAND_BIND_ADDR: "${MARKHAND_BIND_ADDR:-0.0.0.0:8787}"
+  MARKHAND_DATABASE_URL: "${MARKHAND_DATABASE_URL:-postgres://markhand:markhand_poc_change_me@postgres:5432/markhand}"
+  MARKHAND_QDRANT_URL: "${MARKHAND_QDRANT_URL:-http://qdrant:6333}"
+  MARKHAND_QDRANT_API_KEY: "${MARKHAND_QDRANT_API_KEY:-}"
+  MARKHAND_MINIO_URL: "${MARKHAND_MINIO_URL:-http://minio:9000}"
+  MARKHAND_MINIO_ACCESS_KEY: "${MARKHAND_MINIO_ACCESS_KEY:-markhand}"
+  # CHANGE IN PROD: this dev-only object-store secret is for isolated POC runs only.
+  MARKHAND_MINIO_SECRET_KEY: "${MARKHAND_MINIO_SECRET_KEY:-markhand_poc_change_me}"
+  MARKHAND_MINIO_BUCKET: "${MARKHAND_MINIO_BUCKET:-markhand-documents}"
+  MARKHAND_MINIO_REGION: "${MARKHAND_MINIO_REGION:-us-east-1}"
+  MARKHAND_MINIO_PATH_STYLE: "${MARKHAND_MINIO_PATH_STYLE:-true}"
+  MARKHAND_MINIO_OPERATION_TIMEOUT_SECS: "${MARKHAND_MINIO_OPERATION_TIMEOUT_SECS:-30}"
+  MARKHAND_AUTH_ISSUER: "${MARKHAND_AUTH_ISSUER:-http://127.0.0.1:8787/dev-issuer}"
+  MARKHAND_AUTH_AUDIENCE: "${MARKHAND_AUTH_AUDIENCE:-markhand-poc}"
+  # CHANGE IN PROD: this dev-only JWT key also derives the download capability key.
+  MARKHAND_AUTH_SIGNING_KEY: "${MARKHAND_AUTH_SIGNING_KEY:-CHANGE-ME-dev-only-poc-signing-key-32b}"
+  MARKHAND_AUTH_ALG: "${MARKHAND_AUTH_ALG:-HS256}"
+  MARKHAND_AUTH_KID: "${MARKHAND_AUTH_KID:-dev-poc}"
+  MARKHAND_AUTH_ACCESS_TOKEN_TTL_SECS: "${MARKHAND_AUTH_ACCESS_TOKEN_TTL_SECS:-900}"
+  MARKHAND_AUTH_REFRESH_TOKEN_TTL_SECS: "${MARKHAND_AUTH_REFRESH_TOKEN_TTL_SECS:-604800}"
+  MARKHAND_AUTH_ARGON2_MEMORY_KIB: "${MARKHAND_AUTH_ARGON2_MEMORY_KIB:-19456}"
+  MARKHAND_AUTH_ARGON2_TIME_COST: "${MARKHAND_AUTH_ARGON2_TIME_COST:-2}"
+  MARKHAND_AUTH_ARGON2_PARALLELISM: "${MARKHAND_AUTH_ARGON2_PARALLELISM:-1}"
+  MARKHAND_MAX_UPLOAD_BYTES: "${MARKHAND_MAX_UPLOAD_BYTES:-209715200}"
+  MARKHAND_JOB_LEASE_SECONDS: "${MARKHAND_JOB_LEASE_SECONDS:-60}"
+  MARKHAND_MAX_ARCHIVE_ENTRIES: "${MARKHAND_MAX_ARCHIVE_ENTRIES:-4096}"
+  MARKHAND_MAX_ARCHIVE_UNCOMPRESSED_BYTES: "${MARKHAND_MAX_ARCHIVE_UNCOMPRESSED_BYTES:-1073741824}"
+  MARKHAND_MAX_ARCHIVE_COMPRESSION_RATIO: "${MARKHAND_MAX_ARCHIVE_COMPRESSION_RATIO:-100}"
+  MARKHAND_MAX_PDF_PAGES: "${MARKHAND_MAX_PDF_PAGES:-500}"
+  MARKHAND_MAX_IMAGE_PIXELS: "${MARKHAND_MAX_IMAGE_PIXELS:-80000000}"
+  MARKHAND_MAX_AUDIO_DURATION_SECS: "${MARKHAND_MAX_AUDIO_DURATION_SECS:-3600}"
+  MARKHAND_MAX_MULTIPART_PARTS: "${MARKHAND_MAX_MULTIPART_PARTS:-8}"
+  MARKHAND_MAX_PART_HEADER_BYTES: "${MARKHAND_MAX_PART_HEADER_BYTES:-8192}"
+  MARKHAND_UPLOAD_TIMEOUT_SECS: "${MARKHAND_UPLOAD_TIMEOUT_SECS:-120}"
+  MARKHAND_UPLOAD_IDLE_TIMEOUT_SECS: "${MARKHAND_UPLOAD_IDLE_TIMEOUT_SECS:-15}"
+  MARKHAND_QUOTA_SWEEP_INTERVAL_SECS: "${MARKHAND_QUOTA_SWEEP_INTERVAL_SECS:-60}"
+  MARKHAND_QUOTA_SWEEP_BATCH_SIZE: "${MARKHAND_QUOTA_SWEEP_BATCH_SIZE:-500}"
+  MARKHAND_RATE_LIMIT_AUTH_PER_MINUTE: "${MARKHAND_RATE_LIMIT_AUTH_PER_MINUTE:-20}"
+  MARKHAND_RATE_LIMIT_LLM_PER_MINUTE: "${MARKHAND_RATE_LIMIT_LLM_PER_MINUTE:-60}"
+  MARKHAND_RATE_LIMIT_AUTHENTICATED_PER_MINUTE: "${MARKHAND_RATE_LIMIT_AUTHENTICATED_PER_MINUTE:-300}"
+  MARKHAND_RATE_LIMIT_FALLBACK_PER_MINUTE: "${MARKHAND_RATE_LIMIT_FALLBACK_PER_MINUTE:-120}"
+  MARKHAND_RATE_LIMIT_MAX_ENTRIES: "${MARKHAND_RATE_LIMIT_MAX_ENTRIES:-8192}"
+  MARKHAND_TRUSTED_PROXY: "${MARKHAND_TRUSTED_PROXY:-false}"
+  MARKHAND_CORS_ALLOWED_ORIGINS: "${MARKHAND_CORS_ALLOWED_ORIGINS:-}"
+  MARKHAND_INDEX_SIGNATURE: "${MARKHAND_INDEX_SIGNATURE:-}"
+  MARKHAND_LOG_FORMAT: "${MARKHAND_LOG_FORMAT:-json}"
+  MARKHAND_LOG_LEVEL: "${MARKHAND_LOG_LEVEL:-info}"
+  MARKHAND_METRICS_ENABLED: "${MARKHAND_METRICS_ENABLED:-true}"
+  MARKHAND_OTLP_ENDPOINT: "${MARKHAND_OTLP_ENDPOINT:-}"
+  FILECONV_LLM_PROVIDER: "${FILECONV_LLM_PROVIDER:-openai}"
+  FILECONV_LLM_MODEL: "${FILECONV_LLM_MODEL:-gpt-4o}"
+  FILECONV_LLM_BASE_URL: "${FILECONV_LLM_BASE_URL:-https://api.openai.com/v1}"
+  FILECONV_LLM_API_KEY: "${FILECONV_LLM_API_KEY:-}"
+
+x-worker-environment: &worker-environment
+  MARKHAND_PROFILE: "${MARKHAND_PROFILE:-dev}"
+  MARKHAND_BIND_ADDR: "${MARKHAND_WORKER_BIND_ADDR:-127.0.0.1:8787}"
+  MARKHAND_DATABASE_URL: "${MARKHAND_DATABASE_URL:-postgres://markhand:markhand_poc_change_me@postgres:5432/markhand}"
+  MARKHAND_QDRANT_URL: "${MARKHAND_QDRANT_URL:-http://qdrant:6333}"
+  MARKHAND_QDRANT_API_KEY: "${MARKHAND_QDRANT_API_KEY:-}"
+  MARKHAND_MINIO_URL: "${MARKHAND_MINIO_URL:-http://minio:9000}"
+  MARKHAND_MINIO_ACCESS_KEY: "${MARKHAND_MINIO_ACCESS_KEY:-markhand}"
+  MARKHAND_MINIO_SECRET_KEY: "${MARKHAND_MINIO_SECRET_KEY:-markhand_poc_change_me}"
+  MARKHAND_MINIO_BUCKET: "${MARKHAND_MINIO_BUCKET:-markhand-documents}"
+  MARKHAND_MINIO_REGION: "${MARKHAND_MINIO_REGION:-us-east-1}"
+  MARKHAND_MINIO_PATH_STYLE: "${MARKHAND_MINIO_PATH_STYLE:-true}"
+  MARKHAND_MINIO_OPERATION_TIMEOUT_SECS: "${MARKHAND_MINIO_OPERATION_TIMEOUT_SECS:-30}"
+  MARKHAND_MAX_UPLOAD_BYTES: "${MARKHAND_MAX_UPLOAD_BYTES:-209715200}"
+  MARKHAND_JOB_LEASE_SECONDS: "${MARKHAND_JOB_LEASE_SECONDS:-60}"
+  MARKHAND_MAX_ARCHIVE_ENTRIES: "${MARKHAND_MAX_ARCHIVE_ENTRIES:-4096}"
+  MARKHAND_MAX_ARCHIVE_UNCOMPRESSED_BYTES: "${MARKHAND_MAX_ARCHIVE_UNCOMPRESSED_BYTES:-1073741824}"
+  MARKHAND_MAX_ARCHIVE_COMPRESSION_RATIO: "${MARKHAND_MAX_ARCHIVE_COMPRESSION_RATIO:-100}"
+  MARKHAND_MAX_PDF_PAGES: "${MARKHAND_MAX_PDF_PAGES:-500}"
+  MARKHAND_MAX_IMAGE_PIXELS: "${MARKHAND_MAX_IMAGE_PIXELS:-80000000}"
+  MARKHAND_MAX_AUDIO_DURATION_SECS: "${MARKHAND_MAX_AUDIO_DURATION_SECS:-3600}"
+  MARKHAND_MAX_MULTIPART_PARTS: "${MARKHAND_MAX_MULTIPART_PARTS:-8}"
+  MARKHAND_MAX_PART_HEADER_BYTES: "${MARKHAND_MAX_PART_HEADER_BYTES:-8192}"
+  MARKHAND_UPLOAD_TIMEOUT_SECS: "${MARKHAND_UPLOAD_TIMEOUT_SECS:-120}"
+  MARKHAND_UPLOAD_IDLE_TIMEOUT_SECS: "${MARKHAND_UPLOAD_IDLE_TIMEOUT_SECS:-15}"
+  MARKHAND_QUOTA_SWEEP_INTERVAL_SECS: "${MARKHAND_QUOTA_SWEEP_INTERVAL_SECS:-60}"
+  MARKHAND_QUOTA_SWEEP_BATCH_SIZE: "${MARKHAND_QUOTA_SWEEP_BATCH_SIZE:-500}"
+  MARKHAND_RATE_LIMIT_AUTH_PER_MINUTE: "${MARKHAND_RATE_LIMIT_AUTH_PER_MINUTE:-20}"
+  MARKHAND_RATE_LIMIT_LLM_PER_MINUTE: "${MARKHAND_RATE_LIMIT_LLM_PER_MINUTE:-60}"
+  MARKHAND_RATE_LIMIT_AUTHENTICATED_PER_MINUTE: "${MARKHAND_RATE_LIMIT_AUTHENTICATED_PER_MINUTE:-300}"
+  MARKHAND_RATE_LIMIT_FALLBACK_PER_MINUTE: "${MARKHAND_RATE_LIMIT_FALLBACK_PER_MINUTE:-120}"
+  MARKHAND_RATE_LIMIT_MAX_ENTRIES: "${MARKHAND_RATE_LIMIT_MAX_ENTRIES:-8192}"
+  MARKHAND_TRUSTED_PROXY: "${MARKHAND_TRUSTED_PROXY:-false}"
+  MARKHAND_CORS_ALLOWED_ORIGINS: "${MARKHAND_CORS_ALLOWED_ORIGINS:-}"
+  MARKHAND_INDEX_SIGNATURE: "${MARKHAND_INDEX_SIGNATURE:-}"
+  MARKHAND_LOG_FORMAT: "${MARKHAND_LOG_FORMAT:-json}"
+  MARKHAND_LOG_LEVEL: "${MARKHAND_LOG_LEVEL:-info}"
+  MARKHAND_METRICS_ENABLED: "${MARKHAND_METRICS_ENABLED:-true}"
+  MARKHAND_OTLP_ENDPOINT: "${MARKHAND_OTLP_ENDPOINT:-}"
+  MARKHAND_WORKER_ORG_ID: "${MARKHAND_WORKER_ORG_ID:-11111111-1111-4111-8111-111111111111}"
+  MARKHAND_WORKER_USER_ID: "${MARKHAND_WORKER_USER_ID:-22222222-2222-4222-8222-222222222222}"
+  MARKHAND_WORKER_CLAIM_LIMIT: "${MARKHAND_WORKER_CLAIM_LIMIT:-1}"
+  MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS: "${MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS:-5}"
+  MARKHAND_WORKER_MAX_JOB_SECS: "${MARKHAND_WORKER_MAX_JOB_SECS:-150}"
+  MARKHAND_INDEX_EMBEDDING_BATCH_SIZE: "${MARKHAND_INDEX_EMBEDDING_BATCH_SIZE:-64}"
+  MARKHAND_CONVERTER_ARGV_JSON: '${MARKHAND_CONVERTER_ARGV_JSON:-["/usr/local/bin/fileconv","one","{input}"]}'
+  MARKHAND_CONVERTER_TIMEOUT_SECS: "${MARKHAND_CONVERTER_TIMEOUT_SECS:-120}"
+  MARKHAND_CONVERTER_MEMORY_BYTES: "${MARKHAND_CONVERTER_MEMORY_BYTES:-805306368}"
+  MARKHAND_CONVERTER_CPU_SECONDS: "${MARKHAND_CONVERTER_CPU_SECONDS:-60}"
+  MARKHAND_CONVERTER_FILE_SIZE_BYTES: "${MARKHAND_CONVERTER_FILE_SIZE_BYTES:-67108864}"
+  MARKHAND_CONVERTER_MAX_PROCESSES: "${MARKHAND_CONVERTER_MAX_PROCESSES:-512}"
+  MARKHAND_CONVERTER_MAX_OPEN_FILES: "${MARKHAND_CONVERTER_MAX_OPEN_FILES:-256}"
+  FILECONV_PDFIUM_LIB: "${FILECONV_PDFIUM_LIB:-/opt/fileconv/pdfium/lib}"
+  FILECONV_WHISPER_MODEL: "${FILECONV_WHISPER_MODEL:-}"
+
+x-app-security: &app-security
+  read_only: true
+  tmpfs:
+    - /tmp:rw,noexec,nosuid,nodev,size=256m
+  cap_drop: ["ALL"]
+  security_opt:
+    - no-new-privileges:true
+
+x-worker-service: &worker-service
+  build:
+    context: ..
+    dockerfile: deploy/Dockerfile.worker
+  depends_on:
+    postgres:
+      condition: service_healthy
+    qdrant:
+      condition: service_healthy
+    minio:
+      condition: service_healthy
+    minio-init:
+      condition: service_completed_successfully
+    server:
+      condition: service_healthy
+  networks: [private]
+  restart: unless-stopped
+  <<: *app-security
+
+services:
+  postgres:
+    image: postgres:18.4-bookworm@sha256:1961f96e6029a02c3812d7cb329a3b03a3ac2bb067058dec17b0f5596aca9296
+    environment:
+      POSTGRES_DB: "${MARKHAND_POSTGRES_DB:-markhand}"
+      POSTGRES_USER: "${MARKHAND_POSTGRES_USER:-markhand}"
+      # CHANGE IN PROD: this dev-only database password is for isolated POC runs only.
+      POSTGRES_PASSWORD: "${MARKHAND_POSTGRES_PASSWORD:-markhand_poc_change_me}"
+    ports:
+      - "127.0.0.1:${MARKHAND_POC_POSTGRES_PORT:-15432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    networks: [private]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant:v1.18.2@sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c
+    environment:
+      QDRANT__TELEMETRY_DISABLED: "true"
+    ports:
+      - "127.0.0.1:${MARKHAND_POC_QDRANT_HTTP_PORT:-16333}:6333"
+      - "127.0.0.1:${MARKHAND_POC_QDRANT_GRPC_PORT:-16334}:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    networks: [private]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:6333/healthz >/dev/null"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    restart: unless-stopped
+
+  minio:
+    image: pgsty/minio:RELEASE.2026-06-18T00-00-00Z@sha256:dacff8306a6e0a734518533992dbdcca26bc1ca47f77cf47cb9945725f92b29b
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: "${MARKHAND_MINIO_ACCESS_KEY:-markhand}"
+      # CHANGE IN PROD: this dev-only MinIO root secret is for isolated POC runs only.
+      MINIO_ROOT_PASSWORD: "${MARKHAND_MINIO_SECRET_KEY:-markhand_poc_change_me}"
+    ports:
+      - "127.0.0.1:${MARKHAND_POC_MINIO_API_PORT:-19000}:9000"
+      - "127.0.0.1:${MARKHAND_POC_MINIO_CONSOLE_PORT:-19001}:9001"
+    volumes:
+      - minio_data:/data
+    networks: [private]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    restart: unless-stopped
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MC_HOST_local: "http://${MARKHAND_MINIO_ACCESS_KEY:-markhand}:${MARKHAND_MINIO_SECRET_KEY:-markhand_poc_change_me}@minio:9000"
+    command:
+      [
+        "mb",
+        "--ignore-existing",
+        "local/markhand-quarantine",
+        "local/markhand-documents",
+        "local/markhand-artifacts"
+      ]
+    networks: [private]
+    restart: on-failure
+
+  server:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.server
+    environment:
+      <<: *server-environment
+    depends_on:
+      postgres:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    ports:
+      - "127.0.0.1:${MARKHAND_POC_SERVER_PORT:-8787}:8787"
+    networks: [private]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8787/api/v1/health/ready >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 20s
+    restart: unless-stopped
+    <<: *app-security
+
+  worker-convert:
+    <<: *worker-service
+    environment:
+      <<: *worker-environment
+      MARKHAND_WORKER_ID: "${MARKHAND_WORKER_CONVERT_ID:-fileconv-worker-convert}"
+      MARKHAND_WORKER_KIND: "convert"
+
+  worker-index:
+    <<: *worker-service
+    environment:
+      <<: *worker-environment
+      MARKHAND_WORKER_ID: "${MARKHAND_WORKER_INDEX_ID:-fileconv-worker-index}"
+      MARKHAND_WORKER_KIND: "index"
+
+  worker-delete:
+    <<: *worker-service
+    environment:
+      <<: *worker-environment
+      MARKHAND_WORKER_ID: "${MARKHAND_WORKER_DELETE_ID:-fileconv-worker-delete}"
+      MARKHAND_WORKER_KIND: "delete"
+
+  worker-reconcile:
+    <<: *worker-service
+    environment:
+      <<: *worker-environment
+      MARKHAND_WORKER_ID: "${MARKHAND_WORKER_RECONCILE_ID:-fileconv-worker-reconcile}"
+      MARKHAND_WORKER_KIND: "reconcile"
+      MARKHAND_RECONCILE_MODE: "${MARKHAND_RECONCILE_MODE:-repair}"
+
+networks:
+  private:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  qdrant_data:
+  minio_data:

--- a/deploy/poc/README.md
+++ b/deploy/poc/README.md
@@ -1,0 +1,145 @@
+# Isolated single-org POC deployment scaffold
+
+This scaffold is for a local, single-organization Markhand POC stack. It is not a
+production deployment recipe.
+
+> **NOT build-validated in this sandbox:** this Cursor Cloud environment has no
+> Docker daemon, so `deploy/Dockerfile.server`, `deploy/Dockerfile.worker`, and
+> `deploy/compose.poc.yml` were validated structurally only. Before relying on
+> these artifacts, verify them on a host with Docker Engine:
+>
+> ```bash
+> docker compose -f deploy/compose.poc.yml build
+> docker compose -f deploy/compose.poc.yml up
+> ```
+
+## Run
+
+From the repository root:
+
+```bash
+docker compose -f deploy/compose.poc.yml up --build
+```
+
+Stop and remove containers:
+
+```bash
+docker compose -f deploy/compose.poc.yml down
+```
+
+Remove named volumes as well:
+
+```bash
+docker compose -f deploy/compose.poc.yml down --volumes
+```
+
+## Services and ports
+
+All externally published ports bind to `127.0.0.1` only.
+
+| Service | Internal endpoint | Host endpoint | Purpose |
+| --- | --- | --- | --- |
+| `server` | `http://server:8787` | `http://127.0.0.1:${MARKHAND_POC_SERVER_PORT:-8787}` | API; runs migrations on startup |
+| `postgres` | `postgres:5432` | `127.0.0.1:${MARKHAND_POC_POSTGRES_PORT:-15432}` | PostgreSQL 18.4 |
+| `qdrant` | `http://qdrant:6333`, `qdrant:6334` | `127.0.0.1:${MARKHAND_POC_QDRANT_HTTP_PORT:-16333}`, `127.0.0.1:${MARKHAND_POC_QDRANT_GRPC_PORT:-16334}` | Vector store |
+| `minio` | `http://minio:9000` | `127.0.0.1:${MARKHAND_POC_MINIO_API_PORT:-19000}` | S3-compatible object store |
+| `minio` console | `http://minio:9001` | `127.0.0.1:${MARKHAND_POC_MINIO_CONSOLE_PORT:-19001}` | MinIO UI |
+
+Health endpoints:
+
+```bash
+curl -fsS http://127.0.0.1:${MARKHAND_POC_SERVER_PORT:-8787}/api/v1/health/live
+curl -fsS http://127.0.0.1:${MARKHAND_POC_SERVER_PORT:-8787}/api/v1/health/ready
+curl -fsS http://127.0.0.1:${MARKHAND_POC_QDRANT_HTTP_PORT:-16333}/healthz
+curl -fsS http://127.0.0.1:${MARKHAND_POC_MINIO_API_PORT:-19000}/minio/health/live
+```
+
+`/api/v1/health/ready` checks PostgreSQL connectivity, applied migrations,
+Qdrant, MinIO, and the readiness fence. The O03 restore flow sets the fence to
+`reconciling`/`restoring` during restore and back to `ready` after reconciliation.
+Manual fence commands use the worker binary:
+
+```bash
+docker compose -f deploy/compose.poc.yml run --rm worker-reconcile readiness-fence reconciling "restore in progress"
+docker compose -f deploy/compose.poc.yml run --rm worker-reconcile readiness-fence ready
+```
+
+## Binary and worker mapping
+
+The Dockerfiles follow the actual Cargo package and bin names:
+
+| Image | Cargo command | Runtime binary |
+| --- | --- | --- |
+| `server` | `cargo build --release -p fileconv-server --bin fileconv-server` | `/usr/local/bin/fileconv-server` |
+| `worker-*` | `cargo build --release -p fileconv-server --bin fileconv-worker` | `/usr/local/bin/fileconv-worker` |
+| `worker-*` convert helper | `cargo build --release -p fileconv-cli --bin fileconv` | `/usr/local/bin/fileconv` |
+
+The compose file runs one worker service for each code-supported
+`MARKHAND_WORKER_KIND`:
+
+| Service | `MARKHAND_WORKER_KIND` | Notes |
+| --- | --- | --- |
+| `worker-convert` | `convert` | Uses `MARKHAND_CONVERTER_ARGV_JSON`, defaulting to `["/usr/local/bin/fileconv","one","{input}"]`. |
+| `worker-index` | `index` | Uses local hash embeddings and `MARKHAND_INDEX_EMBEDDING_BATCH_SIZE`. |
+| `worker-delete` | `delete` | Cleans object/vector state for delete jobs. |
+| `worker-reconcile` | `reconcile` | Uses `MARKHAND_RECONCILE_MODE` (`repair` by default; code also accepts dry-run spellings). |
+
+Workers require `MARKHAND_WORKER_ORG_ID` and `MARKHAND_WORKER_USER_ID`. The POC
+defaults are placeholders for a single tenant context; override them to match the
+seeded POC org/user IDs. Workers intentionally do **not** receive
+`MARKHAND_AUTH_*` because `fileconv-worker` rejects API authentication settings.
+
+## Configuration and secrets
+
+`deploy/compose.poc.yml` passes the full server `MARKHAND_*` configuration surface
+used by `crates/server/src/config.rs`, plus worker-only variables read by
+`crates/server/src/bin/worker.rs`.
+
+Change these before any non-local use:
+
+- `MARKHAND_POSTGRES_PASSWORD` and the matching `MARKHAND_DATABASE_URL`
+- `MARKHAND_MINIO_ACCESS_KEY` / `MARKHAND_MINIO_SECRET_KEY`
+- `MARKHAND_AUTH_SIGNING_KEY` (also derives the download capability key in code)
+- `MARKHAND_AUTH_ISSUER`, `MARKHAND_AUTH_AUDIENCE`, `MARKHAND_AUTH_KID`
+- `MARKHAND_INDEX_SIGNATURE` if enforcing a pinned embedding runtime signature
+- Any `FILECONV_LLM_*` settings if enabling cloud/compatible LLM Q&A
+
+Isolation defaults:
+
+- Single Compose project and a private bridge network named by the project.
+- No cross-tenant posture: one worker org/user context is expected.
+- Host ports bind to `127.0.0.1`.
+- `MARKHAND_CORS_ALLOWED_ORIGINS` defaults empty and `MARKHAND_TRUSTED_PROXY`
+  defaults false.
+- Server and worker containers run as a non-root `markhand` user, with
+  `read_only`, `cap_drop: ["ALL"]`, `no-new-privileges`, and `/tmp` tmpfs in
+  compose.
+- Images do not bake secrets; defaults are development-only Compose environment
+  values marked `CHANGE IN PROD`.
+
+## Native conversion runtime
+
+`deploy/Dockerfile.server` installs only API runtime libraries
+(`ca-certificates`, `libssl3`, `libstdc++6`, and `curl` for healthchecks).
+
+`deploy/Dockerfile.worker` additionally installs conversion/OCR runtime
+dependencies:
+
+- `tesseract-ocr`
+- `tesseract-ocr-vie`
+- `tesseract-ocr-eng`
+- `libstdc++6`
+
+PDFium is not baked into the image. The worker image creates
+`/opt/fileconv/pdfium/lib` and sets `FILECONV_PDFIUM_LIB` there; mount the output
+of `bash bench/download_pdfium.sh` at that path for PDFium-backed rendering/OCR.
+Without it, the converter falls back to the Rust/pdf-extract path where supported.
+
+Optional runtime mounts:
+
+- `FILECONV_PDFIUM_LIB=/opt/fileconv/pdfium/lib`
+- `FILECONV_TESSDATA=/opt/fileconv/tessdata_best` after mounting `tessdata_best`
+- `FILECONV_WHISPER_MODEL=/opt/fileconv/models/<model>.bin` after mounting a
+  permitted Whisper model
+
+Audio model weights, customer data, and real credentials must stay outside Git.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-F02 — POC deployment & isolation scaffold

Adds the previously-missing (false-done) deployment scaffold. **Ops/config artifacts only — no Rust changes.** Stacks on O03. Closes #79.

### Deliverables
- **`deploy/Dockerfile.server`** — multi-stage GNU-toolchain build (`cmake`/`clang`/gcc for `whisper-rs-sys`) of `fileconv-server`; slim pinned non-root runtime (libssl/ca-certs/libstdc++); `HEALTHCHECK /api/v1/health/live`; no baked secrets.
- **`deploy/Dockerfile.worker`** — builds `fileconv-worker` (+ the `fileconv` CLI the convert sandbox shells out to); runtime installs Tesseract `vie+eng`; PDFium via `FILECONV_PDFIUM_LIB` mount; non-root.
- **`deploy/compose.poc.yml`** — isolated single-org POC stack: `postgres`/`qdrant`/`minio`/`minio-init` (reused from dev) + `server` + per-kind workers (`convert`/`index`/`delete`/`reconcile`). `depends_on: service_healthy`, migrations-on-startup, dev-only `${VAR:-default}` secrets marked **CHANGE IN PROD**, hardened services (`read_only`, `cap_drop: [ALL]`, `no-new-privileges`, tmpfs), `127.0.0.1` port binds, isolated bridge network, named volumes.
- **`deploy/poc/README.md`** — build/run, env/secret knobs, isolation model, O03 readiness-fence note.

### Isolation / security posture
Non-root users, pinned base images, no secrets in images, least-privilege container caps, loopback-only host ports, isolated network; conservative single-org defaults (empty CORS, `trusted_proxy=false`); workers deliberately lack `MARKHAND_AUTH_*` (matches `from_worker_env()`).

### Validation
Service names/ports/env vars/bin names **cross-checked against `config.rs`/`main.rs`/`worker.rs`/`Cargo.toml`**; `compose.poc.yml` YAML-parses; `make check-boundaries` + `classify-ci` self-tests pass.

> ⚠️ **Not build-validated in this environment** — the sandbox has no Docker daemon, so images were not `docker build`/`compose up` run. Verify on a Docker-capable host (`docker compose -f deploy/compose.poc.yml up --build`). The scaffold is structurally correct and code-matched; treat a real build/boot as the acceptance gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

