### PR TITLE
feat(bench): P1B-O05 mixed-load soak & POC qualification

### DIFF
--- a/bench/markhand_web/reports/phase-1b-gate.py
+++ b/bench/markhand_web/reports/phase-1b-gate.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Aggregate Phase-1B qualification gate report.
+
+The report evaluates only target-valid evidence. Missing evidence, synthetic
+smoke evidence, and targetMatch=false evidence remain pending with null measured
+values so the report is safe to render before real infrastructure exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import string
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CORPUS = ROOT / "bench/markhand_web"
+GATES_PATH = CORPUS / "gates.yaml"
+SUMMARY_PATH = CORPUS / "reports/phase-1b-gate/summary.json"
+REPORT_PATH = CORPUS / "reports/phase-1b-gate/report.md"
+TEMPLATE_PATH = CORPUS / "reports/phase-1b-gate/template.md"
+DEFAULT_EVIDENCE = {
+    "soak": "bench/markhand_web/soak/summary.json",
+    "query_load": "bench/markhand_web/query_load/summary.json",
+    "ingest": "bench/markhand_web/ingest/summary.json",
+    "restore": "bench/markhand_web/restore/summary.json",
+}
+SUPPORTED_GATE_IDS = {
+    "G0-SLO-QUERY-P95",
+    "G0-SLO-QUERY-P99",
+    "G0-CAP-INGEST-THROUGHPUT",
+    "G0-DR-RPO",
+    "G0-DR-QUERY-READY-RTO",
+    "G0-DR-FULL-VECTOR-RTO",
+}
+
+
+class ReportError(RuntimeError):
+    """Actionable report generation error."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def relative(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReportError(f"{relative(path)}: cannot load JSON-compatible YAML: {error}") from error
+    if not isinstance(payload, dict):
+        raise ReportError(f"{relative(path)}: expected object")
+    return payload
+
+
+def load_optional(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    return load_json(path)
+
+
+def git(*args: str) -> str:
+    try:
+        return subprocess.check_output(["git", *args], cwd=ROOT, text=True).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def git_status() -> dict[str, Any]:
+    raw = ""
+    try:
+        raw = subprocess.check_output(["git", "status", "--porcelain"], cwd=ROOT, text=True)
+    except (OSError, subprocess.CalledProcessError):
+        pass
+    dirty_paths = []
+    for line in raw.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if path.startswith('"') and path.endswith('"'):
+            path = path[1:-1]
+        dirty_paths.append(path)
+    return {
+        "commit": git("rev-parse", "HEAD"),
+        "branch": git("branch", "--show-current"),
+        "dirty": bool(dirty_paths),
+        "dirtyPaths": dirty_paths,
+    }
+
+
+def get_path(payload: dict[str, Any] | None, dotted: str) -> Any:
+    current: Any = payload
+    for part in dotted.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def evidence_target_valid(payload: dict[str, Any] | None) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("targetResultsValidForGate") is True:
+        return True
+    return payload.get("targetMatch") is True and payload.get("targetResultsValidForGate") is not False
+
+
+def numeric(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def compare(value: float, threshold: dict[str, Any]) -> bool:
+    operator = threshold.get("operator")
+    target = numeric(threshold.get("value"))
+    if target is None:
+        return False
+    if operator == ">=":
+        return value >= target
+    if operator == "<=":
+        return value <= target
+    if operator == "==":
+        return value == target
+    raise ReportError(f"unsupported threshold operator: {operator}")
+
+
+def candidate(
+    source_name: str,
+    source_path: Path,
+    payload: dict[str, Any] | None,
+    path: str,
+) -> dict[str, Any]:
+    value = numeric(get_path(payload, path))
+    return {
+        "source": source_name,
+        "path": relative(source_path),
+        "jsonPath": path,
+        "targetValid": evidence_target_valid(payload),
+        "targetMatch": bool(payload.get("targetMatch")) if isinstance(payload, dict) else False,
+        "rawValue": value,
+        "reportId": payload.get("reportId") if isinstance(payload, dict) else None,
+    }
+
+
+def gate_candidates(gate_id: str, evidence: dict[str, tuple[Path, dict[str, Any] | None]]) -> list[dict[str, Any]]:
+    soak_path, soak = evidence["soak"]
+    query_path, query = evidence["query_load"]
+    ingest_path, ingest = evidence["ingest"]
+    restore_path, restore = evidence["restore"]
+    if gate_id == "G0-SLO-QUERY-P95":
+        return [
+            candidate("soak", soak_path, soak, "operations.query_search.durationMs.p95"),
+            candidate("query_load", query_path, query, "metrics.queryLatencyP95Ms"),
+            candidate("query_load", query_path, query, "metrics.queryLatencyP95MsSynthetic"),
+        ]
+    if gate_id == "G0-SLO-QUERY-P99":
+        return [
+            candidate("soak", soak_path, soak, "operations.query_search.durationMs.p99"),
+            candidate("query_load", query_path, query, "metrics.filteredQueryLatencyP99Ms"),
+            candidate("query_load", query_path, query, "metrics.filteredQueryLatencyP99MsSynthetic"),
+        ]
+    if gate_id == "G0-CAP-INGEST-THROUGHPUT":
+        return [
+            candidate("soak", soak_path, soak, "operations.ingest.successfulDocumentsPerHour"),
+            candidate("ingest", ingest_path, ingest, "docsPerHour"),
+            candidate("ingest", ingest_path, ingest, "headroomEstimate.effectiveCapacityDocsPerHourForGate"),
+        ]
+    if gate_id == "G0-DR-RPO":
+        return [
+            candidate("restore", restore_path, restore, "timings.rpoMinutes"),
+            candidate("restore", restore_path, restore, "timings.rpoMinutesSynthetic"),
+        ]
+    if gate_id == "G0-DR-QUERY-READY-RTO":
+        return [
+            candidate("restore", restore_path, restore, "timings.queryReadyRtoMinutes"),
+            candidate("restore", restore_path, restore, "timings.queryReadyRtoMinutesSynthetic"),
+        ]
+    if gate_id == "G0-DR-FULL-VECTOR-RTO":
+        return [
+            candidate("restore", restore_path, restore, "timings.fullVectorRtoMinutes"),
+            candidate("restore", restore_path, restore, "timings.fullVectorRtoMinutesSynthetic"),
+        ]
+    return []
+
+
+def evaluate_gate(gate: dict[str, Any], evidence: dict[str, tuple[Path, dict[str, Any] | None]]) -> dict[str, Any]:
+    gate_id = str(gate.get("id"))
+    candidates = gate_candidates(gate_id, evidence)
+    valid = [item for item in candidates if item["targetValid"] and item["rawValue"] is not None]
+    selected = valid[0] if valid else None
+    threshold = gate.get("threshold", {})
+    measured = selected["rawValue"] if selected else None
+    if measured is None:
+        status = "pending"
+        reason = pending_reason(gate_id, candidates)
+    else:
+        passed = compare(float(measured), threshold)
+        status = "pass" if passed else "fail"
+        reason = "target-valid evidence evaluated"
+    return {
+        "gateId": gate_id,
+        "externalGate": gate.get("externalGate"),
+        "metric": gate.get("metric"),
+        "threshold": threshold,
+        "status": status,
+        "measuredValue": measured,
+        "evidence": selected,
+        "candidateEvidence": candidates,
+        "pendingReason": reason if status == "pending" else None,
+        "supportedByPhase1BReport": gate_id in SUPPORTED_GATE_IDS,
+    }
+
+
+def pending_reason(gate_id: str, candidates: list[dict[str, Any]]) -> str:
+    if gate_id not in SUPPORTED_GATE_IDS:
+        return "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set"
+    if not candidates:
+        return "no candidate evidence mapping"
+    if not any(item["rawValue"] is not None for item in candidates):
+        return "evidence absent or missing measured value"
+    if not any(item["targetValid"] for item in candidates):
+        return "evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false)"
+    return "target-valid evidence missing numeric value"
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    gates = load_json(args.gates)
+    gate_rows = gates.get("gates", [])
+    if not isinstance(gate_rows, list):
+        raise ReportError("gates.yaml missing gates array")
+    evidence: dict[str, tuple[Path, dict[str, Any] | None]] = {}
+    for name, rel in DEFAULT_EVIDENCE.items():
+        path = (args.evidence_root / rel).resolve()
+        evidence[name] = (path, load_optional(path))
+    evaluated = [evaluate_gate(gate, evidence) for gate in gate_rows if isinstance(gate, dict)]
+    counts = {
+        "pass": sum(1 for item in evaluated if item["status"] == "pass"),
+        "fail": sum(1 for item in evaluated if item["status"] == "fail"),
+        "pending": sum(1 for item in evaluated if item["status"] == "pending"),
+    }
+    all_supported_present = all(
+        item["status"] == "pass" for item in evaluated if item["gateId"] in SUPPORTED_GATE_IDS
+    )
+    target_match = bool(evaluated) and counts["fail"] == 0 and counts["pending"] == 0 and all_supported_present
+    return {
+        "version": 1,
+        "reportId": "phase-1b-gate-qualification",
+        "generatedAt": utc_now(),
+        "command": "python3 bench/markhand_web/reports/phase-1b-gate.py",
+        "targetMatch": target_match,
+        "statusCounts": counts,
+        "git": git_status(),
+        "gatesPath": relative(args.gates),
+        "evidenceRoot": relative(args.evidence_root),
+        "evidenceInputs": {
+            name: {
+                "path": relative(path),
+                "present": payload is not None,
+                "targetMatch": bool(payload.get("targetMatch")) if isinstance(payload, dict) else False,
+                "targetResultsValidForGate": (
+                    bool(payload.get("targetResultsValidForGate")) if isinstance(payload, dict) else False
+                ),
+                "reportId": payload.get("reportId") if isinstance(payload, dict) else None,
+            }
+            for name, (path, payload) in evidence.items()
+        },
+        "gates": evaluated,
+        "caveat": (
+            "Numeric G0-SLO/G0-CAP/DR/soak gates require sustained real infrastructure "
+            "with targetMatch=true; pending/null rows are expected in this sandbox."
+        ),
+    }
+
+
+def fmt(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, float):
+        return f"{value:.3f}".rstrip("0").rstrip(".")
+    return str(value)
+
+
+def threshold_text(threshold: dict[str, Any]) -> str:
+    return f"{threshold.get('operator')} {threshold.get('value')}"
+
+
+def gate_rows_markdown(gates: list[dict[str, Any]]) -> str:
+    lines = [
+        "| gate id | metric | threshold | status | measured value | evidence | reason |",
+        "|---|---|---:|---|---:|---|---|",
+    ]
+    for gate in gates:
+        metric = gate.get("metric") or {}
+        evidence = gate.get("evidence") or {}
+        evidence_text = "none"
+        if evidence:
+            evidence_text = f"{evidence.get('source')}:{evidence.get('jsonPath')}"
+        reason = gate.get("pendingReason") or "evaluated"
+        lines.append(
+            "| "
+            f"`{gate['gateId']}` | `{metric.get('name')}` `{metric.get('statistic')}` | "
+            f"`{threshold_text(gate.get('threshold') or {})}` | `{gate['status']}` | "
+            f"`{fmt(gate.get('measuredValue'))}` | `{evidence_text}` | {reason} |"
+        )
+    return "\n".join(lines)
+
+
+def evidence_inputs_markdown(inputs: dict[str, dict[str, Any]]) -> str:
+    lines = [
+        "| evidence | path | present | targetMatch | target-valid | report id |",
+        "|---|---|---|---|---|---|",
+    ]
+    for name, item in inputs.items():
+        lines.append(
+            "| "
+            f"`{name}` | `{item['path']}` | `{str(item['present']).lower()}` | "
+            f"`{str(item['targetMatch']).lower()}` | `{str(item['targetResultsValidForGate']).lower()}` | "
+            f"`{item['reportId']}` |"
+        )
+    return "\n".join(lines)
+
+
+def render_report(payload: dict[str, Any], template_path: Path) -> str:
+    if template_path.is_file():
+        template_text = template_path.read_text(encoding="utf-8")
+    else:
+        template_text = DEFAULT_TEMPLATE
+    template = string.Template(template_text)
+    return template.safe_substitute(
+        generatedAt=payload["generatedAt"],
+        targetMatch=str(payload["targetMatch"]).lower(),
+        passCount=payload["statusCounts"]["pass"],
+        failCount=payload["statusCounts"]["fail"],
+        pendingCount=payload["statusCounts"]["pending"],
+        caveat=payload["caveat"],
+        evidenceInputs=evidence_inputs_markdown(payload["evidenceInputs"]),
+        gateRows=gate_rows_markdown(payload["gates"]),
+        gitCommit=payload["git"]["commit"],
+        gitDirty=str(payload["git"]["dirty"]).lower(),
+    )
+
+
+DEFAULT_TEMPLATE = """# Phase-1B gate qualification
+
+- Generated: `$generatedAt`
+- Git commit: `$gitCommit`
+- Dirty at report time: `$gitDirty`
+- `targetMatch`: `$targetMatch`
+- Counts: pass `$passCount`, fail `$failCount`, pending `$pendingCount`
+
+> $caveat
+
+## Evidence inputs
+
+$evidenceInputs
+
+## Gates
+
+$gateRows
+"""
+
+
+def write_outputs(payload: dict[str, Any], summary: Path, report: Path, template: Path) -> None:
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    report.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    report.write_text(render_report(payload, template), encoding="utf-8")
+
+
+def self_test() -> None:
+    assert compare(1.0, {"operator": ">=", "value": 1.0}) is True
+    assert compare(2.0, {"operator": "<=", "value": 1.0}) is False
+    row = evaluate_gate(
+        {
+            "id": "G0-SLO-QUERY-P95",
+            "metric": {"name": "query_latency", "statistic": "p95"},
+            "threshold": {"operator": "<=", "value": 500},
+        },
+        {
+            "soak": (Path("/missing/soak.json"), None),
+            "query_load": (Path("/missing/query.json"), None),
+            "ingest": (Path("/missing/ingest.json"), None),
+            "restore": (Path("/missing/restore.json"), None),
+        },
+    )
+    assert row["status"] == "pending"
+    assert row["measuredValue"] is None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gates", type=Path, default=GATES_PATH)
+    parser.add_argument("--evidence-root", type=Path, default=ROOT)
+    parser.add_argument("--summary", type=Path, default=SUMMARY_PATH)
+    parser.add_argument("--report", type=Path, default=REPORT_PATH)
+    parser.add_argument("--template", type=Path, default=TEMPLATE_PATH)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    args.gates = args.gates.resolve()
+    args.evidence_root = args.evidence_root.resolve()
+    args.summary = args.summary.resolve()
+    args.report = args.report.resolve()
+    args.template = args.template.resolve()
+
+    if args.self_test:
+        self_test()
+        print("self-test ok")
+        return 0
+    try:
+        payload = build_payload(args)
+        write_outputs(payload, args.summary, args.report, args.template)
+    except ReportError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    print(f"wrote {relative(args.summary)}")
+    print(f"wrote {relative(args.report)}")
+    print(f"targetMatch={str(payload['targetMatch']).lower()}")
+    print(f"pending={payload['statusCounts']['pending']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/markhand_web/reports/phase-1b-gate/report.md
+++ b/bench/markhand_web/reports/phase-1b-gate/report.md
@@ -1,0 +1,46 @@
+# Phase-1B gate qualification
+
+- Generated: `2026-07-20T00:44:24.980717Z`
+- Git commit: `2395b2ba8c9249181d79529b86e4981d081d6331`
+- Dirty at report time: `true`
+- `targetMatch`: `false`
+- Counts: pass `0`, fail `0`, pending `16`
+
+> Numeric G0-SLO/G0-CAP/DR/soak gates require sustained real infrastructure with targetMatch=true; pending/null rows are expected in this sandbox.
+
+## Evidence inputs
+
+| evidence | path | present | targetMatch | target-valid | report id |
+|---|---|---|---|---|---|
+| `soak` | `bench/markhand_web/soak/summary.json` | `true` | `false` | `false` | `p1b-o05-mixed-load-soak` |
+| `query_load` | `bench/markhand_web/query_load/summary.json` | `true` | `false` | `false` | `p0-10-query-load-smoke` |
+| `ingest` | `bench/markhand_web/ingest/summary.json` | `true` | `false` | `false` | `p0-08-ingest-capacity` |
+| `restore` | `bench/markhand_web/restore/summary.json` | `true` | `false` | `false` | `p0-10-restore-drill` |
+
+## Gates
+
+| gate id | metric | threshold | status | measured value | evidence | reason |
+|---|---|---:|---|---:|---|---|
+| `G0-ARCH-DECISIONS` | `approved_architecture_decisions` `min` | `>= 7` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+| `G0-RET-RECALL-AT-5` | `recall_at_5` `min` | `>= 0.85` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+| `G0-RET-BEST-MODEL-GAP` | `best_model_ndcg_gap` `max` | `<= 0.02` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+| `G0-RET-VLLM-CUTOVER` | `onprem_embedding_cutover_ready` `min` | `>= 1.0` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+| `G0-RET-TEMPORAL-ACCURACY` | `temporal_answer_accuracy` `min` | `>= 0.95` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+| `G0-RET-CHANGE-ACCURACY` | `version_change_accuracy` `min` | `>= 0.95` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+| `G0-RET-VERSION-CITATION-PRECISION` | `version_citation_precision` `min` | `>= 1.0` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+| `G0-RET-VERSION-CITATION-RECALL` | `version_citation_recall` `min` | `>= 1.0` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+| `G0-SEC-UPLOAD-DENIAL` | `blocked_attack_fixtures` `min` | `>= 1.0` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+| `G0-CAP-INGEST-THROUGHPUT` | `ingest_documents_per_hour` `min` | `>= 1200` | `pending` | `null` | `none` | evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false) |
+| `G0-SLO-QUERY-P95` | `query_latency` `p95` | `<= 500` | `pending` | `null` | `none` | evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false) |
+| `G0-SLO-QUERY-P99` | `filtered_query_latency` `p99` | `<= 1000` | `pending` | `null` | `none` | evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false) |
+| `G0-DR-RPO` | `recovery_point` `max` | `<= 15` | `pending` | `null` | `none` | evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false) |
+| `G0-DR-QUERY-READY-RTO` | `query_ready_recovery_time` `max` | `<= 60` | `pending` | `null` | `none` | evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false) |
+| `G0-DR-FULL-VECTOR-RTO` | `full_vector_recovery_time` `max` | `<= 240` | `pending` | `null` | `none` | evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false) |
+| `G0-LIC-INVENTORY` | `approved_runtime_licenses` `min` | `== 1.0` | `pending` | `null` | `none` | not part of the P1B-O05 numeric soak/query/ingest/restore evidence set |
+
+## Interpretation
+
+- `pending` means no target-valid evidence was available for that gate.
+- `measured value` is `null` unless the source evidence is target-valid.
+- Synthetic, redacted, local, or sandbox evidence must not be used as a numeric
+  G0-SLO/G0-CAP/DR/soak pass.

--- a/bench/markhand_web/reports/phase-1b-gate/soak.md
+++ b/bench/markhand_web/reports/phase-1b-gate/soak.md
@@ -1,0 +1,77 @@
+# Phase-1B mixed-load soak
+
+- Generated: `2026-07-20T00:44:24.926811Z`
+- Mode: `self-skip-no-live-target`
+- Status: `skipped`
+- Profile: `phase-1b-soak-smoke`
+- Git commit: `2395b2ba8c9249181d79529b86e4981d081d6331`
+- Dirty at harness start: `true`
+- `targetMatch`: `false`
+- `targetResultsValidForGate`: `false`
+
+## Caveat
+
+Numeric G0-SLO/G0-CAP/soak gates require sustained real infrastructure. 
+This sandbox does not provide that infrastructure; self-skip or targetMatch=false output is pending evidence only.
+
+## Operation mix
+
+- Duration seconds: `60`
+- Ramp seconds: `10`
+- Concurrency: `4`
+- Operation weights: `{"ask": 20, "delete": 10, "ingest": 25, "query_search": 35, "reconcile": 10}`
+
+| operation | attempts | ok | partial | error | skipped | p95 ms | p99 ms |
+|---|---:|---:|---:|---:|---:|---:|---:|
+
+## Monitored metrics
+
+- Samples: `0`
+- Ready failures: `0`
+- Metrics scrape failures: `0`
+- Families observed: `none`
+
+Queue/leak proxy gauges:
+
+| metric | samples | first | last | min | max | growth | monotonic |
+|---|---:|---:|---:|---:|---:|---:|---|
+| none | 0 |  |  |  |  |  |  |
+
+Unavailable optional leak proxies:
+
+- `markhand_process_resident_memory_bytes`
+- `process_resident_memory_bytes`
+- `markhand_temp_bytes`
+- `markhand_open_connections`
+- `markhand_jobs_dead_letter_total`
+- `markhand_jobs_dead_letter_depth`
+
+## Gate metric mapping
+
+| gate id | soak metric |
+|---|---|
+| `G0-SLO-QUERY-P95` | `operations.query_search.durationMs.p95` |
+| `G0-SLO-QUERY-P99` | `operations.query_search.durationMs.p99` |
+| `G0-CAP-INGEST-THROUGHPUT` | `operations.ingest.successfulDocumentsPerHour` |
+| `G0-DR-RPO` | `restore.rpoMinutes` |
+| `G0-DR-QUERY-READY-RTO` | `restore.queryReadyRtoMinutes` |
+| `G0-DR-FULL-VECTOR-RTO` | `restore.fullVectorRtoMinutes` |
+
+## Failure-injection plan
+
+| id | executed by harness | operator recorded executed | expected signal |
+|---|---|---|---|
+| `pause-convert-worker` | `false` | `false` | markhand_jobs_queue_depth remains bounded after worker recovery |
+| `readiness-fence-reconciling` | `false` | `false` | /api/v1/health/ready reports not_reconciled until fence is ready |
+
+## Notes
+
+- No target URL/token was configured, so no live load was executed.
+- Run against F02 compose.poc.yml or real on-prem-reference infrastructure to produce numeric evidence.
+- does NOT claim numeric G0-SLO/G0-CAP/soak pass evidence without sustained real infra
+
+Dirty paths at harness start:
+- `bench/markhand_web/reports/phase-1b-gate.py`
+- `bench/markhand_web/reports/phase-1b-gate/`
+- `bench/markhand_web/soak/`
+- `bench/markhand_web/workloads/`

--- a/bench/markhand_web/reports/phase-1b-gate/summary.json
+++ b/bench/markhand_web/reports/phase-1b-gate/summary.json
@@ -1,0 +1,503 @@
+{
+  "version": 1,
+  "reportId": "phase-1b-gate-qualification",
+  "generatedAt": "2026-07-20T00:44:24.980717Z",
+  "command": "python3 bench/markhand_web/reports/phase-1b-gate.py",
+  "targetMatch": false,
+  "statusCounts": {
+    "pass": 0,
+    "fail": 0,
+    "pending": 16
+  },
+  "git": {
+    "commit": "2395b2ba8c9249181d79529b86e4981d081d6331",
+    "branch": "cursor/p1b-o05-soak-qualification-f084",
+    "dirty": true,
+    "dirtyPaths": [
+      "bench/markhand_web/reports/phase-1b-gate.py",
+      "bench/markhand_web/reports/phase-1b-gate/",
+      "bench/markhand_web/soak/",
+      "bench/markhand_web/workloads/"
+    ]
+  },
+  "gatesPath": "bench/markhand_web/gates.yaml",
+  "evidenceRoot": ".",
+  "evidenceInputs": {
+    "soak": {
+      "path": "bench/markhand_web/soak/summary.json",
+      "present": true,
+      "targetMatch": false,
+      "targetResultsValidForGate": false,
+      "reportId": "p1b-o05-mixed-load-soak"
+    },
+    "query_load": {
+      "path": "bench/markhand_web/query_load/summary.json",
+      "present": true,
+      "targetMatch": false,
+      "targetResultsValidForGate": false,
+      "reportId": "p0-10-query-load-smoke"
+    },
+    "ingest": {
+      "path": "bench/markhand_web/ingest/summary.json",
+      "present": true,
+      "targetMatch": false,
+      "targetResultsValidForGate": false,
+      "reportId": "p0-08-ingest-capacity"
+    },
+    "restore": {
+      "path": "bench/markhand_web/restore/summary.json",
+      "present": true,
+      "targetMatch": false,
+      "targetResultsValidForGate": false,
+      "reportId": "p0-10-restore-drill"
+    }
+  },
+  "gates": [
+    {
+      "gateId": "G0-ARCH-DECISIONS",
+      "externalGate": "G0-ARCH",
+      "metric": {
+        "name": "approved_architecture_decisions",
+        "unit": "count",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": ">=",
+        "value": 7
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    },
+    {
+      "gateId": "G0-RET-RECALL-AT-5",
+      "externalGate": "G0-RET",
+      "metric": {
+        "name": "recall_at_5",
+        "unit": "ratio",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": ">=",
+        "value": 0.85
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    },
+    {
+      "gateId": "G0-RET-BEST-MODEL-GAP",
+      "externalGate": "G0-RET",
+      "metric": {
+        "name": "best_model_ndcg_gap",
+        "unit": "ratio",
+        "statistic": "max"
+      },
+      "threshold": {
+        "operator": "<=",
+        "value": 0.02
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    },
+    {
+      "gateId": "G0-RET-VLLM-CUTOVER",
+      "externalGate": "G0-RET",
+      "metric": {
+        "name": "onprem_embedding_cutover_ready",
+        "unit": "ratio",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": ">=",
+        "value": 1.0
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    },
+    {
+      "gateId": "G0-RET-TEMPORAL-ACCURACY",
+      "externalGate": "G0-RET",
+      "metric": {
+        "name": "temporal_answer_accuracy",
+        "unit": "ratio",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": ">=",
+        "value": 0.95
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    },
+    {
+      "gateId": "G0-RET-CHANGE-ACCURACY",
+      "externalGate": "G0-RET",
+      "metric": {
+        "name": "version_change_accuracy",
+        "unit": "ratio",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": ">=",
+        "value": 0.95
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    },
+    {
+      "gateId": "G0-RET-VERSION-CITATION-PRECISION",
+      "externalGate": "G0-RET",
+      "metric": {
+        "name": "version_citation_precision",
+        "unit": "ratio",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": ">=",
+        "value": 1.0
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    },
+    {
+      "gateId": "G0-RET-VERSION-CITATION-RECALL",
+      "externalGate": "G0-RET",
+      "metric": {
+        "name": "version_citation_recall",
+        "unit": "ratio",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": ">=",
+        "value": 1.0
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    },
+    {
+      "gateId": "G0-SEC-UPLOAD-DENIAL",
+      "externalGate": "G0-SEC",
+      "metric": {
+        "name": "blocked_attack_fixtures",
+        "unit": "ratio",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": ">=",
+        "value": 1.0
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    },
+    {
+      "gateId": "G0-CAP-INGEST-THROUGHPUT",
+      "externalGate": "G0-CAP",
+      "metric": {
+        "name": "ingest_documents_per_hour",
+        "unit": "count_per_hour",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": ">=",
+        "value": 1200
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [
+        {
+          "source": "soak",
+          "path": "bench/markhand_web/soak/summary.json",
+          "jsonPath": "operations.ingest.successfulDocumentsPerHour",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": null,
+          "reportId": "p1b-o05-mixed-load-soak"
+        },
+        {
+          "source": "ingest",
+          "path": "bench/markhand_web/ingest/summary.json",
+          "jsonPath": "docsPerHour",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": 40359.4,
+          "reportId": "p0-08-ingest-capacity"
+        },
+        {
+          "source": "ingest",
+          "path": "bench/markhand_web/ingest/summary.json",
+          "jsonPath": "headroomEstimate.effectiveCapacityDocsPerHourForGate",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": 0.0,
+          "reportId": "p0-08-ingest-capacity"
+        }
+      ],
+      "pendingReason": "evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false)",
+      "supportedByPhase1BReport": true
+    },
+    {
+      "gateId": "G0-SLO-QUERY-P95",
+      "externalGate": "G0-SLO",
+      "metric": {
+        "name": "query_latency",
+        "unit": "milliseconds",
+        "statistic": "p95"
+      },
+      "threshold": {
+        "operator": "<=",
+        "value": 500
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [
+        {
+          "source": "soak",
+          "path": "bench/markhand_web/soak/summary.json",
+          "jsonPath": "operations.query_search.durationMs.p95",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": null,
+          "reportId": "p1b-o05-mixed-load-soak"
+        },
+        {
+          "source": "query_load",
+          "path": "bench/markhand_web/query_load/summary.json",
+          "jsonPath": "metrics.queryLatencyP95Ms",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": null,
+          "reportId": "p0-10-query-load-smoke"
+        },
+        {
+          "source": "query_load",
+          "path": "bench/markhand_web/query_load/summary.json",
+          "jsonPath": "metrics.queryLatencyP95MsSynthetic",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": 296.008,
+          "reportId": "p0-10-query-load-smoke"
+        }
+      ],
+      "pendingReason": "evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false)",
+      "supportedByPhase1BReport": true
+    },
+    {
+      "gateId": "G0-SLO-QUERY-P99",
+      "externalGate": "G0-SLO",
+      "metric": {
+        "name": "filtered_query_latency",
+        "unit": "milliseconds",
+        "statistic": "p99"
+      },
+      "threshold": {
+        "operator": "<=",
+        "value": 1000
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [
+        {
+          "source": "soak",
+          "path": "bench/markhand_web/soak/summary.json",
+          "jsonPath": "operations.query_search.durationMs.p99",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": null,
+          "reportId": "p1b-o05-mixed-load-soak"
+        },
+        {
+          "source": "query_load",
+          "path": "bench/markhand_web/query_load/summary.json",
+          "jsonPath": "metrics.filteredQueryLatencyP99Ms",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": null,
+          "reportId": "p0-10-query-load-smoke"
+        },
+        {
+          "source": "query_load",
+          "path": "bench/markhand_web/query_load/summary.json",
+          "jsonPath": "metrics.filteredQueryLatencyP99MsSynthetic",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": 820.854,
+          "reportId": "p0-10-query-load-smoke"
+        }
+      ],
+      "pendingReason": "evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false)",
+      "supportedByPhase1BReport": true
+    },
+    {
+      "gateId": "G0-DR-RPO",
+      "externalGate": "G0-SLO",
+      "metric": {
+        "name": "recovery_point",
+        "unit": "minutes",
+        "statistic": "max"
+      },
+      "threshold": {
+        "operator": "<=",
+        "value": 15
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [
+        {
+          "source": "restore",
+          "path": "bench/markhand_web/restore/summary.json",
+          "jsonPath": "timings.rpoMinutes",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": null,
+          "reportId": "p0-10-restore-drill"
+        },
+        {
+          "source": "restore",
+          "path": "bench/markhand_web/restore/summary.json",
+          "jsonPath": "timings.rpoMinutesSynthetic",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": 5.381,
+          "reportId": "p0-10-restore-drill"
+        }
+      ],
+      "pendingReason": "evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false)",
+      "supportedByPhase1BReport": true
+    },
+    {
+      "gateId": "G0-DR-QUERY-READY-RTO",
+      "externalGate": "G0-SLO",
+      "metric": {
+        "name": "query_ready_recovery_time",
+        "unit": "minutes",
+        "statistic": "max"
+      },
+      "threshold": {
+        "operator": "<=",
+        "value": 60
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [
+        {
+          "source": "restore",
+          "path": "bench/markhand_web/restore/summary.json",
+          "jsonPath": "timings.queryReadyRtoMinutes",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": null,
+          "reportId": "p0-10-restore-drill"
+        },
+        {
+          "source": "restore",
+          "path": "bench/markhand_web/restore/summary.json",
+          "jsonPath": "timings.queryReadyRtoMinutesSynthetic",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": 30.828,
+          "reportId": "p0-10-restore-drill"
+        }
+      ],
+      "pendingReason": "evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false)",
+      "supportedByPhase1BReport": true
+    },
+    {
+      "gateId": "G0-DR-FULL-VECTOR-RTO",
+      "externalGate": "G0-SLO",
+      "metric": {
+        "name": "full_vector_recovery_time",
+        "unit": "minutes",
+        "statistic": "max"
+      },
+      "threshold": {
+        "operator": "<=",
+        "value": 240
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [
+        {
+          "source": "restore",
+          "path": "bench/markhand_web/restore/summary.json",
+          "jsonPath": "timings.fullVectorRtoMinutes",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": null,
+          "reportId": "p0-10-restore-drill"
+        },
+        {
+          "source": "restore",
+          "path": "bench/markhand_web/restore/summary.json",
+          "jsonPath": "timings.fullVectorRtoMinutesSynthetic",
+          "targetValid": false,
+          "targetMatch": false,
+          "rawValue": 153.647,
+          "reportId": "p0-10-restore-drill"
+        }
+      ],
+      "pendingReason": "evidence is present but not target-valid (targetMatch=false or targetResultsValidForGate=false)",
+      "supportedByPhase1BReport": true
+    },
+    {
+      "gateId": "G0-LIC-INVENTORY",
+      "externalGate": "G0-LIC",
+      "metric": {
+        "name": "approved_runtime_licenses",
+        "unit": "ratio",
+        "statistic": "min"
+      },
+      "threshold": {
+        "operator": "==",
+        "value": 1.0
+      },
+      "status": "pending",
+      "measuredValue": null,
+      "evidence": null,
+      "candidateEvidence": [],
+      "pendingReason": "not part of the P1B-O05 numeric soak/query/ingest/restore evidence set",
+      "supportedByPhase1BReport": false
+    }
+  ],
+  "caveat": "Numeric G0-SLO/G0-CAP/DR/soak gates require sustained real infrastructure with targetMatch=true; pending/null rows are expected in this sandbox."
+}

--- a/bench/markhand_web/reports/phase-1b-gate/template.md
+++ b/bench/markhand_web/reports/phase-1b-gate/template.md
@@ -1,0 +1,24 @@
+# Phase-1B gate qualification
+
+- Generated: `$generatedAt`
+- Git commit: `$gitCommit`
+- Dirty at report time: `$gitDirty`
+- `targetMatch`: `$targetMatch`
+- Counts: pass `$passCount`, fail `$failCount`, pending `$pendingCount`
+
+> $caveat
+
+## Evidence inputs
+
+$evidenceInputs
+
+## Gates
+
+$gateRows
+
+## Interpretation
+
+- `pending` means no target-valid evidence was available for that gate.
+- `measured value` is `null` unless the source evidence is target-valid.
+- Synthetic, redacted, local, or sandbox evidence must not be used as a numeric
+  G0-SLO/G0-CAP/DR/soak pass.

--- a/bench/markhand_web/soak/README.md
+++ b/bench/markhand_web/soak/README.md
@@ -1,0 +1,195 @@
+# Phase-1B mixed-load soak harness
+
+P1B-O05 delivers the soak harness, workload profiles, and pending aggregate gate
+report shape. It does **not** run numeric G0 gates in this sandbox.
+
+> Numeric G0-SLO/G0-CAP/DR/soak gates require sustained real infrastructure with
+> `targetMatch=true`. This sandbox has no sustained-load/DR stack; harness output
+> here is pending/null evidence only.
+
+## Files
+
+- `bench/markhand_web/soak/run_soak.py` - stdlib Python mixed-load driver.
+- `bench/markhand_web/workloads/soak-smoke.yaml` - short harness smoke profile.
+- `bench/markhand_web/workloads/soak-phase-1b.yaml` - full Phase-1B profile.
+- `bench/markhand_web/reports/phase-1b-gate.py` - aggregate gate report.
+- `bench/markhand_web/reports/phase-1b-gate/template.md` - markdown template.
+
+All workload YAML is JSON-compatible YAML 1.2 and contains only synthetic,
+redacted fixture text.
+
+## Start an F02 POC stack
+
+On a host with Docker Engine:
+
+```bash
+docker compose -f deploy/compose.poc.yml up --build
+curl --fail http://127.0.0.1:${MARKHAND_POC_SERVER_PORT:-8787}/api/v1/health/ready
+```
+
+Seed a single POC org/user after the server applies migrations. The existing
+seed helper inserts the org/user membership but does not commit a password:
+
+```bash
+deploy/scripts/seed-poc-org.sh
+```
+
+Use an owner bearer token from the POC/O04 seed flow, or login after a secure
+local credential has been provisioned:
+
+```bash
+export MARKHAND_BASE_URL="http://127.0.0.1:${MARKHAND_POC_SERVER_PORT:-8787}"
+export MARKHAND_BEARER_TOKEN="<owner access token>"
+
+# Optional: reuse an existing collection instead of letting the harness create one.
+export MARKHAND_COLLECTION_ID="<collection uuid>"
+```
+
+If the target URL or token is unset, the harness self-skips and writes a clear
+pending summary instead of attempting live load.
+
+## Run
+
+Smoke:
+
+```bash
+python3 bench/markhand_web/soak/run_soak.py \
+  --profile bench/markhand_web/workloads/soak-smoke.yaml
+```
+
+Full Phase-1B profile on real target infrastructure:
+
+```bash
+python3 bench/markhand_web/soak/run_soak.py \
+  --profile bench/markhand_web/workloads/soak-phase-1b.yaml \
+  --environment-id on-prem-reference \
+  --target-match
+```
+
+Only use `--target-match` when the operator has verified the approved
+`on-prem-reference` environment and the run duration/concurrency match the full
+profile. Do not use it for local Docker smoke runs unless the report is
+explicitly being kept as non-gate evidence.
+
+Default outputs:
+
+- `bench/markhand_web/soak/summary.json`
+- `bench/markhand_web/reports/phase-1b-gate/soak.md`
+
+## Load mix
+
+The driver runs concurrent weighted operations until `durationSeconds`:
+
+- `ingest`: multipart upload to `/api/v1/uploads`, then document create at
+  `/api/v1/collections/{collectionId}/documents`, then job polling via
+  `/api/v1/jobs/{jobId}`.
+- `query_search`: filtered search via `/api/v1/search` with `collectionIds`.
+- `ask`: grounded JSON answer path via `/api/v1/ask`.
+- `delete`: tombstone request via `DELETE /api/v1/documents/{documentId}`;
+  purge is observed through the delete worker and queue metrics.
+- `reconcile`: there is no public reconcile REST route in Phase 1B. The harness
+  exercises the public consistency leg by POSTing
+  `/api/v1/documents/{documentId}:reindex` when a document exists, otherwise it
+  probes `/api/v1/health/ready`. The actual O03 reconcile/fence leg is executed
+  by the worker/runbook commands below and observed through metrics/readiness.
+
+## Metrics monitored
+
+The sampler polls:
+
+- `GET /api/v1/health/ready`
+- `GET /api/v1/metrics`
+
+The harness records these `markhand_*` families when present:
+
+- `markhand_http_requests_total`
+- `markhand_http_request_duration_seconds_{bucket,sum,count}`
+- `markhand_jobs_processed_total`
+- `markhand_job_duration_seconds_{bucket,sum,count}`
+- `markhand_jobs_in_flight`
+- `markhand_jobs_queue_depth`
+- `markhand_retrieval_latency_seconds_{bucket,sum,count}`
+- `markhand_embedding_latency_seconds_{bucket,sum,count}`
+
+Queue/leak proxies:
+
+- bounded queue/in-flight behavior from `markhand_jobs_queue_depth` and
+  `markhand_jobs_in_flight`;
+- optional future leak proxies if exported:
+  `markhand_process_resident_memory_bytes`, `markhand_temp_bytes`,
+  `markhand_open_connections`, `markhand_jobs_dead_letter_total`, and
+  `markhand_jobs_dead_letter_depth`;
+- unavailable optional proxies are listed explicitly in the summary so the
+  report does not pretend to have memory/temp/connection measurements that the
+  current endpoint does not export.
+
+## Gate mapping
+
+The soak summary feeds the aggregate report with these mappings from the
+workload profiles:
+
+| gate id | soak metric |
+|---|---|
+| `G0-SLO-QUERY-P95` | `operations.query_search.durationMs.p95` |
+| `G0-SLO-QUERY-P99` | `operations.query_search.durationMs.p99` |
+| `G0-CAP-INGEST-THROUGHPUT` | `operations.ingest.successfulDocumentsPerHour` |
+| `G0-DR-RPO` | `restore.rpoMinutes` from restore evidence |
+| `G0-DR-QUERY-READY-RTO` | `restore.queryReadyRtoMinutes` from restore evidence |
+| `G0-DR-FULL-VECTOR-RTO` | `restore.fullVectorRtoMinutes` from restore evidence |
+
+The aggregate report only evaluates a gate when the source evidence is
+target-valid. Synthetic/local/offline values remain `pending` with
+`measuredValue=null`.
+
+## Failure injection and restore legs
+
+Failure steps are documented in each workload profile and recorded in the soak
+summary. They are manual/operator actions, not automatic destructive operations
+from the Python process.
+
+Examples for the F02 POC stack:
+
+```bash
+# Pause converter and verify queue catch-up.
+docker compose -f deploy/compose.poc.yml stop worker-convert
+docker compose -f deploy/compose.poc.yml up -d worker-convert
+
+# Put readiness behind the O03 restore/reconcile fence.
+docker compose -f deploy/compose.poc.yml run --rm worker-reconcile \
+  readiness-fence reconciling "soak restore leg"
+docker compose -f deploy/compose.poc.yml run --rm worker-reconcile readiness-fence ready
+```
+
+For the DR leg, run the restore drill evidence generator after a real
+component-loss restore:
+
+```bash
+python3 bench/markhand_web/scripts/run_restore_drill.py
+```
+
+The existing `run_restore_drill.py` in this sandbox emits an offline synthetic
+smoke report with `targetMatch=false`; it is not a G0-DR pass. A real P1B gate
+run must include PostgreSQL, MinIO, Qdrant, readiness fence, reconcile before
+ready, and post-restore retrieval evidence from sustained infrastructure.
+
+## Aggregate report
+
+Render with whatever evidence is available:
+
+```bash
+python3 bench/markhand_web/reports/phase-1b-gate.py
+```
+
+Render an explicit empty-evidence pending report:
+
+```bash
+mkdir -p /tmp/markhand-empty-evidence
+python3 bench/markhand_web/reports/phase-1b-gate.py \
+  --evidence-root /tmp/markhand-empty-evidence \
+  --summary /tmp/markhand-empty-evidence/phase-1b-summary.json \
+  --report /tmp/markhand-empty-evidence/phase-1b-report.md
+```
+
+The report emits every `gates.yaml` gate as `pass`, `fail`, or `pending`.
+Without target-valid evidence, all numeric P1B soak/query/ingest/restore gates
+remain pending and the aggregate `targetMatch` is `false`.

--- a/bench/markhand_web/soak/run_soak.py
+++ b/bench/markhand_web/soak/run_soak.py
@@ -1,0 +1,1186 @@
+#!/usr/bin/env python3
+"""Phase-1B mixed-load soak harness.
+
+The harness is live-capable but intentionally self-skips when no target URL and
+bearer token are configured. Numeric G0 gates require a real sustained stack
+with targetMatch=true; sandbox/self-skip output is only harness evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import datetime as dt
+import hashlib
+import json
+import os
+import platform
+import random
+import re
+import statistics
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CORPUS = ROOT / "bench/markhand_web"
+DEFAULT_PROFILE = CORPUS / "workloads/soak-smoke.yaml"
+SUMMARY_PATH = CORPUS / "soak/summary.json"
+REPORT_PATH = CORPUS / "reports/phase-1b-gate/soak.md"
+GATES_PATH = CORPUS / "gates.yaml"
+WORKLOAD_PROFILE = CORPUS / "workload-profile.yaml"
+DOES_NOT_CLAIM = (
+    "does NOT claim numeric G0-SLO/G0-CAP/soak pass evidence without sustained real infra"
+)
+TERMINAL_JOB_STATUSES = {"succeeded", "failed", "cancelled", "dead_letter"}
+SUCCESS_JOB_STATUSES = {"succeeded"}
+MONITORED_MARKHAND_METRICS = [
+    "markhand_http_requests_total",
+    "markhand_http_request_duration_seconds_bucket",
+    "markhand_http_request_duration_seconds_sum",
+    "markhand_http_request_duration_seconds_count",
+    "markhand_jobs_processed_total",
+    "markhand_job_duration_seconds_bucket",
+    "markhand_job_duration_seconds_sum",
+    "markhand_job_duration_seconds_count",
+    "markhand_jobs_in_flight",
+    "markhand_jobs_queue_depth",
+    "markhand_retrieval_latency_seconds_bucket",
+    "markhand_retrieval_latency_seconds_sum",
+    "markhand_retrieval_latency_seconds_count",
+    "markhand_embedding_latency_seconds_bucket",
+    "markhand_embedding_latency_seconds_sum",
+    "markhand_embedding_latency_seconds_count",
+]
+OPTIONAL_LEAK_PROXY_METRICS = [
+    "markhand_process_resident_memory_bytes",
+    "process_resident_memory_bytes",
+    "markhand_temp_bytes",
+    "markhand_open_connections",
+    "markhand_jobs_dead_letter_total",
+    "markhand_jobs_dead_letter_depth",
+]
+IMPLEMENTATION_FILES = (
+    "bench/markhand_web/soak/run_soak.py",
+    "bench/markhand_web/workloads/soak-smoke.yaml",
+    "bench/markhand_web/workloads/soak-phase-1b.yaml",
+)
+
+
+class HarnessError(RuntimeError):
+    """Actionable soak harness error."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def relative(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HarnessError(f"{relative(path)}: cannot load JSON-compatible YAML: {error}") from error
+    if not isinstance(payload, dict):
+        raise HarnessError(f"{relative(path)}: expected object")
+    return payload
+
+
+def file_sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def implementation_sha256() -> str:
+    digest = hashlib.sha256()
+    for rel in IMPLEMENTATION_FILES:
+        path = ROOT / rel
+        digest.update(rel.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes() if path.is_file() else b"missing")
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def git(*args: str) -> str:
+    try:
+        return subprocess.check_output(["git", *args], cwd=ROOT, text=True).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def git_status() -> dict[str, Any]:
+    raw = ""
+    try:
+        raw = subprocess.check_output(["git", "status", "--porcelain"], cwd=ROOT, text=True)
+    except (OSError, subprocess.CalledProcessError):
+        pass
+    dirty_paths: list[str] = []
+    for line in raw.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if path.startswith('"') and path.endswith('"'):
+            path = path[1:-1]
+        dirty_paths.append(path)
+    return {
+        "commit": git("rev-parse", "HEAD"),
+        "branch": git("branch", "--show-current"),
+        "dirty": bool(dirty_paths),
+        "dirtyPaths": dirty_paths,
+    }
+
+
+def command_version(args: list[str], timeout: float = 5.0) -> dict[str, Any]:
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        return {"available": False, "argv": args, "error": str(error)}
+    output = (completed.stdout or completed.stderr).strip()
+    return {
+        "available": completed.returncode == 0,
+        "argv": args,
+        "exitCode": completed.returncode,
+        "output": output[:500],
+    }
+
+
+def stack_versions() -> dict[str, Any]:
+    return {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "docker": command_version(["docker", "--version"]),
+        "dockerCompose": command_version(["docker", "compose", "version"]),
+        "profileSha256": file_sha256(DEFAULT_PROFILE),
+        "gatesSha256": file_sha256(GATES_PATH),
+        "workloadProfileSha256": file_sha256(WORKLOAD_PROFILE),
+    }
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return round(ordered[0], 3)
+    rank = (len(ordered) - 1) * pct
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = rank - lower
+    return round(ordered[lower] + (ordered[upper] - ordered[lower]) * fraction, 3)
+
+
+def duration_stats(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {"count": 0, "min": None, "mean": None, "p50": None, "p95": None, "p99": None, "max": None}
+    return {
+        "count": len(values),
+        "min": round(min(values), 3),
+        "mean": round(statistics.fmean(values), 3),
+        "p50": percentile(values, 0.50),
+        "p95": percentile(values, 0.95),
+        "p99": percentile(values, 0.99),
+        "max": round(max(values), 3),
+    }
+
+
+def weighted_choice(weights: dict[str, Any], rng: random.Random) -> str:
+    items = [(str(name), float(weight)) for name, weight in weights.items() if float(weight) > 0]
+    if not items:
+        raise HarnessError("profile operationWeights must contain at least one positive weight")
+    total = sum(weight for _, weight in items)
+    needle = rng.random() * total
+    upto = 0.0
+    for name, weight in items:
+        upto += weight
+        if needle <= upto:
+            return name
+    return items[-1][0]
+
+
+def parse_labels(raw: str) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    for match in re.finditer(r'([a-zA-Z_][a-zA-Z0-9_]*)="((?:\\.|[^"])*)"', raw):
+        labels[match.group(1)] = match.group(2).replace(r"\"", '"').replace(r"\\", "\\")
+    return labels
+
+
+def parse_prometheus(text: str) -> dict[str, Any]:
+    samples: list[dict[str, Any]] = []
+    families: set[str] = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = re.match(
+            r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{([^}]*)\})?\s+"
+            r"([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?|NaN|Inf|-Inf)(?:\s+\d+)?$",
+            line,
+        )
+        if not match:
+            continue
+        name, raw_labels, raw_value = match.groups()
+        if not (name.startswith("markhand_") or name in OPTIONAL_LEAK_PROXY_METRICS):
+            continue
+        try:
+            value = float(raw_value)
+        except ValueError:
+            continue
+        families.add(name)
+        samples.append({"name": name, "labels": parse_labels(raw_labels or ""), "value": value})
+    gauges: dict[str, float] = {}
+    for sample in samples:
+        if sample["labels"]:
+            continue
+        gauges[sample["name"]] = sample["value"]
+    return {"families": sorted(families), "samples": samples, "gauges": gauges}
+
+
+def multipart_body(filename: str, content_type: str, content: bytes) -> tuple[bytes, str]:
+    boundary = f"----markhand-soak-{uuid.uuid4().hex}"
+    body = bytearray()
+    body.extend(
+        (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+            f"Content-Type: {content_type}\r\n\r\n"
+        ).encode()
+    )
+    body.extend(content)
+    body.extend(f"\r\n--{boundary}--\r\n".encode())
+    return bytes(body), f"multipart/form-data; boundary={boundary}"
+
+
+class ApiClient:
+    def __init__(self, base_url: str, token: str, timeout_seconds: float) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout_seconds = timeout_seconds
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any | None = None,
+        body: bytes | None = None,
+        content_type: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        url = urllib.parse.urljoin(f"{self.base_url}/", path.lstrip("/"))
+        data = body
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "User-Agent": "markhand-phase-1b-soak/1",
+        }
+        if json_body is not None:
+            data = json.dumps(json_body, separators=(",", ":")).encode()
+            headers["Content-Type"] = "application/json"
+        elif content_type:
+            headers["Content-Type"] = content_type
+        if extra_headers:
+            headers.update(extra_headers)
+        started = time.perf_counter()
+        status: int | None = None
+        response_text = ""
+        error = None
+        try:
+            request = urllib.request.Request(url, data=data, method=method.upper(), headers=headers)
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                status = int(response.status)
+                response_text = response.read(2 * 1024 * 1024).decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            status = int(exc.code)
+            response_text = exc.read(2 * 1024 * 1024).decode("utf-8", errors="replace")
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            error = str(exc)
+        elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
+        parsed: Any = None
+        if response_text:
+            try:
+                parsed = json.loads(response_text)
+            except json.JSONDecodeError:
+                parsed = response_text[:2000]
+        return {
+            "method": method.upper(),
+            "path": path,
+            "status": status,
+            "ok": status is not None and 200 <= status < 300,
+            "durationMs": elapsed_ms,
+            "json": parsed,
+            "error": error,
+        }
+
+    def get(self, path: str) -> dict[str, Any]:
+        return self.request("GET", path)
+
+    def post_json(self, path: str, body: Any) -> dict[str, Any]:
+        return self.request("POST", path, json_body=body)
+
+    def delete(self, path: str, headers: dict[str, str] | None = None) -> dict[str, Any]:
+        return self.request("DELETE", path, extra_headers=headers)
+
+    def upload(self, filename: str, content_type: str, content: bytes) -> dict[str, Any]:
+        data, multipart_content_type = multipart_body(filename, content_type, content)
+        return self.request("POST", "/api/v1/uploads", body=data, content_type=multipart_content_type)
+
+
+class SharedState:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.active_docs: list[dict[str, Any]] = []
+        self.deleted_docs: list[dict[str, Any]] = []
+        self.jobs: list[dict[str, Any]] = []
+
+    def add_doc(self, doc: dict[str, Any]) -> None:
+        with self.lock:
+            self.active_docs.append(doc)
+
+    def pick_doc(self) -> dict[str, Any] | None:
+        with self.lock:
+            if not self.active_docs:
+                return None
+            return random.choice(self.active_docs)
+
+    def pop_doc(self) -> dict[str, Any] | None:
+        with self.lock:
+            if not self.active_docs:
+                return None
+            index = random.randrange(len(self.active_docs))
+            return self.active_docs.pop(index)
+
+    def mark_deleted(self, doc: dict[str, Any]) -> None:
+        with self.lock:
+            self.deleted_docs.append(doc)
+
+    def add_job(self, job: dict[str, Any]) -> None:
+        with self.lock:
+            self.jobs.append(job)
+
+    def snapshot(self) -> dict[str, int]:
+        with self.lock:
+            return {
+                "activeDocuments": len(self.active_docs),
+                "deletedDocuments": len(self.deleted_docs),
+                "observedJobs": len(self.jobs),
+            }
+
+
+def ensure_collection(client: ApiClient, configured_collection_id: str | None) -> str:
+    if configured_collection_id:
+        return configured_collection_id
+    suffix = uuid.uuid4().hex[:12]
+    body = {
+        "name": f"Phase 1B soak {suffix}",
+        "slug": f"phase-1b-soak-{suffix}",
+        "description": "Synthetic/redacted Phase-1B mixed-load soak collection.",
+        "visibility": "private",
+    }
+    response = client.post_json("/api/v1/collections", body)
+    if response["status"] != 201 or not isinstance(response["json"], dict):
+        raise HarnessError(f"collection create failed status={response['status']} error={response['error']}")
+    collection_id = response["json"].get("id")
+    if not isinstance(collection_id, str):
+        raise HarnessError("collection create response missing id")
+    return collection_id
+
+
+def poll_job(client: ApiClient, job_id: str, timeout_seconds: float, interval_seconds: float) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    attempts = 0
+    last: dict[str, Any] | None = None
+    while time.monotonic() < deadline:
+        attempts += 1
+        response = client.get(f"/api/v1/jobs/{job_id}")
+        last = response
+        if response["ok"] and isinstance(response["json"], dict):
+            status = str(response["json"].get("status"))
+            if status in TERMINAL_JOB_STATUSES:
+                return {
+                    "jobId": job_id,
+                    "terminal": True,
+                    "status": status,
+                    "success": status in SUCCESS_JOB_STATUSES,
+                    "attempts": attempts,
+                    "lastStatus": response["status"],
+                }
+        if response["status"] in {401, 403, 404}:
+            break
+        time.sleep(interval_seconds)
+    status = None
+    if last and isinstance(last.get("json"), dict):
+        status = last["json"].get("status")
+    return {
+        "jobId": job_id,
+        "terminal": False,
+        "status": status,
+        "success": False,
+        "attempts": attempts,
+        "lastStatus": last.get("status") if last else None,
+    }
+
+
+def op_result(operation: str, status: str, started: float, **extra: Any) -> dict[str, Any]:
+    payload = {
+        "operation": operation,
+        "status": status,
+        "durationMs": round((time.perf_counter() - started) * 1000, 3),
+        "at": utc_now(),
+    }
+    payload.update(extra)
+    return payload
+
+
+def ingest_operation(
+    client: ApiClient,
+    profile: dict[str, Any],
+    collection_id: str,
+    state: SharedState,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    data = profile.get("data", {})
+    prefix = str(data.get("fixturePrefix", "P1B-O05-SOAK"))
+    marker = f"{prefix}-{uuid.uuid4().hex}"
+    content = (
+        f"{marker}\n"
+        "Synthetic redacted Markhand Phase-1B soak document.\n"
+        "This fixture contains no customer data or secrets.\n"
+    ).encode("utf-8")
+    filename = f"{marker}.txt"
+    content_type = str(data.get("uploadContentType", "text/plain"))
+    upload = client.upload(filename, content_type, content)
+    if upload["status"] != 201 or not isinstance(upload["json"], dict):
+        return op_result("ingest", "error", started, stage="upload", response=trim_response(upload))
+    object_key = upload["json"].get("objectKey")
+    if not isinstance(object_key, str):
+        return op_result("ingest", "error", started, stage="upload", response="missing objectKey")
+    create = client.post_json(
+        f"/api/v1/collections/{collection_id}/documents",
+        {"objectKey": object_key, "title": f"Synthetic soak {marker}"},
+    )
+    if create["status"] != 201 or not isinstance(create["json"], dict):
+        return op_result("ingest", "error", started, stage="create", response=trim_response(create))
+    document = create["json"].get("document", {})
+    version = create["json"].get("version", {})
+    job_id = create["json"].get("jobId")
+    job = None
+    if isinstance(job_id, str):
+        job = poll_job(
+            client,
+            job_id,
+            float(profile.get("jobPollTimeoutSeconds", 60)),
+            float(profile.get("jobPollIntervalSeconds", 2)),
+        )
+        state.add_job(job)
+    doc = {
+        "id": document.get("id"),
+        "versionId": version.get("id"),
+        "jobId": job_id,
+        "marker": marker,
+        "title": document.get("title"),
+    }
+    if isinstance(doc["id"], str):
+        state.add_doc(doc)
+    success = job is None or bool(job.get("success"))
+    return op_result(
+        "ingest",
+        "ok" if success else "partial",
+        started,
+        documentId=doc["id"],
+        versionId=doc["versionId"],
+        job=job,
+    )
+
+
+def query_text(profile: dict[str, Any], state: SharedState) -> str:
+    doc = state.pick_doc()
+    if doc and isinstance(doc.get("marker"), str) and random.random() < 0.5:
+        return doc["marker"]
+    queries = profile.get("data", {}).get("queries", [])
+    if isinstance(queries, list) and queries:
+        return str(random.choice(queries))
+    return "Markhand Phase 1B soak"
+
+
+def query_operation(
+    client: ApiClient,
+    profile: dict[str, Any],
+    collection_id: str,
+    state: SharedState,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    body = {"query": query_text(profile, state), "collectionIds": [collection_id]}
+    response = client.post_json("/api/v1/search", body)
+    return op_result(
+        "query_search",
+        "ok" if response["ok"] else "error",
+        started,
+        httpStatus=response["status"],
+        response=trim_response(response, include_body=False),
+    )
+
+
+def ask_operation(
+    client: ApiClient,
+    profile: dict[str, Any],
+    collection_id: str,
+    state: SharedState,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    body = {"question": query_text(profile, state), "collectionIds": [collection_id]}
+    response = client.post_json("/api/v1/ask", body)
+    return op_result(
+        "ask",
+        "ok" if response["ok"] else "error",
+        started,
+        httpStatus=response["status"],
+        response=trim_response(response, include_body=False),
+    )
+
+
+def delete_operation(client: ApiClient, state: SharedState) -> dict[str, Any]:
+    started = time.perf_counter()
+    doc = state.pop_doc()
+    if not doc or not isinstance(doc.get("id"), str):
+        return op_result("delete", "skipped", started, reason="no_active_document")
+    response = client.delete(
+        f"/api/v1/documents/{doc['id']}",
+        headers={"Idempotency-Key": f"soak-delete-{doc['id']}-{uuid.uuid4().hex}"},
+    )
+    if response["ok"]:
+        state.mark_deleted(doc)
+    else:
+        state.add_doc(doc)
+    return op_result(
+        "delete",
+        "ok" if response["ok"] else "error",
+        started,
+        documentId=doc["id"],
+        httpStatus=response["status"],
+        response=trim_response(response, include_body=False),
+    )
+
+
+def reconcile_operation(client: ApiClient, state: SharedState) -> dict[str, Any]:
+    """Exercise the public consistency leg available to HTTP callers.
+
+    There is no public reconcile REST route in P1B. The actual reconcile worker is
+    observed through metrics and O03 restore-fence steps; this live HTTP leg
+    enqueues reindex when a document exists and otherwise probes readiness.
+    """
+
+    started = time.perf_counter()
+    doc = state.pick_doc()
+    if doc and isinstance(doc.get("id"), str):
+        response = client.post_json(f"/api/v1/documents/{doc['id']}:reindex", {})
+        if response["ok"] and isinstance(response["json"], dict):
+            job_id = response["json"].get("id")
+            if isinstance(job_id, str):
+                state.add_job({"jobId": job_id, "status": "queued_by_reconcile_leg", "success": None})
+        return op_result(
+            "reconcile",
+            "ok" if response["ok"] else "error",
+            started,
+            leg="document_reindex_public_proxy",
+            documentId=doc["id"],
+            httpStatus=response["status"],
+            response=trim_response(response, include_body=False),
+        )
+    response = client.get("/api/v1/health/ready")
+    return op_result(
+        "reconcile",
+        "ok" if response["ok"] else "error",
+        started,
+        leg="readiness_fence_probe",
+        httpStatus=response["status"],
+        response=trim_response(response, include_body=False),
+    )
+
+
+def trim_response(response: dict[str, Any], include_body: bool = True) -> dict[str, Any]:
+    trimmed = {
+        "method": response.get("method"),
+        "path": response.get("path"),
+        "status": response.get("status"),
+        "durationMs": response.get("durationMs"),
+        "error": response.get("error"),
+    }
+    if include_body:
+        body = response.get("json")
+        if isinstance(body, dict):
+            redacted = {key: value for key, value in body.items() if key not in {"accessToken", "refreshToken"}}
+            trimmed["body"] = redacted
+        elif body is not None:
+            trimmed["body"] = str(body)[:500]
+    return trimmed
+
+
+def sampler(client: ApiClient, interval: float, stop: threading.Event, output: list[dict[str, Any]]) -> None:
+    while not stop.is_set():
+        sample_started = time.perf_counter()
+        ready = client.get("/api/v1/health/ready")
+        metrics = client.get("/api/v1/metrics")
+        parsed = parse_prometheus(metrics.get("json") if isinstance(metrics.get("json"), str) else "")
+        output.append(
+            {
+                "at": utc_now(),
+                "ready": {
+                    "status": ready["status"],
+                    "ok": ready["ok"],
+                    "durationMs": ready["durationMs"],
+                },
+                "metrics": {
+                    "status": metrics["status"],
+                    "ok": metrics["ok"],
+                    "durationMs": metrics["durationMs"],
+                    "families": parsed["families"],
+                    "gauges": parsed["gauges"],
+                    "samples": parsed["samples"],
+                },
+            }
+        )
+        elapsed = time.perf_counter() - sample_started
+        stop.wait(max(0.1, interval - elapsed))
+
+
+def run_worker(
+    worker_index: int,
+    client: ApiClient,
+    profile: dict[str, Any],
+    collection_id: str,
+    state: SharedState,
+    deadline: float,
+    ramp_seconds: float,
+    results: list[dict[str, Any]],
+    result_lock: threading.Lock,
+) -> None:
+    rng = random.Random(20260720 + worker_index)
+    concurrency = max(1, int(profile.get("concurrency", 1)))
+    if ramp_seconds > 0:
+        time.sleep((worker_index / concurrency) * ramp_seconds)
+    weights = profile.get("operationWeights", {})
+    think_time = float(profile.get("thinkTimeSeconds", 0.05))
+    while time.monotonic() < deadline:
+        operation = weighted_choice(weights, rng)
+        try:
+            if operation == "ingest":
+                result = ingest_operation(client, profile, collection_id, state)
+            elif operation == "query_search":
+                result = query_operation(client, profile, collection_id, state)
+            elif operation == "ask":
+                result = ask_operation(client, profile, collection_id, state)
+            elif operation == "delete":
+                result = delete_operation(client, state)
+            elif operation == "reconcile":
+                result = reconcile_operation(client, state)
+            else:
+                result = {
+                    "operation": operation,
+                    "status": "skipped",
+                    "durationMs": 0.0,
+                    "at": utc_now(),
+                    "reason": "unknown_operation",
+                }
+        except Exception as exc:  # noqa: BLE001 - harness must record and continue.
+            result = {
+                "operation": operation,
+                "status": "error",
+                "durationMs": 0.0,
+                "at": utc_now(),
+                "error": type(exc).__name__,
+                "message": str(exc)[:500],
+            }
+        with result_lock:
+            results.append(result)
+        if think_time > 0:
+            time.sleep(think_time)
+
+
+def summarize_metrics(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    families: set[str] = set()
+    gauge_series: dict[str, list[float]] = {}
+    optional_present: set[str] = set()
+    for sample in samples:
+        metrics = sample.get("metrics", {})
+        families.update(metrics.get("families", []))
+        for name, value in metrics.get("gauges", {}).items():
+            gauge_series.setdefault(name, []).append(float(value))
+            if name in OPTIONAL_LEAK_PROXY_METRICS:
+                optional_present.add(name)
+        for item in metrics.get("samples", []):
+            name = item.get("name")
+            if name in OPTIONAL_LEAK_PROXY_METRICS:
+                optional_present.add(str(name))
+    gauge_summary = {}
+    for name, values in gauge_series.items():
+        if not values:
+            continue
+        monotonic = all(values[index] >= values[index - 1] for index in range(1, len(values)))
+        gauge_summary[name] = {
+            "samples": len(values),
+            "first": values[0],
+            "last": values[-1],
+            "min": min(values),
+            "max": max(values),
+            "growth": values[-1] - values[0],
+            "monotonicNonDecreasing": monotonic,
+        }
+    unavailable = [
+        name
+        for name in OPTIONAL_LEAK_PROXY_METRICS
+        if name.startswith("markhand_") and name not in optional_present and name not in gauge_series
+    ]
+    return {
+        "sampleCount": len(samples),
+        "familiesObserved": sorted(families),
+        "monitoredFamilies": MONITORED_MARKHAND_METRICS,
+        "gauges": gauge_summary,
+        "resourceLeakProxyMetricsUnavailable": unavailable,
+        "readyFailures": sum(1 for item in samples if not item.get("ready", {}).get("ok")),
+        "metricsFailures": sum(1 for item in samples if not item.get("metrics", {}).get("ok")),
+    }
+
+
+def summarize_operations(results: list[dict[str, Any]], wall_seconds: float) -> dict[str, Any]:
+    by_op: dict[str, dict[str, Any]] = {}
+    for operation in sorted({str(item.get("operation")) for item in results}):
+        items = [item for item in results if item.get("operation") == operation]
+        durations = [float(item.get("durationMs", 0.0)) for item in items if item.get("status") != "skipped"]
+        successes = [item for item in items if item.get("status") == "ok"]
+        errors = [item for item in items if item.get("status") == "error"]
+        partials = [item for item in items if item.get("status") == "partial"]
+        skipped = [item for item in items if item.get("status") == "skipped"]
+        by_op[operation] = {
+            "attempts": len(items),
+            "successes": len(successes),
+            "partials": len(partials),
+            "errors": len(errors),
+            "skipped": len(skipped),
+            "durationMs": duration_stats(durations),
+            "httpStatusCounts": status_counts(items),
+        }
+    ingest_successes = by_op.get("ingest", {}).get("successes", 0)
+    wall_hours = wall_seconds / 3600.0 if wall_seconds > 0 else 0.0
+    if "ingest" in by_op:
+        by_op["ingest"]["successfulDocumentsPerHour"] = (
+            round(float(ingest_successes) / wall_hours, 3) if wall_hours else 0.0
+        )
+    return by_op
+
+
+def status_counts(items: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        status = item.get("httpStatus")
+        if status is None:
+            response = item.get("response")
+            if isinstance(response, dict):
+                status = response.get("status")
+        key = "none" if status is None else str(status)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def self_skip_payload(args: argparse.Namespace, profile: dict[str, Any], reason: str) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "reportId": "p1b-o05-mixed-load-soak",
+        "generatedAt": utc_now(),
+        "command": "python3 bench/markhand_web/soak/run_soak.py",
+        "mode": "self-skip-no-live-target",
+        "status": "skipped",
+        "skipReason": reason,
+        "profile": profile_metadata(args.profile, profile),
+        "git": git_status(),
+        "environment": {
+            "environmentId": "current-runner-no-live-stack",
+            "targetEnvironmentId": profile.get("targetEnvironmentId", "on-prem-reference"),
+            "targetMatch": False,
+        },
+        "targetMatch": False,
+        "targetResultsValidForGate": False,
+        "implementationSha256": implementation_sha256(),
+        "toolVersions": stack_versions(),
+        "gateMappings": profile.get("gateMappings", []),
+        "metrics": {
+            "sampleCount": 0,
+            "familiesObserved": [],
+            "monitoredFamilies": MONITORED_MARKHAND_METRICS,
+            "resourceLeakProxyMetricsUnavailable": OPTIONAL_LEAK_PROXY_METRICS,
+        },
+        "operations": {},
+        "state": {"activeDocuments": 0, "deletedDocuments": 0, "observedJobs": 0},
+        "failureInjections": failure_injection_plan(profile, []),
+        "doesNotClaim": [
+            "G0-SLO-QUERY-P95 pass",
+            "G0-SLO-QUERY-P99 pass",
+            "G0-CAP-INGEST-THROUGHPUT pass",
+            "soak stability pass",
+            "Profile B evidence",
+        ],
+        "notes": [
+            "No target URL/token was configured, so no live load was executed.",
+            "Run against F02 compose.poc.yml or real on-prem-reference infrastructure to produce numeric evidence.",
+            DOES_NOT_CLAIM,
+        ],
+    }
+
+
+def failure_injection_plan(profile: dict[str, Any], executed: list[str]) -> list[dict[str, Any]]:
+    executed_set = set(executed)
+    planned = []
+    for item in profile.get("failureInjections", []):
+        if not isinstance(item, dict):
+            continue
+        planned.append(
+            {
+                "id": item.get("id"),
+                "mode": item.get("mode", "documented-manual-step"),
+                "command": item.get("command"),
+                "restoreCommand": item.get("restoreCommand"),
+                "expectedSignal": item.get("expectedSignal"),
+                "executedByHarness": False,
+                "operatorRecordedExecuted": item.get("id") in executed_set,
+            }
+        )
+    return planned
+
+
+def profile_metadata(profile_path: Path, profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": relative(profile_path),
+        "sha256": file_sha256(profile_path),
+        "profileId": profile.get("profileId"),
+        "durationSeconds": profile.get("durationSeconds"),
+        "rampSeconds": profile.get("rampSeconds"),
+        "concurrency": profile.get("concurrency"),
+        "operationWeights": profile.get("operationWeights"),
+        "targetRatesPerHour": profile.get("targetRatesPerHour"),
+        "sampleIntervalSeconds": profile.get("sampleIntervalSeconds"),
+    }
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    profile = load_json(args.profile)
+    base_url = args.base_url or os.environ.get(str(profile.get("api", {}).get("baseUrlEnv", "MARKHAND_BASE_URL")))
+    token = args.bearer_token or os.environ.get(
+        str(profile.get("api", {}).get("bearerTokenEnv", "MARKHAND_BEARER_TOKEN"))
+    )
+    if not base_url:
+        return self_skip_payload(args, profile, "target URL unset; pass --base-url or MARKHAND_BASE_URL")
+    if not token:
+        return self_skip_payload(args, profile, "bearer token unset; pass --bearer-token or MARKHAND_BEARER_TOKEN")
+
+    duration = float(args.duration_seconds or profile.get("durationSeconds", 60))
+    concurrency = int(args.concurrency or profile.get("concurrency", 1))
+    if duration <= 0 or concurrency <= 0:
+        raise HarnessError("duration and concurrency must be positive")
+
+    client = ApiClient(base_url, token, float(profile.get("operationTimeoutSeconds", 30)))
+    ready = client.get("/api/v1/health/ready")
+    if not ready["ok"] and not args.allow_unready:
+        raise HarnessError(
+            f"target not ready status={ready['status']}; pass --allow-unready only for failure-injection windows"
+        )
+    collection_env = str(profile.get("api", {}).get("collectionIdEnv", "MARKHAND_COLLECTION_ID"))
+    collection_id = args.collection_id or os.environ.get(collection_env)
+    collection_id = ensure_collection(client, collection_id)
+
+    state = SharedState()
+    samples: list[dict[str, Any]] = []
+    stop = threading.Event()
+    sample_thread = threading.Thread(
+        target=sampler,
+        args=(client, float(profile.get("sampleIntervalSeconds", 5)), stop, samples),
+        daemon=True,
+    )
+    sample_thread.start()
+
+    results: list[dict[str, Any]] = []
+    result_lock = threading.Lock()
+    started = time.monotonic()
+    deadline = started + duration
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as executor:
+        futures = [
+            executor.submit(
+                run_worker,
+                index,
+                client,
+                profile,
+                collection_id,
+                state,
+                deadline,
+                float(profile.get("rampSeconds", 0)),
+                results,
+                result_lock,
+            )
+            for index in range(concurrency)
+        ]
+        for future in futures:
+            future.result()
+    stop.set()
+    sample_thread.join(timeout=5)
+    wall_seconds = time.monotonic() - started
+    operations = summarize_operations(results, wall_seconds)
+    metrics = summarize_metrics(samples)
+    total_errors = sum(int(value.get("errors", 0)) for value in operations.values())
+    target_match = bool(args.target_match)
+
+    return {
+        "version": 1,
+        "reportId": "p1b-o05-mixed-load-soak",
+        "generatedAt": utc_now(),
+        "command": "python3 bench/markhand_web/soak/run_soak.py",
+        "mode": "live-mixed-load-soak",
+        "status": "completed",
+        "profile": profile_metadata(args.profile, profile),
+        "git": git_status(),
+        "environment": {
+            "environmentId": args.environment_id,
+            "targetEnvironmentId": profile.get("targetEnvironmentId", "on-prem-reference"),
+            "targetMatch": target_match,
+            "baseUrl": base_url,
+            "collectionId": collection_id,
+        },
+        "targetMatch": target_match,
+        "targetResultsValidForGate": target_match,
+        "implementationSha256": implementation_sha256(),
+        "toolVersions": stack_versions(),
+        "durationSecondsObserved": round(wall_seconds, 3),
+        "operations": operations,
+        "operationSamples": results[-5000:],
+        "metrics": metrics,
+        "metricSamples": samples[-2000:],
+        "state": state.snapshot(),
+        "gateMappings": profile.get("gateMappings", []),
+        "failureInjections": failure_injection_plan(profile, args.executed_failure_step),
+        "restoreLeg": profile.get("restoreLeg"),
+        "soakQualification": {
+            "completedDurationSeconds": round(wall_seconds, 3),
+            "operationErrors": total_errors,
+            "readyFailures": metrics["readyFailures"],
+            "metricsFailures": metrics["metricsFailures"],
+            "noUnboundedLeakClaimed": False,
+            "numericGateValid": target_match,
+        },
+        "doesNotClaim": [] if target_match else [
+            "G0-SLO-QUERY-P95 pass",
+            "G0-SLO-QUERY-P99 pass",
+            "G0-CAP-INGEST-THROUGHPUT pass",
+            "soak stability pass",
+            "Profile B evidence",
+        ],
+        "notes": [
+            "Live run completed; numeric gate validity still requires targetMatch=true on the approved environment.",
+            "The public HTTP API has no reconcile route; the reconcile leg uses document reindex/readiness probes and observes worker reconcile through metrics/runbook steps.",
+            DOES_NOT_CLAIM if not target_match else "targetMatch=true was asserted by the operator; verify environment fingerprint before gate use.",
+        ],
+    }
+
+
+def render_report(payload: dict[str, Any]) -> str:
+    profile = payload["profile"]
+    lines = [
+        "# Phase-1B mixed-load soak",
+        "",
+        f"- Generated: `{payload['generatedAt']}`",
+        f"- Mode: `{payload['mode']}`",
+        f"- Status: `{payload['status']}`",
+        f"- Profile: `{profile.get('profileId')}`",
+        f"- Git commit: `{payload['git']['commit']}`",
+        f"- Dirty at harness start: `{str(payload['git']['dirty']).lower()}`",
+        f"- `targetMatch`: `{str(payload['targetMatch']).lower()}`",
+        f"- `targetResultsValidForGate`: `{str(payload['targetResultsValidForGate']).lower()}`",
+        "",
+        "## Caveat",
+        "",
+        "Numeric G0-SLO/G0-CAP/soak gates require sustained real infrastructure. ",
+        "This sandbox does not provide that infrastructure; self-skip or targetMatch=false output is pending evidence only.",
+        "",
+        "## Operation mix",
+        "",
+        f"- Duration seconds: `{profile.get('durationSeconds')}`",
+        f"- Ramp seconds: `{profile.get('rampSeconds')}`",
+        f"- Concurrency: `{profile.get('concurrency')}`",
+        f"- Operation weights: `{json.dumps(profile.get('operationWeights'), sort_keys=True)}`",
+        "",
+        "| operation | attempts | ok | partial | error | skipped | p95 ms | p99 ms |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for name, stats in sorted(payload.get("operations", {}).items()):
+        duration = stats.get("durationMs", {})
+        lines.append(
+            "| "
+            f"{name} | {stats.get('attempts', 0)} | {stats.get('successes', 0)} | "
+            f"{stats.get('partials', 0)} | {stats.get('errors', 0)} | {stats.get('skipped', 0)} | "
+            f"{duration.get('p95')} | {duration.get('p99')} |"
+        )
+    metrics = payload.get("metrics", {})
+    lines.extend(
+        [
+            "",
+            "## Monitored metrics",
+            "",
+            f"- Samples: `{metrics.get('sampleCount', 0)}`",
+            f"- Ready failures: `{metrics.get('readyFailures', 0)}`",
+            f"- Metrics scrape failures: `{metrics.get('metricsFailures', 0)}`",
+            f"- Families observed: `{', '.join(metrics.get('familiesObserved', [])) or 'none'}`",
+            "",
+            "Queue/leak proxy gauges:",
+            "",
+            "| metric | samples | first | last | min | max | growth | monotonic |",
+            "|---|---:|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for name, gauge in sorted(metrics.get("gauges", {}).items()):
+        lines.append(
+            "| "
+            f"`{name}` | {gauge['samples']} | {gauge['first']} | {gauge['last']} | "
+            f"{gauge['min']} | {gauge['max']} | {gauge['growth']} | "
+            f"{str(gauge['monotonicNonDecreasing']).lower()} |"
+        )
+    if not metrics.get("gauges"):
+        lines.append("| none | 0 |  |  |  |  |  |  |")
+    lines.extend(
+        [
+            "",
+            "Unavailable optional leak proxies:",
+            "",
+        ]
+    )
+    for name in metrics.get("resourceLeakProxyMetricsUnavailable", []):
+        lines.append(f"- `{name}`")
+    lines.extend(
+        [
+            "",
+            "## Gate metric mapping",
+            "",
+            "| gate id | soak metric |",
+            "|---|---|",
+        ]
+    )
+    for item in payload.get("gateMappings", []):
+        lines.append(f"| `{item.get('gateId')}` | `{item.get('soakMetric')}` |")
+    lines.extend(
+        [
+            "",
+            "## Failure-injection plan",
+            "",
+            "| id | executed by harness | operator recorded executed | expected signal |",
+            "|---|---|---|---|",
+        ]
+    )
+    for item in payload.get("failureInjections", []):
+        lines.append(
+            "| "
+            f"`{item.get('id')}` | `{str(item.get('executedByHarness')).lower()}` | "
+            f"`{str(item.get('operatorRecordedExecuted')).lower()}` | {item.get('expectedSignal')} |"
+        )
+    if payload.get("notes"):
+        lines.extend(["", "## Notes", ""])
+        for note in payload["notes"]:
+            lines.append(f"- {note}")
+    if payload["git"]["dirtyPaths"]:
+        lines.extend(["", "Dirty paths at harness start:"])
+        for path in payload["git"]["dirtyPaths"][:20]:
+            lines.append(f"- `{path}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_outputs(payload: dict[str, Any], summary: Path, report: Path) -> None:
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    report.parent.mkdir(parents=True, exist_ok=True)
+    summary.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    report.write_text(render_report(payload), encoding="utf-8")
+
+
+def self_test() -> None:
+    metrics = parse_prometheus(
+        """
+# HELP markhand_jobs_queue_depth Background jobs waiting.
+markhand_jobs_queue_depth 4
+markhand_jobs_in_flight 2
+markhand_http_requests_total{route="/api/v1/search",method="POST",status="200"} 7
+"""
+    )
+    assert "markhand_jobs_queue_depth" in metrics["families"]
+    assert metrics["gauges"]["markhand_jobs_queue_depth"] == 4.0
+    assert percentile([1, 2, 3], 0.95) == 2.9
+    profile = load_json(DEFAULT_PROFILE)
+    payload = self_skip_payload(
+        argparse.Namespace(profile=DEFAULT_PROFILE),
+        profile,
+        "test",
+    )
+    assert payload["targetMatch"] is False
+    assert payload["status"] == "skipped"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", type=Path, default=DEFAULT_PROFILE)
+    parser.add_argument("--summary", type=Path, default=SUMMARY_PATH)
+    parser.add_argument("--report", type=Path, default=REPORT_PATH)
+    parser.add_argument("--base-url", default=None)
+    parser.add_argument("--bearer-token", default=None)
+    parser.add_argument("--collection-id", default=None)
+    parser.add_argument("--duration-seconds", type=float, default=None)
+    parser.add_argument("--concurrency", type=int, default=None)
+    parser.add_argument("--environment-id", default="current-runner-or-operator-specified")
+    parser.add_argument("--target-match", action="store_true")
+    parser.add_argument("--allow-unready", action="store_true")
+    parser.add_argument("--executed-failure-step", action="append", default=[])
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    args.profile = args.profile.resolve()
+    args.summary = args.summary.resolve()
+    args.report = args.report.resolve()
+
+    if args.self_test:
+        self_test()
+        print("self-test ok")
+        return 0
+
+    try:
+        payload = build_payload(args)
+        write_outputs(payload, args.summary, args.report)
+    except HarnessError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    print(f"wrote {relative(args.summary)}")
+    print(f"wrote {relative(args.report)}")
+    print(f"status={payload['status']}")
+    print(f"targetMatch={str(payload['targetMatch']).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/markhand_web/soak/summary.json
+++ b/bench/markhand_web/soak/summary.json
@@ -1,0 +1,166 @@
+{
+  "version": 1,
+  "reportId": "p1b-o05-mixed-load-soak",
+  "generatedAt": "2026-07-20T00:44:24.926811Z",
+  "command": "python3 bench/markhand_web/soak/run_soak.py",
+  "mode": "self-skip-no-live-target",
+  "status": "skipped",
+  "skipReason": "target URL unset; pass --base-url or MARKHAND_BASE_URL",
+  "profile": {
+    "path": "bench/markhand_web/workloads/soak-smoke.yaml",
+    "sha256": "bcb600a14f586bda3fead13ac401e07d9135643793b13227766e092a8d441909",
+    "profileId": "phase-1b-soak-smoke",
+    "durationSeconds": 60,
+    "rampSeconds": 10,
+    "concurrency": 4,
+    "operationWeights": {
+      "ingest": 25,
+      "query_search": 35,
+      "ask": 20,
+      "delete": 10,
+      "reconcile": 10
+    },
+    "targetRatesPerHour": {
+      "ingest": 60,
+      "delete": 12
+    },
+    "sampleIntervalSeconds": 5
+  },
+  "git": {
+    "commit": "2395b2ba8c9249181d79529b86e4981d081d6331",
+    "branch": "cursor/p1b-o05-soak-qualification-f084",
+    "dirty": true,
+    "dirtyPaths": [
+      "bench/markhand_web/reports/phase-1b-gate.py",
+      "bench/markhand_web/reports/phase-1b-gate/",
+      "bench/markhand_web/soak/",
+      "bench/markhand_web/workloads/"
+    ]
+  },
+  "environment": {
+    "environmentId": "current-runner-no-live-stack",
+    "targetEnvironmentId": "on-prem-reference",
+    "targetMatch": false
+  },
+  "targetMatch": false,
+  "targetResultsValidForGate": false,
+  "implementationSha256": "a130249b154ce9a613e721c20b20923e14c570d1f7dce66113c5dea5a6cccd88",
+  "toolVersions": {
+    "python": "3.12.3",
+    "platform": "Linux-6.12.94+-x86_64-with-glibc2.39",
+    "docker": {
+      "available": false,
+      "argv": [
+        "docker",
+        "--version"
+      ],
+      "error": "[Errno 2] No such file or directory: 'docker'"
+    },
+    "dockerCompose": {
+      "available": false,
+      "argv": [
+        "docker",
+        "compose",
+        "version"
+      ],
+      "error": "[Errno 2] No such file or directory: 'docker'"
+    },
+    "profileSha256": "bcb600a14f586bda3fead13ac401e07d9135643793b13227766e092a8d441909",
+    "gatesSha256": "cce4a785f8ba006555f534be2f7915729963c5fd5b0513b14fd89f9a3930b1db",
+    "workloadProfileSha256": "9edfa099f25758876386e6c008c16f2d80cc8d2ede2b123f4e7b7e988d9c28dc"
+  },
+  "gateMappings": [
+    {
+      "gateId": "G0-SLO-QUERY-P95",
+      "soakMetric": "operations.query_search.durationMs.p95"
+    },
+    {
+      "gateId": "G0-SLO-QUERY-P99",
+      "soakMetric": "operations.query_search.durationMs.p99"
+    },
+    {
+      "gateId": "G0-CAP-INGEST-THROUGHPUT",
+      "soakMetric": "operations.ingest.successfulDocumentsPerHour"
+    },
+    {
+      "gateId": "G0-DR-RPO",
+      "soakMetric": "restore.rpoMinutes"
+    },
+    {
+      "gateId": "G0-DR-QUERY-READY-RTO",
+      "soakMetric": "restore.queryReadyRtoMinutes"
+    },
+    {
+      "gateId": "G0-DR-FULL-VECTOR-RTO",
+      "soakMetric": "restore.fullVectorRtoMinutes"
+    }
+  ],
+  "metrics": {
+    "sampleCount": 0,
+    "familiesObserved": [],
+    "monitoredFamilies": [
+      "markhand_http_requests_total",
+      "markhand_http_request_duration_seconds_bucket",
+      "markhand_http_request_duration_seconds_sum",
+      "markhand_http_request_duration_seconds_count",
+      "markhand_jobs_processed_total",
+      "markhand_job_duration_seconds_bucket",
+      "markhand_job_duration_seconds_sum",
+      "markhand_job_duration_seconds_count",
+      "markhand_jobs_in_flight",
+      "markhand_jobs_queue_depth",
+      "markhand_retrieval_latency_seconds_bucket",
+      "markhand_retrieval_latency_seconds_sum",
+      "markhand_retrieval_latency_seconds_count",
+      "markhand_embedding_latency_seconds_bucket",
+      "markhand_embedding_latency_seconds_sum",
+      "markhand_embedding_latency_seconds_count"
+    ],
+    "resourceLeakProxyMetricsUnavailable": [
+      "markhand_process_resident_memory_bytes",
+      "process_resident_memory_bytes",
+      "markhand_temp_bytes",
+      "markhand_open_connections",
+      "markhand_jobs_dead_letter_total",
+      "markhand_jobs_dead_letter_depth"
+    ]
+  },
+  "operations": {},
+  "state": {
+    "activeDocuments": 0,
+    "deletedDocuments": 0,
+    "observedJobs": 0
+  },
+  "failureInjections": [
+    {
+      "id": "pause-convert-worker",
+      "mode": "documented-manual-step",
+      "command": "docker compose -f deploy/compose.poc.yml stop worker-convert",
+      "restoreCommand": "docker compose -f deploy/compose.poc.yml up -d worker-convert",
+      "expectedSignal": "markhand_jobs_queue_depth remains bounded after worker recovery",
+      "executedByHarness": false,
+      "operatorRecordedExecuted": false
+    },
+    {
+      "id": "readiness-fence-reconciling",
+      "mode": "documented-manual-step",
+      "command": "docker compose -f deploy/compose.poc.yml run --rm worker-reconcile readiness-fence reconciling \"soak smoke fence\"",
+      "restoreCommand": "docker compose -f deploy/compose.poc.yml run --rm worker-reconcile readiness-fence ready",
+      "expectedSignal": "/api/v1/health/ready reports not_reconciled until fence is ready",
+      "executedByHarness": false,
+      "operatorRecordedExecuted": false
+    }
+  ],
+  "doesNotClaim": [
+    "G0-SLO-QUERY-P95 pass",
+    "G0-SLO-QUERY-P99 pass",
+    "G0-CAP-INGEST-THROUGHPUT pass",
+    "soak stability pass",
+    "Profile B evidence"
+  ],
+  "notes": [
+    "No target URL/token was configured, so no live load was executed.",
+    "Run against F02 compose.poc.yml or real on-prem-reference infrastructure to produce numeric evidence.",
+    "does NOT claim numeric G0-SLO/G0-CAP/soak pass evidence without sustained real infra"
+  ]
+}

--- a/bench/markhand_web/workloads/soak-phase-1b.yaml
+++ b/bench/markhand_web/workloads/soak-phase-1b.yaml
@@ -1,0 +1,110 @@
+{
+  "version": 1,
+  "profileId": "phase-1b-soak-full",
+  "description": "Full Phase-1B mixed-load qualification profile. Numeric G0 gates require sustained real infrastructure with targetMatch=true.",
+  "baseWorkloadProfile": "../workload-profile.yaml",
+  "targetEnvironmentId": "on-prem-reference",
+  "targetMatchRequiredForNumericGates": true,
+  "durationSeconds": 14400,
+  "rampSeconds": 300,
+  "concurrency": 96,
+  "sampleIntervalSeconds": 10,
+  "operationTimeoutSeconds": 60,
+  "jobPollTimeoutSeconds": 600,
+  "jobPollIntervalSeconds": 5,
+  "operationWeights": {
+    "ingest": 18,
+    "query_search": 52,
+    "ask": 15,
+    "delete": 8,
+    "reconcile": 7
+  },
+  "targetRatesPerHour": {
+    "ingest": 1200,
+    "delete": 120
+  },
+  "api": {
+    "baseUrlEnv": "MARKHAND_BASE_URL",
+    "bearerTokenEnv": "MARKHAND_BEARER_TOKEN",
+    "collectionIdEnv": "MARKHAND_COLLECTION_ID",
+    "defaultBaseUrl": "http://127.0.0.1:8787"
+  },
+  "data": {
+    "classification": "synthetic-redacted",
+    "fixturePrefix": "P1B-O05-SOAK-FULL",
+    "uploadContentType": "text/plain",
+    "queries": [
+      "P1B-O05 capacity budget marker",
+      "P1B-O05 recovery design marker",
+      "Markhand single org POC retrieval",
+      "current effective document version",
+      "delete tombstone purge reconcile",
+      "restore readiness fence"
+    ]
+  },
+  "gateMappings": [
+    {
+      "gateId": "G0-SLO-QUERY-P95",
+      "soakMetric": "operations.query_search.durationMs.p95"
+    },
+    {
+      "gateId": "G0-SLO-QUERY-P99",
+      "soakMetric": "operations.query_search.durationMs.p99"
+    },
+    {
+      "gateId": "G0-CAP-INGEST-THROUGHPUT",
+      "soakMetric": "operations.ingest.successfulDocumentsPerHour"
+    },
+    {
+      "gateId": "G0-DR-RPO",
+      "soakMetric": "restore.rpoMinutes"
+    },
+    {
+      "gateId": "G0-DR-QUERY-READY-RTO",
+      "soakMetric": "restore.queryReadyRtoMinutes"
+    },
+    {
+      "gateId": "G0-DR-FULL-VECTOR-RTO",
+      "soakMetric": "restore.fullVectorRtoMinutes"
+    }
+  ],
+  "failureInjections": [
+    {
+      "id": "pause-convert-worker",
+      "mode": "documented-manual-step",
+      "command": "docker compose -f deploy/compose.poc.yml stop worker-convert",
+      "restoreCommand": "docker compose -f deploy/compose.poc.yml up -d worker-convert",
+      "expectedSignal": "convert backlog increases, then markhand_jobs_queue_depth returns to baseline without dead-letter growth"
+    },
+    {
+      "id": "pause-index-worker",
+      "mode": "documented-manual-step",
+      "command": "docker compose -f deploy/compose.poc.yml stop worker-index",
+      "restoreCommand": "docker compose -f deploy/compose.poc.yml up -d worker-index",
+      "expectedSignal": "search degrades safely while index jobs catch up after worker recovery"
+    },
+    {
+      "id": "dependency-blip-qdrant",
+      "mode": "documented-manual-step",
+      "command": "docker compose -f deploy/compose.poc.yml stop qdrant",
+      "restoreCommand": "docker compose -f deploy/compose.poc.yml up -d qdrant worker-index worker-reconcile",
+      "expectedSignal": "readiness and query failures are bounded; reconciliation is required before ready"
+    },
+    {
+      "id": "restore-fence-reconcile",
+      "mode": "documented-manual-step",
+      "command": "docker compose -f deploy/compose.poc.yml run --rm worker-reconcile readiness-fence reconciling \"soak restore leg\"",
+      "restoreCommand": "docker compose -f deploy/compose.poc.yml run --rm worker-reconcile readiness-fence ready",
+      "expectedSignal": "/api/v1/health/ready remains false until O03 reconcile completes"
+    }
+  ],
+  "restoreLeg": {
+    "command": "python3 bench/markhand_web/scripts/run_restore_drill.py",
+    "evidence": "bench/markhand_web/restore/summary.json",
+    "requiresRealInfra": true,
+    "notes": [
+      "Run after a component-loss backup/restore on the same stack.",
+      "Numeric RPO/RTO gates are pending until real PostgreSQL, MinIO, Qdrant and reconciliation evidence is recorded with targetMatch=true."
+    ]
+  }
+}

--- a/bench/markhand_web/workloads/soak-smoke.yaml
+++ b/bench/markhand_web/workloads/soak-smoke.yaml
@@ -1,0 +1,84 @@
+{
+  "version": 1,
+  "profileId": "phase-1b-soak-smoke",
+  "description": "Short synthetic/redacted mixed-load smoke for validating the soak harness shape before a real sustained run.",
+  "baseWorkloadProfile": "../workload-profile.yaml",
+  "targetEnvironmentId": "on-prem-reference",
+  "targetMatchRequiredForNumericGates": true,
+  "durationSeconds": 60,
+  "rampSeconds": 10,
+  "concurrency": 4,
+  "sampleIntervalSeconds": 5,
+  "operationTimeoutSeconds": 30,
+  "jobPollTimeoutSeconds": 60,
+  "jobPollIntervalSeconds": 2,
+  "operationWeights": {
+    "ingest": 25,
+    "query_search": 35,
+    "ask": 20,
+    "delete": 10,
+    "reconcile": 10
+  },
+  "targetRatesPerHour": {
+    "ingest": 60,
+    "delete": 12
+  },
+  "api": {
+    "baseUrlEnv": "MARKHAND_BASE_URL",
+    "bearerTokenEnv": "MARKHAND_BEARER_TOKEN",
+    "collectionIdEnv": "MARKHAND_COLLECTION_ID",
+    "defaultBaseUrl": "http://127.0.0.1:8787"
+  },
+  "data": {
+    "classification": "synthetic-redacted",
+    "fixturePrefix": "P1B-O05-SOAK-SMOKE",
+    "uploadContentType": "text/plain",
+    "queries": [
+      "P1B-O05 smoke budget marker",
+      "P1B-O05 smoke design marker",
+      "Markhand single org POC soak"
+    ]
+  },
+  "gateMappings": [
+    {
+      "gateId": "G0-SLO-QUERY-P95",
+      "soakMetric": "operations.query_search.durationMs.p95"
+    },
+    {
+      "gateId": "G0-SLO-QUERY-P99",
+      "soakMetric": "operations.query_search.durationMs.p99"
+    },
+    {
+      "gateId": "G0-CAP-INGEST-THROUGHPUT",
+      "soakMetric": "operations.ingest.successfulDocumentsPerHour"
+    },
+    {
+      "gateId": "G0-DR-RPO",
+      "soakMetric": "restore.rpoMinutes"
+    },
+    {
+      "gateId": "G0-DR-QUERY-READY-RTO",
+      "soakMetric": "restore.queryReadyRtoMinutes"
+    },
+    {
+      "gateId": "G0-DR-FULL-VECTOR-RTO",
+      "soakMetric": "restore.fullVectorRtoMinutes"
+    }
+  ],
+  "failureInjections": [
+    {
+      "id": "pause-convert-worker",
+      "mode": "documented-manual-step",
+      "command": "docker compose -f deploy/compose.poc.yml stop worker-convert",
+      "restoreCommand": "docker compose -f deploy/compose.poc.yml up -d worker-convert",
+      "expectedSignal": "markhand_jobs_queue_depth remains bounded after worker recovery"
+    },
+    {
+      "id": "readiness-fence-reconciling",
+      "mode": "documented-manual-step",
+      "command": "docker compose -f deploy/compose.poc.yml run --rm worker-reconcile readiness-fence reconciling \"soak smoke fence\"",
+      "restoreCommand": "docker compose -f deploy/compose.poc.yml run --rm worker-reconcile readiness-fence ready",
+      "expectedSignal": "/api/v1/health/ready reports not_reconciled until fence is ready"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## P1B-O05 — Mixed-load soak & POC qualification

Soak harness + aggregate Phase-1B gate report. **Bench/ops only — no Rust changes.** Stacks on O02. Closes #101.

### Deliverables
- **`bench/markhand_web/soak/run_soak.py`** — sustained concurrent **mixed load** (ingest upload→create→job-poll, `/search`, `/ask`, delete tombstone, reconcile leg) against a base URL + bearer, configurable duration/concurrency/mix. Samples `/api/v1/metrics` + `/api/v1/health/ready` for latency/error, job queue/in-flight/dead-letter, and resource-leak proxies. Self-skips without `MARKHAND_BASE_URL`/`MARKHAND_BEARER_TOKEN`; synthetic/redacted only; records exact stack versions.
- **`bench/markhand_web/workloads/{soak-smoke,soak-phase-1b}.yaml`** — mixed-load profiles consistent with `workload-profile.yaml`/`gates.yaml`.
- **`bench/markhand_web/reports/phase-1b-gate.py` + template** — aggregates soak + `query_load` + `ingest` + `restore` evidence against `gates.yaml` into a per-gate pass/fail/**pending** report. Renders cleanly with **no evidence** (16 gates `pending`, `targetMatch=false`) — proven.
- **`bench/markhand_web/soak/README.md`** — run against F02 `compose.poc.yml`, failure-injection legs (pause/restart workers, Qdrant blip), restore leg (O03 fence + `run_restore_drill.py`).

### Gate mapping
`G0-SLO-QUERY-P95/P99` ← soak query p95/p99; `G0-CAP-INGEST-THROUGHPUT` ← ingest docs/hour; `G0-DR-RPO`/`RTO` ← restore evidence. Leak/queue via O01 `markhand_jobs_queue_depth`/`_in_flight`/`_processed_total{outcome}` + latency histograms.

### Validation
`py_compile`, `--self-test` on both scripts, empty-evidence report (16 pending), YAML parse, `make check-boundaries` + `classify-ci` pass. **No fabricated measurements**.

> ⚠️ **Numeric G0-SLO/G0-CAP/DR/soak pass-fail requires sustained real infrastructure**. This sandbox delivers the harness + a `pending` qualification report; the numeric gate is produced by running on infra with `targetMatch=true`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7a63-68e2-71cc-9db9-7cb820f6b223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

