### PR TITLE
fix(server): complete P1B-R01 authorization gates

### DIFF
--- a/crates/server/migrations/0017_expand_qa_history_permission.sql
+++ b/crates/server/migrations/0017_expand_qa_history_permission.sql
@@ -1,0 +1,32 @@
+-- Phase: 1B
+-- Owner: retrieval-owner
+-- Change: expand
+-- Lock/data risk: additive permission and POC role grants only.
+-- Rollback compatibility: remove the fixed role grants and permission row.
+-- ADR 0002 requires explicit authorization before superseded versions are exposed.
+
+INSERT INTO permissions (id, code, description)
+VALUES (
+    '33333333-3333-3333-3333-333333333307',
+    'qa.history',
+    'Query superseded document versions'
+)
+ON CONFLICT (id) DO NOTHING;
+
+SET LOCAL app.org_id = '11111111-1111-1111-1111-111111111111';
+
+-- History is deliberately narrower than qa.query in the single-org POC.
+-- Owner/admin may inspect prior versions; editor/viewer remain current-only.
+INSERT INTO role_permissions (org_id, role_id, permission_id)
+VALUES
+    (
+        '11111111-1111-1111-1111-111111111111',
+        '44444444-4444-4444-4444-444444444401',
+        '33333333-3333-3333-3333-333333333307'
+    ),
+    (
+        '11111111-1111-1111-1111-111111111111',
+        '44444444-4444-4444-4444-444444444402',
+        '33333333-3333-3333-3333-333333333307'
+    )
+ON CONFLICT (role_id, permission_id) DO NOTHING;

--- a/crates/server/migrations/manifest.json
+++ b/crates/server/migrations/manifest.json
@@ -16,6 +16,7 @@
     "0013_expand_index_generation_rls.sql": "0a433b0cfe7fdb291e2420e2fa6e41412ab900281a1354ac1fb6f6621ebd924d",
     "0014_expand_vector_cleanup_intents.sql": "fb9ae5f06cbcd5f438eaac6b9b0464627b47aa90e3115717d76c3656e0350932",
     "0015_expand_vector_cleanup_intent_states.sql": "f5f5cdcee30a96f3541a6635efaf1147f8595b09b03b1a919c916ee09e4706a5",
-    "0016_expand_chunks_accent_fold_tsv.sql": "ab850b0ba0f1f323f498e4874c02d51f14421d016f6a792ed63780be4f3f38dd"
+    "0016_expand_chunks_accent_fold_tsv.sql": "ab850b0ba0f1f323f498e4874c02d51f14421d016f6a792ed63780be4f3f38dd",
+    "0017_expand_qa_history_permission.sql": "f804d47e4108251ed368299faed312cfbb093500f066a576d30d8da39f973b3a"
   }
 }

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -70,6 +70,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0016_expand_chunks_accent_fold_tsv.sql",
         include_str!("../migrations/0016_expand_chunks_accent_fold_tsv.sql"),
     ),
+    (
+        "0017_expand_qa_history_permission.sql",
+        include_str!("../migrations/0017_expand_qa_history_permission.sql"),
+    ),
 ];
 
 /// Embedded migration sources in apply order (name, SQL). Used by integration tests.

--- a/crates/server/src/db/search.rs
+++ b/crates/server/src/db/search.rs
@@ -308,13 +308,34 @@ pub async fn hydrate_chunks_by_identity(
                  WHERE c.org_id = $1
                    AND d.collection_id = ANY($2)
                    AND c.chunk_identity_sha256 = ANY($3)
+                   AND EXISTS (
+                     SELECT 1
+                     FROM collections acl_c
+                     JOIN org_memberships acl_m
+                       ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $4
+                     JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     WHERE acl_c.org_id = d.org_id
+                       AND acl_c.id = d.collection_id
+                       AND acl_c.deleted_at IS NULL
+                       AND acl_u.disabled_at IS NULL
+                       AND (
+                         acl_c.visibility = 'org'
+                         OR acl_c.owner_user_id = $4
+                         OR EXISTS (
+                           SELECT 1 FROM collection_user_access cua
+                           WHERE cua.org_id = acl_c.org_id
+                             AND cua.collection_id = acl_c.id
+                             AND cua.user_id = $4
+                         )
+                       )
+                   )
                    AND d.deleted_at IS NULL
                    AND d.state = 'indexed'
                    AND dv.publication_state = 'published'
                    AND dv.is_current
                    AND im.is_active
                    AND im.state = 'active'",
-                &[&ctx.org_id(), &collection_ids, &identities],
+                &[&ctx.org_id(), &collection_ids, &identities, &ctx.user_id()],
             )
             .await?
         }
@@ -343,12 +364,39 @@ pub async fn hydrate_chunks_by_identity(
                    AND d.collection_id = ANY($2)
                    AND c.chunk_identity_sha256 = ANY($3)
                    AND c.version_id = ANY($4)
+                   AND EXISTS (
+                     SELECT 1
+                     FROM collections acl_c
+                     JOIN org_memberships acl_m
+                       ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $5
+                     JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     WHERE acl_c.org_id = d.org_id
+                       AND acl_c.id = d.collection_id
+                       AND acl_c.deleted_at IS NULL
+                       AND acl_u.disabled_at IS NULL
+                       AND (
+                         acl_c.visibility = 'org'
+                         OR acl_c.owner_user_id = $5
+                         OR EXISTS (
+                           SELECT 1 FROM collection_user_access cua
+                           WHERE cua.org_id = acl_c.org_id
+                             AND cua.collection_id = acl_c.id
+                             AND cua.user_id = $5
+                         )
+                       )
+                   )
                    AND d.deleted_at IS NULL
                    AND d.state = 'indexed'
                    AND dv.publication_state = 'published'
                    AND im.is_active
                    AND im.state = 'active'",
-                &[&ctx.org_id(), &collection_ids, &identities, &versions],
+                &[
+                    &ctx.org_id(),
+                    &collection_ids,
+                    &identities,
+                    &versions,
+                    &ctx.user_id(),
+                ],
             )
             .await?
         }
@@ -406,6 +454,48 @@ pub async fn load_authorized_conflict_evidence(
                    AND conf.id = ANY($2)
                    AND da.collection_id = ANY($3)
                    AND db.collection_id = ANY($3)
+                   AND EXISTS (
+                     SELECT 1
+                     FROM collections acl_c
+                     JOIN org_memberships acl_m
+                       ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $4
+                     JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     WHERE acl_c.org_id = da.org_id
+                       AND acl_c.id = da.collection_id
+                       AND acl_c.deleted_at IS NULL
+                       AND acl_u.disabled_at IS NULL
+                       AND (
+                         acl_c.visibility = 'org'
+                         OR acl_c.owner_user_id = $4
+                         OR EXISTS (
+                           SELECT 1 FROM collection_user_access cua
+                           WHERE cua.org_id = acl_c.org_id
+                             AND cua.collection_id = acl_c.id
+                             AND cua.user_id = $4
+                         )
+                       )
+                   )
+                   AND EXISTS (
+                     SELECT 1
+                     FROM collections acl_c
+                     JOIN org_memberships acl_m
+                       ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $4
+                     JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     WHERE acl_c.org_id = db.org_id
+                       AND acl_c.id = db.collection_id
+                       AND acl_c.deleted_at IS NULL
+                       AND acl_u.disabled_at IS NULL
+                       AND (
+                         acl_c.visibility = 'org'
+                         OR acl_c.owner_user_id = $4
+                         OR EXISTS (
+                           SELECT 1 FROM collection_user_access cua
+                           WHERE cua.org_id = acl_c.org_id
+                             AND cua.collection_id = acl_c.id
+                             AND cua.user_id = $4
+                         )
+                       )
+                   )
                    AND da.deleted_at IS NULL
                    AND db.deleted_at IS NULL
                    AND da.state = 'indexed'
@@ -414,7 +504,12 @@ pub async fn load_authorized_conflict_evidence(
                    AND dvb.publication_state = 'published'
                    AND dva.is_current
                    AND dvb.is_current",
-                &[&ctx.org_id(), &conflict_ids, &collection_ids],
+                &[
+                    &ctx.org_id(),
+                    &conflict_ids,
+                    &collection_ids,
+                    &ctx.user_id(),
+                ],
             )
             .await?
         }
@@ -459,6 +554,48 @@ pub async fn load_authorized_conflict_evidence(
                    AND conf.id = ANY($2)
                    AND da.collection_id = ANY($3)
                    AND db.collection_id = ANY($3)
+                   AND EXISTS (
+                     SELECT 1
+                     FROM collections acl_c
+                     JOIN org_memberships acl_m
+                       ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $5
+                     JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     WHERE acl_c.org_id = da.org_id
+                       AND acl_c.id = da.collection_id
+                       AND acl_c.deleted_at IS NULL
+                       AND acl_u.disabled_at IS NULL
+                       AND (
+                         acl_c.visibility = 'org'
+                         OR acl_c.owner_user_id = $5
+                         OR EXISTS (
+                           SELECT 1 FROM collection_user_access cua
+                           WHERE cua.org_id = acl_c.org_id
+                             AND cua.collection_id = acl_c.id
+                             AND cua.user_id = $5
+                         )
+                       )
+                   )
+                   AND EXISTS (
+                     SELECT 1
+                     FROM collections acl_c
+                     JOIN org_memberships acl_m
+                       ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $5
+                     JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     WHERE acl_c.org_id = db.org_id
+                       AND acl_c.id = db.collection_id
+                       AND acl_c.deleted_at IS NULL
+                       AND acl_u.disabled_at IS NULL
+                       AND (
+                         acl_c.visibility = 'org'
+                         OR acl_c.owner_user_id = $5
+                         OR EXISTS (
+                           SELECT 1 FROM collection_user_access cua
+                           WHERE cua.org_id = acl_c.org_id
+                             AND cua.collection_id = acl_c.id
+                             AND cua.user_id = $5
+                         )
+                       )
+                   )
                    AND da.deleted_at IS NULL
                    AND db.deleted_at IS NULL
                    AND da.state = 'indexed'
@@ -467,7 +604,13 @@ pub async fn load_authorized_conflict_evidence(
                    AND dvb.publication_state = 'published'
                    AND ca.version_id = ANY($4)
                    AND cb.version_id = ANY($4)",
-                &[&ctx.org_id(), &conflict_ids, &collection_ids, &versions],
+                &[
+                    &ctx.org_id(),
+                    &conflict_ids,
+                    &collection_ids,
+                    &versions,
+                    &ctx.user_id(),
+                ],
             )
             .await?
         }

--- a/crates/server/src/db/search.rs
+++ b/crates/server/src/db/search.rs
@@ -333,6 +333,14 @@ pub async fn hydrate_chunks_by_identity(
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
                        AND acl_p.code = $5
+                       AND EXISTS (
+                         SELECT 1
+                         FROM role_permissions query_rp
+                         JOIN permissions query_p ON query_p.id = query_rp.permission_id
+                         WHERE query_rp.org_id = acl_r.org_id
+                           AND query_rp.role_id = acl_r.id
+                           AND query_p.code = 'qa.query'
+                       )
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $4
@@ -401,6 +409,14 @@ pub async fn hydrate_chunks_by_identity(
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
                        AND acl_p.code = $6
+                       AND EXISTS (
+                         SELECT 1
+                         FROM role_permissions query_rp
+                         JOIN permissions query_p ON query_p.id = query_rp.permission_id
+                         WHERE query_rp.org_id = acl_r.org_id
+                           AND query_rp.role_id = acl_r.id
+                           AND query_p.code = 'qa.query'
+                       )
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $5
@@ -498,6 +514,14 @@ pub async fn load_authorized_conflict_evidence(
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
                        AND acl_p.code = $5
+                       AND EXISTS (
+                         SELECT 1
+                         FROM role_permissions query_rp
+                         JOIN permissions query_p ON query_p.id = query_rp.permission_id
+                         WHERE query_rp.org_id = acl_r.org_id
+                           AND query_rp.role_id = acl_r.id
+                           AND query_p.code = 'qa.query'
+                       )
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $4
@@ -525,6 +549,14 @@ pub async fn load_authorized_conflict_evidence(
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
                        AND acl_p.code = $5
+                       AND EXISTS (
+                         SELECT 1
+                         FROM role_permissions query_rp
+                         JOIN permissions query_p ON query_p.id = query_rp.permission_id
+                         WHERE query_rp.org_id = acl_r.org_id
+                           AND query_rp.role_id = acl_r.id
+                           AND query_p.code = 'qa.query'
+                       )
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $4
@@ -611,6 +643,14 @@ pub async fn load_authorized_conflict_evidence(
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
                        AND acl_p.code = $6
+                       AND EXISTS (
+                         SELECT 1
+                         FROM role_permissions query_rp
+                         JOIN permissions query_p ON query_p.id = query_rp.permission_id
+                         WHERE query_rp.org_id = acl_r.org_id
+                           AND query_rp.role_id = acl_r.id
+                           AND query_p.code = 'qa.query'
+                       )
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $5
@@ -638,6 +678,14 @@ pub async fn load_authorized_conflict_evidence(
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
                        AND acl_p.code = $6
+                       AND EXISTS (
+                         SELECT 1
+                         FROM role_permissions query_rp
+                         JOIN permissions query_p ON query_p.id = query_rp.permission_id
+                         WHERE query_rp.org_id = acl_r.org_id
+                           AND query_rp.role_id = acl_r.id
+                           AND query_p.code = 'qa.query'
+                       )
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $5

--- a/crates/server/src/db/search.rs
+++ b/crates/server/src/db/search.rs
@@ -82,6 +82,15 @@ pub enum VersionVisibility {
     VersionIds(BTreeSet<Uuid>),
 }
 
+impl VersionVisibility {
+    fn required_permission(&self) -> &'static str {
+        match self {
+            Self::Current => "qa.query",
+            Self::VersionIds(_) => "qa.history",
+        }
+    }
+}
+
 /// Shadow/building/retired generations must not surface in retrieval.
 pub fn index_generation_visible_for_retrieval(
     is_active: bool,
@@ -314,10 +323,16 @@ pub async fn hydrate_chunks_by_identity(
                      JOIN org_memberships acl_m
                        ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $4
                      JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     JOIN roles acl_r
+                       ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+                     JOIN role_permissions acl_rp
+                       ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+                     JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
                      WHERE acl_c.org_id = d.org_id
                        AND acl_c.id = d.collection_id
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
+                       AND acl_p.code = $5
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $4
@@ -335,7 +350,13 @@ pub async fn hydrate_chunks_by_identity(
                    AND dv.is_current
                    AND im.is_active
                    AND im.state = 'active'",
-                &[&ctx.org_id(), &collection_ids, &identities, &ctx.user_id()],
+                &[
+                    &ctx.org_id(),
+                    &collection_ids,
+                    &identities,
+                    &ctx.user_id(),
+                    &visibility.required_permission(),
+                ],
             )
             .await?
         }
@@ -370,10 +391,16 @@ pub async fn hydrate_chunks_by_identity(
                      JOIN org_memberships acl_m
                        ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $5
                      JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     JOIN roles acl_r
+                       ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+                     JOIN role_permissions acl_rp
+                       ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+                     JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
                      WHERE acl_c.org_id = d.org_id
                        AND acl_c.id = d.collection_id
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
+                       AND acl_p.code = $6
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $5
@@ -396,6 +423,7 @@ pub async fn hydrate_chunks_by_identity(
                     &identities,
                     &versions,
                     &ctx.user_id(),
+                    &visibility.required_permission(),
                 ],
             )
             .await?
@@ -460,10 +488,16 @@ pub async fn load_authorized_conflict_evidence(
                      JOIN org_memberships acl_m
                        ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $4
                      JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     JOIN roles acl_r
+                       ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+                     JOIN role_permissions acl_rp
+                       ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+                     JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
                      WHERE acl_c.org_id = da.org_id
                        AND acl_c.id = da.collection_id
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
+                       AND acl_p.code = $5
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $4
@@ -481,10 +515,16 @@ pub async fn load_authorized_conflict_evidence(
                      JOIN org_memberships acl_m
                        ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $4
                      JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     JOIN roles acl_r
+                       ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+                     JOIN role_permissions acl_rp
+                       ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+                     JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
                      WHERE acl_c.org_id = db.org_id
                        AND acl_c.id = db.collection_id
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
+                       AND acl_p.code = $5
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $4
@@ -509,6 +549,7 @@ pub async fn load_authorized_conflict_evidence(
                     &conflict_ids,
                     &collection_ids,
                     &ctx.user_id(),
+                    &visibility.required_permission(),
                 ],
             )
             .await?
@@ -560,10 +601,16 @@ pub async fn load_authorized_conflict_evidence(
                      JOIN org_memberships acl_m
                        ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $5
                      JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     JOIN roles acl_r
+                       ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+                     JOIN role_permissions acl_rp
+                       ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+                     JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
                      WHERE acl_c.org_id = da.org_id
                        AND acl_c.id = da.collection_id
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
+                       AND acl_p.code = $6
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $5
@@ -581,10 +628,16 @@ pub async fn load_authorized_conflict_evidence(
                      JOIN org_memberships acl_m
                        ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $5
                      JOIN users acl_u ON acl_u.id = acl_m.user_id
+                     JOIN roles acl_r
+                       ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+                     JOIN role_permissions acl_rp
+                       ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+                     JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
                      WHERE acl_c.org_id = db.org_id
                        AND acl_c.id = db.collection_id
                        AND acl_c.deleted_at IS NULL
                        AND acl_u.disabled_at IS NULL
+                       AND acl_p.code = $6
                        AND (
                          acl_c.visibility = 'org'
                          OR acl_c.owner_user_id = $5
@@ -610,6 +663,7 @@ pub async fn load_authorized_conflict_evidence(
                     &collection_ids,
                     &versions,
                     &ctx.user_id(),
+                    &visibility.required_permission(),
                 ],
             )
             .await?

--- a/crates/server/src/services/retrieval/mod.rs
+++ b/crates/server/src/services/retrieval/mod.rs
@@ -46,6 +46,8 @@ use crate::storage::qdrant::{QdrantClient, VectorScope};
 
 /// Permission required for retrieval (POC seed).
 pub const PERMISSION_QA_QUERY: &str = "qa.query";
+/// Additional permission required whenever retrieval can expose a superseded version.
+pub const PERMISSION_QA_HISTORY: &str = "qa.history";
 
 /// Candidate pull depth per leg before merge (desktop uses 250/500).
 const LEG_CANDIDATE_LIMIT: usize = 250;
@@ -233,6 +235,14 @@ pub fn validate_request(request: &RetrievalRequest) -> Result<(), RetrievalError
     Ok(())
 }
 
+fn require_mode_permissions(ctx: &OrgContext, mode: &VersionMode) -> Result<(), RetrievalError> {
+    require_permission(ctx, PERMISSION_QA_QUERY)?;
+    if !matches!(mode, VersionMode::Current) {
+        require_permission(ctx, PERMISSION_QA_HISTORY)?;
+    }
+    Ok(())
+}
+
 /// Tenant-scoped hybrid search. OrgContext is mandatory on every path.
 pub async fn hybrid_search(
     pool: &Pool,
@@ -241,7 +251,7 @@ pub async fn hybrid_search(
     ctx: &OrgContext,
     request: RetrievalRequest,
 ) -> Result<RetrievalResponse, RetrievalError> {
-    require_permission(ctx, PERMISSION_QA_QUERY)?;
+    require_mode_permissions(ctx, &request.mode)?;
     validate_request(&request)?;
     let scope = resolve_scope(ctx, request.collection_ids.as_ref())?;
     let collection_ids: Vec<Uuid> = scope.collection_ids.iter().copied().collect();
@@ -856,6 +866,41 @@ mod tests {
         let ctx = ctx_with([allowed]);
         let err = resolve_scope(&ctx, Some(&BTreeSet::from([allowed, foreign]))).unwrap_err();
         assert!(matches!(err, RetrievalError::PermissionDenied));
+    }
+
+    #[test]
+    fn historical_modes_require_explicit_history_permission() {
+        let collection = Uuid::new_v4();
+        let query_only = ctx_with([collection]);
+        let modes = [
+            VersionMode::AsOf { at: Utc::now() },
+            VersionMode::Compare {
+                document_id: Uuid::new_v4(),
+                version_a: Uuid::new_v4(),
+                version_b: Uuid::new_v4(),
+            },
+            VersionMode::History {
+                document_id: Uuid::new_v4(),
+            },
+        ];
+        for mode in &modes {
+            assert!(matches!(
+                require_mode_permissions(&query_only, mode),
+                Err(RetrievalError::PermissionDenied)
+            ));
+        }
+
+        let allowed = OrgContext::try_new(
+            query_only.org_id(),
+            query_only.user_id(),
+            [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+            [collection],
+        )
+        .unwrap();
+        assert!(require_mode_permissions(&allowed, &VersionMode::Current).is_ok());
+        for mode in &modes {
+            assert!(require_mode_permissions(&allowed, mode).is_ok());
+        }
     }
 
     #[test]

--- a/crates/server/tests/retrieval.rs
+++ b/crates/server/tests/retrieval.rs
@@ -159,7 +159,7 @@ async fn as_of_resolves_effective_version_from_postgres() {
                 let user_email = format!("{}@example.test", ctx.user_id());
                 txn.execute(
                     "INSERT INTO users (id, email, display_name, password_hash)
-                     VALUES ($1, $2, 'u', 'x')",
+                     VALUES ($1, $2, 'u', 'test-hash')",
                     &[&ctx.user_id(), &user_email],
                 )
                 .await?;
@@ -280,7 +280,7 @@ async fn fts_rank_accent_fold_and_active_generation_gates() {
                 let user_email = format!("{}@example.test", ctx.user_id());
                 txn.execute(
                     "INSERT INTO users (id, email, display_name, password_hash)
-                     VALUES ($1, $2, 'u', 'x')",
+                     VALUES ($1, $2, 'u', 'test-hash')",
                     &[&ctx.user_id(), &user_email],
                 )
                 .await?;

--- a/crates/server/tests/retrieval.rs
+++ b/crates/server/tests/retrieval.rs
@@ -14,7 +14,7 @@ use fileconv_server::db::pool::{create_pool, with_org_txn};
 use fileconv_server::db::search::{self, VersionVisibility};
 use fileconv_server::services::retrieval::{
     resolve_scope, same_lineage_pair, validate_request, RetrievalError, RetrievalRequest,
-    VersionMode, PERMISSION_QA_QUERY,
+    VersionMode, PERMISSION_QA_HISTORY, PERMISSION_QA_QUERY,
 };
 use tokio_postgres::NoTls;
 use uuid::Uuid;
@@ -141,11 +141,18 @@ async fn as_of_resolves_effective_version_from_postgres() {
     let org = Uuid::new_v4();
     let user = Uuid::new_v4();
     let collection = Uuid::new_v4();
+    let role = Uuid::new_v4();
     let document = Uuid::new_v4();
     let v1 = Uuid::new_v4();
     let v2 = Uuid::new_v4();
     let v3 = Uuid::new_v4();
-    let ctx = OrgContext::try_new(org, user, [PERMISSION_QA_QUERY], [collection]).unwrap();
+    let ctx = OrgContext::try_new(
+        org,
+        user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [collection],
+    )
+    .unwrap();
 
     with_org_txn(&pool, &ctx, {
         let ctx = ctx.clone();
@@ -167,6 +174,27 @@ async fn as_of_resolves_effective_version_from_postgres() {
                     "INSERT INTO org_memberships (org_id, user_id, role)
                      VALUES ($1, $2, 'viewer')",
                     &[&ctx.org_id(), &ctx.user_id()],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO roles (id, org_id, code, name, is_system)
+                     VALUES ($1, $2, 'viewer', 'Viewer', true)",
+                    &[&role, &ctx.org_id()],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     SELECT $1, $2, id
+                     FROM permissions
+                     WHERE code = ANY($3)",
+                    &[
+                        &ctx.org_id(),
+                        &role,
+                        &[
+                            PERMISSION_QA_QUERY.to_string(),
+                            PERMISSION_QA_HISTORY.to_string(),
+                        ],
+                    ],
                 )
                 .await?;
                 txn.execute(
@@ -250,6 +278,7 @@ async fn fts_rank_accent_fold_and_active_generation_gates() {
     let org = Uuid::new_v4();
     let user = Uuid::new_v4();
     let collection = Uuid::new_v4();
+    let role = Uuid::new_v4();
     let document = Uuid::new_v4();
     let version = Uuid::new_v4();
     let meta_active = Uuid::new_v4();
@@ -261,7 +290,13 @@ async fn fts_rank_accent_fold_and_active_generation_gates() {
     let identity_active = sha64('c');
     let identity_shadow = sha64('d');
     let content_sha = sha64('e');
-    let ctx = OrgContext::try_new(org, user, [PERMISSION_QA_QUERY], [collection]).unwrap();
+    let ctx = OrgContext::try_new(
+        org,
+        user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [collection],
+    )
+    .unwrap();
 
     with_org_txn(&pool, &ctx, {
         let ctx = ctx.clone();
@@ -288,6 +323,27 @@ async fn fts_rank_accent_fold_and_active_generation_gates() {
                     "INSERT INTO org_memberships (org_id, user_id, role)
                      VALUES ($1, $2, 'viewer')",
                     &[&ctx.org_id(), &ctx.user_id()],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO roles (id, org_id, code, name, is_system)
+                     VALUES ($1, $2, 'viewer', 'Viewer', true)",
+                    &[&role, &ctx.org_id()],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     SELECT $1, $2, id
+                     FROM permissions
+                     WHERE code = ANY($3)",
+                    &[
+                        &ctx.org_id(),
+                        &role,
+                        &[
+                            PERMISSION_QA_QUERY.to_string(),
+                            PERMISSION_QA_HISTORY.to_string(),
+                        ],
+                    ],
                 )
                 .await?;
                 txn.execute(
@@ -420,6 +476,50 @@ async fn fts_rank_accent_fold_and_active_generation_gates() {
                 )
                 .await?;
                 assert_eq!(hydrated.len(), 1);
+
+                let historical_visibility =
+                    VersionVisibility::VersionIds(BTreeSet::from([version]));
+                let historical = search::hydrate_chunks_by_identity(
+                    txn,
+                    &ctx,
+                    &[collection],
+                    std::slice::from_ref(&identity_active),
+                    &historical_visibility,
+                )
+                .await?;
+                assert_eq!(historical.len(), 1);
+
+                txn.execute(
+                    "DELETE FROM role_permissions
+                     WHERE org_id = $1
+                       AND role_id = $2
+                       AND permission_id = (
+                         SELECT id FROM permissions WHERE code = $3
+                       )",
+                    &[&ctx.org_id(), &role, &PERMISSION_QA_HISTORY],
+                )
+                .await?;
+                let current_after_history_revoke = search::hydrate_chunks_by_identity(
+                    txn,
+                    &ctx,
+                    &[collection],
+                    std::slice::from_ref(&identity_active),
+                    &VersionVisibility::Current,
+                )
+                .await?;
+                assert_eq!(current_after_history_revoke.len(), 1);
+                let denied_historical = search::hydrate_chunks_by_identity(
+                    txn,
+                    &ctx,
+                    &[collection],
+                    std::slice::from_ref(&identity_active),
+                    &historical_visibility,
+                )
+                .await?;
+                assert!(
+                    denied_historical.is_empty(),
+                    "historical hydration must recheck qa.history instead of trusting stale OrgContext"
+                );
 
                 txn.execute(
                     "DELETE FROM org_memberships WHERE org_id = $1 AND user_id = $2",

--- a/crates/server/tests/retrieval.rs
+++ b/crates/server/tests/retrieval.rs
@@ -164,6 +164,12 @@ async fn as_of_resolves_effective_version_from_postgres() {
                 )
                 .await?;
                 txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'viewer')",
+                    &[&ctx.org_id(), &ctx.user_id()],
+                )
+                .await?;
+                txn.execute(
                     "INSERT INTO collections (
                         id, org_id, name, slug, owner_user_id, visibility
                      ) VALUES ($1, $2, 'c', $3, $4, 'org')",
@@ -276,6 +282,12 @@ async fn fts_rank_accent_fold_and_active_generation_gates() {
                     "INSERT INTO users (id, email, display_name, password_hash)
                      VALUES ($1, $2, 'u', 'x')",
                     &[&ctx.user_id(), &user_email],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'viewer')",
+                    &[&ctx.org_id(), &ctx.user_id()],
                 )
                 .await?;
                 txn.execute(
@@ -398,6 +410,34 @@ async fn fts_rank_accent_fold_and_active_generation_gates() {
                     .await?;
                 let rank_f32: f32 = search::read_pg_real_rank(&row, "rank");
                 assert!(rank_f32 > 0.0);
+
+                let hydrated = search::hydrate_chunks_by_identity(
+                    txn,
+                    &ctx,
+                    &[collection],
+                    std::slice::from_ref(&identity_active),
+                    &VersionVisibility::Current,
+                )
+                .await?;
+                assert_eq!(hydrated.len(), 1);
+
+                txn.execute(
+                    "DELETE FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+                    &[&ctx.org_id(), &ctx.user_id()],
+                )
+                .await?;
+                let denied_after_membership_revoke = search::hydrate_chunks_by_identity(
+                    txn,
+                    &ctx,
+                    &[collection],
+                    std::slice::from_ref(&identity_active),
+                    &VersionVisibility::Current,
+                )
+                .await?;
+                assert!(
+                    denied_after_membership_revoke.is_empty(),
+                    "hydration must recheck current membership instead of trusting stale OrgContext"
+                );
 
                 Ok(())
             })

--- a/crates/server/tests/retrieval.rs
+++ b/crates/server/tests/retrieval.rs
@@ -186,15 +186,8 @@ async fn as_of_resolves_effective_version_from_postgres() {
                     "INSERT INTO role_permissions (org_id, role_id, permission_id)
                      SELECT $1, $2, id
                      FROM permissions
-                     WHERE code = ANY($3)",
-                    &[
-                        &ctx.org_id(),
-                        &role,
-                        &[
-                            PERMISSION_QA_QUERY.to_string(),
-                            PERMISSION_QA_HISTORY.to_string(),
-                        ],
-                    ],
+                     WHERE code IN ('qa.query', 'qa.history')",
+                    &[&ctx.org_id(), &role],
                 )
                 .await?;
                 txn.execute(
@@ -335,15 +328,8 @@ async fn fts_rank_accent_fold_and_active_generation_gates() {
                     "INSERT INTO role_permissions (org_id, role_id, permission_id)
                      SELECT $1, $2, id
                      FROM permissions
-                     WHERE code = ANY($3)",
-                    &[
-                        &ctx.org_id(),
-                        &role,
-                        &[
-                            PERMISSION_QA_QUERY.to_string(),
-                            PERMISSION_QA_HISTORY.to_string(),
-                        ],
-                    ],
+                     WHERE code IN ('qa.query', 'qa.history')",
+                    &[&ctx.org_id(), &role],
                 )
                 .await?;
                 txn.execute(

--- a/crates/server/tests/retrieval.rs
+++ b/crates/server/tests/retrieval.rs
@@ -508,6 +508,41 @@ async fn fts_rank_accent_fold_and_active_generation_gates() {
                 );
 
                 txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     SELECT $1, $2, id FROM permissions WHERE code = $3",
+                    &[&ctx.org_id(), &role, &PERMISSION_QA_HISTORY],
+                )
+                .await?;
+                txn.execute(
+                    "DELETE FROM role_permissions
+                     WHERE org_id = $1
+                       AND role_id = $2
+                       AND permission_id = (
+                         SELECT id FROM permissions WHERE code = $3
+                       )",
+                    &[&ctx.org_id(), &role, &PERMISSION_QA_QUERY],
+                )
+                .await?;
+                let denied_without_query = search::hydrate_chunks_by_identity(
+                    txn,
+                    &ctx,
+                    &[collection],
+                    std::slice::from_ref(&identity_active),
+                    &historical_visibility,
+                )
+                .await?;
+                assert!(
+                    denied_without_query.is_empty(),
+                    "historical hydration must recheck qa.query as well as qa.history"
+                );
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     SELECT $1, $2, id FROM permissions WHERE code = $3",
+                    &[&ctx.org_id(), &role, &PERMISSION_QA_QUERY],
+                )
+                .await?;
+
+                txn.execute(
                     "DELETE FROM org_memberships WHERE org_id = $1 AND user_id = $2",
                     &[&ctx.org_id(), &ctx.user_id()],
                 )

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -191,7 +191,8 @@ ghi trong issue đã `Done`.
 
 ### P1B-R01 — Tenant-scoped hybrid retrieval
 
-- **Status:** Review — draft PR #252; addressing Sol REQUEST_CHANGES. Do not mark Done until Sol APPROVE.
+- **Status:** Review — PR #252 merged; post-merge authorization hardening and live
+  PostgreSQL acceptance evidence are in PR #254. Mark Done after that PR merges.
 - **Plan:** Resolve scope + current/as-of/compare/history mode; query embed; parallel
   Qdrant/FTS với version filter; knowledge merge/rerank; PG hydration/recheck
   state/ACL/version; hydrate only conflict evidence whose both sides remain authorized.

--- a/plans/markhand-web/phase-1c-multi-org-security.md
+++ b/plans/markhand-web/phase-1c-multi-org-security.md
@@ -22,7 +22,7 @@ API gồm org list/detail, members CRUD và org switch/session refresh.
 Permission constants:
 
 - `doc.upload`, `doc.delete`;
-- `qa.query`;
+- `qa.query`, `qa.history`;
 - `member.manage`, `settings.manage`;
 - `intel.use`, `pii.manage`, `export.run`;
 - `audit.view`.
@@ -38,6 +38,7 @@ Canonical built-in matrix:
 | `doc.upload` | ✓ | ✓ | ✓ | |
 | `doc.delete` | ✓ | ✓ | own/explicit policy | |
 | `qa.query` | ✓ | ✓ | ✓ | ✓ |
+| `qa.history` | ✓ | ✓ | | |
 | `member.manage` | ✓ | ✓, không quản owner | | |
 | `settings.manage` | ✓ | ✓, trừ owner/security | | |
 | `intel.use` | ✓ | ✓ | ✓ | theo org policy |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Closes the remaining P1B-R01 authorization gaps found during post-merge review of PR #252.

## Scope

- Require explicit `qa.query` plus `qa.history` permission for `as_of`, `compare`, and `history` retrieval.
- Seed the POC owner/admin roles with `qa.history` through an additive migration.
- Recheck live membership, user state, both required role permissions, collection deletion, visibility, ownership, and direct grants in PostgreSQL when hydrating chunks and conflict evidence.
- Add regressions for revoking `qa.history`, revoking `qa.query`, and removing membership while the request retains a stale `OrgContext`.

## Evidence

- [x] Tests: complete `cargo test -p fileconv-server` suite passes.
- [x] PostgreSQL integration: both ignored retrieval tests pass against local PostgreSQL, including live permission and membership revocation checks.
- [x] Lint: `cargo clippy -p fileconv-server --all-targets --no-deps -- -D warnings` passes.
- [x] Migration evidence: additive migration applied in ephemeral databases and immutable manifest check passes.
- [x] Mandatory preflight: rustfmt, locked metadata, dependency policy, migration manifest, and roadmap checks pass.
- [x] Independent final security review: APPROVE with no remaining findings.

## Boundary and security review

- [x] Dependency boundary check passed.
- [x] Tenant/ACL impact reviewed: hydration fails closed against current PostgreSQL authorization state.
- [x] Sensitive logging/secret/egress impact reviewed: no logging or egress changes.
- [x] Security review trigger checked: authorization behavior is covered by dedicated PostgreSQL regressions.

## Follow-up

- [ ] After this PR merges, mark P1B-R01 Done, rebuild the roadmap, and close issue #91.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8539-2448-79bf-bb28-1135cc995007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8539-2448-79bf-bb28-1135cc995007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

