### PR TITLE
feat(server): P1B-I05 idempotent conversion promotion saga

### DIFF
--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -45,7 +45,9 @@ mod tests {
         assert_eq!(error.code, "validation_failed");
         assert_eq!(
             serde_json::to_string_pretty(&error).unwrap(),
-            include_str!("../openapi/fixtures/error.json").trim()
+            include_str!("../openapi/fixtures/error.json")
+                .trim()
+                .replace("\r\n", "\n")
         );
 
         let page: PageInfo =

--- a/crates/server/src/db/document_versions.rs
+++ b/crates/server/src/db/document_versions.rs
@@ -1,0 +1,302 @@
+//! Tenant-scoped immutable document-version promotion repository.
+
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{ArtifactKind, DocumentVersion, PublicationState};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversionSourceVersion {
+    pub document_id: Uuid,
+    pub source_version_id: Uuid,
+    pub original_object_key: String,
+    pub content_sha256: String,
+    pub source_filename: Option<String>,
+    pub source_content_type: Option<String>,
+    pub byte_size: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewPublishedVersion<'a> {
+    pub id: Uuid,
+    pub document_id: Uuid,
+    pub parent_version_id: Uuid,
+    pub content_sha256: &'a str,
+    pub original_object_key: &'a str,
+    pub markdown_object_key: &'a str,
+    pub source_filename: Option<&'a str>,
+    pub source_content_type: Option<&'a str>,
+    pub byte_size: i64,
+    pub change_summary: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewDerivedArtifact<'a> {
+    pub id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub kind: ArtifactKind,
+    pub object_key: &'a str,
+    pub content_sha256: &'a str,
+    pub content_type: &'a str,
+    pub byte_size: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactInsertOutcome {
+    pub created: bool,
+    pub object_key: String,
+    pub content_sha256: String,
+    pub byte_size: Option<i64>,
+}
+
+pub async fn source_for_conversion(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<ConversionSourceVersion, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT document_id, id, original_object_key, content_sha256,
+                    source_filename, source_content_type, byte_size
+             FROM document_versions
+             WHERE org_id = $1 AND document_id = $2 AND id = $3",
+            &[&ctx.org_id(), &document_id, &version_id],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    Ok(ConversionSourceVersion {
+        document_id: row.get("document_id"),
+        source_version_id: row.get("id"),
+        original_object_key: row.get("original_object_key"),
+        content_sha256: row.get("content_sha256"),
+        source_filename: row.get("source_filename"),
+        source_content_type: row.get("source_content_type"),
+        byte_size: row.get("byte_size"),
+    })
+}
+
+pub async fn find_by_id(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<Option<DocumentVersion>, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, document_id, version_number, parent_version_id,
+                    publication_state, is_current, content_sha256, original_object_key,
+                    markdown_object_key, source_filename, source_content_type, byte_size,
+                    effective_from, effective_to, change_summary, created_by_user_id, created_at
+             FROM document_versions
+             WHERE org_id = $1 AND document_id = $2 AND id = $3",
+            &[&ctx.org_id(), &document_id, &version_id],
+        )
+        .await?;
+    row.map(|row| map_version(&row)).transpose()
+}
+
+pub async fn insert_published_version_if_absent(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewPublishedVersion<'_>,
+) -> Result<(DocumentVersion, bool), DbError> {
+    let publication_state = "published";
+    let row = txn
+        .query_opt(
+            "WITH next_number AS (
+                SELECT COALESCE(MAX(version_number), 0)::integer + 1 AS version_number
+                FROM document_versions
+                WHERE org_id = $2 AND document_id = $3
+             ),
+             inserted AS (
+                INSERT INTO document_versions (
+                    id, org_id, document_id, version_number, parent_version_id,
+                    publication_state, is_current, content_sha256, original_object_key,
+                    markdown_object_key, source_filename, source_content_type, byte_size,
+                    change_summary, created_by_user_id
+                )
+                SELECT $1, $2, $3, next_number.version_number, $4, $5, false,
+                       $6, $7, $8, $9, $10, $11, $12, $13
+                FROM next_number
+                ON CONFLICT (id) DO NOTHING
+                RETURNING id, org_id, document_id, version_number, parent_version_id,
+                          publication_state, is_current, content_sha256, original_object_key,
+                          markdown_object_key, source_filename, source_content_type, byte_size,
+                          effective_from, effective_to, change_summary, created_by_user_id,
+                          created_at, true AS created
+             )
+             SELECT id, org_id, document_id, version_number, parent_version_id,
+                    publication_state, is_current, content_sha256, original_object_key,
+                    markdown_object_key, source_filename, source_content_type, byte_size,
+                    effective_from, effective_to, change_summary, created_by_user_id,
+                    created_at, created
+             FROM inserted
+             UNION ALL
+             SELECT id, org_id, document_id, version_number, parent_version_id,
+                    publication_state, is_current, content_sha256, original_object_key,
+                    markdown_object_key, source_filename, source_content_type, byte_size,
+                    effective_from, effective_to, change_summary, created_by_user_id,
+                    created_at, false AS created
+             FROM document_versions
+             WHERE org_id = $2 AND document_id = $3 AND id = $1
+             LIMIT 1",
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &input.document_id,
+                &input.parent_version_id,
+                &publication_state,
+                &input.content_sha256,
+                &input.original_object_key,
+                &input.markdown_object_key,
+                &input.source_filename,
+                &input.source_content_type,
+                &Some(input.byte_size),
+                &input.change_summary,
+                &ctx.user_id(),
+            ],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    let version = map_version(&row)?;
+    Ok((version, row.get("created")))
+}
+
+pub async fn insert_artifact_if_absent(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewDerivedArtifact<'_>,
+) -> Result<ArtifactInsertOutcome, DbError> {
+    let kind = input.kind.as_str();
+    let row = txn
+        .query_one(
+            "WITH inserted AS (
+                INSERT INTO derived_artifacts (
+                    id, org_id, document_id, version_id, artifact_kind, object_key,
+                    content_sha256, content_type, byte_size
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                ON CONFLICT (version_id, artifact_kind) DO NOTHING
+                RETURNING object_key, content_sha256, byte_size, true AS created
+             )
+             SELECT object_key, content_sha256, byte_size, created FROM inserted
+             UNION ALL
+             SELECT object_key, content_sha256, byte_size, false AS created
+             FROM derived_artifacts
+             WHERE org_id = $2 AND version_id = $4 AND artifact_kind = $5
+             LIMIT 1",
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &input.document_id,
+                &input.version_id,
+                &kind,
+                &input.object_key,
+                &input.content_sha256,
+                &input.content_type,
+                &Some(input.byte_size),
+            ],
+        )
+        .await?;
+    Ok(ArtifactInsertOutcome {
+        object_key: row.get("object_key"),
+        content_sha256: row.get("content_sha256"),
+        byte_size: row.get("byte_size"),
+        created: row.get("created"),
+    })
+}
+
+pub async fn promote_current_if_needed(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<(), DbError> {
+    let row = txn
+        .query_one(
+            "SELECT is_current
+             FROM document_versions
+             WHERE org_id = $1 AND document_id = $2 AND id = $3
+             FOR UPDATE",
+            &[&ctx.org_id(), &document_id, &version_id],
+        )
+        .await?;
+    let already_current: bool = row.get("is_current");
+    if already_current {
+        txn.execute(
+            "UPDATE documents
+             SET current_version_id = $3, state = 'converted', updated_at = clock_timestamp()
+             WHERE org_id = $1 AND id = $2",
+            &[&ctx.org_id(), &document_id, &version_id],
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let effective_to = txn
+        .query_one("SELECT clock_timestamp()", &[])
+        .await?
+        .get::<_, chrono::DateTime<chrono::Utc>>(0);
+    txn.execute(
+        "UPDATE document_versions
+         SET is_current = false, effective_to = $3
+         WHERE org_id = $1
+           AND document_id = $2
+           AND is_current
+           AND effective_to IS NULL",
+        &[&ctx.org_id(), &document_id, &effective_to],
+    )
+    .await?;
+    txn.execute(
+        "UPDATE document_versions
+         SET is_current = true
+         WHERE org_id = $1 AND document_id = $2 AND id = $3",
+        &[&ctx.org_id(), &document_id, &version_id],
+    )
+    .await?;
+    txn.execute(
+        "UPDATE documents
+         SET current_version_id = $3, state = 'converted', updated_at = clock_timestamp()
+         WHERE org_id = $1 AND id = $2",
+        &[&ctx.org_id(), &document_id, &version_id],
+    )
+    .await?;
+    Ok(())
+}
+
+fn map_version(row: &Row) -> Result<DocumentVersion, DbError> {
+    let publication_state: String = row.get("publication_state");
+    let publication_state = match publication_state.as_str() {
+        "draft" => PublicationState::Draft,
+        "published" => PublicationState::Published,
+        other => {
+            return Err(DbError::Config(format!(
+                "unknown publication state: {other}"
+            )));
+        }
+    };
+    Ok(DocumentVersion {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        document_id: row.get("document_id"),
+        version_number: row.get("version_number"),
+        parent_version_id: row.get("parent_version_id"),
+        publication_state,
+        is_current: row.get("is_current"),
+        content_sha256: row.get("content_sha256"),
+        original_object_key: row.get("original_object_key"),
+        markdown_object_key: row.get("markdown_object_key"),
+        source_filename: row.get("source_filename"),
+        source_content_type: row.get("source_content_type"),
+        byte_size: row.get("byte_size"),
+        effective_from: row.get("effective_from"),
+        effective_to: row.get("effective_to"),
+        change_summary: row.get("change_summary"),
+        created_by_user_id: row.get("created_by_user_id"),
+        created_at: row.get("created_at"),
+    })
+}

--- a/crates/server/src/db/document_versions.rs
+++ b/crates/server/src/db/document_versions.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
 use crate::db::error::DbError;
-use crate::db::models::{ArtifactKind, DocumentVersion, PublicationState};
+use crate::db::models::{ArtifactKind, Document, DocumentState, DocumentVersion, PublicationState};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConversionSourceVersion {
@@ -241,7 +241,7 @@ pub async fn find_markdown_artifact(
 pub async fn promote_current_if_needed(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
-    document_id: Uuid,
+    document: &Document,
     version_id: Uuid,
 ) -> Result<(), DbError> {
     let row = txn
@@ -250,19 +250,28 @@ pub async fn promote_current_if_needed(
              FROM document_versions
              WHERE org_id = $1 AND document_id = $2 AND id = $3
              FOR UPDATE",
-            &[&ctx.org_id(), &document_id, &version_id],
+            &[&ctx.org_id(), &document.id, &version_id],
         )
         .await?;
     let already_current: bool = row.get("is_current");
     if already_current {
-        txn.execute(
-            "UPDATE documents
-             SET current_version_id = $3, state = 'converted', updated_at = clock_timestamp()
-             WHERE org_id = $1 AND id = $2",
-            &[&ctx.org_id(), &document_id, &version_id],
-        )
-        .await?;
-        return Ok(());
+        return if document.current_version_id == Some(version_id) {
+            Ok(())
+        } else {
+            Err(DbError::StaleState {
+                expected: version_id.to_string(),
+                observed: document
+                    .current_version_id
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| "none".into()),
+            })
+        };
+    }
+    if !is_eligible_for_conversion_promotion(document) {
+        return Err(DbError::StaleState {
+            expected: "uploaded, converting, or converted and not deleted".into(),
+            observed: document.state.to_string(),
+        });
     }
 
     let effective_to = txn
@@ -276,24 +285,43 @@ pub async fn promote_current_if_needed(
            AND document_id = $2
            AND is_current
            AND effective_to IS NULL",
-        &[&ctx.org_id(), &document_id, &effective_to],
+        &[&ctx.org_id(), &document.id, &effective_to],
     )
     .await?;
     txn.execute(
         "UPDATE document_versions
          SET is_current = true
          WHERE org_id = $1 AND document_id = $2 AND id = $3",
-        &[&ctx.org_id(), &document_id, &version_id],
+        &[&ctx.org_id(), &document.id, &version_id],
     )
     .await?;
-    txn.execute(
-        "UPDATE documents
+    let expected_state = document.state.as_str();
+    let updated = txn
+        .execute(
+            "UPDATE documents
          SET current_version_id = $3, state = 'converted', updated_at = clock_timestamp()
-         WHERE org_id = $1 AND id = $2",
-        &[&ctx.org_id(), &document_id, &version_id],
-    )
-    .await?;
+         WHERE org_id = $1
+           AND id = $2
+           AND state = $4
+           AND deleted_at IS NULL",
+            &[&ctx.org_id(), &document.id, &version_id, &expected_state],
+        )
+        .await?;
+    if updated != 1 {
+        return Err(DbError::StaleState {
+            expected: expected_state.into(),
+            observed: "missing_or_changed".into(),
+        });
+    }
     Ok(())
+}
+
+fn is_eligible_for_conversion_promotion(document: &Document) -> bool {
+    document.deleted_at.is_none()
+        && matches!(
+            document.state,
+            DocumentState::Uploaded | DocumentState::Converting | DocumentState::Converted
+        )
 }
 
 fn map_version(row: &Row) -> Result<DocumentVersion, DbError> {

--- a/crates/server/src/db/document_versions.rs
+++ b/crates/server/src/db/document_versions.rs
@@ -46,6 +46,7 @@ pub struct NewDerivedArtifact<'a> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArtifactInsertOutcome {
+    pub id: Uuid,
     pub created: bool,
     pub object_key: String,
     pub content_sha256: String,
@@ -181,11 +182,11 @@ pub async fn insert_artifact_if_absent(
                 )
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
                 ON CONFLICT (version_id, artifact_kind) DO NOTHING
-                RETURNING object_key, content_sha256, byte_size, true AS created
+                RETURNING id, object_key, content_sha256, byte_size, true AS created
              )
-             SELECT object_key, content_sha256, byte_size, created FROM inserted
+             SELECT id, object_key, content_sha256, byte_size, created FROM inserted
              UNION ALL
-             SELECT object_key, content_sha256, byte_size, false AS created
+             SELECT id, object_key, content_sha256, byte_size, false AS created
              FROM derived_artifacts
              WHERE org_id = $2 AND version_id = $4 AND artifact_kind = $5
              LIMIT 1",
@@ -203,11 +204,38 @@ pub async fn insert_artifact_if_absent(
         )
         .await?;
     Ok(ArtifactInsertOutcome {
+        id: row.get("id"),
         object_key: row.get("object_key"),
         content_sha256: row.get("content_sha256"),
         byte_size: row.get("byte_size"),
         created: row.get("created"),
     })
+}
+
+pub async fn find_markdown_artifact(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    version_id: Uuid,
+) -> Result<Option<ArtifactInsertOutcome>, DbError> {
+    let kind = ArtifactKind::Markdown.as_str();
+    let row = txn
+        .query_opt(
+            "SELECT id, object_key, content_sha256, byte_size, false AS created
+             FROM derived_artifacts
+             WHERE org_id = $1 AND version_id = $2 AND artifact_kind = $3",
+            &[&ctx.org_id(), &version_id, &kind],
+        )
+        .await?;
+    row.map(|row| {
+        Ok(ArtifactInsertOutcome {
+            id: row.get("id"),
+            object_key: row.get("object_key"),
+            content_sha256: row.get("content_sha256"),
+            byte_size: row.get("byte_size"),
+            created: row.get("created"),
+        })
+    })
+    .transpose()
 }
 
 pub async fn promote_current_if_needed(

--- a/crates/server/src/db/jobs.rs
+++ b/crates/server/src/db/jobs.rs
@@ -836,6 +836,7 @@ fn validate_checkpoint_payload(value: &JsonValue) -> Result<(), DbError> {
                             ));
                         }
                     }
+                    "staged_object_keys" => validate_checkpoint_object_keys(nested)?,
                     _ => validate_id_only_value(nested)?,
                 }
             }
@@ -845,6 +846,37 @@ fn validate_checkpoint_payload(value: &JsonValue) -> Result<(), DbError> {
             "checkpoint payload must be an object".into(),
         )),
     }
+}
+
+fn validate_checkpoint_object_keys(value: &JsonValue) -> Result<(), DbError> {
+    let JsonValue::Array(values) = value else {
+        return Err(DbError::Config(
+            "checkpoint staged_object_keys must be an array".into(),
+        ));
+    };
+    for value in values {
+        let JsonValue::String(key) = value else {
+            return Err(DbError::Config(
+                "checkpoint staged_object_keys entries must be strings".into(),
+            ));
+        };
+        if key.is_empty()
+            || key.len() > 256
+            || !key.starts_with("trusted/")
+            || key.starts_with('/')
+            || key.contains('\\')
+            || key.contains('\0')
+            || key.chars().any(char::is_control)
+            || key
+                .split('/')
+                .any(|part| part.is_empty() || part == "." || part == ".." || part.contains(".."))
+        {
+            return Err(DbError::Config(
+                "checkpoint staged_object_keys entry is invalid".into(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod chunks;
 pub mod collections;
+pub mod document_versions;
 pub mod documents;
 pub mod error;
 pub(crate) mod jobs;

--- a/crates/server/src/jobs/mod.rs
+++ b/crates/server/src/jobs/mod.rs
@@ -40,6 +40,8 @@ pub struct JobPayload {
     pub collection_id: Option<Uuid>,
     pub upload_id: Option<Uuid>,
     pub batch_id: Option<Uuid>,
+    /// Parent conversion job for an independent reconciliation job.
+    pub cleanup_target_job_id: Option<Uuid>,
 }
 
 impl JobPayload {
@@ -67,6 +69,7 @@ impl From<JobPayloadV1> for JobPayload {
             collection_id: None,
             upload_id: None,
             batch_id: None,
+            cleanup_target_job_id: None,
         }
     }
 }

--- a/crates/server/src/jobs/mod.rs
+++ b/crates/server/src/jobs/mod.rs
@@ -112,6 +112,7 @@ impl EventPayload {
 pub struct CheckpointPayload {
     pub cursor_id: Option<Uuid>,
     pub completed_ids: Vec<Uuid>,
+    pub staged_object_keys: Vec<String>,
     pub offset: Option<u64>,
 }
 
@@ -901,6 +902,7 @@ mod tests {
         let checkpoint = CheckpointPayload {
             cursor_id: Some(Uuid::new_v4()),
             completed_ids: vec![Uuid::new_v4()],
+            staged_object_keys: vec![],
             offset: Some(42),
         };
         assert!(checkpoint.to_json().is_ok());

--- a/crates/server/src/services/artifacts.rs
+++ b/crates/server/src/services/artifacts.rs
@@ -1,0 +1,121 @@
+//! Derived artifact staging for conversion promotion.
+
+use bytes::Bytes;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::services::conversion::ConversionIdentity;
+use crate::storage::keys::trusted_key;
+use crate::storage::minio::{MinioClient, ObjectIdentityMeta};
+use crate::storage::{ObjectKey, StorageError};
+
+#[derive(Debug, Clone)]
+pub struct MarkdownStageInput {
+    pub collection_id: Option<Uuid>,
+    pub document_id: Uuid,
+    pub promoted_version_id: Uuid,
+    pub markdown: Vec<u8>,
+    pub markdown_sha256: String,
+    pub markdown_len: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct StagedMarkdown {
+    pub key: ObjectKey,
+    pub object_key: String,
+    pub content_sha256: String,
+    pub byte_size: u64,
+    pub created_or_verified: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum ArtifactStageError {
+    #[error("staged markdown length is invalid")]
+    InvalidLength,
+    #[error("staged markdown hash is invalid")]
+    InvalidHash,
+    #[error("storage error")]
+    Storage(#[from] StorageError),
+}
+
+pub async fn stage_markdown(
+    storage: &MinioClient,
+    ctx: &OrgContext,
+    identity: &ConversionIdentity,
+    input: MarkdownStageInput,
+) -> Result<StagedMarkdown, ArtifactStageError> {
+    let expected_len =
+        usize::try_from(input.markdown_len).map_err(|_| ArtifactStageError::InvalidLength)?;
+    if input.markdown.len() != expected_len {
+        return Err(ArtifactStageError::InvalidLength);
+    }
+    let actual_sha256 = hex::encode(Sha256::digest(&input.markdown));
+    if actual_sha256 != input.markdown_sha256 {
+        return Err(ArtifactStageError::InvalidHash);
+    }
+
+    let key = markdown_key(identity, input.promoted_version_id)?;
+    if storage.object_exists(ctx.org_id(), &key).await? {
+        let metadata = storage.head_metadata(ctx.org_id(), &key).await?;
+        if metadata.get("content-sha256").map(String::as_str)
+            == Some(input.markdown_sha256.as_str())
+            && metadata
+                .get("disposition")
+                .map(String::as_str)
+                .is_some_and(|value| value == "staged" || value == "trusted")
+        {
+            return Ok(StagedMarkdown {
+                object_key: key.as_str(),
+                key,
+                content_sha256: input.markdown_sha256,
+                byte_size: input.markdown_len,
+                created_or_verified: false,
+            });
+        }
+        return Err(ArtifactStageError::Storage(StorageError::OwnershipConflict));
+    }
+
+    let meta = ObjectIdentityMeta {
+        org_id: ctx.org_id(),
+        collection_id: input.collection_id,
+        document_id: Some(input.document_id),
+        version_id: Some(input.promoted_version_id),
+        original_filename: None,
+        canonical_format: Some("md".into()),
+        content_sha256: Some(input.markdown_sha256.clone()),
+        content_length: Some(input.markdown_len),
+        // The trusted object is not visible to readers until derived_artifacts is
+        // inserted in the promote transaction.
+        disposition: Some("staged".into()),
+    };
+    storage
+        .put_object(
+            ctx.org_id(),
+            &key,
+            Bytes::from(input.markdown),
+            &meta,
+            "text/markdown; charset=utf-8",
+        )
+        .await?;
+    Ok(StagedMarkdown {
+        object_key: key.as_str(),
+        key,
+        content_sha256: input.markdown_sha256,
+        byte_size: input.markdown_len,
+        created_or_verified: true,
+    })
+}
+
+pub fn markdown_key(
+    identity: &ConversionIdentity,
+    promoted_version_id: Uuid,
+) -> Result<ObjectKey, StorageError> {
+    trusted_key(
+        identity.org_id,
+        promoted_version_id,
+        identity.markdown_artifact_id(),
+        None,
+    )
+}

--- a/crates/server/src/services/artifacts.rs
+++ b/crates/server/src/services/artifacts.rs
@@ -116,11 +116,12 @@ pub fn markdown_key(
     promoted_version_id: Uuid,
     job_id: Uuid,
     attempts: i32,
+    lease_token: &str,
 ) -> Result<ObjectKey, StorageError> {
     trusted_key(
         identity.org_id,
         promoted_version_id,
-        identity.staged_markdown_object_id(job_id, attempts),
+        identity.staged_markdown_object_id(job_id, attempts, lease_token),
         None,
     )
 }

--- a/crates/server/src/services/artifacts.rs
+++ b/crates/server/src/services/artifacts.rs
@@ -16,6 +16,7 @@ pub struct MarkdownStageInput {
     pub collection_id: Option<Uuid>,
     pub document_id: Uuid,
     pub promoted_version_id: Uuid,
+    pub staging_key: ObjectKey,
     pub markdown: Vec<u8>,
     pub markdown_sha256: String,
     pub markdown_len: u64,
@@ -43,7 +44,6 @@ pub enum ArtifactStageError {
 pub async fn stage_markdown(
     storage: &MinioClient,
     ctx: &OrgContext,
-    identity: &ConversionIdentity,
     input: MarkdownStageInput,
 ) -> Result<StagedMarkdown, ArtifactStageError> {
     let expected_len =
@@ -56,7 +56,10 @@ pub async fn stage_markdown(
         return Err(ArtifactStageError::InvalidHash);
     }
 
-    let key = markdown_key(identity, input.promoted_version_id)?;
+    let key = input.staging_key;
+    if !key.belongs_to_org(ctx.org_id()) || !key.belongs_to_version(input.promoted_version_id) {
+        return Err(ArtifactStageError::Storage(StorageError::KeyOrgMismatch));
+    }
     if storage.object_exists(ctx.org_id(), &key).await? {
         let metadata = storage.head_metadata(ctx.org_id(), &key).await?;
         if metadata.get("content-sha256").map(String::as_str)
@@ -111,11 +114,13 @@ pub async fn stage_markdown(
 pub fn markdown_key(
     identity: &ConversionIdentity,
     promoted_version_id: Uuid,
+    job_id: Uuid,
+    attempts: i32,
 ) -> Result<ObjectKey, StorageError> {
     trusted_key(
         identity.org_id,
         promoted_version_id,
-        identity.markdown_artifact_id(),
+        identity.staged_markdown_object_id(job_id, attempts),
         None,
     )
 }

--- a/crates/server/src/services/conversion.rs
+++ b/crates/server/src/services/conversion.rs
@@ -1,0 +1,141 @@
+//! Conversion promotion identity and checkpoint helpers.
+
+use serde_json::Value as JsonValue;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::jobs::CheckpointPayload;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversionIdentity {
+    pub org_id: Uuid,
+    pub document_id: Uuid,
+    pub source_version_id: Uuid,
+    pub job_idempotency_key: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversionStep {
+    Downloaded,
+    Converted,
+    Staged,
+    Promoted,
+}
+
+impl ConversionIdentity {
+    pub fn new(
+        org_id: Uuid,
+        document_id: Uuid,
+        source_version_id: Uuid,
+        job_idempotency_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            org_id,
+            document_id,
+            source_version_id,
+            job_idempotency_key: job_idempotency_key.into(),
+        }
+    }
+
+    pub fn promoted_version_id(&self) -> Uuid {
+        deterministic_uuid("markhand-conversion-promoted-version-v1", |hasher| {
+            self.hash_material(hasher);
+        })
+    }
+
+    pub fn markdown_artifact_id(&self) -> Uuid {
+        deterministic_uuid("markhand-conversion-markdown-artifact-v1", |hasher| {
+            self.hash_material(hasher);
+        })
+    }
+
+    pub fn storage_quota_reservation_key(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(b"markhand-conversion-storage-quota-v1");
+        self.hash_material(&mut hasher);
+        let digest = hex::encode(hasher.finalize());
+        format!("convert.storage.{}", &digest[..48])
+    }
+
+    pub fn index_outbox_key(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(b"markhand-conversion-index-outbox-v1");
+        self.hash_material(&mut hasher);
+        let digest = hex::encode(hasher.finalize());
+        format!("document.index_requested.{}", &digest[..48])
+    }
+
+    pub fn step_id(&self, step: ConversionStep) -> Uuid {
+        deterministic_uuid("markhand-conversion-checkpoint-step-v1", |hasher| {
+            self.hash_material(hasher);
+            hasher.update(step.as_bytes());
+        })
+    }
+
+    fn hash_material(&self, hasher: &mut Sha256) {
+        hasher.update(self.org_id.as_bytes());
+        hasher.update(self.document_id.as_bytes());
+        hasher.update(self.source_version_id.as_bytes());
+        hasher.update(self.job_idempotency_key.as_bytes());
+        hasher.update(b"fileconv-sandbox-v1");
+    }
+}
+
+impl ConversionStep {
+    const fn as_bytes(self) -> &'static [u8] {
+        match self {
+            Self::Downloaded => b"downloaded",
+            Self::Converted => b"converted",
+            Self::Staged => b"staged",
+            Self::Promoted => b"promoted",
+        }
+    }
+}
+
+pub fn checkpoint_with_step(
+    existing: Option<&JsonValue>,
+    identity: &ConversionIdentity,
+    step: ConversionStep,
+) -> CheckpointPayload {
+    let mut checkpoint = existing
+        .cloned()
+        .and_then(|value| serde_json::from_value::<CheckpointPayload>(value).ok())
+        .unwrap_or_default();
+    checkpoint.cursor_id = Some(identity.promoted_version_id());
+    let step_id = identity.step_id(step);
+    if !checkpoint.completed_ids.contains(&step_id) {
+        checkpoint.completed_ids.push(step_id);
+    }
+    checkpoint
+}
+
+fn deterministic_uuid(label: &'static str, write: impl FnOnce(&mut Sha256)) -> Uuid {
+    let mut hasher = Sha256::new();
+    hasher.update(label.as_bytes());
+    write(&mut hasher);
+    let digest = hasher.finalize();
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    Uuid::from_bytes(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversion_identity_is_stable_and_distinct_by_source() {
+        let org_id = Uuid::new_v4();
+        let document_id = Uuid::new_v4();
+        let source = Uuid::new_v4();
+        let same = ConversionIdentity::new(org_id, document_id, source, "convert-a");
+        let retry = ConversionIdentity::new(org_id, document_id, source, "convert-a");
+        let other = ConversionIdentity::new(org_id, document_id, Uuid::new_v4(), "convert-a");
+        assert_eq!(same.promoted_version_id(), retry.promoted_version_id());
+        assert_ne!(same.promoted_version_id(), other.promoted_version_id());
+        assert_ne!(
+            same.step_id(ConversionStep::Downloaded),
+            same.step_id(ConversionStep::Promoted)
+        );
+    }
+}

--- a/crates/server/src/services/conversion.rs
+++ b/crates/server/src/services/conversion.rs
@@ -50,11 +50,17 @@ impl ConversionIdentity {
         })
     }
 
-    pub fn staged_markdown_object_id(&self, job_id: Uuid, attempts: i32) -> Uuid {
-        deterministic_uuid("markhand-conversion-staged-markdown-attempt-v1", |hasher| {
+    pub fn staged_markdown_object_id(
+        &self,
+        job_id: Uuid,
+        attempts: i32,
+        lease_token: &str,
+    ) -> Uuid {
+        deterministic_uuid("markhand-conversion-staged-markdown-claim-v1", |hasher| {
             self.hash_material(hasher);
             hasher.update(job_id.as_bytes());
             hasher.update(attempts.to_be_bytes());
+            hasher.update(lease_token.as_bytes());
         })
     }
 

--- a/crates/server/src/services/conversion.rs
+++ b/crates/server/src/services/conversion.rs
@@ -18,6 +18,7 @@ pub struct ConversionIdentity {
 pub enum ConversionStep {
     Downloaded,
     Converted,
+    StagingIntent,
     Staged,
     Promoted,
 }
@@ -46,6 +47,14 @@ impl ConversionIdentity {
     pub fn markdown_artifact_id(&self) -> Uuid {
         deterministic_uuid("markhand-conversion-markdown-artifact-v1", |hasher| {
             self.hash_material(hasher);
+        })
+    }
+
+    pub fn staged_markdown_object_id(&self, job_id: Uuid, attempts: i32) -> Uuid {
+        deterministic_uuid("markhand-conversion-staged-markdown-attempt-v1", |hasher| {
+            self.hash_material(hasher);
+            hasher.update(job_id.as_bytes());
+            hasher.update(attempts.to_be_bytes());
         })
     }
 
@@ -86,6 +95,7 @@ impl ConversionStep {
         match self {
             Self::Downloaded => b"downloaded",
             Self::Converted => b"converted",
+            Self::StagingIntent => b"staging_intent",
             Self::Staged => b"staged",
             Self::Promoted => b"promoted",
         }
@@ -107,6 +117,30 @@ pub fn checkpoint_with_step(
         checkpoint.completed_ids.push(step_id);
     }
     checkpoint
+}
+
+pub fn checkpoint_with_staged_key(
+    existing: Option<&JsonValue>,
+    identity: &ConversionIdentity,
+    object_key: &str,
+) -> CheckpointPayload {
+    let mut checkpoint = checkpoint_with_step(existing, identity, ConversionStep::StagingIntent);
+    if !checkpoint
+        .staged_object_keys
+        .iter()
+        .any(|existing| existing == object_key)
+    {
+        checkpoint.staged_object_keys.push(object_key.to_string());
+    }
+    checkpoint
+}
+
+pub fn staged_keys_from_checkpoint(existing: Option<&JsonValue>) -> Vec<String> {
+    existing
+        .cloned()
+        .and_then(|value| serde_json::from_value::<CheckpointPayload>(value).ok())
+        .map(|checkpoint| checkpoint.staged_object_keys)
+        .unwrap_or_default()
 }
 
 fn deterministic_uuid(label: &'static str, write: impl FnOnce(&mut Sha256)) -> Uuid {

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -1,6 +1,9 @@
 //! Application services (use cases over repositories).
 
+pub mod artifacts;
+pub mod conversion;
 pub mod document_state;
 pub mod index_signature;
+pub mod promotion;
 pub mod quota;
 pub mod upload;

--- a/crates/server/src/services/promotion.rs
+++ b/crates/server/src/services/promotion.rs
@@ -1,0 +1,405 @@
+//! Idempotent conversion promotion saga.
+
+use deadpool_postgres::Pool;
+use serde_json::Value as JsonValue;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::document_versions::{
+    self, ConversionSourceVersion, NewDerivedArtifact, NewPublishedVersion,
+};
+use crate::db::error::DbError;
+use crate::db::jobs as jobs_repo;
+use crate::db::models::{ArtifactKind, DocumentVersion, Job, JobStatus, ResourceKind};
+use crate::db::{documents, pool, quota as quota_repo};
+use crate::jobs::{self, CheckpointPayload, EventPayload, JobError};
+use crate::services::conversion::{checkpoint_with_step, ConversionIdentity, ConversionStep};
+use crate::services::quota::QuotaError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromotionFault {
+    AfterStagingPut,
+    AfterVersionInsert,
+    AfterPointerSwap,
+    AfterOutboxInsert,
+}
+
+#[derive(Debug, Clone)]
+pub struct PromoteConversionInput {
+    pub job_id: Uuid,
+    pub lease_token: String,
+    pub claimed_attempts: i32,
+    pub identity: ConversionIdentity,
+    pub source: ConversionSourceVersion,
+    pub artifact_id: Uuid,
+    pub staged_object_key: String,
+    pub markdown_sha256: String,
+    pub markdown_byte_size: i64,
+    pub quota_reservation_key: String,
+    pub fault: Option<PromotionFault>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PromoteConversionOutcome {
+    pub job: Job,
+    pub version: DocumentVersion,
+    pub artifact_created: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum PromotionError {
+    #[error("database error")]
+    Db(#[from] DbError),
+    #[error("job error")]
+    Job(#[from] JobError),
+    #[error("quota error")]
+    Quota(#[from] QuotaError),
+    #[error("job lease was lost")]
+    LeaseLost,
+    #[error("promotion idempotency conflict")]
+    IdempotencyConflict,
+    #[error("injected promotion fault at {0:?}")]
+    Injected(PromotionFault),
+}
+
+impl From<PromotionError> for JobError {
+    fn from(error: PromotionError) -> Self {
+        match error {
+            PromotionError::Db(error) => JobError::Database(error),
+            PromotionError::Job(error) => error,
+            PromotionError::Quota(error) => JobError::Database(DbError::Config(error.to_string())),
+            PromotionError::LeaseLost => JobError::LeaseLost,
+            PromotionError::IdempotencyConflict => {
+                JobError::Database(DbError::Config("promotion idempotency conflict".into()))
+            }
+            PromotionError::Injected(fault) => {
+                JobError::Database(DbError::Config(format!("promotion fault: {fault:?}")))
+            }
+        }
+    }
+}
+
+pub async fn promote_conversion(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    input: PromoteConversionInput,
+) -> Result<PromoteConversionOutcome, PromotionError> {
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let job = jobs_repo::get_by_id_for_update(txn, &ctx, input.job_id)
+                    .await?
+                    .filter(|job| {
+                        job.status == JobStatus::Leased
+                            && job.lease_owner.as_deref() == Some(input.lease_token.as_str())
+                            && job.attempts == input.claimed_attempts
+                    })
+                    .ok_or(PromotionError::LeaseLost)?;
+
+                let document =
+                    documents::get_by_id_for_update(txn, &ctx, input.source.document_id).await?;
+                let promoted_version_id = input.identity.promoted_version_id();
+                let existing = document_versions::find_by_id(
+                    txn,
+                    &ctx,
+                    input.source.document_id,
+                    promoted_version_id,
+                )
+                .await?;
+
+                let (version, created) = match existing {
+                    Some(version) => {
+                        ensure_existing_version_matches(&version, &input)?;
+                        (version, false)
+                    }
+                    None => {
+                        let inserted = document_versions::insert_published_version_if_absent(
+                            txn,
+                            &ctx,
+                            NewPublishedVersion {
+                                id: promoted_version_id,
+                                document_id: input.source.document_id,
+                                parent_version_id: input.source.source_version_id,
+                                content_sha256: &input.markdown_sha256,
+                                original_object_key: &input.source.original_object_key,
+                                markdown_object_key: &input.staged_object_key,
+                                source_filename: input.source.source_filename.as_deref(),
+                                source_content_type: Some("text/markdown; charset=utf-8"),
+                                byte_size: input.markdown_byte_size,
+                                change_summary: "Converted upload to Markdown",
+                            },
+                        )
+                        .await?;
+                        maybe_fault(input.fault, PromotionFault::AfterVersionInsert)?;
+                        inserted
+                    }
+                };
+
+                let artifact = document_versions::insert_artifact_if_absent(
+                    txn,
+                    &ctx,
+                    NewDerivedArtifact {
+                        id: input.artifact_id,
+                        document_id: input.source.document_id,
+                        version_id: promoted_version_id,
+                        kind: ArtifactKind::Markdown,
+                        object_key: &input.staged_object_key,
+                        content_sha256: &input.markdown_sha256,
+                        content_type: "text/markdown; charset=utf-8",
+                        byte_size: input.markdown_byte_size,
+                    },
+                )
+                .await?;
+                ensure_artifact_matches(&artifact, &input)?;
+
+                if created || version.is_current {
+                    document_versions::promote_current_if_needed(
+                        txn,
+                        &ctx,
+                        input.source.document_id,
+                        promoted_version_id,
+                    )
+                    .await?;
+                }
+                maybe_fault(input.fault, PromotionFault::AfterPointerSwap)?;
+
+                let index_payload = validated_event_payload(EventPayload {
+                    job_id: Some(job.id),
+                    document_id: Some(input.source.document_id),
+                    version_id: Some(promoted_version_id),
+                    outbox_event_id: None,
+                })?;
+                let index_outbox_key = input.identity.index_outbox_key();
+                jobs_repo::insert_outbox_event(
+                    txn,
+                    &ctx,
+                    jobs_repo::NewOutboxEvent {
+                        event_type: "document.index_requested",
+                        payload_version: jobs::CURRENT_EVENT_PAYLOAD_VERSION,
+                        payload: &index_payload,
+                        idempotency_key: &index_outbox_key,
+                        job_id: Some(job.id),
+                    },
+                )
+                .await?;
+                maybe_fault(input.fault, PromotionFault::AfterOutboxInsert)?;
+
+                finalize_storage_quota_locked(
+                    txn,
+                    &ctx,
+                    &input.quota_reservation_key,
+                    input.markdown_byte_size,
+                    input.job_id,
+                )
+                .await?;
+
+                let checkpoint = checkpoint_with_step(
+                    job.checkpoint.as_ref(),
+                    &input.identity,
+                    ConversionStep::Promoted,
+                );
+                save_checkpoint_locked(
+                    txn,
+                    &ctx,
+                    input.job_id,
+                    &input.lease_token,
+                    input.claimed_attempts,
+                    checkpoint,
+                )
+                .await?;
+
+                let completed = jobs_repo::complete_owned(
+                    txn,
+                    &ctx,
+                    input.job_id,
+                    &input.lease_token,
+                    input.claimed_attempts,
+                )
+                .await?
+                .ok_or(PromotionError::LeaseLost)?;
+                write_job_succeeded_event(txn, &ctx, &completed).await?;
+
+                // The version/document relation is the ACL inheritance boundary: new
+                // versions stay on the same document and collection.
+                if document.id != version.document_id || document.org_id != version.org_id {
+                    return Err(PromotionError::IdempotencyConflict);
+                }
+
+                Ok(PromoteConversionOutcome {
+                    job: completed,
+                    version,
+                    artifact_created: artifact.created,
+                })
+            })
+        }
+    })
+    .await
+}
+
+pub async fn promoted_version(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    identity: &ConversionIdentity,
+) -> Result<Option<DocumentVersion>, PromotionError> {
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let identity = identity.clone();
+        move |txn| {
+            Box::pin(async move {
+                document_versions::find_by_id(
+                    txn,
+                    &ctx,
+                    identity.document_id,
+                    identity.promoted_version_id(),
+                )
+                .await
+                .map_err(Into::into)
+            })
+        }
+    })
+    .await
+}
+
+fn ensure_existing_version_matches(
+    version: &DocumentVersion,
+    input: &PromoteConversionInput,
+) -> Result<(), PromotionError> {
+    if version.document_id != input.source.document_id
+        || version.parent_version_id != Some(input.source.source_version_id)
+        || version.content_sha256 != input.markdown_sha256
+        || version.markdown_object_key.as_deref() != Some(input.staged_object_key.as_str())
+    {
+        return Err(PromotionError::IdempotencyConflict);
+    }
+    Ok(())
+}
+
+fn ensure_artifact_matches(
+    artifact: &document_versions::ArtifactInsertOutcome,
+    input: &PromoteConversionInput,
+) -> Result<(), PromotionError> {
+    if artifact.object_key != input.staged_object_key
+        || artifact.content_sha256 != input.markdown_sha256
+        || artifact.byte_size != Some(input.markdown_byte_size)
+    {
+        return Err(PromotionError::IdempotencyConflict);
+    }
+    Ok(())
+}
+
+async fn save_checkpoint_locked(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_token: &str,
+    claimed_attempts: i32,
+    checkpoint: CheckpointPayload,
+) -> Result<(), PromotionError> {
+    let checkpoint = checkpoint
+        .to_json()
+        .map_err(PromotionError::Job)
+        .and_then(|value| {
+            jobs_repo::ValidatedCheckpointPayload::new(value)
+                .map_err(|error| PromotionError::Job(JobError::InvalidPayload(error.to_string())))
+        })?;
+    jobs_repo::save_checkpoint(txn, ctx, job_id, lease_token, claimed_attempts, &checkpoint)
+        .await?
+        .ok_or(PromotionError::LeaseLost)?;
+    Ok(())
+}
+
+async fn write_job_succeeded_event(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    job: &Job,
+) -> Result<(), PromotionError> {
+    let payload = validated_event_payload(EventPayload {
+        job_id: Some(job.id),
+        document_id: job.document_id,
+        version_id: job.version_id,
+        outbox_event_id: None,
+    })?;
+    jobs_repo::append_event_and_outbox(
+        txn,
+        ctx,
+        jobs_repo::NewEventLogEntry {
+            event_type: "job.succeeded",
+            payload_version: jobs::CURRENT_EVENT_PAYLOAD_VERSION,
+            payload: &payload,
+            job_id: Some(job.id),
+            document_id: job.document_id,
+            version_id: job.version_id,
+        },
+        &format!("job.succeeded:{}:{}", job.id, job.attempts),
+    )
+    .await?;
+    Ok(())
+}
+
+fn validated_event_payload(
+    payload: EventPayload,
+) -> Result<jobs_repo::ValidatedEventPayload, PromotionError> {
+    let value: JsonValue = payload.to_json().map_err(PromotionError::Job)?;
+    jobs_repo::ValidatedEventPayload::new(value)
+        .map_err(|error| PromotionError::Job(JobError::InvalidPayload(error.to_string())))
+}
+
+async fn finalize_storage_quota_locked(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+    reservation_key: &str,
+    amount: i64,
+    job_id: Uuid,
+) -> Result<(), PromotionError> {
+    quota_repo::lock_admission(txn, ctx, ResourceKind::StorageBytes).await?;
+    let observed_at = quota_repo::fresh_clock_timestamp(txn).await?;
+    let reservation = quota_repo::get_by_key_for_update(txn, ctx, reservation_key)
+        .await
+        .map_err(|error| match error {
+            DbError::NotFound => PromotionError::Quota(QuotaError::ReservationNotFound),
+            other => PromotionError::Db(other),
+        })?;
+    if reservation.resource_kind != ResourceKind::StorageBytes
+        || reservation.amount != amount
+        || reservation.job_id != Some(job_id)
+    {
+        return Err(PromotionError::Quota(QuotaError::ReservationConflict));
+    }
+    match reservation.status {
+        crate::db::models::ReservationStatus::Finalized => return Ok(()),
+        crate::db::models::ReservationStatus::Refunded => {
+            return Err(PromotionError::Quota(QuotaError::RefundedCannotFinalize));
+        }
+        crate::db::models::ReservationStatus::Expired => {
+            return Err(PromotionError::Quota(QuotaError::ExpiredCannotFinalize));
+        }
+        crate::db::models::ReservationStatus::Reserved => {}
+    }
+    let finalized =
+        quota_repo::finalize_reserved_by_key(txn, ctx, reservation_key, observed_at).await?;
+    let Some(finalized) = finalized else {
+        return Err(PromotionError::Quota(QuotaError::ReservationConflict));
+    };
+    let period = quota_repo::current_period(txn, finalized.resource_kind, observed_at).await?;
+    let current = quota_repo::lock_committed_counter(txn, ctx, finalized.resource_kind, period)
+        .await?
+        .unwrap_or(0);
+    let value = current
+        .checked_add(finalized.amount)
+        .ok_or(QuotaError::ArithmeticOverflow)?;
+    quota_repo::upsert_counter_value(txn, ctx, finalized.resource_kind, period, value).await?;
+    Ok(())
+}
+
+fn maybe_fault(
+    configured: Option<PromotionFault>,
+    point: PromotionFault,
+) -> Result<(), PromotionError> {
+    if configured == Some(point) {
+        Err(PromotionError::Injected(point))
+    } else {
+        Ok(())
+    }
+}

--- a/crates/server/src/services/promotion.rs
+++ b/crates/server/src/services/promotion.rs
@@ -170,7 +170,7 @@ pub async fn promote_conversion(
                     document_versions::promote_current_if_needed(
                         txn,
                         &ctx,
-                        input.source.document_id,
+                        &document,
                         promoted_version_id,
                     )
                     .await?;

--- a/crates/server/src/services/promotion.rs
+++ b/crates/server/src/services/promotion.rs
@@ -23,6 +23,8 @@ pub enum PromotionFault {
     AfterVersionInsert,
     AfterPointerSwap,
     AfterOutboxInsert,
+    /// Simulates a lost response after the transaction has committed.
+    AfterCommit,
 }
 
 #[derive(Debug, Clone)]
@@ -60,6 +62,8 @@ pub enum PromotionError {
     LeaseLost,
     #[error("promotion idempotency conflict")]
     IdempotencyConflict,
+    #[error("promotion may have committed but its result was not acknowledged")]
+    CommittedOutcomeUnknown,
     #[error("injected promotion fault at {0:?}")]
     Injected(PromotionFault),
 }
@@ -74,6 +78,9 @@ impl From<PromotionError> for JobError {
             PromotionError::IdempotencyConflict => {
                 JobError::Database(DbError::Config("promotion idempotency conflict".into()))
             }
+            PromotionError::CommittedOutcomeUnknown => JobError::Database(DbError::Config(
+                "promotion result was not acknowledged after commit".into(),
+            )),
             PromotionError::Injected(fault) => {
                 JobError::Database(DbError::Config(format!("promotion fault: {fault:?}")))
             }
@@ -86,7 +93,8 @@ pub async fn promote_conversion(
     ctx: &OrgContext,
     input: PromoteConversionInput,
 ) -> Result<PromoteConversionOutcome, PromotionError> {
-    pool::with_org_txn_typed(db_pool, ctx, {
+    let fault = input.fault;
+    let outcome = pool::with_org_txn_typed(db_pool, ctx, {
         let ctx = ctx.clone();
         move |txn| {
             Box::pin(async move {
@@ -240,7 +248,11 @@ pub async fn promote_conversion(
             })
         }
     })
-    .await
+    .await?;
+    if fault == Some(PromotionFault::AfterCommit) {
+        return Err(PromotionError::CommittedOutcomeUnknown);
+    }
+    Ok(outcome)
 }
 
 pub async fn promoted_version(

--- a/crates/server/src/services/promotion.rs
+++ b/crates/server/src/services/promotion.rs
@@ -45,6 +45,7 @@ pub struct PromoteConversionOutcome {
     pub job: Job,
     pub version: DocumentVersion,
     pub artifact_created: bool,
+    pub committed_object_key: String,
 }
 
 #[derive(Debug, Error)]
@@ -153,6 +154,9 @@ pub async fn promote_conversion(
                 )
                 .await?;
                 ensure_artifact_matches(&artifact, &input)?;
+                if version.markdown_object_key.as_deref() != Some(artifact.object_key.as_str()) {
+                    return Err(PromotionError::IdempotencyConflict);
+                }
 
                 if created || version.is_current {
                     document_versions::promote_current_if_needed(
@@ -231,6 +235,7 @@ pub async fn promote_conversion(
                     job: completed,
                     version,
                     artifact_created: artifact.created,
+                    committed_object_key: artifact.object_key,
                 })
             })
         }
@@ -262,6 +267,32 @@ pub async fn promoted_version(
     .await
 }
 
+pub async fn committed_markdown_object_key(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    identity: &ConversionIdentity,
+) -> Result<Option<String>, PromotionError> {
+    pool::with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let identity = identity.clone();
+        move |txn| {
+            Box::pin(async move {
+                let version_id = identity.promoted_version_id();
+                let Some(artifact) =
+                    document_versions::find_markdown_artifact(txn, &ctx, version_id).await?
+                else {
+                    return Ok(None);
+                };
+                if artifact.id != identity.markdown_artifact_id() {
+                    return Err(PromotionError::IdempotencyConflict);
+                }
+                Ok(Some(artifact.object_key))
+            })
+        }
+    })
+    .await
+}
+
 fn ensure_existing_version_matches(
     version: &DocumentVersion,
     input: &PromoteConversionInput,
@@ -269,7 +300,7 @@ fn ensure_existing_version_matches(
     if version.document_id != input.source.document_id
         || version.parent_version_id != Some(input.source.source_version_id)
         || version.content_sha256 != input.markdown_sha256
-        || version.markdown_object_key.as_deref() != Some(input.staged_object_key.as_str())
+        || version.markdown_object_key.is_none()
     {
         return Err(PromotionError::IdempotencyConflict);
     }
@@ -280,7 +311,7 @@ fn ensure_artifact_matches(
     artifact: &document_versions::ArtifactInsertOutcome,
     input: &PromoteConversionInput,
 ) -> Result<(), PromotionError> {
-    if artifact.object_key != input.staged_object_key
+    if artifact.id != input.artifact_id
         || artifact.content_sha256 != input.markdown_sha256
         || artifact.byte_size != Some(input.markdown_byte_size)
     {

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::time::Duration;
 
-use bytes::Bytes;
 use deadpool_postgres::Pool;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -15,13 +14,17 @@ use tokio::time::{
 use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
-use crate::db::documents;
+use crate::db::document_versions::ConversionSourceVersion;
 use crate::db::error::DbError;
-use crate::db::models::{Job, JobType};
+use crate::db::models::{Job, JobType, ResourceKind};
 use crate::db::pool::with_org_txn;
-use crate::jobs::{self, CompleteConvertArtifact, JobError, JobPayload};
-use crate::storage::keys::{parse_key_for_org, trusted_key};
-use crate::storage::minio::{MinioClient, ObjectIdentityMeta};
+use crate::jobs::{self, JobError, JobPayload};
+use crate::services::artifacts::{self, MarkdownStageInput, StagedMarkdown};
+use crate::services::conversion::{checkpoint_with_step, ConversionIdentity, ConversionStep};
+use crate::services::promotion::{self, PromoteConversionInput, PromotionError, PromotionFault};
+use crate::services::quota::{self, QuotaError, DEFAULT_RESERVATION_TTL};
+use crate::storage::keys::parse_key_for_org;
+use crate::storage::minio::MinioClient;
 use crate::storage::{ObjectNamespace, StorageError};
 
 use super::limits::ResourceLimits;
@@ -42,6 +45,7 @@ pub struct ConvertWorkerConfig {
     pub sandbox: SandboxConfig,
     pub post_upload_settlement_delay: Duration,
     pub max_job_duration: Duration,
+    pub promotion_fault: Option<PromotionFault>,
 }
 
 impl ConvertWorkerConfig {
@@ -55,6 +59,7 @@ impl ConvertWorkerConfig {
             sandbox,
             post_upload_settlement_delay: Duration::ZERO,
             max_job_duration,
+            promotion_fault: None,
         }
     }
 
@@ -74,6 +79,7 @@ impl ConvertWorkerConfig {
             post_upload_settlement_delay: Duration::ZERO,
             max_job_duration: ResourceLimits::default().wall_timeout
                 + Duration::from_secs(DEFAULT_JOB_GRACE_SECS),
+            promotion_fault: None,
         }
     }
 
@@ -92,6 +98,14 @@ impl ConvertWorkerConfig {
         }
         Ok(())
     }
+}
+
+struct ClaimedJobScope<'a> {
+    ctx: &'a OrgContext,
+    job: &'a Job,
+    lease_token: &'a str,
+    attempts: i32,
+    deadline: TokioInstant,
 }
 
 #[derive(Clone)]
@@ -148,91 +162,144 @@ impl ConvertWorker {
             .convert_claimed(ctx, &job, &lease_token, attempts, deadline)
             .await
         {
-            Ok(ConversionSuccess {
+            Ok(ConversionOutput {
                 markdown,
-                artifact_key,
                 markdown_sha256,
                 markdown_len,
-                document_id,
-                version_id,
+                source,
+                identity,
+                checkpoint,
             }) => {
                 let byte_size = match i64::try_from(markdown_len) {
                     Ok(byte_size) => byte_size,
-                    Err(_) => {
-                        let _ = self
-                            .storage
-                            .cleanup_generated_object(ctx.org_id(), &artifact_key)
-                            .await;
-                        return Err(ConvertWorkerError::InvalidMarkdownLength);
-                    }
+                    Err(_) => return Err(ConvertWorkerError::InvalidMarkdownLength),
                 };
-                let artifact_key_string = artifact_key.as_str();
-                if !self.config.post_upload_settlement_delay.is_zero() {
-                    let delay = self.config.post_upload_settlement_delay;
-                    match self
-                        .heartbeat_while(ctx, &job, &lease_token, attempts, deadline, async {
-                            tokio::time::sleep(delay).await;
-                            Ok::<(), JobError>(())
-                        })
-                        .await
-                    {
-                        Ok(()) => {}
-                        Err(ConvertWorkerError::LeaseLost)
-                        | Err(ConvertWorkerError::Job(JobError::LeaseLost)) => {
-                            let _ = self
-                                .storage
-                                .cleanup_generated_object(ctx.org_id(), &artifact_key)
-                                .await;
-                            return Ok(ConvertWorkerRun::LeaseLost { job_id: job.id });
-                        }
-                        Err(error) => {
-                            let _ = self
-                                .storage
-                                .cleanup_generated_object(ctx.org_id(), &artifact_key)
-                                .await;
-                            return Err(error);
-                        }
-                    }
-                }
-                let completed = match self
+                let quota_reservation_key =
+                    quota_reservation_key_for_attempt(&identity, job.id, attempts);
+                if let Err(error) = self
                     .heartbeat_while(
                         ctx,
                         &job,
                         &lease_token,
                         attempts,
                         deadline,
-                        jobs::complete_with_markdown_artifact(
+                        quota::reserve(
                             &self.db_pool,
                             ctx,
-                            job.id,
-                            &lease_token,
-                            attempts,
-                            CompleteConvertArtifact {
-                                artifact_id: Uuid::new_v4(),
-                                document_id,
-                                version_id,
-                                object_key: &artifact_key_string,
-                                content_sha256: &markdown_sha256,
-                                byte_size,
-                            },
+                            &quota_reservation_key,
+                            ResourceKind::StorageBytes,
+                            markdown_len,
+                            DEFAULT_RESERVATION_TTL,
+                            Some(job.id),
                         ),
                     )
                     .await
                 {
+                    return self
+                        .fail_retryable_or_return(ctx, &job, &lease_token, attempts, error)
+                        .await;
+                }
+
+                let mut staged: Option<StagedMarkdown> = None;
+                let claimed = ClaimedJobScope {
+                    ctx,
+                    job: &job,
+                    lease_token: &lease_token,
+                    attempts,
+                    deadline,
+                };
+                let promotion_result = async {
+                    let staged_markdown = self
+                        .heartbeat_while(
+                            ctx,
+                            &job,
+                            &lease_token,
+                            attempts,
+                            deadline,
+                            artifacts::stage_markdown(
+                                &self.storage,
+                                ctx,
+                                &identity,
+                                MarkdownStageInput {
+                                    collection_id: None,
+                                    document_id: source.document_id,
+                                    promoted_version_id: identity.promoted_version_id(),
+                                    markdown,
+                                    markdown_sha256: markdown_sha256.clone(),
+                                    markdown_len,
+                                },
+                            ),
+                        )
+                        .await?;
+                    staged = Some(staged_markdown.clone());
+                    self.save_checkpoint_step(
+                        &claimed,
+                        &identity,
+                        checkpoint.as_ref(),
+                        ConversionStep::Staged,
+                    )
+                    .await?;
+                    if self.config.promotion_fault == Some(PromotionFault::AfterStagingPut) {
+                        return Err(ConvertWorkerError::Promotion(PromotionError::Injected(
+                            PromotionFault::AfterStagingPut,
+                        )));
+                    }
+                    if !self.config.post_upload_settlement_delay.is_zero() {
+                        let delay = self.config.post_upload_settlement_delay;
+                        self.heartbeat_while(ctx, &job, &lease_token, attempts, deadline, async {
+                            tokio::time::sleep(delay).await;
+                            Ok::<(), JobError>(())
+                        })
+                        .await?;
+                    }
+                    self.heartbeat_while(
+                        ctx,
+                        &job,
+                        &lease_token,
+                        attempts,
+                        deadline,
+                        promotion::promote_conversion(
+                            &self.db_pool,
+                            ctx,
+                            PromoteConversionInput {
+                                job_id: job.id,
+                                lease_token: lease_token.to_string(),
+                                claimed_attempts: attempts,
+                                identity: identity.clone(),
+                                source: source.clone(),
+                                artifact_id: identity.markdown_artifact_id(),
+                                staged_object_key: staged_markdown.object_key.clone(),
+                                markdown_sha256: markdown_sha256.clone(),
+                                markdown_byte_size: byte_size,
+                                quota_reservation_key: quota_reservation_key.clone(),
+                                fault: self.config.promotion_fault,
+                            },
+                        ),
+                    )
+                    .await
+                }
+                .await;
+
+                let completed = match promotion_result {
                     Ok(outcome) => outcome,
-                    Err(ConvertWorkerError::Job(JobError::LeaseLost))
+                    Err(ConvertWorkerError::Promotion(PromotionError::LeaseLost))
+                    | Err(ConvertWorkerError::Job(JobError::LeaseLost))
                     | Err(ConvertWorkerError::LeaseLost) => {
-                        let _ = self
-                            .storage
-                            .cleanup_generated_object(ctx.org_id(), &artifact_key)
-                            .await;
+                        self.compensate_after_promotion_failure(
+                            ctx,
+                            staged.as_ref(),
+                            &quota_reservation_key,
+                        )
+                        .await;
                         return Ok(ConvertWorkerRun::LeaseLost { job_id: job.id });
                     }
                     Err(error) if error.is_retryable_job_failure() => {
-                        let _ = self
-                            .storage
-                            .cleanup_generated_object(ctx.org_id(), &artifact_key)
-                            .await;
+                        self.compensate_after_promotion_failure(
+                            ctx,
+                            staged.as_ref(),
+                            &quota_reservation_key,
+                        )
+                        .await;
                         let failed = jobs::fail(
                             &self.db_pool,
                             ctx,
@@ -248,24 +315,18 @@ impl ConvertWorker {
                         });
                     }
                     Err(error) => {
-                        let _ = self
-                            .storage
-                            .cleanup_generated_object(ctx.org_id(), &artifact_key)
-                            .await;
+                        self.compensate_after_promotion_failure(
+                            ctx,
+                            staged.as_ref(),
+                            &quota_reservation_key,
+                        )
+                        .await;
                         return Err(error);
                     }
                 };
-                if !completed.artifact.created
-                    && completed.artifact.object_key != artifact_key_string
-                {
-                    let _ = self
-                        .storage
-                        .cleanup_generated_object(ctx.org_id(), &artifact_key)
-                        .await;
-                }
                 Ok(ConvertWorkerRun::Completed {
                     job_id: completed.job.id,
-                    markdown_bytes: markdown.len(),
+                    markdown_bytes: markdown_len as usize,
                 })
             }
             Err(ConvertWorkerError::LeaseLost) => {
@@ -300,9 +361,23 @@ impl ConvertWorker {
         lease_token: &str,
         attempts: i32,
         deadline: TokioInstant,
-    ) -> Result<ConversionSuccess, ConvertWorkerError> {
+    ) -> Result<ConversionOutput, ConvertWorkerError> {
         let payload = jobs::decode_job_payload(job.payload_version, job.payload.clone())?;
         let source = with_deadline(deadline, self.load_source(ctx, payload)).await?;
+        let identity = ConversionIdentity::new(
+            ctx.org_id(),
+            source.document_id,
+            source.source_version_id,
+            job.idempotency_key.clone(),
+        );
+        let claimed = ClaimedJobScope {
+            ctx,
+            job,
+            lease_token,
+            attempts,
+            deadline,
+        };
+        let mut checkpoint = job.checkpoint.clone();
         let quarantine_key = parse_key_for_org(&source.original_object_key, ctx.org_id())?;
         if quarantine_key.namespace() != ObjectNamespace::Quarantine {
             return Err(ConvertWorkerError::SourceNotQuarantine);
@@ -357,6 +432,15 @@ impl ConvertWorker {
                 .map_err(|_| ConvertWorkerError::SandboxJoin)?
             })
             .await?;
+        let saved = self
+            .save_checkpoint_step(
+                &claimed,
+                &identity,
+                checkpoint.as_ref(),
+                ConversionStep::Downloaded,
+            )
+            .await?;
+        checkpoint = saved.checkpoint;
         let sandbox_output = self
             .run_sandbox_with_heartbeat(ctx, job, lease_token, attempts, deadline, sandbox_input)
             .await?;
@@ -375,59 +459,27 @@ impl ConvertWorker {
         let markdown_sha256 = hex::encode(Sha256::digest(&markdown));
         let markdown_len =
             u64::try_from(markdown.len()).map_err(|_| ConvertWorkerError::InvalidMarkdownLength)?;
-        let artifact_key = trusted_key(
-            ctx.org_id(),
-            source.version_id,
-            artifact_object_id_for_attempt(job.id, attempts),
-            None,
-        )?;
-        let meta = ObjectIdentityMeta {
-            org_id: ctx.org_id(),
-            collection_id: None,
-            document_id: Some(source.document_id),
-            version_id: Some(source.version_id),
-            original_filename: None,
-            canonical_format: Some("md".into()),
-            content_sha256: Some(markdown_sha256.clone()),
-            content_length: Some(markdown_len),
-            disposition: Some("trusted".into()),
-        };
-        if let Err(error) = self
-            .heartbeat_while(
-                ctx,
-                job,
-                lease_token,
-                attempts,
-                deadline,
-                self.storage.put_object(
-                    ctx.org_id(),
-                    &artifact_key,
-                    Bytes::from(markdown.clone()),
-                    &meta,
-                    "text/markdown; charset=utf-8",
-                ),
+        let saved = self
+            .save_checkpoint_step(
+                &claimed,
+                &identity,
+                checkpoint.as_ref(),
+                ConversionStep::Converted,
             )
-            .await
-        {
-            let _ = self
-                .storage
-                .cleanup_generated_object(ctx.org_id(), &artifact_key)
-                .await;
-            return Err(error);
-        }
-        Ok(ConversionSuccess {
+            .await?;
+        Ok(ConversionOutput {
             markdown,
-            artifact_key,
             markdown_sha256,
             markdown_len,
-            document_id: source.document_id,
-            version_id: source.version_id,
+            source,
+            identity,
+            checkpoint: saved.checkpoint,
         })
     }
 
     fn verify_quarantine_metadata(
         &self,
-        source: &documents::VersionSource,
+        source: &ConversionSourceVersion,
         metadata: &HashMap<String, String>,
     ) -> Result<(), ConvertWorkerError> {
         match metadata.get("disposition").map(String::as_str) {
@@ -439,7 +491,7 @@ impl ConvertWorker {
         {
             return Err(ConvertWorkerError::InvalidQuarantineMetadata);
         }
-        let version_id = source.version_id.to_string();
+        let version_id = source.source_version_id.to_string();
         if metadata.get("version-id").map(String::as_str) != Some(version_id.as_str()) {
             return Err(ConvertWorkerError::InvalidQuarantineMetadata);
         }
@@ -593,7 +645,7 @@ impl ConvertWorker {
         &self,
         ctx: &OrgContext,
         payload: JobPayload,
-    ) -> Result<documents::VersionSource, ConvertWorkerError> {
+    ) -> Result<ConversionSourceVersion, ConvertWorkerError> {
         let document_id = payload
             .document_id
             .ok_or(ConvertWorkerError::InvalidConvertPayload)?;
@@ -604,13 +656,97 @@ impl ConvertWorker {
             let ctx = ctx.clone();
             move |txn| {
                 Box::pin(async move {
-                    documents::get_version_source_for_convert(txn, &ctx, document_id, version_id)
-                        .await
+                    crate::db::document_versions::source_for_conversion(
+                        txn,
+                        &ctx,
+                        document_id,
+                        version_id,
+                    )
+                    .await
                 })
             }
         })
         .await
         .map_err(ConvertWorkerError::Db)
+    }
+
+    async fn save_checkpoint_step(
+        &self,
+        claimed: &ClaimedJobScope<'_>,
+        identity: &ConversionIdentity,
+        existing: Option<&serde_json::Value>,
+        step: ConversionStep,
+    ) -> Result<Job, ConvertWorkerError> {
+        let checkpoint = checkpoint_with_step(existing, identity, step);
+        self.heartbeat_while(
+            claimed.ctx,
+            claimed.job,
+            claimed.lease_token,
+            claimed.attempts,
+            claimed.deadline,
+            jobs::checkpoint(
+                &self.db_pool,
+                claimed.ctx,
+                claimed.job.id,
+                claimed.lease_token,
+                claimed.attempts,
+                checkpoint,
+            ),
+        )
+        .await
+    }
+
+    async fn compensate_after_promotion_failure(
+        &self,
+        ctx: &OrgContext,
+        staged: Option<&StagedMarkdown>,
+        quota_reservation_key: &str,
+    ) {
+        if let Some(staged) = staged.filter(|staged| staged.created_or_verified) {
+            if let Err(error) = self
+                .storage
+                .cleanup_generated_object(ctx.org_id(), &staged.key)
+                .await
+            {
+                eprintln!(
+                    "fileconv-server: staged conversion artifact cleanup failed: {}",
+                    error.code()
+                );
+            }
+        }
+        if let Err(error) = quota::refund(&self.db_pool, ctx, quota_reservation_key).await {
+            eprintln!(
+                "fileconv-server: conversion quota refund failed: {}",
+                error.code()
+            );
+        }
+    }
+
+    async fn fail_retryable_or_return(
+        &self,
+        ctx: &OrgContext,
+        job: &Job,
+        lease_token: &str,
+        attempts: i32,
+        error: ConvertWorkerError,
+    ) -> Result<ConvertWorkerRun, ConvertWorkerError> {
+        if error.is_retryable_job_failure() {
+            let failed = jobs::fail(
+                &self.db_pool,
+                ctx,
+                job.id,
+                lease_token,
+                attempts,
+                error.safe_job_error(),
+            )
+            .await?;
+            Ok(ConvertWorkerRun::Failed {
+                job_id: failed.id,
+                terminal: failed.status == crate::db::models::JobStatus::DeadLetter,
+            })
+        } else {
+            Err(error)
+        }
     }
 }
 
@@ -629,7 +765,7 @@ where
 }
 
 fn verify_downloaded_integrity(
-    source: &documents::VersionSource,
+    source: &ConversionSourceVersion,
     bytes: &[u8],
     metadata: &HashMap<String, String>,
 ) -> Result<(), ConvertWorkerError> {
@@ -691,6 +827,19 @@ pub fn artifact_object_id_for_attempt(job_id: Uuid, attempts: i32) -> Uuid {
     Uuid::from_bytes(bytes)
 }
 
+fn quota_reservation_key_for_attempt(
+    identity: &ConversionIdentity,
+    job_id: Uuid,
+    attempts: i32,
+) -> String {
+    format!(
+        "{}.{}.{}",
+        identity.storage_quota_reservation_key(),
+        job_id,
+        attempts.max(0)
+    )
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConvertWorkerRun {
     NoJob,
@@ -700,13 +849,13 @@ pub enum ConvertWorkerRun {
 }
 
 #[derive(Debug)]
-struct ConversionSuccess {
+struct ConversionOutput {
     markdown: Vec<u8>,
-    artifact_key: crate::storage::ObjectKey,
     markdown_sha256: String,
     markdown_len: u64,
-    document_id: Uuid,
-    version_id: Uuid,
+    source: ConversionSourceVersion,
+    identity: ConversionIdentity,
+    checkpoint: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Error)]
@@ -717,6 +866,12 @@ pub enum ConvertWorkerError {
     Job(#[from] JobError),
     #[error("storage error")]
     Storage(#[from] StorageError),
+    #[error("artifact staging error")]
+    ArtifactStage(#[from] artifacts::ArtifactStageError),
+    #[error("promotion error")]
+    Promotion(#[from] PromotionError),
+    #[error("quota error")]
+    Quota(#[from] QuotaError),
     #[error("sandbox error")]
     Sandbox(#[from] SandboxError),
     #[error("sandbox task failed")]
@@ -761,6 +916,9 @@ impl ConvertWorkerError {
             self,
             Self::Db(_)
                 | Self::Storage(_)
+                | Self::ArtifactStage(_)
+                | Self::Promotion(_)
+                | Self::Quota(_)
                 | Self::Sandbox(_)
                 | Self::SandboxJoin
                 | Self::SandboxTimedOut
@@ -781,6 +939,9 @@ impl ConvertWorkerError {
         match self {
             Self::Db(_) => "convert database error",
             Self::Storage(_) => "convert storage error",
+            Self::ArtifactStage(_) => "convert artifact staging error",
+            Self::Promotion(_) => "convert promotion error",
+            Self::Quota(_) => "convert quota error",
             Self::Sandbox(_) => "convert sandbox error",
             Self::SandboxJoin => "convert sandbox join error",
             Self::SandboxTimedOut => "convert sandbox timeout",

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -20,7 +20,10 @@ use crate::db::models::{Job, JobType, ResourceKind};
 use crate::db::pool::with_org_txn;
 use crate::jobs::{self, JobError, JobPayload};
 use crate::services::artifacts::{self, MarkdownStageInput, StagedMarkdown};
-use crate::services::conversion::{checkpoint_with_step, ConversionIdentity, ConversionStep};
+use crate::services::conversion::{
+    checkpoint_with_staged_key, checkpoint_with_step, staged_keys_from_checkpoint,
+    ConversionIdentity, ConversionStep,
+};
 use crate::services::promotion::{self, PromoteConversionInput, PromotionError, PromotionFault};
 use crate::services::quota::{self, QuotaError, DEFAULT_RESERVATION_TTL};
 use crate::storage::keys::parse_key_for_org;
@@ -46,6 +49,10 @@ pub struct ConvertWorkerConfig {
     pub post_upload_settlement_delay: Duration,
     pub max_job_duration: Duration,
     pub promotion_fault: Option<PromotionFault>,
+    pub quota_reservation_ttl: Duration,
+    pub fail_cleanup_delete: bool,
+    pub fail_quota_refund: bool,
+    pub lose_staged_handle_after_put: bool,
 }
 
 impl ConvertWorkerConfig {
@@ -60,6 +67,10 @@ impl ConvertWorkerConfig {
             post_upload_settlement_delay: Duration::ZERO,
             max_job_duration,
             promotion_fault: None,
+            quota_reservation_ttl: DEFAULT_RESERVATION_TTL,
+            fail_cleanup_delete: false,
+            fail_quota_refund: false,
+            lose_staged_handle_after_put: false,
         }
     }
 
@@ -80,6 +91,10 @@ impl ConvertWorkerConfig {
             max_job_duration: ResourceLimits::default().wall_timeout
                 + Duration::from_secs(DEFAULT_JOB_GRACE_SECS),
             promotion_fault: None,
+            quota_reservation_ttl: DEFAULT_RESERVATION_TTL,
+            fail_cleanup_delete: false,
+            fail_quota_refund: false,
+            lose_staged_handle_after_put: false,
         }
     }
 
@@ -174,6 +189,24 @@ impl ConvertWorker {
                     Ok(byte_size) => byte_size,
                     Err(_) => return Err(ConvertWorkerError::InvalidMarkdownLength),
                 };
+                if let Err(error) = self
+                    .cleanup_checkpointed_staging(ctx, &identity, checkpoint.as_ref(), None)
+                    .await
+                {
+                    let failed = jobs::fail(
+                        &self.db_pool,
+                        ctx,
+                        job.id,
+                        &lease_token,
+                        attempts,
+                        error.safe_job_error(),
+                    )
+                    .await?;
+                    return Ok(ConvertWorkerRun::Failed {
+                        job_id: failed.id,
+                        terminal: failed.status == crate::db::models::JobStatus::DeadLetter,
+                    });
+                }
                 let quota_reservation_key =
                     quota_reservation_key_for_attempt(&identity, job.id, attempts);
                 if let Err(error) = self
@@ -189,7 +222,7 @@ impl ConvertWorker {
                             &quota_reservation_key,
                             ResourceKind::StorageBytes,
                             markdown_len,
-                            DEFAULT_RESERVATION_TTL,
+                            self.config.quota_reservation_ttl,
                             Some(job.id),
                         ),
                     )
@@ -201,6 +234,14 @@ impl ConvertWorker {
                 }
 
                 let mut staged: Option<StagedMarkdown> = None;
+                let mut checkpoint_for_compensation = checkpoint.clone();
+                let current_staging_key = artifacts::markdown_key(
+                    &identity,
+                    identity.promoted_version_id(),
+                    job.id,
+                    attempts,
+                )?;
+                let current_staging_key_string = current_staging_key.as_str();
                 let claimed = ClaimedJobScope {
                     ctx,
                     job: &job,
@@ -209,6 +250,17 @@ impl ConvertWorker {
                     deadline,
                 };
                 let promotion_result = async {
+                    let saved = self
+                        .save_checkpoint_payload(
+                            &claimed,
+                            checkpoint_with_staged_key(
+                                checkpoint.as_ref(),
+                                &identity,
+                                &current_staging_key_string,
+                            ),
+                        )
+                        .await?;
+                    checkpoint_for_compensation = saved.checkpoint;
                     let staged_markdown = self
                         .heartbeat_while(
                             ctx,
@@ -219,11 +271,11 @@ impl ConvertWorker {
                             artifacts::stage_markdown(
                                 &self.storage,
                                 ctx,
-                                &identity,
                                 MarkdownStageInput {
                                     collection_id: None,
                                     document_id: source.document_id,
                                     promoted_version_id: identity.promoted_version_id(),
+                                    staging_key: current_staging_key.clone(),
                                     markdown,
                                     markdown_sha256: markdown_sha256.clone(),
                                     markdown_len,
@@ -231,11 +283,16 @@ impl ConvertWorker {
                             ),
                         )
                         .await?;
+                    if self.config.lose_staged_handle_after_put {
+                        return Err(ConvertWorkerError::Promotion(PromotionError::Injected(
+                            PromotionFault::AfterStagingPut,
+                        )));
+                    }
                     staged = Some(staged_markdown.clone());
                     self.save_checkpoint_step(
                         &claimed,
                         &identity,
-                        checkpoint.as_ref(),
+                        checkpoint_for_compensation.as_ref(),
                         ConversionStep::Staged,
                     )
                     .await?;
@@ -285,28 +342,35 @@ impl ConvertWorker {
                     Err(ConvertWorkerError::Promotion(PromotionError::LeaseLost))
                     | Err(ConvertWorkerError::Job(JobError::LeaseLost))
                     | Err(ConvertWorkerError::LeaseLost) => {
-                        self.compensate_after_promotion_failure(
-                            ctx,
-                            staged.as_ref(),
-                            &quota_reservation_key,
-                        )
-                        .await;
+                        let _ = self
+                            .compensate_after_promotion_failure(
+                                ctx,
+                                &identity,
+                                checkpoint_for_compensation.as_ref(),
+                                staged.as_ref().map(|staged| staged.object_key.as_str()),
+                                &quota_reservation_key,
+                            )
+                            .await;
                         return Ok(ConvertWorkerRun::LeaseLost { job_id: job.id });
                     }
                     Err(error) if error.is_retryable_job_failure() => {
-                        self.compensate_after_promotion_failure(
-                            ctx,
-                            staged.as_ref(),
-                            &quota_reservation_key,
-                        )
-                        .await;
+                        let compensation = self
+                            .compensate_after_promotion_failure(
+                                ctx,
+                                &identity,
+                                checkpoint_for_compensation.as_ref(),
+                                staged.as_ref().map(|staged| staged.object_key.as_str()),
+                                &quota_reservation_key,
+                            )
+                            .await;
+                        let job_error = compensation.err().unwrap_or(error);
                         let failed = jobs::fail(
                             &self.db_pool,
                             ctx,
                             job.id,
                             &lease_token,
                             attempts,
-                            error.safe_job_error(),
+                            job_error.safe_job_error(),
                         )
                         .await?;
                         return Ok(ConvertWorkerRun::Failed {
@@ -315,12 +379,15 @@ impl ConvertWorker {
                         });
                     }
                     Err(error) => {
-                        self.compensate_after_promotion_failure(
-                            ctx,
-                            staged.as_ref(),
-                            &quota_reservation_key,
-                        )
-                        .await;
+                        let _ = self
+                            .compensate_after_promotion_failure(
+                                ctx,
+                                &identity,
+                                checkpoint_for_compensation.as_ref(),
+                                staged.as_ref().map(|staged| staged.object_key.as_str()),
+                                &quota_reservation_key,
+                            )
+                            .await;
                         return Err(error);
                     }
                 };
@@ -696,29 +763,129 @@ impl ConvertWorker {
         .await
     }
 
+    async fn save_checkpoint_payload(
+        &self,
+        claimed: &ClaimedJobScope<'_>,
+        checkpoint: jobs::CheckpointPayload,
+    ) -> Result<Job, ConvertWorkerError> {
+        self.heartbeat_while(
+            claimed.ctx,
+            claimed.job,
+            claimed.lease_token,
+            claimed.attempts,
+            claimed.deadline,
+            jobs::checkpoint(
+                &self.db_pool,
+                claimed.ctx,
+                claimed.job.id,
+                claimed.lease_token,
+                claimed.attempts,
+                checkpoint,
+            ),
+        )
+        .await
+    }
+
+    async fn cleanup_checkpointed_staging(
+        &self,
+        ctx: &OrgContext,
+        identity: &ConversionIdentity,
+        checkpoint: Option<&serde_json::Value>,
+        extra_key: Option<&str>,
+    ) -> Result<(), ConvertWorkerError> {
+        let mut keys = staged_keys_from_checkpoint(checkpoint);
+        if let Some(extra_key) = extra_key {
+            if !keys.iter().any(|key| key == extra_key) {
+                keys.push(extra_key.to_string());
+            }
+        }
+        for key in keys {
+            self.cleanup_staging_key_if_uncommitted(ctx, identity, &key)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn cleanup_staging_key_if_uncommitted(
+        &self,
+        ctx: &OrgContext,
+        identity: &ConversionIdentity,
+        object_key: &str,
+    ) -> Result<(), ConvertWorkerError> {
+        if let Some(committed) =
+            promotion::committed_markdown_object_key(&self.db_pool, ctx, identity).await?
+        {
+            if committed == object_key {
+                return Ok(());
+            }
+        }
+        if self.config.fail_cleanup_delete {
+            eprintln!(
+                "fileconv-server: injected staged conversion artifact cleanup failure; key={object_key}"
+            );
+            return Err(ConvertWorkerError::CompensationDeferred);
+        }
+        let key = parse_key_for_org(object_key, ctx.org_id())?;
+        if !key.belongs_to_version(identity.promoted_version_id()) {
+            return Err(ConvertWorkerError::CompensationDeferred);
+        }
+        if let Err(error) = self
+            .storage
+            .cleanup_generated_object(ctx.org_id(), &key)
+            .await
+        {
+            eprintln!(
+                "fileconv-server: staged conversion artifact cleanup failed; key={} code={}",
+                object_key,
+                error.code()
+            );
+            return Err(ConvertWorkerError::CompensationDeferred);
+        }
+        Ok(())
+    }
+
     async fn compensate_after_promotion_failure(
         &self,
         ctx: &OrgContext,
-        staged: Option<&StagedMarkdown>,
+        identity: &ConversionIdentity,
+        checkpoint: Option<&serde_json::Value>,
+        staged_key: Option<&str>,
         quota_reservation_key: &str,
-    ) {
-        if let Some(staged) = staged.filter(|staged| staged.created_or_verified) {
-            if let Err(error) = self
-                .storage
-                .cleanup_generated_object(ctx.org_id(), &staged.key)
-                .await
-            {
-                eprintln!(
-                    "fileconv-server: staged conversion artifact cleanup failed: {}",
-                    error.code()
-                );
-            }
-        }
-        if let Err(error) = quota::refund(&self.db_pool, ctx, quota_reservation_key).await {
+    ) -> Result<(), ConvertWorkerError> {
+        let mut deferred = false;
+        if let Err(error) = self
+            .cleanup_checkpointed_staging(ctx, identity, checkpoint, staged_key)
+            .await
+        {
             eprintln!(
-                "fileconv-server: conversion quota refund failed: {}",
+                "fileconv-server: conversion staging cleanup deferred: {}",
+                error.safe_job_error()
+            );
+            deferred = true;
+        }
+        if self.config.fail_quota_refund {
+            eprintln!(
+                "fileconv-server: injected conversion quota refund failure; reservation_key={quota_reservation_key}"
+            );
+            // TODO(I07): durable dead-letter GC/reconciliation should consume the
+            // checkpointed staging keys and quota marker if retries are exhausted.
+            deferred = true;
+        } else if let Err(error) = quota::refund(&self.db_pool, ctx, quota_reservation_key).await {
+            eprintln!(
+                "fileconv-server: conversion quota refund failed; reservation_key={} code={}",
+                quota_reservation_key,
                 error.code()
             );
+            // I02 quota reservations are bounded by expires_at; the sweep path is
+            // the durable backstop if inline refund cannot settle this attempt.
+            // TODO(I07): emit/consume a durable conversion-cleanup marker for
+            // permanently dead-lettered conversion attempts.
+            deferred = true;
+        }
+        if deferred {
+            Err(ConvertWorkerError::CompensationDeferred)
+        } else {
+            Ok(())
         }
     }
 
@@ -872,6 +1039,8 @@ pub enum ConvertWorkerError {
     Promotion(#[from] PromotionError),
     #[error("quota error")]
     Quota(#[from] QuotaError),
+    #[error("conversion compensation is deferred")]
+    CompensationDeferred,
     #[error("sandbox error")]
     Sandbox(#[from] SandboxError),
     #[error("sandbox task failed")]
@@ -919,6 +1088,7 @@ impl ConvertWorkerError {
                 | Self::ArtifactStage(_)
                 | Self::Promotion(_)
                 | Self::Quota(_)
+                | Self::CompensationDeferred
                 | Self::Sandbox(_)
                 | Self::SandboxJoin
                 | Self::SandboxTimedOut
@@ -942,6 +1112,7 @@ impl ConvertWorkerError {
             Self::ArtifactStage(_) => "convert artifact staging error",
             Self::Promotion(_) => "convert promotion error",
             Self::Quota(_) => "convert quota error",
+            Self::CompensationDeferred => "convert compensation deferred",
             Self::Sandbox(_) => "convert sandbox error",
             Self::SandboxJoin => "convert sandbox join error",
             Self::SandboxTimedOut => "convert sandbox timeout",

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -590,7 +590,8 @@ impl ConvertWorker {
                 biased;
                 result = &mut promotion => {
                     return match result {
-                        Err(PromotionError::Db(_)) | Err(PromotionError::CommittedOutcomeUnknown) => {
+                        Err(PromotionError::Db(DbError::Pool(_) | DbError::Query(_)))
+                        | Err(PromotionError::CommittedOutcomeUnknown) => {
                             PromotionWait::ReconciliationNeeded
                         }
                         result => PromotionWait::Finished(result),

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -18,9 +18,10 @@ use uuid::Uuid;
 use crate::auth::context::OrgContext;
 use crate::db::document_versions::ConversionSourceVersion;
 use crate::db::error::DbError;
-use crate::db::models::{Job, JobType, ResourceKind};
+use crate::db::jobs as jobs_repo;
+use crate::db::models::{Job, JobStatus, JobType, ResourceKind};
 use crate::db::pool::with_org_txn;
-use crate::jobs::{self, JobError, JobPayload};
+use crate::jobs::{self, EnqueueJob, JobError, JobPayload};
 use crate::services::artifacts::{self, MarkdownStageInput, StagedMarkdown};
 use crate::services::conversion::{
     checkpoint_with_staged_key, checkpoint_with_step, staged_keys_from_checkpoint,
@@ -41,6 +42,7 @@ const DEFAULT_CLAIM_LIMIT: u32 = 1;
 const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 5;
 const DEFAULT_JOB_GRACE_SECS: u64 = 30;
 const SANDBOX_CANCEL_REAP_TIMEOUT: Duration = Duration::from_secs(2);
+const RECONCILIATION_MAX_ATTEMPTS: u32 = 32;
 
 #[derive(Debug, Clone)]
 pub struct ConvertWorkerConfig {
@@ -140,6 +142,11 @@ struct ClaimedJobScope<'a> {
     deadline: TokioInstant,
 }
 
+enum PromotionWait {
+    Finished(Result<promotion::PromoteConversionOutcome, PromotionError>),
+    ReconciliationNeeded,
+}
+
 #[derive(Clone)]
 pub struct ConvertWorker {
     db_pool: Pool,
@@ -172,10 +179,22 @@ impl ConvertWorker {
             self.config.lease_ttl,
         )
         .await?;
+        if let Some(job) = jobs.into_iter().next() {
+            return self.process_claimed_job(ctx, job).await;
+        }
+        let jobs = jobs::claim_type(
+            &self.db_pool,
+            ctx,
+            JobType::Reconcile,
+            &self.config.worker_id,
+            DEFAULT_CLAIM_LIMIT,
+            self.config.lease_ttl,
+        )
+        .await?;
         let Some(job) = jobs.into_iter().next() else {
             return Ok(ConvertWorkerRun::NoJob);
         };
-        self.process_claimed_job(ctx, job).await
+        self.process_reconciliation_job(ctx, job).await
     }
 
     pub async fn process_claimed_job(
@@ -210,6 +229,7 @@ impl ConvertWorker {
                     .cleanup_checkpointed_staging(ctx, &identity, checkpoint.as_ref(), None)
                     .await
                 {
+                    self.enqueue_conversion_reconciliation(ctx, &job).await?;
                     let failed = jobs::fail(
                         &self.db_pool,
                         ctx,
@@ -331,15 +351,13 @@ impl ConvertWorker {
                         })
                         .await?;
                     }
-                    self.heartbeat_while(
-                        ctx,
-                        &job,
-                        &lease_token,
-                        attempts,
-                        deadline,
-                        promotion::promote_conversion(
-                            &self.db_pool,
+                    Ok::<PromotionWait, ConvertWorkerError>(
+                        self.await_promotion_or_reconciliation(
                             ctx,
+                            &job,
+                            &lease_token,
+                            attempts,
+                            deadline,
                             PromoteConversionInput {
                                 job_id: job.id,
                                 lease_token: lease_token.to_string(),
@@ -353,29 +371,25 @@ impl ConvertWorker {
                                 quota_reservation_key: quota_reservation_key.clone(),
                                 fault: self.config.promotion_fault,
                             },
-                        ),
+                        )
+                        .await,
                     )
-                    .await
                 }
                 .await;
 
                 let completed = match promotion_result {
-                    Ok(outcome) => outcome,
-                    Err(ConvertWorkerError::Promotion(PromotionError::LeaseLost))
-                    | Err(ConvertWorkerError::Job(JobError::LeaseLost))
-                    | Err(ConvertWorkerError::LeaseLost) => {
-                        let _ = self
-                            .compensate_after_promotion_failure(
-                                ctx,
-                                &identity,
-                                checkpoint_for_compensation.as_ref(),
-                                staged.as_ref().map(|staged| staged.object_key.as_str()),
-                                &quota_reservation_key,
-                            )
-                            .await;
+                    Ok(PromotionWait::Finished(Ok(outcome))) => outcome,
+                    Ok(PromotionWait::ReconciliationNeeded) => {
+                        self.enqueue_conversion_reconciliation(ctx, &job).await?;
+                        return Ok(ConvertWorkerRun::ReconciliationNeeded { job_id: job.id });
+                    }
+                    Ok(PromotionWait::Finished(Err(PromotionError::LeaseLost)))
+                    | Err(ConvertWorkerError::LeaseLost)
+                    | Err(ConvertWorkerError::Job(JobError::LeaseLost)) => {
+                        self.enqueue_conversion_reconciliation(ctx, &job).await?;
                         return Ok(ConvertWorkerRun::LeaseLost { job_id: job.id });
                     }
-                    Err(error) if error.is_retryable_job_failure() => {
+                    Ok(PromotionWait::Finished(Err(error))) => {
                         let compensation = self
                             .compensate_after_promotion_failure(
                                 ctx,
@@ -385,7 +399,15 @@ impl ConvertWorker {
                                 &quota_reservation_key,
                             )
                             .await;
-                        let job_error = compensation.err().unwrap_or(error);
+                        if compensation.is_err() {
+                            self.enqueue_conversion_reconciliation(ctx, &job).await?;
+                        }
+                        let job_error = compensation
+                            .err()
+                            .unwrap_or_else(|| ConvertWorkerError::Promotion(error));
+                        if !job_error.is_retryable_job_failure() {
+                            return Err(job_error);
+                        }
                         let failed = jobs::fail(
                             &self.db_pool,
                             ctx,
@@ -401,7 +423,7 @@ impl ConvertWorker {
                         });
                     }
                     Err(error) => {
-                        let _ = self
+                        let compensation = self
                             .compensate_after_promotion_failure(
                                 ctx,
                                 &identity,
@@ -410,7 +432,26 @@ impl ConvertWorker {
                                 &quota_reservation_key,
                             )
                             .await;
-                        return Err(error);
+                        if compensation.is_err() {
+                            self.enqueue_conversion_reconciliation(ctx, &job).await?;
+                        }
+                        let job_error = compensation.err().unwrap_or(error);
+                        if !job_error.is_retryable_job_failure() {
+                            return Err(job_error);
+                        }
+                        let failed = jobs::fail(
+                            &self.db_pool,
+                            ctx,
+                            job.id,
+                            &lease_token,
+                            attempts,
+                            job_error.safe_job_error(),
+                        )
+                        .await?;
+                        return Ok(ConvertWorkerRun::Failed {
+                            job_id: failed.id,
+                            terminal: failed.status == crate::db::models::JobStatus::DeadLetter,
+                        });
                     }
                 };
                 Ok(ConvertWorkerRun::Completed {
@@ -441,6 +482,203 @@ impl ConvertWorker {
             }
             Err(error) => Err(error),
         }
+    }
+
+    async fn process_reconciliation_job(
+        &self,
+        ctx: &OrgContext,
+        job: Job,
+    ) -> Result<ConvertWorkerRun, ConvertWorkerError> {
+        let lease_token = job
+            .lease_owner
+            .as_deref()
+            .ok_or(ConvertWorkerError::MissingLease)?;
+        let payload = jobs::decode_job_payload(job.payload_version, job.payload.clone())?;
+        let parent_job_id = payload
+            .cleanup_target_job_id
+            .ok_or(ConvertWorkerError::InvalidReconciliationPayload)?;
+        let parent = self.reconciliation_parent(ctx, parent_job_id).await?;
+        if parent.job_type != JobType::Convert {
+            return Err(ConvertWorkerError::InvalidReconciliationPayload);
+        }
+        if matches!(
+            parent.status,
+            JobStatus::Pending | JobStatus::Leased | JobStatus::Running
+        ) {
+            let failed = jobs::fail(
+                &self.db_pool,
+                ctx,
+                job.id,
+                lease_token,
+                job.attempts,
+                "conversion cleanup waiting for parent terminal state",
+            )
+            .await?;
+            return Ok(ConvertWorkerRun::Failed {
+                job_id: failed.id,
+                terminal: failed.status == JobStatus::DeadLetter,
+            });
+        }
+
+        let parent_payload =
+            jobs::decode_job_payload(parent.payload_version, parent.payload.clone())?;
+        let document_id = parent_payload
+            .document_id
+            .ok_or(ConvertWorkerError::InvalidReconciliationPayload)?;
+        let source_version_id = parent_payload
+            .version_id
+            .ok_or(ConvertWorkerError::InvalidReconciliationPayload)?;
+        let identity = ConversionIdentity::new(
+            ctx.org_id(),
+            document_id,
+            source_version_id,
+            parent.idempotency_key.clone(),
+        );
+        let cleanup_result = async {
+            self.cleanup_checkpointed_staging(ctx, &identity, parent.checkpoint.as_ref(), None)
+                .await?;
+            self.refund_attempt_reservations(ctx, &identity, &parent)
+                .await
+        }
+        .await;
+        if let Err(error) = cleanup_result {
+            let failed = jobs::fail(
+                &self.db_pool,
+                ctx,
+                job.id,
+                lease_token,
+                job.attempts,
+                error.safe_job_error(),
+            )
+            .await?;
+            return Ok(ConvertWorkerRun::Failed {
+                job_id: failed.id,
+                terminal: failed.status == JobStatus::DeadLetter,
+            });
+        }
+        let completed =
+            jobs::complete(&self.db_pool, ctx, job.id, lease_token, job.attempts).await?;
+        Ok(ConvertWorkerRun::Reconciled {
+            job_id: completed.id,
+        })
+    }
+
+    async fn await_promotion_or_reconciliation(
+        &self,
+        ctx: &OrgContext,
+        job: &Job,
+        lease_token: &str,
+        attempts: i32,
+        deadline: TokioInstant,
+        input: PromoteConversionInput,
+    ) -> PromotionWait {
+        // Once the promote transaction starts, dropping its future leaves commit
+        // status unknowable. Every cancellation/transport path therefore becomes
+        // reconciliation work rather than an immediate object deletion.
+        if self
+            .heartbeat_once(ctx, job, lease_token, attempts, deadline)
+            .await
+            .is_err()
+        {
+            return PromotionWait::ReconciliationNeeded;
+        }
+        let promotion = promotion::promote_conversion(&self.db_pool, ctx, input);
+        tokio::pin!(promotion);
+        let mut heartbeat = heartbeat_interval(self.config.heartbeat_interval);
+        loop {
+            tokio::select! {
+                biased;
+                result = &mut promotion => {
+                    return match result {
+                        Err(PromotionError::Db(_)) | Err(PromotionError::CommittedOutcomeUnknown) => {
+                            PromotionWait::ReconciliationNeeded
+                        }
+                        result => PromotionWait::Finished(result),
+                    };
+                }
+                _ = sleep_until(deadline) => return PromotionWait::ReconciliationNeeded,
+                _ = heartbeat.tick() => {
+                    let heartbeat = timeout(
+                        heartbeat_call_timeout(self.config.lease_ttl, deadline),
+                        jobs::heartbeat(
+                            &self.db_pool,
+                            ctx,
+                            job.id,
+                            lease_token,
+                            attempts,
+                            self.config.lease_ttl,
+                        ),
+                    )
+                    .await;
+                    if !matches!(heartbeat, Ok(Ok(()))) {
+                        return PromotionWait::ReconciliationNeeded;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn enqueue_conversion_reconciliation(
+        &self,
+        ctx: &OrgContext,
+        parent_job: &Job,
+    ) -> Result<(), ConvertWorkerError> {
+        let document_id = parent_job
+            .document_id
+            .ok_or(ConvertWorkerError::InvalidConvertPayload)?;
+        let version_id = parent_job
+            .version_id
+            .ok_or(ConvertWorkerError::InvalidConvertPayload)?;
+        let mut input = EnqueueJob::new(
+            JobType::Reconcile,
+            JobPayload {
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                collection_id: None,
+                upload_id: None,
+                batch_id: None,
+                cleanup_target_job_id: Some(parent_job.id),
+            },
+            format!("convert.cleanup:{}", parent_job.id),
+        );
+        input.max_attempts = RECONCILIATION_MAX_ATTEMPTS;
+        jobs::enqueue(&self.db_pool, ctx, input).await?;
+        Ok(())
+    }
+
+    async fn reconciliation_parent(
+        &self,
+        ctx: &OrgContext,
+        parent_job_id: Uuid,
+    ) -> Result<Job, ConvertWorkerError> {
+        with_org_txn(&self.db_pool, ctx, {
+            let ctx = ctx.clone();
+            move |txn| {
+                Box::pin(async move {
+                    jobs_repo::get_by_id_for_update(txn, &ctx, parent_job_id)
+                        .await?
+                        .ok_or(DbError::NotFound)
+                })
+            }
+        })
+        .await
+        .map_err(ConvertWorkerError::Db)
+    }
+
+    async fn refund_attempt_reservations(
+        &self,
+        ctx: &OrgContext,
+        identity: &ConversionIdentity,
+        parent: &Job,
+    ) -> Result<(), ConvertWorkerError> {
+        for attempts in 1..=parent.attempts.max(0) {
+            let reservation_key = quota_reservation_key_for_attempt(identity, parent.id, attempts);
+            match quota::refund(&self.db_pool, ctx, &reservation_key).await {
+                Ok(_) | Err(QuotaError::ReservationNotFound) => {}
+                Err(error) => return Err(ConvertWorkerError::Quota(error)),
+            }
+        }
+        Ok(())
     }
 
     async fn convert_claimed(
@@ -1032,9 +1270,24 @@ fn quota_reservation_key_for_attempt(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConvertWorkerRun {
     NoJob,
-    Completed { job_id: Uuid, markdown_bytes: usize },
-    Failed { job_id: Uuid, terminal: bool },
-    LeaseLost { job_id: Uuid },
+    Completed {
+        job_id: Uuid,
+        markdown_bytes: usize,
+    },
+    Failed {
+        job_id: Uuid,
+        terminal: bool,
+    },
+    LeaseLost {
+        job_id: Uuid,
+    },
+    /// Promotion completion is uncertain; a durable reconciliation job was queued.
+    ReconciliationNeeded {
+        job_id: Uuid,
+    },
+    Reconciled {
+        job_id: Uuid,
+    },
 }
 
 #[derive(Debug)]
@@ -1081,6 +1334,8 @@ pub enum ConvertWorkerError {
     MissingLease,
     #[error("convert payload is missing document_id or version_id")]
     InvalidConvertPayload,
+    #[error("reconciliation payload is invalid")]
+    InvalidReconciliationPayload,
     #[error("quarantine object is missing canonical format metadata")]
     MissingCanonicalFormat,
     #[error("quarantine object has unsupported canonical format metadata")]
@@ -1117,6 +1372,7 @@ impl ConvertWorkerError {
                 | Self::SandboxOutputTruncated
                 | Self::ConverterFailed
                 | Self::InvalidConvertPayload
+                | Self::InvalidReconciliationPayload
                 | Self::MissingCanonicalFormat
                 | Self::UnsupportedCanonicalFormat
                 | Self::InvalidMarkdownLength
@@ -1145,6 +1401,7 @@ impl ConvertWorkerError {
             Self::Job(_) => "convert job error",
             Self::MissingLease => "convert missing lease",
             Self::InvalidConvertPayload => "convert payload invalid",
+            Self::InvalidReconciliationPayload => "convert reconciliation payload invalid",
             Self::MissingCanonicalFormat => "convert canonical format missing",
             Self::UnsupportedCanonicalFormat => "convert canonical format unsupported",
             Self::InvalidMarkdownLength => "convert markdown too large",

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -2,7 +2,10 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
 use deadpool_postgres::Pool;
@@ -152,6 +155,7 @@ pub struct ConvertWorker {
     db_pool: Pool,
     storage: MinioClient,
     config: ConvertWorkerConfig,
+    next_claim_prefers_reconciliation: Arc<AtomicBool>,
 }
 
 impl ConvertWorker {
@@ -166,35 +170,38 @@ impl ConvertWorker {
             db_pool,
             storage,
             config,
+            next_claim_prefers_reconciliation: Arc::new(AtomicBool::new(false)),
         })
     }
 
     pub async fn run_once(&self, ctx: &OrgContext) -> Result<ConvertWorkerRun, ConvertWorkerError> {
-        let jobs = jobs::claim_type(
-            &self.db_pool,
-            ctx,
-            JobType::Convert,
-            &self.config.worker_id,
-            DEFAULT_CLAIM_LIMIT,
-            self.config.lease_ttl,
-        )
-        .await?;
-        if let Some(job) = jobs.into_iter().next() {
-            return self.process_claimed_job(ctx, job).await;
-        }
-        let jobs = jobs::claim_type(
-            &self.db_pool,
-            ctx,
-            JobType::Reconcile,
-            &self.config.worker_id,
-            DEFAULT_CLAIM_LIMIT,
-            self.config.lease_ttl,
-        )
-        .await?;
-        let Some(job) = jobs.into_iter().next() else {
-            return Ok(ConvertWorkerRun::NoJob);
+        let claim_order = if self
+            .next_claim_prefers_reconciliation
+            .fetch_xor(true, Ordering::Relaxed)
+        {
+            [JobType::Reconcile, JobType::Convert]
+        } else {
+            [JobType::Convert, JobType::Reconcile]
         };
-        self.process_reconciliation_job(ctx, job).await
+        for job_type in claim_order {
+            let jobs = jobs::claim_type(
+                &self.db_pool,
+                ctx,
+                job_type,
+                &self.config.worker_id,
+                DEFAULT_CLAIM_LIMIT,
+                self.config.lease_ttl,
+            )
+            .await?;
+            if let Some(job) = jobs.into_iter().next() {
+                return if job_type == JobType::Convert {
+                    self.process_claimed_job(ctx, job).await
+                } else {
+                    self.process_reconciliation_job(ctx, job).await
+                };
+            }
+        }
+        Ok(ConvertWorkerRun::NoJob)
     }
 
     pub async fn process_claimed_job(

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -2,11 +2,13 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
 use deadpool_postgres::Pool;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio::time::{
     interval_at, sleep_until, timeout, timeout_at, Instant as TokioInstant, MissedTickBehavior,
@@ -53,6 +55,7 @@ pub struct ConvertWorkerConfig {
     pub fail_cleanup_delete: bool,
     pub fail_quota_refund: bool,
     pub lose_staged_handle_after_put: bool,
+    pub pause_after_staging: Option<ConvertWorkerPause>,
 }
 
 impl ConvertWorkerConfig {
@@ -71,6 +74,7 @@ impl ConvertWorkerConfig {
             fail_cleanup_delete: false,
             fail_quota_refund: false,
             lose_staged_handle_after_put: false,
+            pause_after_staging: None,
         }
     }
 
@@ -95,6 +99,7 @@ impl ConvertWorkerConfig {
             fail_cleanup_delete: false,
             fail_quota_refund: false,
             lose_staged_handle_after_put: false,
+            pause_after_staging: None,
         }
     }
 
@@ -112,6 +117,18 @@ impl ConvertWorkerConfig {
             return Err(ConvertWorkerError::InvalidMaxJobDuration);
         }
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct ConvertWorkerPause {
+    pub staged: Arc<Notify>,
+    pub release: Arc<Notify>,
+}
+
+impl std::fmt::Debug for ConvertWorkerPause {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ConvertWorkerPause")
     }
 }
 
@@ -240,6 +257,7 @@ impl ConvertWorker {
                     identity.promoted_version_id(),
                     job.id,
                     attempts,
+                    &lease_token,
                 )?;
                 let current_staging_key_string = current_staging_key.as_str();
                 let claimed = ClaimedJobScope {
@@ -296,6 +314,10 @@ impl ConvertWorker {
                         ConversionStep::Staged,
                     )
                     .await?;
+                    if let Some(pause) = &self.config.pause_after_staging {
+                        pause.staged.notify_waiters();
+                        pause.release.notified().await;
+                    }
                     if self.config.promotion_fault == Some(PromotionFault::AfterStagingPut) {
                         return Err(ConvertWorkerError::Promotion(PromotionError::Injected(
                             PromotionFault::AfterStagingPut,

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -146,7 +146,7 @@ struct ClaimedJobScope<'a> {
 }
 
 enum PromotionWait {
-    Finished(Result<promotion::PromoteConversionOutcome, PromotionError>),
+    Finished(Box<Result<promotion::PromoteConversionOutcome, PromotionError>>),
     ReconciliationNeeded,
 }
 
@@ -385,49 +385,54 @@ impl ConvertWorker {
                 .await;
 
                 let completed = match promotion_result {
-                    Ok(PromotionWait::Finished(Ok(outcome))) => outcome,
+                    Ok(PromotionWait::Finished(result)) => match *result {
+                        Ok(outcome) => outcome,
+                        Err(PromotionError::LeaseLost) => {
+                            self.enqueue_conversion_reconciliation(ctx, &job).await?;
+                            return Ok(ConvertWorkerRun::LeaseLost { job_id: job.id });
+                        }
+                        Err(error) => {
+                            let compensation = self
+                                .compensate_after_promotion_failure(
+                                    ctx,
+                                    &identity,
+                                    checkpoint_for_compensation.as_ref(),
+                                    staged.as_ref().map(|staged| staged.object_key.as_str()),
+                                    &quota_reservation_key,
+                                )
+                                .await;
+                            if compensation.is_err() {
+                                self.enqueue_conversion_reconciliation(ctx, &job).await?;
+                            }
+                            let job_error = compensation
+                                .err()
+                                .unwrap_or_else(|| ConvertWorkerError::Promotion(error));
+                            if !job_error.is_retryable_job_failure() {
+                                return Err(job_error);
+                            }
+                            let failed = jobs::fail(
+                                &self.db_pool,
+                                ctx,
+                                job.id,
+                                &lease_token,
+                                attempts,
+                                job_error.safe_job_error(),
+                            )
+                            .await?;
+                            return Ok(ConvertWorkerRun::Failed {
+                                job_id: failed.id,
+                                terminal: failed.status == crate::db::models::JobStatus::DeadLetter,
+                            });
+                        }
+                    },
                     Ok(PromotionWait::ReconciliationNeeded) => {
                         self.enqueue_conversion_reconciliation(ctx, &job).await?;
                         return Ok(ConvertWorkerRun::ReconciliationNeeded { job_id: job.id });
                     }
-                    Ok(PromotionWait::Finished(Err(PromotionError::LeaseLost)))
-                    | Err(ConvertWorkerError::LeaseLost)
+                    Err(ConvertWorkerError::LeaseLost)
                     | Err(ConvertWorkerError::Job(JobError::LeaseLost)) => {
                         self.enqueue_conversion_reconciliation(ctx, &job).await?;
                         return Ok(ConvertWorkerRun::LeaseLost { job_id: job.id });
-                    }
-                    Ok(PromotionWait::Finished(Err(error))) => {
-                        let compensation = self
-                            .compensate_after_promotion_failure(
-                                ctx,
-                                &identity,
-                                checkpoint_for_compensation.as_ref(),
-                                staged.as_ref().map(|staged| staged.object_key.as_str()),
-                                &quota_reservation_key,
-                            )
-                            .await;
-                        if compensation.is_err() {
-                            self.enqueue_conversion_reconciliation(ctx, &job).await?;
-                        }
-                        let job_error = compensation
-                            .err()
-                            .unwrap_or_else(|| ConvertWorkerError::Promotion(error));
-                        if !job_error.is_retryable_job_failure() {
-                            return Err(job_error);
-                        }
-                        let failed = jobs::fail(
-                            &self.db_pool,
-                            ctx,
-                            job.id,
-                            &lease_token,
-                            attempts,
-                            job_error.safe_job_error(),
-                        )
-                        .await?;
-                        return Ok(ConvertWorkerRun::Failed {
-                            job_id: failed.id,
-                            terminal: failed.status == crate::db::models::JobStatus::DeadLetter,
-                        });
                     }
                     Err(error) => {
                         let compensation = self
@@ -601,7 +606,7 @@ impl ConvertWorker {
                         | Err(PromotionError::CommittedOutcomeUnknown) => {
                             PromotionWait::ReconciliationNeeded
                         }
-                        result => PromotionWait::Finished(result),
+                        result => PromotionWait::Finished(Box::new(result)),
                     };
                 }
                 _ = sleep_until(deadline) => return PromotionWait::ReconciliationNeeded,

--- a/crates/server/src/workers/sandbox.rs
+++ b/crates/server/src/workers/sandbox.rs
@@ -3,962 +3,1090 @@
 //! The heavy converter remains outside `fileconv-server`; this module only
 //! materializes a single input file and executes a configured argv template.
 
-use std::ffi::CString;
-use std::fs::{self, File};
-use std::io::{self, Write};
-use std::os::fd::AsRawFd;
-use std::os::fd::RawFd;
-use std::os::unix::process::{CommandExt, ExitStatusExt};
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+#[cfg(unix)]
+mod imp {
+    use std::ffi::CString;
+    use std::fs::{self, File};
+    use std::io::{self, Write};
+    use std::os::fd::AsRawFd;
+    use std::os::fd::RawFd;
+    use std::os::unix::process::{CommandExt, ExitStatusExt};
+    use std::path::{Path, PathBuf};
+    use std::process::{Child, Command, Stdio};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
-use tempfile::TempDir;
+    use tempfile::TempDir;
 
-use super::limits::ResourceLimits;
+    use super::super::limits::ResourceLimits;
 
-const INPUT_PLACEHOLDER: &str = "{input}";
-const POLL_INTERVAL: Duration = Duration::from_millis(20);
-const DRAIN_GRACE: Duration = Duration::from_millis(250);
-const KILL_REAP_GRACE: Duration = Duration::from_millis(500);
+    const INPUT_PLACEHOLDER: &str = "{input}";
+    const POLL_INTERVAL: Duration = Duration::from_millis(20);
+    const DRAIN_GRACE: Duration = Duration::from_millis(250);
+    const KILL_REAP_GRACE: Duration = Duration::from_millis(500);
 
-const ACCESS_FS_EXECUTE: u64 = 1 << 0;
-const ACCESS_FS_WRITE_FILE: u64 = 1 << 1;
-const ACCESS_FS_READ_FILE: u64 = 1 << 2;
-const ACCESS_FS_READ_DIR: u64 = 1 << 3;
-const ACCESS_FS_REMOVE_DIR: u64 = 1 << 4;
-const ACCESS_FS_REMOVE_FILE: u64 = 1 << 5;
-const ACCESS_FS_MAKE_CHAR: u64 = 1 << 6;
-const ACCESS_FS_MAKE_DIR: u64 = 1 << 7;
-const ACCESS_FS_MAKE_REG: u64 = 1 << 8;
-const ACCESS_FS_MAKE_SOCK: u64 = 1 << 9;
-const ACCESS_FS_MAKE_FIFO: u64 = 1 << 10;
-const ACCESS_FS_MAKE_BLOCK: u64 = 1 << 11;
-const ACCESS_FS_MAKE_SYM: u64 = 1 << 12;
-const LANDLOCK_RULE_PATH_BENEATH: libc::c_int = 1;
-const LANDLOCK_CREATE_RULESET_VERSION: libc::c_uint = 1;
-const LANDLOCK_ACCESS_FS_READ_EXECUTE: u64 =
-    ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE | ACCESS_FS_READ_DIR;
-const LANDLOCK_ACCESS_FS_EXEC_FILE: u64 = ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE;
-const LANDLOCK_ACCESS_FS_ALL_V1: u64 = ACCESS_FS_EXECUTE
-    | ACCESS_FS_WRITE_FILE
-    | ACCESS_FS_READ_FILE
-    | ACCESS_FS_READ_DIR
-    | ACCESS_FS_REMOVE_DIR
-    | ACCESS_FS_REMOVE_FILE
-    | ACCESS_FS_MAKE_CHAR
-    | ACCESS_FS_MAKE_DIR
-    | ACCESS_FS_MAKE_REG
-    | ACCESS_FS_MAKE_SOCK
-    | ACCESS_FS_MAKE_FIFO
-    | ACCESS_FS_MAKE_BLOCK
-    | ACCESS_FS_MAKE_SYM;
+    const ACCESS_FS_EXECUTE: u64 = 1 << 0;
+    const ACCESS_FS_WRITE_FILE: u64 = 1 << 1;
+    const ACCESS_FS_READ_FILE: u64 = 1 << 2;
+    const ACCESS_FS_READ_DIR: u64 = 1 << 3;
+    const ACCESS_FS_REMOVE_DIR: u64 = 1 << 4;
+    const ACCESS_FS_REMOVE_FILE: u64 = 1 << 5;
+    const ACCESS_FS_MAKE_CHAR: u64 = 1 << 6;
+    const ACCESS_FS_MAKE_DIR: u64 = 1 << 7;
+    const ACCESS_FS_MAKE_REG: u64 = 1 << 8;
+    const ACCESS_FS_MAKE_SOCK: u64 = 1 << 9;
+    const ACCESS_FS_MAKE_FIFO: u64 = 1 << 10;
+    const ACCESS_FS_MAKE_BLOCK: u64 = 1 << 11;
+    const ACCESS_FS_MAKE_SYM: u64 = 1 << 12;
+    const LANDLOCK_RULE_PATH_BENEATH: libc::c_int = 1;
+    const LANDLOCK_CREATE_RULESET_VERSION: libc::c_uint = 1;
+    const LANDLOCK_ACCESS_FS_READ_EXECUTE: u64 =
+        ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE | ACCESS_FS_READ_DIR;
+    const LANDLOCK_ACCESS_FS_EXEC_FILE: u64 = ACCESS_FS_EXECUTE | ACCESS_FS_READ_FILE;
+    const LANDLOCK_ACCESS_FS_ALL_V1: u64 = ACCESS_FS_EXECUTE
+        | ACCESS_FS_WRITE_FILE
+        | ACCESS_FS_READ_FILE
+        | ACCESS_FS_READ_DIR
+        | ACCESS_FS_REMOVE_DIR
+        | ACCESS_FS_REMOVE_FILE
+        | ACCESS_FS_MAKE_CHAR
+        | ACCESS_FS_MAKE_DIR
+        | ACCESS_FS_MAKE_REG
+        | ACCESS_FS_MAKE_SOCK
+        | ACCESS_FS_MAKE_FIFO
+        | ACCESS_FS_MAKE_BLOCK
+        | ACCESS_FS_MAKE_SYM;
 
-#[repr(C)]
-struct LandlockRulesetAttr {
-    handled_access_fs: u64,
-}
-
-#[repr(C)]
-struct LandlockPathBeneathAttr {
-    allowed_access: u64,
-    parent_fd: i32,
-}
-
-#[derive(Debug, Clone)]
-pub struct SandboxConfig {
-    pub argv_template: Vec<String>,
-    pub limits: ResourceLimits,
-}
-
-impl SandboxConfig {
-    pub fn validate(&self) -> Result<(), SandboxError> {
-        if self.argv_template.is_empty() {
-            return Err(SandboxError::InvalidConfig(
-                "converter argv template must not be empty".into(),
-            ));
-        }
-        if !Path::new(&self.argv_template[0]).is_absolute() {
-            return Err(SandboxError::InvalidConfig(
-                "converter executable must be an absolute path".into(),
-            ));
-        }
-        let placeholder_count = self
-            .argv_template
-            .iter()
-            .filter(|arg| arg.contains(INPUT_PLACEHOLDER))
-            .count();
-        if placeholder_count == 0 {
-            return Err(SandboxError::InvalidConfig(
-                "converter argv template must contain {input}".into(),
-            ));
-        }
-        self.limits.validate().map_err(SandboxError::InvalidConfig)
-    }
-}
-
-#[derive(Debug)]
-pub struct SandboxInput {
-    pub bytes: Vec<u8>,
-    pub canonical_extension: String,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SandboxExit {
-    Success,
-    Exit(i32),
-    Signaled(i32),
-    TimedOut,
-    Cancelled,
-}
-
-impl SandboxExit {
-    pub const fn success(self) -> bool {
-        matches!(self, Self::Success)
-    }
-}
-
-#[derive(Debug)]
-pub struct SandboxOutput {
-    pub exit: SandboxExit,
-    pub stdout: Vec<u8>,
-    pub stderr: Vec<u8>,
-    pub stdout_truncated: bool,
-    pub stderr_truncated: bool,
-    /// Host PID of PID namespace init. It is gone after timeout/cancel cleanup.
-    pub pid1_host_pid: Option<u32>,
-    /// Path retained for tests/evidence; RAII cleanup has removed it by return.
-    pub workspace_path: PathBuf,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum SandboxError {
-    #[error("sandbox configuration is invalid: {0}")]
-    InvalidConfig(String),
-    #[error("sandbox isolation is unavailable")]
-    IsolationUnavailable,
-    #[error("sandbox io failed")]
-    Io(#[from] io::Error),
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct SandboxCancel {
-    cancelled: Arc<AtomicBool>,
-}
-
-impl SandboxCancel {
-    pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::SeqCst);
+    #[repr(C)]
+    struct LandlockRulesetAttr {
+        handled_access_fs: u64,
     }
 
-    pub fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::SeqCst)
-    }
-}
-
-/// Probe isolation support with a tiny command. Workers call this at startup and
-/// tests use it to skip only when the kernel truly lacks unprivileged isolation.
-pub fn preflight() -> Result<(), SandboxError> {
-    let config = SandboxConfig {
-        argv_template: vec!["/bin/true".into(), INPUT_PLACEHOLDER.into()],
-        limits: ResourceLimits {
-            wall_timeout: Duration::from_secs(5),
-            memory_bytes: 64 * 1024 * 1024,
-            cpu_seconds: 2,
-            file_size_bytes: 1024 * 1024,
-            max_processes: 512,
-            max_open_files: 32,
-            stdout_stderr_bytes: 1024 * 1024,
-        },
-    };
-    let output = run(
-        &config,
-        SandboxInput {
-            bytes: Vec::new(),
-            canonical_extension: "txt".into(),
-        },
-        &SandboxCancel::default(),
-    )?;
-    if output.exit.success() {
-        Ok(())
-    } else {
-        Err(SandboxError::IsolationUnavailable)
-    }
-}
-
-pub fn run(
-    config: &SandboxConfig,
-    input: SandboxInput,
-    cancel: &SandboxCancel,
-) -> Result<SandboxOutput, SandboxError> {
-    config.validate()?;
-    let workspace = TempDir::new()?;
-    let workspace_path = workspace.path().to_path_buf();
-    let input_name = safe_input_name(&input.canonical_extension)?;
-    let input_path = workspace.path().join(input_name);
-    {
-        let mut file = File::create(&input_path)?;
-        file.write_all(&input.bytes)?;
-        file.sync_all()?;
+    #[repr(C)]
+    struct LandlockPathBeneathAttr {
+        allowed_access: u64,
+        parent_fd: i32,
     }
 
-    let argv = materialize_argv(&config.argv_template, &input_path)?;
-    let executable = argv
-        .first()
-        .ok_or_else(|| SandboxError::InvalidConfig("converter argv is empty".into()))?;
-    let (pid_read_fd, pid_write_fd) = pipe_cloexec()?;
-    let pre_exec = PreExecConfig::new(
-        config,
-        workspace.path(),
-        executable,
-        pid_read_fd,
-        pid_write_fd,
-    )?;
-
-    let mut command = Command::new(executable);
-    command
-        .args(&argv[1..])
-        .current_dir(workspace.path())
-        .env_clear()
-        .env("PATH", "/usr/bin:/bin")
-        .env("LC_ALL", "C")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    unsafe {
-        command.pre_exec(move || pre_exec.apply());
+    #[derive(Debug, Clone)]
+    pub struct SandboxConfig {
+        pub argv_template: Vec<String>,
+        pub limits: ResourceLimits,
     }
 
-    let child = match command.spawn() {
-        Ok(child) => child,
-        Err(error) => {
-            close_fd(pid_read_fd);
-            close_fd(pid_write_fd);
-            return Err(error.into());
-        }
-    };
-    close_fd(pid_write_fd);
-    let child_pid = child.id() as libc::pid_t;
-    let mut supervisor = SandboxSupervisor::new(child, child_pid);
-    let pid1_host_pid = match read_pid_from_pipe(pid_read_fd) {
-        Ok(Some(pid)) => pid,
-        Ok(None) => {
-            close_fd(pid_read_fd);
-            return Err(SandboxError::IsolationUnavailable);
-        }
-        Err(error) => {
-            close_fd(pid_read_fd);
-            return Err(SandboxError::Io(error));
-        }
-    };
-    supervisor.set_pid1(pid1_host_pid);
-    close_fd(pid_read_fd);
-    let cgroup_guard = CgroupGuard::best_effort_apply(pid1_host_pid, &config.limits);
-    let stdout = supervisor.child_mut().stdout.take().expect("stdout piped");
-    let stderr = supervisor.child_mut().stderr.take().expect("stderr piped");
-    set_nonblocking(stdout.as_raw_fd())?;
-    set_nonblocking(stderr.as_raw_fd())?;
-    let mut stdout_capture = CapturedPipe::new(config.limits.stdout_stderr_bytes);
-    let mut stderr_capture = CapturedPipe::new(config.limits.stdout_stderr_bytes);
-
-    let deadline = Instant::now() + config.limits.wall_timeout;
-    let exit = loop {
-        drain_available(stdout.as_raw_fd(), &mut stdout_capture)?;
-        drain_available(stderr.as_raw_fd(), &mut stderr_capture)?;
-        if let Some(status) = supervisor.child_mut().try_wait()? {
-            supervisor.disarm();
-            break exit_from_status(status);
-        }
-        if cancel.is_cancelled() {
-            supervisor.kill_and_reap()?;
-            break SandboxExit::Cancelled;
-        }
-        if Instant::now() >= deadline {
-            supervisor.kill_and_reap()?;
-            break SandboxExit::TimedOut;
-        }
-        std::thread::sleep(POLL_INTERVAL);
-    };
-
-    let drain_deadline = Instant::now() + DRAIN_GRACE;
-    while Instant::now() < drain_deadline && (!stdout_capture.eof || !stderr_capture.eof) {
-        drain_available(stdout.as_raw_fd(), &mut stdout_capture)?;
-        drain_available(stderr.as_raw_fd(), &mut stderr_capture)?;
-        if stdout_capture.eof && stderr_capture.eof {
-            break;
-        }
-        std::thread::sleep(POLL_INTERVAL);
-    }
-    if !stdout_capture.eof {
-        stdout_capture.truncated = true;
-    }
-    if !stderr_capture.eof {
-        stderr_capture.truncated = true;
-    }
-    drop(cgroup_guard);
-    drop(workspace);
-    Ok(SandboxOutput {
-        exit,
-        stdout: stdout_capture.bytes,
-        stderr: stderr_capture.bytes,
-        stdout_truncated: stdout_capture.truncated,
-        stderr_truncated: stderr_capture.truncated,
-        pid1_host_pid: Some(pid1_host_pid),
-        workspace_path,
-    })
-}
-
-fn materialize_argv(template: &[String], input_path: &Path) -> Result<Vec<String>, SandboxError> {
-    let input = input_path
-        .to_str()
-        .ok_or_else(|| SandboxError::InvalidConfig("input path is not UTF-8".into()))?;
-    Ok(template
-        .iter()
-        .map(|arg| arg.replace(INPUT_PLACEHOLDER, input))
-        .collect())
-}
-
-fn safe_input_name(extension: &str) -> Result<String, SandboxError> {
-    let ext = extension.trim_start_matches('.').to_ascii_lowercase();
-    if ext.is_empty()
-        || ext.len() > 16
-        || !ext
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
-    {
-        return Err(SandboxError::InvalidConfig(
-            "canonical extension is invalid".into(),
-        ));
-    }
-    Ok(format!("input.{ext}"))
-}
-
-struct CapturedPipe {
-    bytes: Vec<u8>,
-    limit: usize,
-    truncated: bool,
-    eof: bool,
-}
-
-impl CapturedPipe {
-    fn new(limit: usize) -> Self {
-        Self {
-            bytes: Vec::with_capacity(limit.min(8192)),
-            limit,
-            truncated: false,
-            eof: false,
-        }
-    }
-
-    fn capacity_remaining(&self) -> usize {
-        self.limit.saturating_sub(self.bytes.len())
-    }
-}
-
-fn drain_available(fd: RawFd, capture: &mut CapturedPipe) -> io::Result<()> {
-    let mut buf = [0_u8; 8192];
-    loop {
-        let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast::<libc::c_void>(), buf.len()) };
-        if n < 0 {
-            let error = io::Error::last_os_error();
-            if matches!(
-                error.raw_os_error(),
-                Some(code) if code == libc::EAGAIN || code == libc::EWOULDBLOCK
-            ) {
-                return Ok(());
+    impl SandboxConfig {
+        pub fn validate(&self) -> Result<(), SandboxError> {
+            if self.argv_template.is_empty() {
+                return Err(SandboxError::InvalidConfig(
+                    "converter argv template must not be empty".into(),
+                ));
             }
-            if error.raw_os_error() == Some(libc::EINTR) {
-                continue;
+            if !Path::new(&self.argv_template[0]).is_absolute() {
+                return Err(SandboxError::InvalidConfig(
+                    "converter executable must be an absolute path".into(),
+                ));
             }
-            return Err(error);
-        }
-        if n == 0 {
-            capture.eof = true;
-            return Ok(());
-        }
-        let n = n as usize;
-        let allowed = capture.capacity_remaining().min(n);
-        if allowed > 0 {
-            capture.bytes.extend_from_slice(&buf[..allowed]);
-        }
-        if allowed < n {
-            capture.truncated = true;
-        }
-    }
-}
-
-fn exit_from_status(status: std::process::ExitStatus) -> SandboxExit {
-    if status.success() {
-        SandboxExit::Success
-    } else if let Some(code) = status.code() {
-        SandboxExit::Exit(code)
-    } else if let Some(signal) = status.signal() {
-        SandboxExit::Signaled(signal)
-    } else {
-        SandboxExit::Exit(-1)
-    }
-}
-
-fn reap_child_bounded(child: &mut Child, grace: Duration) -> io::Result<()> {
-    let deadline = Instant::now() + grace;
-    loop {
-        if child.try_wait()?.is_some() {
-            return Ok(());
-        }
-        if Instant::now() >= deadline {
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "sandbox child did not reap after kill",
-            ));
-        }
-        std::thread::sleep(POLL_INTERVAL);
-    }
-}
-
-struct SandboxSupervisor {
-    child: Option<Child>,
-    wrapper_pid: libc::pid_t,
-    pid1_host_pid: Option<u32>,
-}
-
-impl SandboxSupervisor {
-    fn new(child: Child, wrapper_pid: libc::pid_t) -> Self {
-        Self {
-            child: Some(child),
-            wrapper_pid,
-            pid1_host_pid: None,
+            let placeholder_count = self
+                .argv_template
+                .iter()
+                .filter(|arg| arg.contains(INPUT_PLACEHOLDER))
+                .count();
+            if placeholder_count == 0 {
+                return Err(SandboxError::InvalidConfig(
+                    "converter argv template must contain {input}".into(),
+                ));
+            }
+            self.limits.validate().map_err(SandboxError::InvalidConfig)
         }
     }
 
-    fn child_mut(&mut self) -> &mut Child {
-        self.child.as_mut().expect("sandbox child present")
+    #[derive(Debug)]
+    pub struct SandboxInput {
+        pub bytes: Vec<u8>,
+        pub canonical_extension: String,
     }
 
-    fn set_pid1(&mut self, pid1_host_pid: u32) {
-        self.pid1_host_pid = Some(pid1_host_pid);
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum SandboxExit {
+        Success,
+        Exit(i32),
+        Signaled(i32),
+        TimedOut,
+        Cancelled,
     }
 
-    fn disarm(&mut self) {
-        self.child = None;
+    impl SandboxExit {
+        pub const fn success(self) -> bool {
+            matches!(self, Self::Success)
+        }
     }
 
-    fn kill_and_reap(&mut self) -> io::Result<()> {
-        let Some(child) = self.child.as_mut() else {
-            return Ok(());
+    #[derive(Debug)]
+    pub struct SandboxOutput {
+        pub exit: SandboxExit,
+        pub stdout: Vec<u8>,
+        pub stderr: Vec<u8>,
+        pub stdout_truncated: bool,
+        pub stderr_truncated: bool,
+        /// Host PID of PID namespace init. It is gone after timeout/cancel cleanup.
+        pub pid1_host_pid: Option<u32>,
+        /// Path retained for tests/evidence; RAII cleanup has removed it by return.
+        pub workspace_path: PathBuf,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum SandboxError {
+        #[error("sandbox configuration is invalid: {0}")]
+        InvalidConfig(String),
+        #[error("sandbox isolation is unavailable")]
+        IsolationUnavailable,
+        #[error("sandbox io failed")]
+        Io(#[from] io::Error),
+    }
+
+    #[derive(Clone, Debug, Default)]
+    pub struct SandboxCancel {
+        cancelled: Arc<AtomicBool>,
+    }
+
+    impl SandboxCancel {
+        pub fn cancel(&self) {
+            self.cancelled.store(true, Ordering::SeqCst);
+        }
+
+        pub fn is_cancelled(&self) -> bool {
+            self.cancelled.load(Ordering::SeqCst)
+        }
+    }
+
+    /// Probe isolation support with a tiny command. Workers call this at startup and
+    /// tests use it to skip only when the kernel truly lacks unprivileged isolation.
+    pub fn preflight() -> Result<(), SandboxError> {
+        let config = SandboxConfig {
+            argv_template: vec!["/bin/true".into(), INPUT_PLACEHOLDER.into()],
+            limits: ResourceLimits {
+                wall_timeout: Duration::from_secs(5),
+                memory_bytes: 64 * 1024 * 1024,
+                cpu_seconds: 2,
+                file_size_bytes: 1024 * 1024,
+                max_processes: 512,
+                max_open_files: 32,
+                stdout_stderr_bytes: 1024 * 1024,
+            },
         };
-        kill_and_reap_child(child, self.pid1_host_pid, self.wrapper_pid)?;
-        self.child = None;
-        Ok(())
-    }
-}
-
-impl Drop for SandboxSupervisor {
-    fn drop(&mut self) {
-        let _ = self.kill_and_reap();
-    }
-}
-
-fn kill_and_reap_child(
-    child: &mut Child,
-    pid1_host_pid: Option<u32>,
-    wrapper_pid: libc::pid_t,
-) -> io::Result<()> {
-    if let Some(pid1) = pid1_host_pid {
-        unsafe {
-            let _ = libc::kill(pid1 as libc::pid_t, libc::SIGKILL);
+        let output = run(
+            &config,
+            SandboxInput {
+                bytes: Vec::new(),
+                canonical_extension: "txt".into(),
+            },
+            &SandboxCancel::default(),
+        )?;
+        if output.exit.success() {
+            Ok(())
+        } else {
+            Err(SandboxError::IsolationUnavailable)
         }
     }
-    if reap_child_bounded(child, KILL_REAP_GRACE).is_ok() {
-        return Ok(());
-    }
-    unsafe {
-        let _ = libc::kill(wrapper_pid, libc::SIGKILL);
-    }
-    if reap_child_bounded(child, KILL_REAP_GRACE).is_ok() {
-        return Ok(());
-    }
-    if let Some(pid1) = pid1_host_pid {
-        unsafe {
-            let _ = libc::kill(pid1 as libc::pid_t, libc::SIGKILL);
-        }
-    }
-    unsafe {
-        let _ = libc::kill(wrapper_pid, libc::SIGKILL);
-    }
-    reap_child_bounded(child, KILL_REAP_GRACE)
-}
 
-struct PreExecConfig {
-    limits: ResourceLimits,
-    pid_read_fd: RawFd,
-    pid_write_fd: RawFd,
-    uid_map: Vec<u8>,
-    gid_map: Vec<u8>,
-    setgroups: CString,
-    uid_map_path: CString,
-    gid_map_path: CString,
-    root_path: CString,
-    landlock_allow: Vec<(CString, u64)>,
-}
-
-impl PreExecConfig {
-    fn new(
+    pub fn run(
         config: &SandboxConfig,
-        workspace: &Path,
-        executable: &str,
-        pid_read_fd: RawFd,
-        pid_write_fd: RawFd,
-    ) -> io::Result<Self> {
-        let workspace = CString::new(path_to_bytes(workspace)?)?;
-        let uid = unsafe { libc::getuid() };
-        let gid = unsafe { libc::getgid() };
-        let executable_path = CString::new(path_to_bytes(Path::new(executable))?)?;
-        let landlock_allow = vec![
-            (workspace.clone(), LANDLOCK_ACCESS_FS_ALL_V1),
-            (executable_path, LANDLOCK_ACCESS_FS_EXEC_FILE),
-            (cstring_path("/lib")?, LANDLOCK_ACCESS_FS_READ_EXECUTE),
-            (cstring_path("/lib64")?, LANDLOCK_ACCESS_FS_READ_EXECUTE),
-            (cstring_path("/usr/lib")?, LANDLOCK_ACCESS_FS_READ_EXECUTE),
-            (cstring_path("/usr/lib64")?, LANDLOCK_ACCESS_FS_READ_EXECUTE),
-            (cstring_path("/etc/ld.so.cache")?, ACCESS_FS_READ_FILE),
-        ];
-        Ok(Self {
-            limits: config.limits.clone(),
+        input: SandboxInput,
+        cancel: &SandboxCancel,
+    ) -> Result<SandboxOutput, SandboxError> {
+        config.validate()?;
+        let workspace = TempDir::new()?;
+        let workspace_path = workspace.path().to_path_buf();
+        let input_name = safe_input_name(&input.canonical_extension)?;
+        let input_path = workspace.path().join(input_name);
+        {
+            let mut file = File::create(&input_path)?;
+            file.write_all(&input.bytes)?;
+            file.sync_all()?;
+        }
+
+        let argv = materialize_argv(&config.argv_template, &input_path)?;
+        let executable = argv
+            .first()
+            .ok_or_else(|| SandboxError::InvalidConfig("converter argv is empty".into()))?;
+        let (pid_read_fd, pid_write_fd) = pipe_cloexec()?;
+        let pre_exec = PreExecConfig::new(
+            config,
+            workspace.path(),
+            executable,
             pid_read_fd,
             pid_write_fd,
-            uid_map: format!("0 {uid} 1\n").into_bytes(),
-            gid_map: format!("0 {gid} 1\n").into_bytes(),
-            setgroups: cstring_path("/proc/self/setgroups")?,
-            uid_map_path: cstring_path("/proc/self/uid_map")?,
-            gid_map_path: cstring_path("/proc/self/gid_map")?,
-            root_path: cstring_path("/")?,
-            landlock_allow,
+        )?;
+
+        let mut command = Command::new(executable);
+        command
+            .args(&argv[1..])
+            .current_dir(workspace.path())
+            .env_clear()
+            .env("PATH", "/usr/bin:/bin")
+            .env("LC_ALL", "C")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        unsafe {
+            command.pre_exec(move || pre_exec.apply());
+        }
+
+        let child = match command.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                close_fd(pid_read_fd);
+                close_fd(pid_write_fd);
+                return Err(error.into());
+            }
+        };
+        close_fd(pid_write_fd);
+        let child_pid = child.id() as libc::pid_t;
+        let mut supervisor = SandboxSupervisor::new(child, child_pid);
+        let pid1_host_pid = match read_pid_from_pipe(pid_read_fd) {
+            Ok(Some(pid)) => pid,
+            Ok(None) => {
+                close_fd(pid_read_fd);
+                return Err(SandboxError::IsolationUnavailable);
+            }
+            Err(error) => {
+                close_fd(pid_read_fd);
+                return Err(SandboxError::Io(error));
+            }
+        };
+        supervisor.set_pid1(pid1_host_pid);
+        close_fd(pid_read_fd);
+        let cgroup_guard = CgroupGuard::best_effort_apply(pid1_host_pid, &config.limits);
+        let stdout = supervisor.child_mut().stdout.take().expect("stdout piped");
+        let stderr = supervisor.child_mut().stderr.take().expect("stderr piped");
+        set_nonblocking(stdout.as_raw_fd())?;
+        set_nonblocking(stderr.as_raw_fd())?;
+        let mut stdout_capture = CapturedPipe::new(config.limits.stdout_stderr_bytes);
+        let mut stderr_capture = CapturedPipe::new(config.limits.stdout_stderr_bytes);
+
+        let deadline = Instant::now() + config.limits.wall_timeout;
+        let exit = loop {
+            drain_available(stdout.as_raw_fd(), &mut stdout_capture)?;
+            drain_available(stderr.as_raw_fd(), &mut stderr_capture)?;
+            if let Some(status) = supervisor.child_mut().try_wait()? {
+                supervisor.disarm();
+                break exit_from_status(status);
+            }
+            if cancel.is_cancelled() {
+                supervisor.kill_and_reap()?;
+                break SandboxExit::Cancelled;
+            }
+            if Instant::now() >= deadline {
+                supervisor.kill_and_reap()?;
+                break SandboxExit::TimedOut;
+            }
+            std::thread::sleep(POLL_INTERVAL);
+        };
+
+        let drain_deadline = Instant::now() + DRAIN_GRACE;
+        while Instant::now() < drain_deadline && (!stdout_capture.eof || !stderr_capture.eof) {
+            drain_available(stdout.as_raw_fd(), &mut stdout_capture)?;
+            drain_available(stderr.as_raw_fd(), &mut stderr_capture)?;
+            if stdout_capture.eof && stderr_capture.eof {
+                break;
+            }
+            std::thread::sleep(POLL_INTERVAL);
+        }
+        if !stdout_capture.eof {
+            stdout_capture.truncated = true;
+        }
+        if !stderr_capture.eof {
+            stderr_capture.truncated = true;
+        }
+        drop(cgroup_guard);
+        drop(workspace);
+        Ok(SandboxOutput {
+            exit,
+            stdout: stdout_capture.bytes,
+            stderr: stderr_capture.bytes,
+            stdout_truncated: stdout_capture.truncated,
+            stderr_truncated: stderr_capture.truncated,
+            pid1_host_pid: Some(pid1_host_pid),
+            workspace_path,
         })
     }
 
-    fn apply(&self) -> io::Result<()> {
-        unsafe {
-            if libc::setsid() < 0 {
-                return Err(io::Error::last_os_error());
-            }
-        }
-        apply_rlimit(libc::RLIMIT_AS, self.limits.memory_bytes)?;
-        apply_rlimit(libc::RLIMIT_CPU, self.limits.cpu_seconds)?;
-        apply_rlimit(libc::RLIMIT_FSIZE, self.limits.file_size_bytes)?;
-        apply_rlimit(libc::RLIMIT_CORE, 0)?;
-        self.unshare_user_and_network()?;
-        self.apply_landlock()?;
-        apply_rlimit(libc::RLIMIT_NOFILE, self.limits.max_open_files)?;
-        self.enter_pid_namespace()?;
-        Ok(())
+    fn materialize_argv(
+        template: &[String],
+        input_path: &Path,
+    ) -> Result<Vec<String>, SandboxError> {
+        let input = input_path
+            .to_str()
+            .ok_or_else(|| SandboxError::InvalidConfig("input path is not UTF-8".into()))?;
+        Ok(template
+            .iter()
+            .map(|arg| arg.replace(INPUT_PLACEHOLDER, input))
+            .collect())
     }
 
-    fn unshare_user_and_network(&self) -> io::Result<()> {
-        unsafe {
-            if libc::unshare(libc::CLONE_NEWUSER) < 0 {
-                return Err(io::Error::last_os_error());
-            }
+    fn safe_input_name(extension: &str) -> Result<String, SandboxError> {
+        let ext = extension.trim_start_matches('.').to_ascii_lowercase();
+        if ext.is_empty()
+            || ext.len() > 16
+            || !ext
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        {
+            return Err(SandboxError::InvalidConfig(
+                "canonical extension is invalid".into(),
+            ));
         }
-        write_all_raw(&self.setgroups, b"deny\n")?;
-        write_all_raw(&self.uid_map_path, &self.uid_map)?;
-        write_all_raw(&self.gid_map_path, &self.gid_map)?;
-        unsafe {
-            if libc::unshare(libc::CLONE_NEWNET) < 0 {
-                return Err(io::Error::last_os_error());
-            }
-            if libc::unshare(libc::CLONE_NEWNS) < 0 {
-                return Err(io::Error::last_os_error());
-            }
-            if libc::mount(
-                std::ptr::null(),
-                self.root_path.as_ptr(),
-                std::ptr::null(),
-                (libc::MS_REC | libc::MS_PRIVATE) as libc::c_ulong,
-                std::ptr::null(),
-            ) < 0
-            {
-                return Err(io::Error::last_os_error());
-            }
-        }
-        Ok(())
+        Ok(format!("input.{ext}"))
     }
 
-    fn enter_pid_namespace(&self) -> io::Result<()> {
-        unsafe {
-            if libc::unshare(libc::CLONE_NEWPID) < 0 {
-                return Err(io::Error::last_os_error());
+    struct CapturedPipe {
+        bytes: Vec<u8>,
+        limit: usize,
+        truncated: bool,
+        eof: bool,
+    }
+
+    impl CapturedPipe {
+        fn new(limit: usize) -> Self {
+            Self {
+                bytes: Vec::with_capacity(limit.min(8192)),
+                limit,
+                truncated: false,
+                eof: false,
             }
-            let pid = libc::fork();
-            if pid < 0 {
-                return Err(io::Error::last_os_error());
+        }
+
+        fn capacity_remaining(&self) -> usize {
+            self.limit.saturating_sub(self.bytes.len())
+        }
+    }
+
+    fn drain_available(fd: RawFd, capture: &mut CapturedPipe) -> io::Result<()> {
+        let mut buf = [0_u8; 8192];
+        loop {
+            let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast::<libc::c_void>(), buf.len()) };
+            if n < 0 {
+                let error = io::Error::last_os_error();
+                if matches!(
+                    error.raw_os_error(),
+                    Some(code) if code == libc::EAGAIN || code == libc::EWOULDBLOCK
+                ) {
+                    return Ok(());
+                }
+                if error.raw_os_error() == Some(libc::EINTR) {
+                    continue;
+                }
+                return Err(error);
             }
-            if pid == 0 {
-                let _ = libc::close(self.pid_read_fd);
-                let _ = libc::close(self.pid_write_fd);
-                apply_rlimit(libc::RLIMIT_NPROC, self.limits.max_processes)?;
-                close_fds_from(3);
+            if n == 0 {
+                capture.eof = true;
                 return Ok(());
             }
+            let n = n as usize;
+            let allowed = capture.capacity_remaining().min(n);
+            if allowed > 0 {
+                capture.bytes.extend_from_slice(&buf[..allowed]);
+            }
+            if allowed < n {
+                capture.truncated = true;
+            }
+        }
+    }
 
-            let _ = libc::close(self.pid_read_fd);
-            if !write_all_fd_raw(self.pid_write_fd, &(pid as u32).to_ne_bytes()) {
-                let _ = libc::kill(pid, libc::SIGKILL);
+    fn exit_from_status(status: std::process::ExitStatus) -> SandboxExit {
+        if status.success() {
+            SandboxExit::Success
+        } else if let Some(code) = status.code() {
+            SandboxExit::Exit(code)
+        } else if let Some(signal) = status.signal() {
+            SandboxExit::Signaled(signal)
+        } else {
+            SandboxExit::Exit(-1)
+        }
+    }
+
+    fn reap_child_bounded(child: &mut Child, grace: Duration) -> io::Result<()> {
+        let deadline = Instant::now() + grace;
+        loop {
+            if child.try_wait()?.is_some() {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "sandbox child did not reap after kill",
+                ));
+            }
+            std::thread::sleep(POLL_INTERVAL);
+        }
+    }
+
+    struct SandboxSupervisor {
+        child: Option<Child>,
+        wrapper_pid: libc::pid_t,
+        pid1_host_pid: Option<u32>,
+    }
+
+    impl SandboxSupervisor {
+        fn new(child: Child, wrapper_pid: libc::pid_t) -> Self {
+            Self {
+                child: Some(child),
+                wrapper_pid,
+                pid1_host_pid: None,
+            }
+        }
+
+        fn child_mut(&mut self) -> &mut Child {
+            self.child.as_mut().expect("sandbox child present")
+        }
+
+        fn set_pid1(&mut self, pid1_host_pid: u32) {
+            self.pid1_host_pid = Some(pid1_host_pid);
+        }
+
+        fn disarm(&mut self) {
+            self.child = None;
+        }
+
+        fn kill_and_reap(&mut self) -> io::Result<()> {
+            let Some(child) = self.child.as_mut() else {
+                return Ok(());
+            };
+            kill_and_reap_child(child, self.pid1_host_pid, self.wrapper_pid)?;
+            self.child = None;
+            Ok(())
+        }
+    }
+
+    impl Drop for SandboxSupervisor {
+        fn drop(&mut self) {
+            let _ = self.kill_and_reap();
+        }
+    }
+
+    fn kill_and_reap_child(
+        child: &mut Child,
+        pid1_host_pid: Option<u32>,
+        wrapper_pid: libc::pid_t,
+    ) -> io::Result<()> {
+        if let Some(pid1) = pid1_host_pid {
+            unsafe {
+                let _ = libc::kill(pid1 as libc::pid_t, libc::SIGKILL);
+            }
+        }
+        if reap_child_bounded(child, KILL_REAP_GRACE).is_ok() {
+            return Ok(());
+        }
+        unsafe {
+            let _ = libc::kill(wrapper_pid, libc::SIGKILL);
+        }
+        if reap_child_bounded(child, KILL_REAP_GRACE).is_ok() {
+            return Ok(());
+        }
+        if let Some(pid1) = pid1_host_pid {
+            unsafe {
+                let _ = libc::kill(pid1 as libc::pid_t, libc::SIGKILL);
+            }
+        }
+        unsafe {
+            let _ = libc::kill(wrapper_pid, libc::SIGKILL);
+        }
+        reap_child_bounded(child, KILL_REAP_GRACE)
+    }
+
+    struct PreExecConfig {
+        limits: ResourceLimits,
+        pid_read_fd: RawFd,
+        pid_write_fd: RawFd,
+        uid_map: Vec<u8>,
+        gid_map: Vec<u8>,
+        setgroups: CString,
+        uid_map_path: CString,
+        gid_map_path: CString,
+        root_path: CString,
+        landlock_allow: Vec<(CString, u64)>,
+    }
+
+    impl PreExecConfig {
+        fn new(
+            config: &SandboxConfig,
+            workspace: &Path,
+            executable: &str,
+            pid_read_fd: RawFd,
+            pid_write_fd: RawFd,
+        ) -> io::Result<Self> {
+            let workspace = CString::new(path_to_bytes(workspace)?)?;
+            let uid = unsafe { libc::getuid() };
+            let gid = unsafe { libc::getgid() };
+            let executable_path = CString::new(path_to_bytes(Path::new(executable))?)?;
+            let landlock_allow = vec![
+                (workspace.clone(), LANDLOCK_ACCESS_FS_ALL_V1),
+                (executable_path, LANDLOCK_ACCESS_FS_EXEC_FILE),
+                (cstring_path("/lib")?, LANDLOCK_ACCESS_FS_READ_EXECUTE),
+                (cstring_path("/lib64")?, LANDLOCK_ACCESS_FS_READ_EXECUTE),
+                (cstring_path("/usr/lib")?, LANDLOCK_ACCESS_FS_READ_EXECUTE),
+                (cstring_path("/usr/lib64")?, LANDLOCK_ACCESS_FS_READ_EXECUTE),
+                (cstring_path("/etc/ld.so.cache")?, ACCESS_FS_READ_FILE),
+            ];
+            Ok(Self {
+                limits: config.limits.clone(),
+                pid_read_fd,
+                pid_write_fd,
+                uid_map: format!("0 {uid} 1\n").into_bytes(),
+                gid_map: format!("0 {gid} 1\n").into_bytes(),
+                setgroups: cstring_path("/proc/self/setgroups")?,
+                uid_map_path: cstring_path("/proc/self/uid_map")?,
+                gid_map_path: cstring_path("/proc/self/gid_map")?,
+                root_path: cstring_path("/")?,
+                landlock_allow,
+            })
+        }
+
+        fn apply(&self) -> io::Result<()> {
+            unsafe {
+                if libc::setsid() < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+            apply_rlimit(libc::RLIMIT_AS, self.limits.memory_bytes)?;
+            apply_rlimit(libc::RLIMIT_CPU, self.limits.cpu_seconds)?;
+            apply_rlimit(libc::RLIMIT_FSIZE, self.limits.file_size_bytes)?;
+            apply_rlimit(libc::RLIMIT_CORE, 0)?;
+            self.unshare_user_and_network()?;
+            self.apply_landlock()?;
+            apply_rlimit(libc::RLIMIT_NOFILE, self.limits.max_open_files)?;
+            self.enter_pid_namespace()?;
+            Ok(())
+        }
+
+        fn unshare_user_and_network(&self) -> io::Result<()> {
+            unsafe {
+                if libc::unshare(libc::CLONE_NEWUSER) < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+            write_all_raw(&self.setgroups, b"deny\n")?;
+            write_all_raw(&self.uid_map_path, &self.uid_map)?;
+            write_all_raw(&self.gid_map_path, &self.gid_map)?;
+            unsafe {
+                if libc::unshare(libc::CLONE_NEWNET) < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if libc::unshare(libc::CLONE_NEWNS) < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if libc::mount(
+                    std::ptr::null(),
+                    self.root_path.as_ptr(),
+                    std::ptr::null(),
+                    (libc::MS_REC | libc::MS_PRIVATE) as libc::c_ulong,
+                    std::ptr::null(),
+                ) < 0
+                {
+                    return Err(io::Error::last_os_error());
+                }
+            }
+            Ok(())
+        }
+
+        fn enter_pid_namespace(&self) -> io::Result<()> {
+            unsafe {
+                if libc::unshare(libc::CLONE_NEWPID) < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                let pid = libc::fork();
+                if pid < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if pid == 0 {
+                    let _ = libc::close(self.pid_read_fd);
+                    let _ = libc::close(self.pid_write_fd);
+                    apply_rlimit(libc::RLIMIT_NPROC, self.limits.max_processes)?;
+                    close_fds_from(3);
+                    return Ok(());
+                }
+
+                let _ = libc::close(self.pid_read_fd);
+                if !write_all_fd_raw(self.pid_write_fd, &(pid as u32).to_ne_bytes()) {
+                    let _ = libc::kill(pid, libc::SIGKILL);
+                    let mut status: libc::c_int = 0;
+                    loop {
+                        if libc::waitpid(pid, &mut status, 0) >= 0 {
+                            break;
+                        }
+                        if errno_raw() != libc::EINTR {
+                            break;
+                        }
+                    }
+                    let _ = libc::close(self.pid_write_fd);
+                    libc::_exit(127);
+                }
+                let _ = libc::close(self.pid_write_fd);
+                close_fds_from(3);
+
                 let mut status: libc::c_int = 0;
                 loop {
                     if libc::waitpid(pid, &mut status, 0) >= 0 {
                         break;
                     }
                     if errno_raw() != libc::EINTR {
-                        break;
+                        libc::_exit(127);
                     }
                 }
-                let _ = libc::close(self.pid_write_fd);
+                if libc::WIFEXITED(status) {
+                    libc::_exit(libc::WEXITSTATUS(status));
+                }
+                if libc::WIFSIGNALED(status) {
+                    libc::_exit(128 + libc::WTERMSIG(status));
+                }
                 libc::_exit(127);
             }
-            let _ = libc::close(self.pid_write_fd);
-            close_fds_from(3);
+        }
 
-            let mut status: libc::c_int = 0;
-            loop {
-                if libc::waitpid(pid, &mut status, 0) >= 0 {
-                    break;
+        fn apply_landlock(&self) -> io::Result<()> {
+            unsafe {
+                let abi = libc::syscall(
+                    libc::SYS_landlock_create_ruleset,
+                    std::ptr::null::<libc::c_void>(),
+                    0,
+                    LANDLOCK_CREATE_RULESET_VERSION,
+                );
+                if abi < 1 {
+                    return Err(io::Error::last_os_error());
                 }
-                if errno_raw() != libc::EINTR {
-                    libc::_exit(127);
+                let ruleset_attr = LandlockRulesetAttr {
+                    handled_access_fs: LANDLOCK_ACCESS_FS_ALL_V1,
+                };
+                let ruleset_fd = libc::syscall(
+                    libc::SYS_landlock_create_ruleset,
+                    &ruleset_attr as *const LandlockRulesetAttr,
+                    std::mem::size_of::<LandlockRulesetAttr>(),
+                    0,
+                ) as RawFd;
+                if ruleset_fd < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                for (path, access) in &self.landlock_allow {
+                    let fd = libc::open(path.as_ptr(), libc::O_PATH | libc::O_CLOEXEC);
+                    if fd < 0 {
+                        if io::Error::last_os_error().kind() == io::ErrorKind::NotFound {
+                            continue;
+                        }
+                        let error = io::Error::last_os_error();
+                        let _ = libc::close(ruleset_fd);
+                        return Err(error);
+                    }
+                    let rule = LandlockPathBeneathAttr {
+                        allowed_access: *access,
+                        parent_fd: fd,
+                    };
+                    let add_result = libc::syscall(
+                        libc::SYS_landlock_add_rule,
+                        ruleset_fd,
+                        LANDLOCK_RULE_PATH_BENEATH,
+                        &rule as *const LandlockPathBeneathAttr,
+                        0,
+                    );
+                    let close_result = libc::close(fd);
+                    if add_result < 0 {
+                        let error = io::Error::last_os_error();
+                        let _ = libc::close(ruleset_fd);
+                        return Err(error);
+                    }
+                    if close_result < 0 {
+                        let error = io::Error::last_os_error();
+                        let _ = libc::close(ruleset_fd);
+                        return Err(error);
+                    }
+                }
+                if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0 {
+                    let error = io::Error::last_os_error();
+                    let _ = libc::close(ruleset_fd);
+                    return Err(error);
+                }
+                let restrict_result =
+                    libc::syscall(libc::SYS_landlock_restrict_self, ruleset_fd, 0);
+                let close_result = libc::close(ruleset_fd);
+                if restrict_result < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                if close_result < 0 {
+                    return Err(io::Error::last_os_error());
                 }
             }
-            if libc::WIFEXITED(status) {
-                libc::_exit(libc::WEXITSTATUS(status));
-            }
-            if libc::WIFSIGNALED(status) {
-                libc::_exit(128 + libc::WTERMSIG(status));
-            }
-            libc::_exit(127);
+            Ok(())
         }
     }
 
-    fn apply_landlock(&self) -> io::Result<()> {
+    fn apply_rlimit(resource: libc::__rlimit_resource_t, value: u64) -> io::Result<()> {
+        let limit = libc::rlimit {
+            rlim_cur: value as libc::rlim_t,
+            rlim_max: value as libc::rlim_t,
+        };
         unsafe {
-            let abi = libc::syscall(
-                libc::SYS_landlock_create_ruleset,
-                std::ptr::null::<libc::c_void>(),
-                0,
-                LANDLOCK_CREATE_RULESET_VERSION,
-            );
-            if abi < 1 {
-                return Err(io::Error::last_os_error());
+            if libc::setrlimit(resource, &limit) < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
             }
-            let ruleset_attr = LandlockRulesetAttr {
-                handled_access_fs: LANDLOCK_ACCESS_FS_ALL_V1,
+        }
+    }
+
+    fn pipe_cloexec() -> io::Result<(RawFd, RawFd)> {
+        let mut fds = [0; 2];
+        unsafe {
+            if libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok((fds[0], fds[1]))
+            }
+        }
+    }
+
+    fn close_fd(fd: RawFd) {
+        unsafe {
+            let _ = libc::close(fd);
+        }
+    }
+
+    fn read_pid_from_pipe(fd: RawFd) -> io::Result<Option<u32>> {
+        let mut bytes = [0_u8; 4];
+        let mut read = 0;
+        while read < bytes.len() {
+            let n = unsafe {
+                libc::read(
+                    fd,
+                    bytes[read..].as_mut_ptr().cast::<libc::c_void>(),
+                    bytes.len() - read,
+                )
             };
-            let ruleset_fd = libc::syscall(
-                libc::SYS_landlock_create_ruleset,
-                &ruleset_attr as *const LandlockRulesetAttr,
-                std::mem::size_of::<LandlockRulesetAttr>(),
-                0,
-            ) as RawFd;
-            if ruleset_fd < 0 {
-                return Err(io::Error::last_os_error());
-            }
-            for (path, access) in &self.landlock_allow {
-                let fd = libc::open(path.as_ptr(), libc::O_PATH | libc::O_CLOEXEC);
-                if fd < 0 {
-                    if io::Error::last_os_error().kind() == io::ErrorKind::NotFound {
-                        continue;
-                    }
-                    let error = io::Error::last_os_error();
-                    let _ = libc::close(ruleset_fd);
-                    return Err(error);
-                }
-                let rule = LandlockPathBeneathAttr {
-                    allowed_access: *access,
-                    parent_fd: fd,
-                };
-                let add_result = libc::syscall(
-                    libc::SYS_landlock_add_rule,
-                    ruleset_fd,
-                    LANDLOCK_RULE_PATH_BENEATH,
-                    &rule as *const LandlockPathBeneathAttr,
-                    0,
-                );
-                let close_result = libc::close(fd);
-                if add_result < 0 {
-                    let error = io::Error::last_os_error();
-                    let _ = libc::close(ruleset_fd);
-                    return Err(error);
-                }
-                if close_result < 0 {
-                    let error = io::Error::last_os_error();
-                    let _ = libc::close(ruleset_fd);
-                    return Err(error);
-                }
-            }
-            if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0 {
+            if n < 0 {
                 let error = io::Error::last_os_error();
-                let _ = libc::close(ruleset_fd);
+                if error.raw_os_error() == Some(libc::EINTR) {
+                    continue;
+                }
                 return Err(error);
             }
-            let restrict_result = libc::syscall(libc::SYS_landlock_restrict_self, ruleset_fd, 0);
-            let close_result = libc::close(ruleset_fd);
-            if restrict_result < 0 {
+            if n == 0 {
+                return Ok(None);
+            }
+            read += n as usize;
+        }
+        Ok(Some(u32::from_ne_bytes(bytes)))
+    }
+
+    fn set_nonblocking(fd: RawFd) -> io::Result<()> {
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFL);
+            if flags < 0 {
                 return Err(io::Error::last_os_error());
             }
-            if close_result < 0 {
+            if libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
                 return Err(io::Error::last_os_error());
             }
         }
         Ok(())
     }
-}
 
-fn apply_rlimit(resource: libc::__rlimit_resource_t, value: u64) -> io::Result<()> {
-    let limit = libc::rlimit {
-        rlim_cur: value as libc::rlim_t,
-        rlim_max: value as libc::rlim_t,
-    };
-    unsafe {
-        if libc::setrlimit(resource, &limit) < 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(())
-        }
-    }
-}
-
-fn pipe_cloexec() -> io::Result<(RawFd, RawFd)> {
-    let mut fds = [0; 2];
-    unsafe {
-        if libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) < 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok((fds[0], fds[1]))
-        }
-    }
-}
-
-fn close_fd(fd: RawFd) {
-    unsafe {
-        let _ = libc::close(fd);
-    }
-}
-
-fn read_pid_from_pipe(fd: RawFd) -> io::Result<Option<u32>> {
-    let mut bytes = [0_u8; 4];
-    let mut read = 0;
-    while read < bytes.len() {
-        let n = unsafe {
-            libc::read(
-                fd,
-                bytes[read..].as_mut_ptr().cast::<libc::c_void>(),
-                bytes.len() - read,
-            )
-        };
-        if n < 0 {
-            let error = io::Error::last_os_error();
-            if error.raw_os_error() == Some(libc::EINTR) {
-                continue;
-            }
-            return Err(error);
-        }
-        if n == 0 {
-            return Ok(None);
-        }
-        read += n as usize;
-    }
-    Ok(Some(u32::from_ne_bytes(bytes)))
-}
-
-fn set_nonblocking(fd: RawFd) -> io::Result<()> {
-    unsafe {
-        let flags = libc::fcntl(fd, libc::F_GETFL);
-        if flags < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        if libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
-            return Err(io::Error::last_os_error());
-        }
-    }
-    Ok(())
-}
-
-fn write_all_fd_raw(fd: RawFd, bytes: &[u8]) -> bool {
-    let mut written = 0;
-    while written < bytes.len() {
-        let n = unsafe {
-            libc::write(
-                fd,
-                bytes[written..].as_ptr().cast::<libc::c_void>(),
-                bytes.len() - written,
-            )
-        };
-        if n < 0 {
-            if errno_raw() == libc::EINTR {
-                continue;
-            }
-            return false;
-        }
-        written += n as usize;
-    }
-    true
-}
-
-fn errno_raw() -> libc::c_int {
-    unsafe { *libc::__errno_location() }
-}
-
-fn close_fds_from(first: RawFd) {
-    unsafe {
-        #[cfg(target_os = "linux")]
-        {
-            let result = libc::syscall(libc::SYS_close_range, first as libc::c_uint, !0_u32, 0_u32);
-            if result == 0 {
-                return;
-            }
-        }
-        let mut limit = libc::rlimit {
-            rlim_cur: 0,
-            rlim_max: 0,
-        };
-        let max = if libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) == 0 {
-            limit.rlim_cur.min(4096) as RawFd
-        } else {
-            1024
-        };
-        for fd in first..max {
-            let _ = libc::close(fd);
-        }
-    }
-}
-
-struct CgroupGuard {
-    path: Option<PathBuf>,
-}
-
-impl CgroupGuard {
-    // TODO(F02): cgroup v2 aggregate limits via container runtime. This best-effort
-    // hook only activates when a writable delegated subtree exists.
-    fn best_effort_apply(pid: u32, limits: &ResourceLimits) -> Self {
-        match Self::try_apply(pid, limits) {
-            Ok(path) => Self { path: Some(path) },
-            Err(_) => Self { path: None },
-        }
-    }
-
-    fn try_apply(pid: u32, limits: &ResourceLimits) -> io::Result<PathBuf> {
-        let root = Path::new("/sys/fs/cgroup");
-        if !root.join("cgroup.controllers").exists() {
-            return Err(io::Error::new(io::ErrorKind::NotFound, "cgroup v2 missing"));
-        }
-        let path = root.join(format!("markhand-convert-{pid}"));
-        fs::create_dir(&path)?;
-        fs::write(path.join("memory.max"), limits.memory_bytes.to_string())?;
-        fs::write(path.join("pids.max"), limits.max_processes.to_string())?;
-        fs::write(path.join("cgroup.procs"), pid.to_string())?;
-        Ok(path)
-    }
-}
-
-impl Drop for CgroupGuard {
-    fn drop(&mut self) {
-        if let Some(path) = self.path.take() {
-            let _ = fs::remove_dir(path);
-        }
-    }
-}
-
-fn write_all_raw(path: &CString, bytes: &[u8]) -> io::Result<()> {
-    unsafe {
-        let fd = libc::open(
-            path.as_ptr(),
-            libc::O_WRONLY | libc::O_CLOEXEC | libc::O_TRUNC,
-        );
-        if fd < 0 {
-            return Err(io::Error::last_os_error());
-        }
+    fn write_all_fd_raw(fd: RawFd, bytes: &[u8]) -> bool {
         let mut written = 0;
         while written < bytes.len() {
-            let n = libc::write(
-                fd,
-                bytes[written..].as_ptr().cast::<libc::c_void>(),
-                bytes.len() - written,
-            );
+            let n = unsafe {
+                libc::write(
+                    fd,
+                    bytes[written..].as_ptr().cast::<libc::c_void>(),
+                    bytes.len() - written,
+                )
+            };
             if n < 0 {
-                let error = io::Error::last_os_error();
-                let _ = libc::close(fd);
-                return Err(error);
+                if errno_raw() == libc::EINTR {
+                    continue;
+                }
+                return false;
             }
             written += n as usize;
         }
-        if libc::close(fd) < 0 {
-            return Err(io::Error::last_os_error());
-        }
+        true
     }
-    Ok(())
-}
 
-fn cstring_path(path: &str) -> io::Result<CString> {
-    CString::new(path).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "nul path"))
-}
-
-fn path_to_bytes(path: &Path) -> io::Result<Vec<u8>> {
-    use std::os::unix::ffi::OsStrExt;
-    let bytes = path.as_os_str().as_bytes();
-    if bytes.contains(&0) {
-        Err(io::Error::new(io::ErrorKind::InvalidInput, "nul path"))
-    } else {
-        Ok(bytes.to_vec())
+    fn errno_raw() -> libc::c_int {
+        unsafe { *libc::__errno_location() }
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn shell_config(script: &str, timeout: Duration) -> SandboxConfig {
-        SandboxConfig {
-            argv_template: vec![
-                "/bin/sh".into(),
-                "-c".into(),
-                script.into(),
-                "sh".into(),
-                INPUT_PLACEHOLDER.into(),
-            ],
-            limits: ResourceLimits {
-                wall_timeout: timeout,
-                memory_bytes: 128 * 1024 * 1024,
-                cpu_seconds: 5,
-                file_size_bytes: 1024 * 1024,
-                max_processes: 32,
-                max_open_files: 32,
-                stdout_stderr_bytes: 1024 * 1024,
-            },
+    fn close_fds_from(first: RawFd) {
+        unsafe {
+            #[cfg(target_os = "linux")]
+            {
+                let result =
+                    libc::syscall(libc::SYS_close_range, first as libc::c_uint, !0_u32, 0_u32);
+                if result == 0 {
+                    return;
+                }
+            }
+            let mut limit = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            let max = if libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) == 0 {
+                limit.rlim_cur.min(4096) as RawFd
+            } else {
+                1024
+            };
+            for fd in first..max {
+                let _ = libc::close(fd);
+            }
         }
     }
 
-    fn input() -> SandboxInput {
-        SandboxInput {
-            bytes: b"hello".to_vec(),
-            canonical_extension: "txt".into(),
+    struct CgroupGuard {
+        path: Option<PathBuf>,
+    }
+
+    impl CgroupGuard {
+        // TODO(F02): cgroup v2 aggregate limits via container runtime. This best-effort
+        // hook only activates when a writable delegated subtree exists.
+        fn best_effort_apply(pid: u32, limits: &ResourceLimits) -> Self {
+            match Self::try_apply(pid, limits) {
+                Ok(path) => Self { path: Some(path) },
+                Err(_) => Self { path: None },
+            }
+        }
+
+        fn try_apply(pid: u32, limits: &ResourceLimits) -> io::Result<PathBuf> {
+            let root = Path::new("/sys/fs/cgroup");
+            if !root.join("cgroup.controllers").exists() {
+                return Err(io::Error::new(io::ErrorKind::NotFound, "cgroup v2 missing"));
+            }
+            let path = root.join(format!("markhand-convert-{pid}"));
+            fs::create_dir(&path)?;
+            fs::write(path.join("memory.max"), limits.memory_bytes.to_string())?;
+            fs::write(path.join("pids.max"), limits.max_processes.to_string())?;
+            fs::write(path.join("cgroup.procs"), pid.to_string())?;
+            Ok(path)
         }
     }
 
-    #[test]
-    fn sandbox_cleans_workspace_after_success() {
-        if preflight().is_err() {
-            eprintln!("skipped: sandbox isolation unavailable");
-            return;
+    impl Drop for CgroupGuard {
+        fn drop(&mut self) {
+            if let Some(path) = self.path.take() {
+                let _ = fs::remove_dir(path);
+            }
         }
-        let output = run(
-            &shell_config("printf ok", Duration::from_secs(5)),
-            input(),
-            &SandboxCancel::default(),
-        )
-        .expect("sandbox run");
-        assert_eq!(output.exit, SandboxExit::Success);
-        assert_eq!(output.stdout, b"ok");
-        assert!(!output.workspace_path.exists());
+    }
+
+    fn write_all_raw(path: &CString, bytes: &[u8]) -> io::Result<()> {
+        unsafe {
+            let fd = libc::open(
+                path.as_ptr(),
+                libc::O_WRONLY | libc::O_CLOEXEC | libc::O_TRUNC,
+            );
+            if fd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            let mut written = 0;
+            while written < bytes.len() {
+                let n = libc::write(
+                    fd,
+                    bytes[written..].as_ptr().cast::<libc::c_void>(),
+                    bytes.len() - written,
+                );
+                if n < 0 {
+                    let error = io::Error::last_os_error();
+                    let _ = libc::close(fd);
+                    return Err(error);
+                }
+                written += n as usize;
+            }
+            if libc::close(fd) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+        Ok(())
+    }
+
+    fn cstring_path(path: &str) -> io::Result<CString> {
+        CString::new(path).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "nul path"))
+    }
+
+    fn path_to_bytes(path: &Path) -> io::Result<Vec<u8>> {
+        use std::os::unix::ffi::OsStrExt;
+        let bytes = path.as_os_str().as_bytes();
+        if bytes.contains(&0) {
+            Err(io::Error::new(io::ErrorKind::InvalidInput, "nul path"))
+        } else {
+            Ok(bytes.to_vec())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn shell_config(script: &str, timeout: Duration) -> SandboxConfig {
+            SandboxConfig {
+                argv_template: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    script.into(),
+                    "sh".into(),
+                    INPUT_PLACEHOLDER.into(),
+                ],
+                limits: ResourceLimits {
+                    wall_timeout: timeout,
+                    memory_bytes: 128 * 1024 * 1024,
+                    cpu_seconds: 5,
+                    file_size_bytes: 1024 * 1024,
+                    max_processes: 32,
+                    max_open_files: 32,
+                    stdout_stderr_bytes: 1024 * 1024,
+                },
+            }
+        }
+
+        fn input() -> SandboxInput {
+            SandboxInput {
+                bytes: b"hello".to_vec(),
+                canonical_extension: "txt".into(),
+            }
+        }
+
+        #[test]
+        fn sandbox_cleans_workspace_after_success() {
+            if preflight().is_err() {
+                eprintln!("skipped: sandbox isolation unavailable");
+                return;
+            }
+            let output = run(
+                &shell_config("printf ok", Duration::from_secs(5)),
+                input(),
+                &SandboxCancel::default(),
+            )
+            .expect("sandbox run");
+            assert_eq!(output.exit, SandboxExit::Success);
+            assert_eq!(output.stdout, b"ok");
+            assert!(!output.workspace_path.exists());
+        }
     }
 }
+
+#[cfg(unix)]
+pub use imp::*;
+
+// The production sandbox depends on Linux isolation primitives. A Windows
+// worker must fail closed rather than execute conversion commands without those
+// protections; this also permits the rest of the server crate to build and
+// report that isolation is unavailable.
+#[cfg(not(unix))]
+mod imp {
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    use super::super::limits::ResourceLimits;
+
+    const INPUT_PLACEHOLDER: &str = "{input}";
+
+    #[derive(Debug, Clone)]
+    pub struct SandboxConfig {
+        pub argv_template: Vec<String>,
+        pub limits: ResourceLimits,
+    }
+
+    impl SandboxConfig {
+        pub fn validate(&self) -> Result<(), SandboxError> {
+            if self.argv_template.is_empty() {
+                return Err(SandboxError::InvalidConfig(
+                    "converter argv template must not be empty".into(),
+                ));
+            }
+            if !Path::new(&self.argv_template[0]).is_absolute() {
+                return Err(SandboxError::InvalidConfig(
+                    "converter executable must be an absolute path".into(),
+                ));
+            }
+            if !self
+                .argv_template
+                .iter()
+                .any(|arg| arg.contains(INPUT_PLACEHOLDER))
+            {
+                return Err(SandboxError::InvalidConfig(
+                    "converter argv template must contain {input}".into(),
+                ));
+            }
+            self.limits.validate().map_err(SandboxError::InvalidConfig)
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct SandboxInput {
+        pub bytes: Vec<u8>,
+        pub canonical_extension: String,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum SandboxExit {
+        Success,
+        Exit(i32),
+        Signaled(i32),
+        TimedOut,
+        Cancelled,
+    }
+
+    impl SandboxExit {
+        pub const fn success(self) -> bool {
+            matches!(self, Self::Success)
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct SandboxOutput {
+        pub exit: SandboxExit,
+        pub stdout: Vec<u8>,
+        pub stderr: Vec<u8>,
+        pub stdout_truncated: bool,
+        pub stderr_truncated: bool,
+        pub pid1_host_pid: Option<u32>,
+        pub workspace_path: PathBuf,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum SandboxError {
+        #[error("sandbox configuration is invalid: {0}")]
+        InvalidConfig(String),
+        #[error("sandbox isolation is unavailable")]
+        IsolationUnavailable,
+    }
+
+    #[derive(Clone, Debug, Default)]
+    pub struct SandboxCancel {
+        cancelled: Arc<AtomicBool>,
+    }
+
+    impl SandboxCancel {
+        pub fn cancel(&self) {
+            self.cancelled.store(true, Ordering::SeqCst);
+        }
+
+        pub fn is_cancelled(&self) -> bool {
+            self.cancelled.load(Ordering::SeqCst)
+        }
+    }
+
+    pub fn preflight() -> Result<(), SandboxError> {
+        Err(SandboxError::IsolationUnavailable)
+    }
+
+    pub fn run(
+        config: &SandboxConfig,
+        _input: SandboxInput,
+        _cancel: &SandboxCancel,
+    ) -> Result<SandboxOutput, SandboxError> {
+        config.validate()?;
+        Err(SandboxError::IsolationUnavailable)
+    }
+}
+
+#[cfg(not(unix))]
+pub use imp::*;

--- a/crates/server/tests/jobs.rs
+++ b/crates/server/tests/jobs.rs
@@ -739,6 +739,7 @@ async fn checkpoint_survives_kill_reclaim_and_resume_claim() {
     let checkpoint = CheckpointPayload {
         cursor_id: Some(Uuid::new_v4()),
         completed_ids: vec![Uuid::new_v4(), Uuid::new_v4()],
+        staged_object_keys: vec![],
         offset: Some(7),
     };
     let checkpoint_json = checkpoint.to_json().expect("checkpoint json");
@@ -816,6 +817,7 @@ async fn max_length_worker_id_yields_usable_lease_tokens_for_all_worker_mutation
         CheckpointPayload {
             cursor_id: Some(Uuid::new_v4()),
             completed_ids: vec![Uuid::new_v4()],
+            staged_object_keys: vec![],
             offset: Some(1),
         },
     )
@@ -915,6 +917,7 @@ async fn non_owner_checkpoint_is_rejected_without_mutating_checkpoint() {
             CheckpointPayload {
                 cursor_id: Some(Uuid::new_v4()),
                 completed_ids: vec![],
+                staged_object_keys: vec![],
                 offset: Some(1),
             },
         )

--- a/crates/server/tests/worker.rs
+++ b/crates/server/tests/worker.rs
@@ -20,6 +20,7 @@ use fileconv_server::db::pool::{create_pool, with_org_txn};
 use fileconv_server::jobs::{self, EnqueueJob, JobPayload};
 use fileconv_server::services::conversion::ConversionIdentity;
 use fileconv_server::services::promotion::PromotionFault;
+use fileconv_server::services::quota;
 use fileconv_server::storage::keys::quarantine_key;
 use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
 use fileconv_server::workers::convert::{ConvertWorker, ConvertWorkerConfig, ConvertWorkerRun};
@@ -614,6 +615,51 @@ async fn quota_reservation_statuses(pool: &Pool, ctx: &OrgContext, job_id: Uuid)
     })
     .await
     .expect("quota status query")
+}
+
+fn staging_key_for_attempt(
+    ctx: &OrgContext,
+    document_id: Uuid,
+    source_version_id: Uuid,
+    job: &Job,
+    attempts: i32,
+) -> fileconv_server::storage::ObjectKey {
+    let identity = ConversionIdentity::new(
+        ctx.org_id(),
+        document_id,
+        source_version_id,
+        job.idempotency_key.clone(),
+    );
+    fileconv_server::services::artifacts::markdown_key(
+        &identity,
+        identity.promoted_version_id(),
+        job.id,
+        attempts,
+    )
+    .expect("staging key")
+}
+
+async fn first_markdown_artifact_key(pool: &Pool, ctx: &OrgContext, document_id: Uuid) -> String {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT object_key
+                         FROM derived_artifacts
+                         WHERE org_id = $1
+                           AND document_id = $2
+                           AND artifact_kind = 'markdown'",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("artifact key query")
 }
 
 async fn make_job_available(pool: &Pool, ctx: &OrgContext, job_id: Uuid) {
@@ -1269,6 +1315,8 @@ async fn live_convert_worker_fault_injection_rolls_back_and_retries_promotion() 
         let staged_key = fileconv_server::services::artifacts::markdown_key(
             &identity,
             identity.promoted_version_id(),
+            job.id,
+            job.attempts + 1,
         )
         .expect("staged key");
         let mut fault_config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
@@ -1320,6 +1368,329 @@ async fn live_convert_worker_fault_injection_rolls_back_and_retries_promotion() 
             vec!["refunded".to_string(), "finalized".to_string()]
         );
     }
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_reclaim_style_retry_keeps_committed_attempt_object_present() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"race retry\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let job = jobs::enqueue(
+        &pool,
+        &ctx,
+        EnqueueJob::new(
+            JobType::Convert,
+            JobPayload {
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                collection_id: None,
+                upload_id: None,
+                batch_id: None,
+            },
+            format!("convert-reclaim-race-{version_id}"),
+        ),
+    )
+    .await
+    .expect("enqueue")
+    .job;
+    let attempt_one_key = staging_key_for_attempt(&ctx, document_id, version_id, &job, 1);
+    let mut first_config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
+    first_config.promotion_fault = Some(PromotionFault::AfterStagingPut);
+    first_config.fail_cleanup_delete = true;
+    let first_worker =
+        ConvertWorker::new(pool.clone(), storage.clone(), first_config).expect("first worker");
+    assert!(matches!(
+        first_worker.run_once(&ctx).await.expect("first attempt"),
+        ConvertWorkerRun::Failed { job_id, .. } if job_id == job.id
+    ));
+    assert!(storage
+        .object_exists(ctx.org_id(), &attempt_one_key)
+        .await
+        .expect("attempt one exists"));
+
+    make_job_available(&pool, &ctx, job.id).await;
+    let attempt_two_key = staging_key_for_attempt(&ctx, document_id, version_id, &job, 2);
+    let retry_worker = ConvertWorker::new(
+        pool.clone(),
+        storage.clone(),
+        stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+    )
+    .expect("retry worker");
+    assert!(matches!(
+        retry_worker.run_once(&ctx).await.expect("retry attempt"),
+        ConvertWorkerRun::Completed { job_id, .. } if job_id == job.id
+    ));
+
+    assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 1);
+    assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 1);
+    let committed_key = first_markdown_artifact_key(&pool, &ctx, document_id).await;
+    assert_eq!(committed_key, attempt_two_key.as_str());
+    let committed = fileconv_server::storage::parse_key_for_org(&committed_key, ctx.org_id())
+        .expect("committed key");
+    assert!(storage
+        .object_exists(ctx.org_id(), &committed)
+        .await
+        .expect("committed exists"));
+    assert!(!storage
+        .object_exists(ctx.org_id(), &attempt_one_key)
+        .await
+        .expect("attempt one cleaned"));
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_checkpointed_key_cleans_ambiguous_after_put() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"ambiguous put\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
+    let attempt_one_key = staging_key_for_attempt(&ctx, document_id, version_id, &job, 1);
+    let mut ambiguous_config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
+    ambiguous_config.lose_staged_handle_after_put = true;
+    let ambiguous_worker =
+        ConvertWorker::new(pool.clone(), storage.clone(), ambiguous_config).expect("worker");
+    assert!(matches!(
+        ambiguous_worker.run_once(&ctx).await.expect("ambiguous run"),
+        ConvertWorkerRun::Failed { job_id, .. } if job_id == job.id
+    ));
+    assert!(!storage
+        .object_exists(ctx.org_id(), &attempt_one_key)
+        .await
+        .expect("checkpoint cleanup"));
+
+    make_job_available(&pool, &ctx, job.id).await;
+    let retry_worker = ConvertWorker::new(
+        pool.clone(),
+        storage.clone(),
+        stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+    )
+    .expect("retry worker");
+    assert!(matches!(
+        retry_worker.run_once(&ctx).await.expect("retry"),
+        ConvertWorkerRun::Completed { job_id, .. } if job_id == job.id
+    ));
+    assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 1);
+    assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 1);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_delete_failure_is_surfaced_and_retry_cleans() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"delete failure\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
+    let attempt_one_key = staging_key_for_attempt(&ctx, document_id, version_id, &job, 1);
+    let mut config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
+    config.promotion_fault = Some(PromotionFault::AfterStagingPut);
+    config.fail_cleanup_delete = true;
+    let worker = ConvertWorker::new(pool.clone(), storage.clone(), config).expect("worker");
+    assert!(matches!(
+        worker.run_once(&ctx).await.expect("delete failure run"),
+        ConvertWorkerRun::Failed { job_id, .. } if job_id == job.id
+    ));
+    assert_eq!(
+        get_job(&pool, &ctx, job.id).await.last_error.as_deref(),
+        Some("convert compensation deferred")
+    );
+    assert!(storage
+        .object_exists(ctx.org_id(), &attempt_one_key)
+        .await
+        .expect("left for retry"));
+
+    make_job_available(&pool, &ctx, job.id).await;
+    let retry_worker = ConvertWorker::new(
+        pool.clone(),
+        storage.clone(),
+        stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+    )
+    .expect("retry worker");
+    assert!(matches!(
+        retry_worker.run_once(&ctx).await.expect("retry"),
+        ConvertWorkerRun::Completed { job_id, .. } if job_id == job.id
+    ));
+    assert!(!storage
+        .object_exists(ctx.org_id(), &attempt_one_key)
+        .await
+        .expect("cleaned on retry"));
+    assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 1);
+    assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 1);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_refund_failure_expires_via_quota_sweep_and_retries() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"refund failure\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
+    let mut config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
+    config.promotion_fault = Some(PromotionFault::AfterStagingPut);
+    config.fail_quota_refund = true;
+    config.quota_reservation_ttl = Duration::from_secs(1);
+    let worker = ConvertWorker::new(pool.clone(), storage.clone(), config).expect("worker");
+    assert!(matches!(
+        worker.run_once(&ctx).await.expect("refund failure run"),
+        ConvertWorkerRun::Failed { job_id, .. } if job_id == job.id
+    ));
+    assert_eq!(
+        get_job(&pool, &ctx, job.id).await.last_error.as_deref(),
+        Some("convert compensation deferred")
+    );
+    assert_eq!(
+        quota_reservation_statuses(&pool, &ctx, job.id).await,
+        vec!["reserved".to_string()]
+    );
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert_eq!(
+        quota::expire_reserved(&pool, &ctx, 10)
+            .await
+            .expect("quota sweep"),
+        1
+    );
+    assert_eq!(
+        quota_reservation_statuses(&pool, &ctx, job.id).await,
+        vec!["expired".to_string()]
+    );
+
+    make_job_available(&pool, &ctx, job.id).await;
+    let retry_worker = ConvertWorker::new(
+        pool.clone(),
+        storage.clone(),
+        stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+    )
+    .expect("retry worker");
+    assert!(matches!(
+        retry_worker.run_once(&ctx).await.expect("retry"),
+        ConvertWorkerRun::Completed { job_id, .. } if job_id == job.id
+    ));
+    assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 1);
+    assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 1);
+    assert_eq!(
+        quota_reservation_statuses(&pool, &ctx, job.id).await,
+        vec!["expired".to_string(), "finalized".to_string()]
+    );
 
     ephemeral.drop().await;
 }
@@ -1621,6 +1992,8 @@ async fn live_convert_worker_cancel_after_upload_cleans_generated_object() {
     let generated_trusted = fileconv_server::services::artifacts::markdown_key(
         &identity,
         identity.promoted_version_id(),
+        job.id,
+        job.attempts + 1,
     )
     .expect("trusted key");
     let mut config = stub_worker_config("printf converted-after-upload", 50);

--- a/crates/server/tests/worker.rs
+++ b/crates/server/tests/worker.rs
@@ -18,11 +18,11 @@ use fileconv_server::db::models::{CollectionVisibility, Job, JobStatus, JobType}
 use fileconv_server::db::orgs;
 use fileconv_server::db::pool::{create_pool, with_org_txn};
 use fileconv_server::jobs::{self, EnqueueJob, JobPayload};
-use fileconv_server::storage::keys::{quarantine_key, trusted_key};
+use fileconv_server::services::conversion::ConversionIdentity;
+use fileconv_server::services::promotion::PromotionFault;
+use fileconv_server::storage::keys::quarantine_key;
 use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
-use fileconv_server::workers::convert::{
-    artifact_object_id_for_attempt, ConvertWorker, ConvertWorkerConfig, ConvertWorkerRun,
-};
+use fileconv_server::workers::convert::{ConvertWorker, ConvertWorkerConfig, ConvertWorkerRun};
 use fileconv_server::workers::limits::ResourceLimits;
 use fileconv_server::workers::sandbox::{
     self, SandboxCancel, SandboxConfig, SandboxExit, SandboxInput,
@@ -33,6 +33,7 @@ use uuid::Uuid;
 
 const INPUT: &str = "{input}";
 static SANDBOX_TEST_LOCK: Mutex<()> = Mutex::new(());
+const ECHO_INPUT_SCRIPT: &str = r#"while IFS= read -r line; do printf '%s\n' "$line"; done < "$1""#;
 
 fn sandbox_test_guard() -> MutexGuard<'static, ()> {
     SANDBOX_TEST_LOCK
@@ -232,6 +233,16 @@ async fn seed_org_collection_document_version(
                 orgs::ensure_user(txn, &ctx, ctx.user_id(), "worker@example.test", "Worker")
                     .await?;
                 orgs::ensure_membership(txn, &ctx).await?;
+                txn.execute(
+                    "INSERT INTO org_quotas (
+                        org_id, max_storage_bytes, max_documents,
+                        max_concurrent_jobs, max_monthly_tokens
+                     )
+                     VALUES ($1, 1000000000, 100000, 100, 1000000000)
+                     ON CONFLICT (org_id) DO NOTHING",
+                    &[&ctx.org_id()],
+                )
+                .await?;
                 let collection_name = format!("Worker Collection {collection_id}");
                 let collection_slug = format!("worker-collection-{collection_id}");
                 collections::insert(
@@ -281,6 +292,50 @@ async fn seed_org_collection_document_version(
     .await
     .expect("seed document version");
     (document_id, version_id)
+}
+
+async fn seed_additional_source_version(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+    original_object_key: &str,
+    sha256: &str,
+    byte_size: u64,
+) {
+    let original_object_key = original_object_key.to_string();
+    let sha256 = sha256.to_string();
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, content_sha256,
+                        original_object_key, source_content_type, byte_size,
+                        created_by_user_id
+                     )
+                     SELECT $1, $2, $3, COALESCE(MAX(version_number), 0)::integer + 1,
+                            $4, $5, 'text/plain', $6, $7
+                     FROM document_versions
+                     WHERE org_id = $2 AND document_id = $3",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &sha256,
+                        &original_object_key,
+                        &(byte_size as i64),
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed additional source version");
 }
 
 async fn put_quarantine_object(
@@ -416,6 +471,272 @@ async fn markdown_artifact_key(pool: &Pool, ctx: &OrgContext, version_id: Uuid) 
     })
     .await
     .expect("artifact query")
+}
+
+async fn published_version_for_source(
+    pool: &Pool,
+    ctx: &OrgContext,
+    source_version_id: Uuid,
+) -> Option<Uuid> {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_opt(
+                        "SELECT id
+                         FROM document_versions
+                         WHERE org_id = $1
+                           AND parent_version_id = $2
+                           AND publication_state = 'published'",
+                        &[&ctx.org_id(), &source_version_id],
+                    )
+                    .await?;
+                Ok(row.map(|row| row.get(0)))
+            })
+        }
+    })
+    .await
+    .expect("published version query")
+}
+
+async fn document_current_version(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+) -> Option<Uuid> {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT current_version_id
+                         FROM documents
+                         WHERE org_id = $1 AND id = $2",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("current version query")
+}
+
+async fn count_published_versions(pool: &Pool, ctx: &OrgContext, document_id: Uuid) -> i64 {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM document_versions
+                         WHERE org_id = $1
+                           AND document_id = $2
+                           AND publication_state = 'published'",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("published count query")
+}
+
+async fn count_markdown_artifacts(pool: &Pool, ctx: &OrgContext, document_id: Uuid) -> i64 {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM derived_artifacts
+                         WHERE org_id = $1
+                           AND document_id = $2
+                           AND artifact_kind = 'markdown'",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("artifact count query")
+}
+
+async fn count_index_outbox(pool: &Pool, ctx: &OrgContext, job_id: Uuid) -> i64 {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM outbox_events
+                         WHERE org_id = $1
+                           AND job_id = $2
+                           AND event_type = 'document.index_requested'",
+                        &[&ctx.org_id(), &job_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("index outbox count query")
+}
+
+async fn quota_reservation_statuses(pool: &Pool, ctx: &OrgContext, job_id: Uuid) -> Vec<String> {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let rows = txn
+                    .query(
+                        "SELECT status
+                         FROM quota_reservations
+                         WHERE org_id = $1 AND job_id = $2
+                         ORDER BY created_at, id",
+                        &[&ctx.org_id(), &job_id],
+                    )
+                    .await?;
+                Ok(rows.into_iter().map(|row| row.get(0)).collect())
+            })
+        }
+    })
+    .await
+    .expect("quota status query")
+}
+
+async fn make_job_available(pool: &Pool, ctx: &OrgContext, job_id: Uuid) {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE jobs
+                     SET available_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &job_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("make job available");
+}
+
+async fn version_inherits_document_collection(
+    pool: &Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> bool {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT d.collection_id = d2.collection_id
+                         FROM documents d
+                         JOIN document_versions v
+                           ON v.org_id = d.org_id AND v.document_id = d.id
+                         JOIN documents d2
+                           ON d2.org_id = v.org_id AND d2.id = v.document_id
+                         WHERE d.org_id = $1 AND d.id = $2 AND v.id = $3",
+                        &[&ctx.org_id(), &document_id, &version_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("collection inheritance query")
+}
+
+async fn version_current_and_expired(
+    pool: &Pool,
+    ctx: &OrgContext,
+    version_id: Uuid,
+) -> (bool, bool) {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT is_current, effective_to IS NOT NULL AS expired
+                         FROM document_versions
+                         WHERE org_id = $1 AND id = $2",
+                        &[&ctx.org_id(), &version_id],
+                    )
+                    .await?;
+                Ok((row.get(0), row.get(1)))
+            })
+        }
+    })
+    .await
+    .expect("version current query")
+}
+
+async fn illegal_version_content_update_is_rejected(
+    pool: &Pool,
+    ctx: &OrgContext,
+    version_id: Uuid,
+) -> bool {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE document_versions
+                     SET content_sha256 = repeat('a', 64)
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &version_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .is_err()
+}
+
+async fn illegal_original_key_update_is_rejected(
+    pool: &Pool,
+    ctx: &OrgContext,
+    version_id: Uuid,
+) -> bool {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE document_versions
+                     SET original_object_key = original_object_key || '-mutated'
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &version_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .is_err()
 }
 
 fn stub_worker_config(script: &str, heartbeat_ms: u64) -> ConvertWorkerConfig {
@@ -724,7 +1045,7 @@ fn real_fileconv_smoke_for_simple_formats_when_built() {
 }
 
 #[tokio::test]
-async fn live_convert_worker_completes_and_stores_trusted_markdown() {
+async fn live_convert_worker_promotes_immutable_markdown_version() {
     let Some(base_url) = test_database_url() else {
         return;
     };
@@ -780,7 +1101,28 @@ async fn live_convert_worker_completes_and_stores_trusted_markdown() {
         get_job(&pool, &ctx, job.id).await.status,
         JobStatus::Succeeded
     );
-    let artifact_key = markdown_artifact_key(&pool, &ctx, version_id)
+    let promoted_version_id = published_version_for_source(&pool, &ctx, version_id)
+        .await
+        .expect("published promoted version");
+    assert_ne!(promoted_version_id, version_id);
+    assert_eq!(
+        document_current_version(&pool, &ctx, document_id).await,
+        Some(promoted_version_id)
+    );
+    assert!(
+        version_inherits_document_collection(&pool, &ctx, document_id, promoted_version_id).await
+    );
+    assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 1);
+    assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 1);
+    assert_eq!(count_index_outbox(&pool, &ctx, job.id).await, 1);
+    assert_eq!(
+        quota_reservation_statuses(&pool, &ctx, job.id).await,
+        vec!["finalized".to_string()]
+    );
+    assert!(markdown_artifact_key(&pool, &ctx, version_id)
+        .await
+        .is_none());
+    let artifact_key = markdown_artifact_key(&pool, &ctx, promoted_version_id)
         .await
         .expect("artifact key");
     let trusted = fileconv_server::storage::parse_key_for_org(&artifact_key, ctx.org_id())
@@ -790,6 +1132,303 @@ async fn live_convert_worker_completes_and_stores_trusted_markdown() {
         .await
         .expect("get trusted markdown");
     assert_eq!(markdown.as_ref(), b"hello from quarantine\n");
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_duplicate_enqueue_converges_to_one_promotion() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"idempotent retry\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
+    let duplicate = enqueue_convert(&pool, &ctx, document_id, version_id).await;
+    assert_eq!(duplicate.id, job.id);
+    let worker = ConvertWorker::new(
+        pool.clone(),
+        storage.clone(),
+        stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+    )
+    .expect("worker");
+
+    assert!(matches!(
+        worker.run_once(&ctx).await.expect("first run"),
+        ConvertWorkerRun::Completed { job_id, .. } if job_id == job.id
+    ));
+    assert_eq!(
+        worker.run_once(&ctx).await.expect("second run"),
+        ConvertWorkerRun::NoJob
+    );
+    assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 1);
+    assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 1);
+    assert_eq!(count_index_outbox(&pool, &ctx, job.id).await, 1);
+    let promoted = published_version_for_source(&pool, &ctx, version_id)
+        .await
+        .expect("promoted version");
+    assert_eq!(
+        document_current_version(&pool, &ctx, document_id).await,
+        Some(promoted)
+    );
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_fault_injection_rolls_back_and_retries_promotion() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+
+    for fault in [
+        PromotionFault::AfterStagingPut,
+        PromotionFault::AfterVersionInsert,
+        PromotionFault::AfterPointerSwap,
+        PromotionFault::AfterOutboxInsert,
+    ] {
+        let document_id = Uuid::new_v4();
+        let version_id = Uuid::new_v4();
+        let quarantine =
+            quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+        let payload = b"fault retry\n";
+        let sha256 = put_quarantine_object(
+            &storage,
+            &ctx,
+            &quarantine,
+            payload,
+            "txt",
+            document_id,
+            version_id,
+        )
+        .await;
+        let (document_id, version_id) = seed_org_collection_document_version(
+            &pool,
+            &ctx,
+            document_id,
+            version_id,
+            &quarantine.as_str(),
+            &sha256,
+            payload.len() as u64,
+        )
+        .await;
+        let job = jobs::enqueue(
+            &pool,
+            &ctx,
+            EnqueueJob::new(
+                JobType::Convert,
+                JobPayload {
+                    document_id: Some(document_id),
+                    version_id: Some(version_id),
+                    collection_id: None,
+                    upload_id: None,
+                    batch_id: None,
+                },
+                format!("convert-fault-{fault:?}-{version_id}"),
+            ),
+        )
+        .await
+        .expect("enqueue")
+        .job;
+        let identity = ConversionIdentity::new(
+            ctx.org_id(),
+            document_id,
+            version_id,
+            job.idempotency_key.clone(),
+        );
+        let staged_key = fileconv_server::services::artifacts::markdown_key(
+            &identity,
+            identity.promoted_version_id(),
+        )
+        .expect("staged key");
+        let mut fault_config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
+        fault_config.promotion_fault = Some(fault);
+        let fault_worker =
+            ConvertWorker::new(pool.clone(), storage.clone(), fault_config).expect("worker");
+
+        assert!(matches!(
+            fault_worker.run_once(&ctx).await.expect("fault run"),
+            ConvertWorkerRun::Failed {
+                job_id,
+                terminal: false
+            } if job_id == job.id
+        ));
+        assert!(published_version_for_source(&pool, &ctx, version_id)
+            .await
+            .is_none());
+        assert_eq!(
+            document_current_version(&pool, &ctx, document_id).await,
+            None
+        );
+        assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 0);
+        assert_eq!(count_index_outbox(&pool, &ctx, job.id).await, 0);
+        assert_eq!(
+            quota_reservation_statuses(&pool, &ctx, job.id).await,
+            vec!["refunded".to_string()]
+        );
+        assert!(!storage
+            .object_exists(ctx.org_id(), &staged_key)
+            .await
+            .expect("staged object existence"));
+
+        make_job_available(&pool, &ctx, job.id).await;
+        let retry_worker = ConvertWorker::new(
+            pool.clone(),
+            storage.clone(),
+            stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+        )
+        .expect("retry worker");
+        assert!(matches!(
+            retry_worker.run_once(&ctx).await.expect("retry run"),
+            ConvertWorkerRun::Completed { job_id, .. } if job_id == job.id
+        ));
+        assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 1);
+        assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 1);
+        assert_eq!(count_index_outbox(&pool, &ctx, job.id).await, 1);
+        assert_eq!(
+            quota_reservation_statuses(&pool, &ctx, job.id).await,
+            vec!["refunded".to_string(), "finalized".to_string()]
+        );
+    }
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_second_promotion_demotes_current_and_preserves_original() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let source_one = Uuid::new_v4();
+    let quarantine_one =
+        quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload_one = b"first source\n";
+    let sha_one = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine_one,
+        payload_one,
+        "txt",
+        document_id,
+        source_one,
+    )
+    .await;
+    let (document_id, source_one) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        source_one,
+        &quarantine_one.as_str(),
+        &sha_one,
+        payload_one.len() as u64,
+    )
+    .await;
+    let first_job = enqueue_convert(&pool, &ctx, document_id, source_one).await;
+    let worker = ConvertWorker::new(
+        pool.clone(),
+        storage.clone(),
+        stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+    )
+    .expect("worker");
+    assert!(matches!(
+        worker.run_once(&ctx).await.expect("first promotion"),
+        ConvertWorkerRun::Completed { job_id, .. } if job_id == first_job.id
+    ));
+    let first_promoted = published_version_for_source(&pool, &ctx, source_one)
+        .await
+        .expect("first promoted");
+
+    let source_two = Uuid::new_v4();
+    let quarantine_two =
+        quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload_two = b"second source\n";
+    let sha_two = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine_two,
+        payload_two,
+        "txt",
+        document_id,
+        source_two,
+    )
+    .await;
+    seed_additional_source_version(
+        &pool,
+        &ctx,
+        document_id,
+        source_two,
+        &quarantine_two.as_str(),
+        &sha_two,
+        payload_two.len() as u64,
+    )
+    .await;
+    let second_job = enqueue_convert(&pool, &ctx, document_id, source_two).await;
+    assert!(matches!(
+        worker.run_once(&ctx).await.expect("second promotion"),
+        ConvertWorkerRun::Completed { job_id, .. } if job_id == second_job.id
+    ));
+    let second_promoted = published_version_for_source(&pool, &ctx, source_two)
+        .await
+        .expect("second promoted");
+
+    assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 2);
+    assert_eq!(
+        document_current_version(&pool, &ctx, document_id).await,
+        Some(second_promoted)
+    );
+    assert_eq!(
+        version_current_and_expired(&pool, &ctx, first_promoted).await,
+        (false, true)
+    );
+    assert_eq!(
+        version_current_and_expired(&pool, &ctx, second_promoted).await,
+        (true, false)
+    );
+    assert!(illegal_version_content_update_is_rejected(&pool, &ctx, second_promoted).await);
+    assert!(illegal_original_key_update_is_rejected(&pool, &ctx, source_one).await);
+    let original = storage
+        .get_object(ctx.org_id(), &quarantine_one)
+        .await
+        .expect("original quarantine object");
+    assert_eq!(original.as_ref(), payload_one);
+    assert!(version_inherits_document_collection(&pool, &ctx, document_id, second_promoted).await);
+
     ephemeral.drop().await;
 }
 
@@ -852,6 +1491,13 @@ async fn live_convert_worker_converter_error_retries_job() {
     assert!(markdown_artifact_key(&pool, &ctx, version_id)
         .await
         .is_none());
+    assert!(published_version_for_source(&pool, &ctx, version_id)
+        .await
+        .is_none());
+    assert_eq!(
+        document_current_version(&pool, &ctx, document_id).await,
+        None
+    );
     ephemeral.drop().await;
 }
 
@@ -925,6 +1571,9 @@ else:
     assert!(markdown_artifact_key(&pool, &ctx, version_id)
         .await
         .is_none());
+    assert!(published_version_for_source(&pool, &ctx, version_id)
+        .await
+        .is_none());
     ephemeral.drop().await;
 }
 
@@ -963,11 +1612,15 @@ async fn live_convert_worker_cancel_after_upload_cleans_generated_object() {
     )
     .await;
     let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
-    let generated_trusted = trusted_key(
+    let identity = ConversionIdentity::new(
         ctx.org_id(),
+        document_id,
         version_id,
-        artifact_object_id_for_attempt(job.id, job.attempts + 1),
-        None,
+        format!("convert-{version_id}"),
+    );
+    let generated_trusted = fileconv_server::services::artifacts::markdown_key(
+        &identity,
+        identity.promoted_version_id(),
     )
     .expect("trusted key");
     let mut config = stub_worker_config("printf converted-after-upload", 50);
@@ -986,6 +1639,9 @@ async fn live_convert_worker_cancel_after_upload_cleans_generated_object() {
         JobStatus::Cancelled
     );
     assert!(markdown_artifact_key(&pool, &ctx, version_id)
+        .await
+        .is_none());
+    assert!(published_version_for_source(&pool, &ctx, version_id)
         .await
         .is_none());
     assert!(!storage

--- a/crates/server/tests/worker.rs
+++ b/crates/server/tests/worker.rs
@@ -1572,6 +1572,149 @@ async fn live_convert_worker_reconciliation_cleans_terminal_parent_leak() {
 }
 
 #[tokio::test]
+async fn live_convert_worker_reconciliation_runs_with_pending_convert_work() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"fair reconciliation scheduling\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let first_convert = jobs::enqueue(
+        &pool,
+        &ctx,
+        EnqueueJob::new(
+            JobType::Convert,
+            JobPayload {
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                collection_id: None,
+                upload_id: None,
+                batch_id: None,
+                cleanup_target_job_id: None,
+            },
+            format!("convert-fair-first-{version_id}"),
+        ),
+    )
+    .await
+    .expect("enqueue first convert")
+    .job;
+    let second_convert = jobs::enqueue(
+        &pool,
+        &ctx,
+        EnqueueJob::new(
+            JobType::Convert,
+            JobPayload {
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                collection_id: None,
+                upload_id: None,
+                batch_id: None,
+                cleanup_target_job_id: None,
+            },
+            format!("convert-fair-second-{version_id}"),
+        ),
+    )
+    .await
+    .expect("enqueue second convert")
+    .job;
+    let parent = jobs::enqueue(
+        &pool,
+        &ctx,
+        EnqueueJob::new(
+            JobType::Convert,
+            JobPayload {
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                collection_id: None,
+                upload_id: None,
+                batch_id: None,
+                cleanup_target_job_id: None,
+            },
+            format!("convert-fair-cleanup-parent-{version_id}"),
+        ),
+    )
+    .await
+    .expect("enqueue cleanup parent")
+    .job;
+    jobs::cancel(&pool, &ctx, parent.id)
+        .await
+        .expect("cancel cleanup parent");
+    jobs::enqueue(
+        &pool,
+        &ctx,
+        EnqueueJob::new(
+            JobType::Reconcile,
+            JobPayload {
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                collection_id: None,
+                upload_id: None,
+                batch_id: None,
+                cleanup_target_job_id: Some(parent.id),
+            },
+            format!("convert.cleanup:{}", parent.id),
+        ),
+    )
+    .await
+    .expect("enqueue reconciliation");
+    let worker = ConvertWorker::new(
+        pool.clone(),
+        storage,
+        stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+    )
+    .expect("worker");
+
+    assert!(matches!(
+        worker.run_once(&ctx).await.expect("first scheduling run"),
+        ConvertWorkerRun::Completed { .. }
+    ));
+    assert!(matches!(
+        worker
+            .run_once(&ctx)
+            .await
+            .expect("fair reconciliation run"),
+        ConvertWorkerRun::Reconciled { .. }
+    ));
+    assert!(
+        matches!(
+            get_job(&pool, &ctx, first_convert.id).await.status,
+            JobStatus::Pending
+        ) || matches!(
+            get_job(&pool, &ctx, second_convert.id).await.status,
+            JobStatus::Pending
+        ),
+        "one conversion must remain pending when reconciliation is selected"
+    );
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
 async fn live_convert_worker_tombstone_before_promotion_does_not_regress_document_state() {
     let Some(base_url) = test_database_url() else {
         return;
@@ -2385,7 +2528,7 @@ else:
 }
 
 #[tokio::test]
-async fn live_convert_worker_cancel_after_upload_cleans_generated_object() {
+async fn live_convert_worker_cancel_after_upload_cleans_generated_object_via_reconciliation() {
     let Some(base_url) = test_database_url() else {
         return;
     };
@@ -2448,6 +2591,13 @@ async fn live_convert_worker_cancel_after_upload_cleans_generated_object() {
     assert!(published_version_for_source(&pool, &ctx, version_id)
         .await
         .is_none());
+    assert!(matches!(
+        worker
+            .run_once(&ctx)
+            .await
+            .expect("reconciliation run after cancellation"),
+        ConvertWorkerRun::Reconciled { .. }
+    ));
     assert!(!storage
         .object_exists(ctx.org_id(), &generated_trusted)
         .await

--- a/crates/server/tests/worker.rs
+++ b/crates/server/tests/worker.rs
@@ -394,6 +394,7 @@ async fn enqueue_convert(
                 collection_id: None,
                 upload_id: None,
                 batch_id: None,
+                cleanup_target_job_id: None,
             },
             format!("convert-{version_id}"),
         ),
@@ -1311,6 +1312,7 @@ async fn live_convert_worker_fault_injection_rolls_back_and_retries_promotion() 
                     collection_id: None,
                     upload_id: None,
                     batch_id: None,
+                    cleanup_target_job_id: None,
                 },
                 format!("convert-fault-{fault:?}-{version_id}"),
             ),
@@ -1376,6 +1378,181 @@ async fn live_convert_worker_fault_injection_rolls_back_and_retries_promotion() 
 }
 
 #[tokio::test]
+async fn live_convert_worker_post_commit_ack_loss_preserves_committed_artifact() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"post commit acknowledgement loss\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
+    let mut config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
+    config.promotion_fault = Some(PromotionFault::AfterCommit);
+    let worker = ConvertWorker::new(pool.clone(), storage.clone(), config).expect("worker");
+
+    assert!(matches!(
+        worker.run_once(&ctx).await.expect("post-commit run"),
+        ConvertWorkerRun::ReconciliationNeeded { job_id } if job_id == job.id
+    ));
+    assert_eq!(
+        get_job(&pool, &ctx, job.id).await.status,
+        JobStatus::Succeeded
+    );
+    let promoted = published_version_for_source(&pool, &ctx, version_id)
+        .await
+        .expect("committed promoted version");
+    let artifact_key = markdown_artifact_key(&pool, &ctx, promoted)
+        .await
+        .expect("committed artifact");
+    let artifact = fileconv_server::storage::parse_key_for_org(&artifact_key, ctx.org_id())
+        .expect("artifact key");
+    assert_eq!(
+        storage
+            .get_object(ctx.org_id(), &artifact)
+            .await
+            .expect("committed object")
+            .as_ref(),
+        payload
+    );
+
+    assert!(matches!(
+        worker.run_once(&ctx).await.expect("reconciliation run"),
+        ConvertWorkerRun::Reconciled { .. }
+    ));
+    assert_eq!(
+        storage
+            .get_object(ctx.org_id(), &artifact)
+            .await
+            .expect("object survives reconciliation")
+            .as_ref(),
+        payload
+    );
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_reconciliation_cleans_terminal_parent_leak() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"terminal cleanup intent\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let mut enqueue = EnqueueJob::new(
+        JobType::Convert,
+        JobPayload {
+            document_id: Some(document_id),
+            version_id: Some(version_id),
+            collection_id: None,
+            upload_id: None,
+            batch_id: None,
+            cleanup_target_job_id: None,
+        },
+        format!("convert-terminal-cleanup-{version_id}"),
+    );
+    enqueue.max_attempts = 1;
+    let job = jobs::enqueue(&pool, &ctx, enqueue)
+        .await
+        .expect("enqueue")
+        .job;
+    let mut failing_config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
+    failing_config.promotion_fault = Some(PromotionFault::AfterStagingPut);
+    failing_config.fail_cleanup_delete = true;
+    let failing_worker =
+        ConvertWorker::new(pool.clone(), storage.clone(), failing_config).expect("worker");
+
+    assert!(matches!(
+        failing_worker.run_once(&ctx).await.expect("failed run"),
+        ConvertWorkerRun::Failed {
+            job_id,
+            terminal: true
+        } if job_id == job.id
+    ));
+    let staged_key = checkpoint_staged_keys(&pool, &ctx, job.id)
+        .await
+        .into_iter()
+        .next()
+        .expect("staged key");
+    let staged =
+        fileconv_server::storage::parse_key_for_org(&staged_key, ctx.org_id()).expect("staged key");
+    assert!(storage
+        .object_exists(ctx.org_id(), &staged)
+        .await
+        .expect("staged object remains before reconciliation"));
+
+    let cleanup_worker = ConvertWorker::new(
+        pool.clone(),
+        storage.clone(),
+        stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+    )
+    .expect("cleanup worker");
+    assert!(matches!(
+        cleanup_worker
+            .run_once(&ctx)
+            .await
+            .expect("terminal cleanup reconciliation"),
+        ConvertWorkerRun::Reconciled { .. }
+    ));
+    assert!(!storage
+        .object_exists(ctx.org_id(), &staged)
+        .await
+        .expect("terminal cleanup removed staged object"));
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
 async fn live_convert_worker_reclaim_style_retry_keeps_committed_attempt_object_present() {
     let Some(base_url) = test_database_url() else {
         return;
@@ -1420,6 +1597,7 @@ async fn live_convert_worker_reclaim_style_retry_keeps_committed_attempt_object_
                 collection_id: None,
                 upload_id: None,
                 batch_id: None,
+                cleanup_target_job_id: None,
             },
             format!("convert-reclaim-race-{version_id}"),
         ),
@@ -1525,6 +1703,7 @@ async fn live_convert_worker_barrier_reclaim_promote_before_old_compensation_kee
                 collection_id: None,
                 upload_id: None,
                 batch_id: None,
+                cleanup_target_job_id: None,
             },
             format!("convert-barrier-reclaim-{version_id}"),
         ),
@@ -2248,6 +2427,7 @@ while True:
                     collection_id: None,
                     upload_id: None,
                     batch_id: None,
+                    cleanup_target_job_id: None,
                 },
                 format!("convert-resource-{name}-{version_id}"),
             ),

--- a/crates/server/tests/worker.rs
+++ b/crates/server/tests/worker.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
@@ -23,12 +23,15 @@ use fileconv_server::services::promotion::PromotionFault;
 use fileconv_server::services::quota;
 use fileconv_server::storage::keys::quarantine_key;
 use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
-use fileconv_server::workers::convert::{ConvertWorker, ConvertWorkerConfig, ConvertWorkerRun};
+use fileconv_server::workers::convert::{
+    ConvertWorker, ConvertWorkerConfig, ConvertWorkerPause, ConvertWorkerRun,
+};
 use fileconv_server::workers::limits::ResourceLimits;
 use fileconv_server::workers::sandbox::{
     self, SandboxCancel, SandboxConfig, SandboxExit, SandboxInput,
 };
 use sha2::{Digest, Sha256};
+use tokio::sync::Notify;
 use tokio_postgres::NoTls;
 use uuid::Uuid;
 
@@ -617,12 +620,11 @@ async fn quota_reservation_statuses(pool: &Pool, ctx: &OrgContext, job_id: Uuid)
     .expect("quota status query")
 }
 
-fn staging_key_for_attempt(
+fn staging_key_for_claim(
     ctx: &OrgContext,
     document_id: Uuid,
     source_version_id: Uuid,
     job: &Job,
-    attempts: i32,
 ) -> fileconv_server::storage::ObjectKey {
     let identity = ConversionIdentity::new(
         ctx.org_id(),
@@ -630,13 +632,23 @@ fn staging_key_for_attempt(
         source_version_id,
         job.idempotency_key.clone(),
     );
+    let lease_token = job.lease_owner.as_deref().expect("claimed job lease");
     fileconv_server::services::artifacts::markdown_key(
         &identity,
         identity.promoted_version_id(),
         job.id,
-        attempts,
+        job.attempts,
+        lease_token,
     )
     .expect("staging key")
+}
+
+async fn checkpoint_staged_keys(pool: &Pool, ctx: &OrgContext, job_id: Uuid) -> Vec<String> {
+    let job = get_job(pool, ctx, job_id).await;
+    job.checkpoint
+        .and_then(|value| value.get("staged_object_keys").cloned())
+        .and_then(|value| serde_json::from_value::<Vec<String>>(value).ok())
+        .unwrap_or_default()
 }
 
 async fn first_markdown_artifact_key(pool: &Pool, ctx: &OrgContext, document_id: Uuid) -> String {
@@ -1306,19 +1318,6 @@ async fn live_convert_worker_fault_injection_rolls_back_and_retries_promotion() 
         .await
         .expect("enqueue")
         .job;
-        let identity = ConversionIdentity::new(
-            ctx.org_id(),
-            document_id,
-            version_id,
-            job.idempotency_key.clone(),
-        );
-        let staged_key = fileconv_server::services::artifacts::markdown_key(
-            &identity,
-            identity.promoted_version_id(),
-            job.id,
-            job.attempts + 1,
-        )
-        .expect("staged key");
         let mut fault_config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
         fault_config.promotion_fault = Some(fault);
         let fault_worker =
@@ -1344,10 +1343,14 @@ async fn live_convert_worker_fault_injection_rolls_back_and_retries_promotion() 
             quota_reservation_statuses(&pool, &ctx, job.id).await,
             vec!["refunded".to_string()]
         );
-        assert!(!storage
-            .object_exists(ctx.org_id(), &staged_key)
-            .await
-            .expect("staged object existence"));
+        for staged_key in checkpoint_staged_keys(&pool, &ctx, job.id).await {
+            let staged_key = fileconv_server::storage::parse_key_for_org(&staged_key, ctx.org_id())
+                .expect("checkpoint staged key");
+            assert!(!storage
+                .object_exists(ctx.org_id(), &staged_key)
+                .await
+                .expect("staged object existence"));
+        }
 
         make_job_available(&pool, &ctx, job.id).await;
         let retry_worker = ConvertWorker::new(
@@ -1424,7 +1427,6 @@ async fn live_convert_worker_reclaim_style_retry_keeps_committed_attempt_object_
     .await
     .expect("enqueue")
     .job;
-    let attempt_one_key = staging_key_for_attempt(&ctx, document_id, version_id, &job, 1);
     let mut first_config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
     first_config.promotion_fault = Some(PromotionFault::AfterStagingPut);
     first_config.fail_cleanup_delete = true;
@@ -1434,13 +1436,20 @@ async fn live_convert_worker_reclaim_style_retry_keeps_committed_attempt_object_
         first_worker.run_once(&ctx).await.expect("first attempt"),
         ConvertWorkerRun::Failed { job_id, .. } if job_id == job.id
     ));
+    let attempt_one_key_raw = checkpoint_staged_keys(&pool, &ctx, job.id)
+        .await
+        .into_iter()
+        .next()
+        .expect("attempt one staged key");
+    let attempt_one_key =
+        fileconv_server::storage::parse_key_for_org(&attempt_one_key_raw, ctx.org_id())
+            .expect("attempt one key");
     assert!(storage
         .object_exists(ctx.org_id(), &attempt_one_key)
         .await
         .expect("attempt one exists"));
 
     make_job_available(&pool, &ctx, job.id).await;
-    let attempt_two_key = staging_key_for_attempt(&ctx, document_id, version_id, &job, 2);
     let retry_worker = ConvertWorker::new(
         pool.clone(),
         storage.clone(),
@@ -1455,7 +1464,7 @@ async fn live_convert_worker_reclaim_style_retry_keeps_committed_attempt_object_
     assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 1);
     assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 1);
     let committed_key = first_markdown_artifact_key(&pool, &ctx, document_id).await;
-    assert_eq!(committed_key, attempt_two_key.as_str());
+    assert_ne!(committed_key, attempt_one_key_raw);
     let committed = fileconv_server::storage::parse_key_for_org(&committed_key, ctx.org_id())
         .expect("committed key");
     assert!(storage
@@ -1466,6 +1475,137 @@ async fn live_convert_worker_reclaim_style_retry_keeps_committed_attempt_object_
         .object_exists(ctx.org_id(), &attempt_one_key)
         .await
         .expect("attempt one cleaned"));
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_barrier_reclaim_promote_before_old_compensation_keeps_committed_object(
+) {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"barrier reclaim\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let job = jobs::enqueue(
+        &pool,
+        &ctx,
+        EnqueueJob::new(
+            JobType::Convert,
+            JobPayload {
+                document_id: Some(document_id),
+                version_id: Some(version_id),
+                collection_id: None,
+                upload_id: None,
+                batch_id: None,
+            },
+            format!("convert-barrier-reclaim-{version_id}"),
+        ),
+    )
+    .await
+    .expect("enqueue")
+    .job;
+
+    let pause = ConvertWorkerPause {
+        staged: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+    };
+    let mut a_config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
+    a_config.lease_ttl = Duration::from_secs(1);
+    a_config.heartbeat_interval = Duration::from_millis(100);
+    a_config.promotion_fault = Some(PromotionFault::AfterStagingPut);
+    a_config.pause_after_staging = Some(pause.clone());
+    let worker_a = ConvertWorker::new(pool.clone(), storage.clone(), a_config).expect("worker a");
+    let run_ctx = ctx.clone();
+    let run_worker = worker_a.clone();
+    let staged_signal = Arc::clone(&pause.staged);
+    let handle_a = tokio::spawn(async move { run_worker.run_once(&run_ctx).await });
+
+    staged_signal.notified().await;
+    let claimed_a = get_job(&pool, &ctx, job.id).await;
+    let key_a = staging_key_for_claim(&ctx, document_id, version_id, &claimed_a);
+    assert!(storage
+        .object_exists(ctx.org_id(), &key_a)
+        .await
+        .expect("key A exists after stage"));
+
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    let reclaimed = jobs::reclaim_expired(&pool, &ctx, 10, Duration::from_secs(1))
+        .await
+        .expect("reclaim expired");
+    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(reclaimed[0].id, job.id);
+    make_job_available(&pool, &ctx, job.id).await;
+
+    let worker_b = ConvertWorker::new(
+        pool.clone(),
+        storage.clone(),
+        stub_worker_config(ECHO_INPUT_SCRIPT, 50),
+    )
+    .expect("worker b");
+    assert!(matches!(
+        worker_b.run_once(&ctx).await.expect("worker b promote"),
+        ConvertWorkerRun::Completed { job_id, .. } if job_id == job.id
+    ));
+    let committed_key = first_markdown_artifact_key(&pool, &ctx, document_id).await;
+    assert_ne!(committed_key, key_a.as_str());
+    let committed = fileconv_server::storage::parse_key_for_org(&committed_key, ctx.org_id())
+        .expect("committed key");
+    let committed_bytes = storage
+        .get_object(ctx.org_id(), &committed)
+        .await
+        .expect("committed object before A release");
+    assert_eq!(committed_bytes.as_ref(), payload);
+
+    pause.release.notify_waiters();
+    match handle_a.await.expect("worker a join") {
+        Ok(ConvertWorkerRun::LeaseLost { job_id }) if job_id == job.id => {}
+        Err(_) => {}
+        other => panic!("unexpected worker A outcome: {other:?}"),
+    }
+
+    assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 1);
+    assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 1);
+    assert_eq!(
+        first_markdown_artifact_key(&pool, &ctx, document_id).await,
+        committed_key
+    );
+    let committed_after = storage
+        .get_object(ctx.org_id(), &committed)
+        .await
+        .expect("committed object after A compensation");
+    assert_eq!(committed_after.as_ref(), payload);
+    assert!(!storage
+        .object_exists(ctx.org_id(), &key_a)
+        .await
+        .expect("key A cleaned"));
 
     ephemeral.drop().await;
 }
@@ -1505,7 +1645,6 @@ async fn live_convert_worker_checkpointed_key_cleans_ambiguous_after_put() {
     )
     .await;
     let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
-    let attempt_one_key = staging_key_for_attempt(&ctx, document_id, version_id, &job, 1);
     let mut ambiguous_config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
     ambiguous_config.lose_staged_handle_after_put = true;
     let ambiguous_worker =
@@ -1514,10 +1653,14 @@ async fn live_convert_worker_checkpointed_key_cleans_ambiguous_after_put() {
         ambiguous_worker.run_once(&ctx).await.expect("ambiguous run"),
         ConvertWorkerRun::Failed { job_id, .. } if job_id == job.id
     ));
-    assert!(!storage
-        .object_exists(ctx.org_id(), &attempt_one_key)
-        .await
-        .expect("checkpoint cleanup"));
+    for staged_key in checkpoint_staged_keys(&pool, &ctx, job.id).await {
+        let staged_key = fileconv_server::storage::parse_key_for_org(&staged_key, ctx.org_id())
+            .expect("checkpoint staged key");
+        assert!(!storage
+            .object_exists(ctx.org_id(), &staged_key)
+            .await
+            .expect("checkpoint cleanup"));
+    }
 
     make_job_available(&pool, &ctx, job.id).await;
     let retry_worker = ConvertWorker::new(
@@ -1571,7 +1714,6 @@ async fn live_convert_worker_delete_failure_is_surfaced_and_retry_cleans() {
     )
     .await;
     let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
-    let attempt_one_key = staging_key_for_attempt(&ctx, document_id, version_id, &job, 1);
     let mut config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
     config.promotion_fault = Some(PromotionFault::AfterStagingPut);
     config.fail_cleanup_delete = true;
@@ -1584,6 +1726,14 @@ async fn live_convert_worker_delete_failure_is_surfaced_and_retry_cleans() {
         get_job(&pool, &ctx, job.id).await.last_error.as_deref(),
         Some("convert compensation deferred")
     );
+    let attempt_one_key_raw = checkpoint_staged_keys(&pool, &ctx, job.id)
+        .await
+        .into_iter()
+        .next()
+        .expect("attempt one staged key");
+    let attempt_one_key =
+        fileconv_server::storage::parse_key_for_org(&attempt_one_key_raw, ctx.org_id())
+            .expect("attempt one key");
     assert!(storage
         .object_exists(ctx.org_id(), &attempt_one_key)
         .await
@@ -1983,19 +2133,6 @@ async fn live_convert_worker_cancel_after_upload_cleans_generated_object() {
     )
     .await;
     let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
-    let identity = ConversionIdentity::new(
-        ctx.org_id(),
-        document_id,
-        version_id,
-        format!("convert-{version_id}"),
-    );
-    let generated_trusted = fileconv_server::services::artifacts::markdown_key(
-        &identity,
-        identity.promoted_version_id(),
-        job.id,
-        job.attempts + 1,
-    )
-    .expect("trusted key");
     let mut config = stub_worker_config("printf converted-after-upload", 50);
     config.post_upload_settlement_delay = Duration::from_secs(1);
     let worker = ConvertWorker::new(pool.clone(), storage.clone(), config).expect("worker");
@@ -2003,6 +2140,14 @@ async fn live_convert_worker_cancel_after_upload_cleans_generated_object() {
     let run_worker = worker.clone();
     let handle = tokio::spawn(async move { run_worker.run_once(&run_ctx).await });
     tokio::time::sleep(Duration::from_millis(250)).await;
+    let staged_key_raw = checkpoint_staged_keys(&pool, &ctx, job.id)
+        .await
+        .into_iter()
+        .next()
+        .expect("checkpoint staged key");
+    let generated_trusted =
+        fileconv_server::storage::parse_key_for_org(&staged_key_raw, ctx.org_id())
+            .expect("trusted key");
     jobs::cancel(&pool, &ctx, job.id).await.expect("cancel");
 
     let outcome = handle.await.expect("join").expect("run once");

--- a/crates/server/tests/worker.rs
+++ b/crates/server/tests/worker.rs
@@ -530,6 +530,25 @@ async fn document_current_version(
     .expect("current version query")
 }
 
+async fn document_state(pool: &Pool, ctx: &OrgContext, document_id: Uuid) -> String {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT state FROM documents WHERE org_id = $1 AND id = $2",
+                        &[&ctx.org_id(), &document_id],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("document state query")
+}
+
 async fn count_published_versions(pool: &Pool, ctx: &OrgContext, document_id: Uuid) -> i64 {
     with_org_txn(pool, ctx, {
         let ctx = ctx.clone();
@@ -1549,6 +1568,94 @@ async fn live_convert_worker_reconciliation_cleans_terminal_parent_leak() {
         .object_exists(ctx.org_id(), &staged)
         .await
         .expect("terminal cleanup removed staged object"));
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+async fn live_convert_worker_tombstone_before_promotion_does_not_regress_document_state() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let Some(storage) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_pool(&base_url).await;
+    let ctx = org_context(Uuid::new_v4(), Uuid::new_v4());
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let quarantine = quarantine_key(ctx.org_id(), Uuid::new_v4(), None).expect("quarantine key");
+    let payload = b"tombstone before promotion\n";
+    let sha256 = put_quarantine_object(
+        &storage,
+        &ctx,
+        &quarantine,
+        payload,
+        "txt",
+        document_id,
+        version_id,
+    )
+    .await;
+    let (document_id, version_id) = seed_org_collection_document_version(
+        &pool,
+        &ctx,
+        document_id,
+        version_id,
+        &quarantine.as_str(),
+        &sha256,
+        payload.len() as u64,
+    )
+    .await;
+    let job = enqueue_convert(&pool, &ctx, document_id, version_id).await;
+    let pause = ConvertWorkerPause {
+        staged: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+    };
+    let mut config = stub_worker_config(ECHO_INPUT_SCRIPT, 50);
+    config.pause_after_staging = Some(pause.clone());
+    let worker = ConvertWorker::new(pool.clone(), storage.clone(), config).expect("worker");
+    let staged_signal = Arc::clone(&pause.staged);
+    let worker_ctx = ctx.clone();
+    let worker_handle = tokio::spawn(async move { worker.run_once(&worker_ctx).await });
+
+    staged_signal.notified().await;
+    with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE documents
+                     SET state = 'tombstoned', deleted_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &document_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("concurrent tombstone");
+    pause.release.notify_waiters();
+
+    assert!(matches!(
+        worker_handle.await.expect("worker join").expect("worker run"),
+        ConvertWorkerRun::Failed {
+            job_id,
+            terminal: false
+        } if job_id == job.id
+    ));
+    assert_eq!(document_state(&pool, &ctx, document_id).await, "tombstoned");
+    assert_eq!(count_published_versions(&pool, &ctx, document_id).await, 0);
+    assert_eq!(count_markdown_artifacts(&pool, &ctx, document_id).await, 0);
+    assert_eq!(count_index_outbox(&pool, &ctx, job.id).await, 0);
+    for staged_key in checkpoint_staged_keys(&pool, &ctx, job.id).await {
+        let staged_key = fileconv_server::storage::parse_key_for_org(&staged_key, ctx.org_id())
+            .expect("staged key");
+        assert!(!storage
+            .object_exists(ctx.org_id(), &staged_key)
+            .await
+            .expect("staged object cleaned"));
+    }
     ephemeral.drop().await;
 }
 


### PR DESCRIPTION
## Summary

- Implements the Phase 1B conversion promotion saga: quarantine download, sandbox convert, staged trusted promotion, immutable version commit, index outbox enqueue, and compensation/refund on failure.
- Adds idempotent retry semantics (one visible version/job), durable reconciliation for uncertain post-COMMIT outcomes, and fair scheduling so cleanup jobs do not starve under sustained convert load.
- Gates document state promotion with expected-state CAS to prevent regressing indexed/tombstoned/deleted documents.

## Scope

P1B-I05 only. Does **not** include I06 index/chunk/embedding worker (separate PR).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `CARGO_BUILD_JOBS=1 cargo test -p fileconv-server` (177 passed)
- [ ] CI Linux integration with `MARKHAND_TEST_DATABASE_URL` + MinIO for full cross-store fault paths

## Review

Orchestrated review loop (3 rounds) — final verdict **APPROVED**.

Made with [Cursor](https://cursor.com)