### PR TITLE
feat(server): add authorized citation preview and download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,7 @@ dependencies = [
  "fileconv-knowledge",
  "futures",
  "hex",
+ "http-body",
  "http-body-util",
  "image",
  "jsonwebtoken",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -34,6 +34,7 @@ fileconv-core = { path = "../core" }
 fileconv-knowledge = { path = "../knowledge" }
 futures = "0.3.33"
 hex = "0.4.3"
+http-body = "1.0.1"
 image = { version = "0.25.10", default-features = false, features = ["png", "jpeg", "bmp", "webp", "tiff"] }
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 libc = "0.2.186"

--- a/crates/server/migrations/0018_expand_download_capabilities.sql
+++ b/crates/server/migrations/0018_expand_download_capabilities.sql
@@ -1,0 +1,51 @@
+-- Phase: 1B
+-- Owner: retrieval-owner, security-owner
+-- Change: expand
+-- Lock/data risk: creates empty download_capabilities table + RLS policy.
+-- Rollback compatibility: additive; drop table to reverse.
+--
+-- Single-use, short-lived download capabilities (P1B-R02 / ADR 0002 / ADR 0007).
+-- Tokens are HMAC-bound to org/user/document/version/purpose/hash/type/size;
+-- PostgreSQL is the authority for issuance, expiry and replay (consumed_at).
+-- Raw MinIO credentials and object keys are never returned to clients.
+
+CREATE TABLE download_capabilities (
+    id uuid PRIMARY KEY,
+    org_id uuid NOT NULL REFERENCES orgs(id) ON DELETE RESTRICT,
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    document_id uuid NOT NULL,
+    version_id uuid NOT NULL,
+    purpose text NOT NULL
+        CHECK (purpose IN ('original', 'markdown')),
+    content_sha256 text NOT NULL
+        CHECK (content_sha256 ~ '^[0-9a-f]{64}$'),
+    content_type text NOT NULL
+        CHECK (length(trim(content_type)) > 0 AND length(content_type) <= 255),
+    byte_size bigint NOT NULL
+        CHECK (byte_size > 0),
+    expires_at timestamptz NOT NULL,
+    consumed_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT fk_download_capabilities__document_org
+        FOREIGN KEY (org_id, document_id) REFERENCES documents (org_id, id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_download_capabilities__version_org
+        FOREIGN KEY (org_id, document_id, version_id)
+        REFERENCES document_versions (org_id, document_id, id)
+        ON DELETE CASCADE,
+    CONSTRAINT ck_download_capabilities__expires_after_created
+        CHECK (expires_at > created_at)
+);
+
+CREATE INDEX idx_download_capabilities__org_user_open
+    ON download_capabilities (org_id, user_id, expires_at)
+    WHERE consumed_at IS NULL;
+
+CREATE INDEX idx_download_capabilities__org_id
+    ON download_capabilities (org_id, id);
+
+ALTER TABLE download_capabilities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE download_capabilities FORCE ROW LEVEL SECURITY;
+CREATE POLICY download_capabilities_org_isolation ON download_capabilities
+    USING (org_id = markhand_current_org_id())
+    WITH CHECK (org_id = markhand_current_org_id());

--- a/crates/server/migrations/0019_expand_download_capability_clock.sql
+++ b/crates/server/migrations/0019_expand_download_capability_clock.sql
@@ -1,0 +1,15 @@
+-- Phase: 1B
+-- Owner: retrieval-owner, security-owner
+-- Change: expand
+-- Lock/data risk: additive CHECK + DEFAULT change on empty/low-traffic table.
+-- Rollback compatibility: drop new CHECK; restore DEFAULT now().
+--
+-- Download capability issuance/consume must use PostgreSQL clock_timestamp()
+-- (see repository SQL). Harden table defaults and max TTL against app clocks.
+
+ALTER TABLE download_capabilities
+    ALTER COLUMN created_at SET DEFAULT clock_timestamp();
+
+ALTER TABLE download_capabilities
+    ADD CONSTRAINT ck_download_capabilities__max_ttl
+        CHECK (expires_at <= created_at + interval '300 seconds');

--- a/crates/server/migrations/manifest.json
+++ b/crates/server/migrations/manifest.json
@@ -17,6 +17,8 @@
     "0014_expand_vector_cleanup_intents.sql": "fb9ae5f06cbcd5f438eaac6b9b0464627b47aa90e3115717d76c3656e0350932",
     "0015_expand_vector_cleanup_intent_states.sql": "f5f5cdcee30a96f3541a6635efaf1147f8595b09b03b1a919c916ee09e4706a5",
     "0016_expand_chunks_accent_fold_tsv.sql": "ab850b0ba0f1f323f498e4874c02d51f14421d016f6a792ed63780be4f3f38dd",
-    "0017_expand_qa_history_permission.sql": "f804d47e4108251ed368299faed312cfbb093500f066a576d30d8da39f973b3a"
+    "0017_expand_qa_history_permission.sql": "f804d47e4108251ed368299faed312cfbb093500f066a576d30d8da39f973b3a",
+    "0018_expand_download_capabilities.sql": "72ea55837f3cbed1448049d3789b5dbeb93bb25cd9468a40e14ebc786bba5349",
+    "0019_expand_download_capability_clock.sql": "d47a68427198c7f9df4f0e4a738e23776df854c4f86ea082c2ad34601a190313"
   }
 }

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -74,6 +74,14 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0017_expand_qa_history_permission.sql",
         include_str!("../migrations/0017_expand_qa_history_permission.sql"),
     ),
+    (
+        "0018_expand_download_capabilities.sql",
+        include_str!("../migrations/0018_expand_download_capabilities.sql"),
+    ),
+    (
+        "0019_expand_download_capability_clock.sql",
+        include_str!("../migrations/0019_expand_download_capability_clock.sql"),
+    ),
 ];
 
 /// Embedded migration sources in apply order (name, SQL). Used by integration tests.
@@ -294,5 +302,19 @@ mod tests {
             .1;
         assert!(source.contains("'pending', 'writing', 'cleaned', 'committed'"));
         assert!(source.contains("status = 'committed'"));
+    }
+
+    #[test]
+    fn download_capabilities_have_mandatory_tenant_rls() {
+        let source = MIGRATIONS
+            .iter()
+            .find(|(name, _)| *name == "0018_expand_download_capabilities.sql")
+            .expect("download capabilities migration")
+            .1;
+        let table = "download_capabilities";
+        assert!(source.contains(&format!("ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;")));
+        assert!(source.contains(&format!("ALTER TABLE {table} FORCE ROW LEVEL SECURITY;")));
+        assert!(source.contains(&format!("CREATE POLICY {table}_org_isolation ON {table}")));
+        assert!(source.contains("purpose IN ('original', 'markdown')"));
     }
 }

--- a/crates/server/src/db/download_capabilities.rs
+++ b/crates/server/src/db/download_capabilities.rs
@@ -1,0 +1,447 @@
+//! Tenant-scoped single-use download capability repository (P1B-R02).
+//!
+//! Issuance and consume expiry are evaluated with PostgreSQL `clock_timestamp()`
+//! so app-side wall clocks before round-trips cannot skew single-use semantics.
+
+use chrono::{DateTime, Utc};
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+
+/// Download purpose bound into the capability (never inferred from client paths).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DownloadPurpose {
+    Original,
+    Markdown,
+}
+
+impl DownloadPurpose {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Original => "original",
+            Self::Markdown => "markdown",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, DbError> {
+        match value {
+            "original" => Ok(Self::Original),
+            "markdown" => Ok(Self::Markdown),
+            _ => Err(DbError::Config("unknown download purpose".into())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DownloadCapabilityRow {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    pub user_id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub purpose: DownloadPurpose,
+    pub content_sha256: String,
+    pub content_type: String,
+    pub byte_size: i64,
+    pub expires_at: DateTime<Utc>,
+    pub consumed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewDownloadCapability<'a> {
+    pub id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub purpose: DownloadPurpose,
+    pub content_sha256: &'a str,
+    pub content_type: &'a str,
+    pub byte_size: i64,
+    /// TTL seconds; `expires_at` / `created_at` are set from DB `clock_timestamp()`.
+    pub ttl_secs: i64,
+}
+
+/// Outcome of an atomic consume attempt classified with the DB clock.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConsumeOutcome {
+    Consumed(DownloadCapabilityRow),
+    Expired,
+    Replay,
+    NotFound,
+}
+
+/// Outcome of auth-gated consume. Wrong-user probes never surface Expired/Replay (IDOR).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthorizedConsumeOutcome {
+    Consumed(DownloadCapabilityRow),
+    Expired,
+    Replay,
+    PermissionDenied,
+    NotFound,
+}
+
+/// Non-mutating liveness probe (DB clock). May race; consume is authoritative.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityLiveness {
+    Open,
+    Expired,
+    Replay,
+    NotFound,
+}
+
+/// Shared ACL / membership / document predicates for download redeem consume.
+/// Mirrors `load_authorized_version_for_read` so revoke/delete cannot race past consume.
+const AUTHORIZED_DOWNLOAD_EXISTS_SQL: &str = "
+    EXISTS (
+      SELECT 1
+      FROM documents d
+      JOIN document_versions dv
+        ON dv.org_id = d.org_id
+       AND dv.document_id = d.id
+       AND dv.id = dc.version_id
+      JOIN collections acl_c
+        ON acl_c.org_id = d.org_id AND acl_c.id = d.collection_id
+      JOIN org_memberships acl_m
+        ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $3
+      JOIN users acl_u ON acl_u.id = acl_m.user_id
+      JOIN roles acl_r
+        ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+      JOIN role_permissions acl_rp
+        ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+      JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
+      WHERE d.org_id = dc.org_id
+        AND d.id = dc.document_id
+        AND d.deleted_at IS NULL
+        AND d.state = 'indexed'
+        AND dv.publication_state = 'published'
+        AND acl_c.deleted_at IS NULL
+        AND acl_u.disabled_at IS NULL
+        AND acl_p.code = CASE WHEN dv.is_current THEN 'qa.query' ELSE 'qa.history' END
+        AND EXISTS (
+          SELECT 1
+          FROM role_permissions query_rp
+          JOIN permissions query_p ON query_p.id = query_rp.permission_id
+          WHERE query_rp.org_id = acl_r.org_id
+            AND query_rp.role_id = acl_r.id
+            AND query_p.code = 'qa.query'
+        )
+        AND (
+          acl_c.visibility = 'org'
+          OR acl_c.owner_user_id = $3
+          OR EXISTS (
+            SELECT 1 FROM collection_user_access cua
+            WHERE cua.org_id = acl_c.org_id
+              AND cua.collection_id = acl_c.id
+              AND cua.user_id = $3
+          )
+        )
+    )";
+
+pub async fn insert(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewDownloadCapability<'_>,
+) -> Result<DownloadCapabilityRow, DbError> {
+    if input.ttl_secs <= 0 {
+        return Err(DbError::Config("invalid capability ttl".into()));
+    }
+    let purpose = input.purpose.as_str();
+    let row = txn
+        .query_one(
+            "INSERT INTO download_capabilities (
+                id, org_id, user_id, document_id, version_id, purpose,
+                content_sha256, content_type, byte_size, expires_at, created_at
+             )
+             SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9,
+                    clock_now + ($10::bigint * interval '1 second'),
+                    clock_now
+             FROM (SELECT clock_timestamp() AS clock_now) AS clock
+             RETURNING id, org_id, user_id, document_id, version_id, purpose,
+                       content_sha256, content_type, byte_size, expires_at,
+                       consumed_at, created_at",
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &ctx.user_id(),
+                &input.document_id,
+                &input.version_id,
+                &purpose,
+                &input.content_sha256,
+                &input.content_type,
+                &input.byte_size,
+                &input.ttl_secs,
+            ],
+        )
+        .await?;
+    map_row(&row)
+}
+
+/// Atomically consumes an open, unexpired capability using DB `clock_timestamp()`.
+pub async fn consume_if_open(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    capability_id: Uuid,
+) -> Result<Option<DownloadCapabilityRow>, DbError> {
+    let row = txn
+        .query_opt(
+            "UPDATE download_capabilities
+             SET consumed_at = clock_timestamp()
+             WHERE org_id = $1
+               AND id = $2
+               AND user_id = $3
+               AND consumed_at IS NULL
+               AND expires_at > clock_timestamp()
+             RETURNING id, org_id, user_id, document_id, version_id, purpose,
+                       content_sha256, content_type, byte_size, expires_at,
+                       consumed_at, created_at",
+            &[&ctx.org_id(), &capability_id, &ctx.user_id()],
+        )
+        .await?;
+    row.map(|row| map_row(&row)).transpose()
+}
+
+/// Classify open/expired/replay using DB `clock_timestamp()` without consuming.
+pub async fn classify_liveness(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    capability_id: Uuid,
+) -> Result<CapabilityLiveness, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT consumed_at IS NOT NULL AS consumed,
+                    expires_at <= clock_timestamp() AS expired
+             FROM download_capabilities
+             WHERE org_id = $1 AND id = $2 AND user_id = $3",
+            &[&ctx.org_id(), &capability_id, &ctx.user_id()],
+        )
+        .await?;
+    let Some(row) = row else {
+        return Ok(CapabilityLiveness::NotFound);
+    };
+    let consumed: bool = row.get(0);
+    let expired: bool = row.get(1);
+    if consumed {
+        Ok(CapabilityLiveness::Replay)
+    } else if expired {
+        Ok(CapabilityLiveness::Expired)
+    } else {
+        Ok(CapabilityLiveness::Open)
+    }
+}
+
+/// Consume when open; otherwise classify expired vs replay with the DB clock in
+/// the same transaction (no app-side `Utc::now()`).
+pub async fn consume_or_classify(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    capability_id: Uuid,
+) -> Result<ConsumeOutcome, DbError> {
+    if let Some(row) = consume_if_open(txn, ctx, capability_id).await? {
+        return Ok(ConsumeOutcome::Consumed(row));
+    }
+    let row = txn
+        .query_opt(
+            "SELECT consumed_at IS NOT NULL AS consumed,
+                    expires_at <= clock_timestamp() AS expired
+             FROM download_capabilities
+             WHERE org_id = $1 AND id = $2 AND user_id = $3",
+            &[&ctx.org_id(), &capability_id, &ctx.user_id()],
+        )
+        .await?;
+    let Some(row) = row else {
+        return Ok(ConsumeOutcome::NotFound);
+    };
+    let consumed: bool = row.get(0);
+    let expired: bool = row.get(1);
+    if consumed {
+        Ok(ConsumeOutcome::Replay)
+    } else if expired {
+        Ok(ConsumeOutcome::Expired)
+    } else {
+        // Lost the race to a concurrent consumer that has not yet become visible
+        // as consumed under READ COMMITTED, or a transient predicate miss —
+        // single-use semantics treat this as replay.
+        Ok(ConsumeOutcome::Replay)
+    }
+}
+
+/// Atomically consume only when live auth + document/version ACL still hold.
+///
+/// Holds `FOR UPDATE` on the capability row, then a single conditional
+/// `UPDATE ... WHERE EXISTS (auth predicates)`. Revoke/delete concurrent with
+/// this statement cannot yield a consumed row. Auth failure leaves the token
+/// open (retryable). Wrong-user probes return [`AuthorizedConsumeOutcome::PermissionDenied`]
+/// rather than Expired/Replay (no IDOR oracle).
+pub async fn consume_authorized_or_classify(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    capability_id: Uuid,
+    expected_document_id: Uuid,
+    expected_version_id: Uuid,
+    expected_purpose: DownloadPurpose,
+    expected_content_sha256: &str,
+    expected_content_type: &str,
+    expected_byte_size: i64,
+) -> Result<AuthorizedConsumeOutcome, DbError> {
+    let purpose = expected_purpose.as_str();
+    // Lock the capability row so classification and conditional consume see one snapshot.
+    let locked = txn
+        .query_opt(
+            "SELECT id, org_id, user_id, document_id, version_id, purpose,
+                    content_sha256, content_type, byte_size, expires_at,
+                    consumed_at, created_at,
+                    consumed_at IS NOT NULL AS was_consumed,
+                    expires_at <= clock_timestamp() AS is_expired
+             FROM download_capabilities
+             WHERE org_id = $1 AND id = $2
+             FOR UPDATE",
+            &[&ctx.org_id(), &capability_id],
+        )
+        .await?;
+    let Some(locked) = locked else {
+        return Ok(AuthorizedConsumeOutcome::NotFound);
+    };
+    let owner: Uuid = locked.get("user_id");
+    if owner != ctx.user_id() {
+        // Do not reveal expired/replay to a different principal.
+        return Ok(AuthorizedConsumeOutcome::PermissionDenied);
+    }
+    let was_consumed: bool = locked.get("was_consumed");
+    if was_consumed {
+        return Ok(AuthorizedConsumeOutcome::Replay);
+    }
+    let is_expired: bool = locked.get("is_expired");
+    if is_expired {
+        return Ok(AuthorizedConsumeOutcome::Expired);
+    }
+
+    let update_sql = format!(
+        "UPDATE download_capabilities dc
+         SET consumed_at = clock_timestamp()
+         WHERE dc.org_id = $1
+           AND dc.id = $2
+           AND dc.user_id = $3
+           AND dc.document_id = $4
+           AND dc.version_id = $5
+           AND dc.purpose = $6
+           AND dc.content_sha256 = $7
+           AND dc.content_type = $8
+           AND dc.byte_size = $9
+           AND dc.consumed_at IS NULL
+           AND dc.expires_at > clock_timestamp()
+           AND {AUTHORIZED_DOWNLOAD_EXISTS_SQL}
+         RETURNING id, org_id, user_id, document_id, version_id, purpose,
+                   content_sha256, content_type, byte_size, expires_at,
+                   consumed_at, created_at"
+    );
+    let row = txn
+        .query_opt(
+            &update_sql,
+            &[
+                &ctx.org_id(),
+                &capability_id,
+                &ctx.user_id(),
+                &expected_document_id,
+                &expected_version_id,
+                &purpose,
+                &expected_content_sha256,
+                &expected_content_type,
+                &expected_byte_size,
+            ],
+        )
+        .await?;
+    if let Some(row) = row {
+        return Ok(AuthorizedConsumeOutcome::Consumed(map_row(&row)?));
+    }
+
+    // Still locked: open + unexpired + owner, but UPDATE missed → auth/bindings failed.
+    // Token remains unconsumed (retryable once access is restored).
+    let auth_sql = format!(
+        "SELECT {AUTHORIZED_DOWNLOAD_EXISTS_SQL} AS authorized
+         FROM download_capabilities dc
+         WHERE dc.org_id = $1 AND dc.id = $2 AND dc.user_id = $3"
+    );
+    let auth_row = txn
+        .query_one(&auth_sql, &[&ctx.org_id(), &capability_id, &ctx.user_id()])
+        .await?;
+    let authorized: bool = auth_row.get(0);
+    if !authorized {
+        return Ok(AuthorizedConsumeOutcome::PermissionDenied);
+    }
+    // Bindings drifted or lost a concurrent consume race under the lock (should be rare).
+    let again = txn
+        .query_one(
+            "SELECT consumed_at IS NOT NULL, expires_at <= clock_timestamp()
+             FROM download_capabilities
+             WHERE org_id = $1 AND id = $2
+             FOR UPDATE",
+            &[&ctx.org_id(), &capability_id],
+        )
+        .await?;
+    let consumed_now: bool = again.get(0);
+    let expired_now: bool = again.get(1);
+    if consumed_now {
+        Ok(AuthorizedConsumeOutcome::Replay)
+    } else if expired_now {
+        Ok(AuthorizedConsumeOutcome::Expired)
+    } else {
+        // Binding mismatch vs expected HMAC fields — fail closed without burning semantics leak.
+        Ok(AuthorizedConsumeOutcome::PermissionDenied)
+    }
+}
+
+pub async fn get_by_id(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    capability_id: Uuid,
+) -> Result<Option<DownloadCapabilityRow>, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, user_id, document_id, version_id, purpose,
+                    content_sha256, content_type, byte_size, expires_at,
+                    consumed_at, created_at
+             FROM download_capabilities
+             WHERE org_id = $1 AND id = $2",
+            &[&ctx.org_id(), &capability_id],
+        )
+        .await?;
+    row.map(|row| map_row(&row)).transpose()
+}
+
+fn map_row(row: &Row) -> Result<DownloadCapabilityRow, DbError> {
+    let purpose = DownloadPurpose::parse(row.get("purpose"))?;
+    Ok(DownloadCapabilityRow {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        user_id: row.get("user_id"),
+        document_id: row.get("document_id"),
+        version_id: row.get("version_id"),
+        purpose,
+        content_sha256: row.get("content_sha256"),
+        content_type: row.get("content_type"),
+        byte_size: row.get("byte_size"),
+        expires_at: row.get("expires_at"),
+        consumed_at: row.get("consumed_at"),
+        created_at: row.get("created_at"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn purpose_round_trip() {
+        assert_eq!(
+            DownloadPurpose::parse("original").unwrap(),
+            DownloadPurpose::Original
+        );
+        assert_eq!(
+            DownloadPurpose::parse("markdown").unwrap(),
+            DownloadPurpose::Markdown
+        );
+        assert!(DownloadPurpose::parse("export").is_err());
+    }
+}

--- a/crates/server/src/db/download_capabilities.rs
+++ b/crates/server/src/db/download_capabilities.rs
@@ -82,6 +82,32 @@ pub enum AuthorizedConsumeOutcome {
     NotFound,
 }
 
+/// HMAC-bound fields required for an authorized single-use consume.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizedConsumeBinding {
+    pub capability_id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub purpose: DownloadPurpose,
+    pub content_sha256: String,
+    pub content_type: String,
+    pub byte_size: i64,
+}
+
+impl AuthorizedConsumeBinding {
+    pub fn from_row(row: &DownloadCapabilityRow) -> Self {
+        Self {
+            capability_id: row.id,
+            document_id: row.document_id,
+            version_id: row.version_id,
+            purpose: row.purpose,
+            content_sha256: row.content_sha256.clone(),
+            content_type: row.content_type.clone(),
+            byte_size: row.byte_size,
+        }
+    }
+}
+
 /// Non-mutating liveness probe (DB clock). May race; consume is authoritative.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CapabilityLiveness {
@@ -277,15 +303,9 @@ pub async fn consume_or_classify(
 pub async fn consume_authorized_or_classify(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
-    capability_id: Uuid,
-    expected_document_id: Uuid,
-    expected_version_id: Uuid,
-    expected_purpose: DownloadPurpose,
-    expected_content_sha256: &str,
-    expected_content_type: &str,
-    expected_byte_size: i64,
+    expected: &AuthorizedConsumeBinding,
 ) -> Result<AuthorizedConsumeOutcome, DbError> {
-    let purpose = expected_purpose.as_str();
+    let purpose = expected.purpose.as_str();
     // Lock the capability row so classification and conditional consume see one snapshot.
     let locked = txn
         .query_opt(
@@ -297,7 +317,7 @@ pub async fn consume_authorized_or_classify(
              FROM download_capabilities
              WHERE org_id = $1 AND id = $2
              FOR UPDATE",
-            &[&ctx.org_id(), &capability_id],
+            &[&ctx.org_id(), &expected.capability_id],
         )
         .await?;
     let Some(locked) = locked else {
@@ -341,14 +361,14 @@ pub async fn consume_authorized_or_classify(
             &update_sql,
             &[
                 &ctx.org_id(),
-                &capability_id,
+                &expected.capability_id,
                 &ctx.user_id(),
-                &expected_document_id,
-                &expected_version_id,
+                &expected.document_id,
+                &expected.version_id,
                 &purpose,
-                &expected_content_sha256,
-                &expected_content_type,
-                &expected_byte_size,
+                &expected.content_sha256,
+                &expected.content_type,
+                &expected.byte_size,
             ],
         )
         .await?;
@@ -364,7 +384,10 @@ pub async fn consume_authorized_or_classify(
          WHERE dc.org_id = $1 AND dc.id = $2 AND dc.user_id = $3"
     );
     let auth_row = txn
-        .query_one(&auth_sql, &[&ctx.org_id(), &capability_id, &ctx.user_id()])
+        .query_one(
+            &auth_sql,
+            &[&ctx.org_id(), &expected.capability_id, &ctx.user_id()],
+        )
         .await?;
     let authorized: bool = auth_row.get(0);
     if !authorized {
@@ -377,7 +400,7 @@ pub async fn consume_authorized_or_classify(
              FROM download_capabilities
              WHERE org_id = $1 AND id = $2
              FOR UPDATE",
-            &[&ctx.org_id(), &capability_id],
+            &[&ctx.org_id(), &expected.capability_id],
         )
         .await?;
     let consumed_now: bool = again.get(0);

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -5,6 +5,7 @@ pub mod claims;
 pub mod collections;
 pub mod document_versions;
 pub mod documents;
+pub mod download_capabilities;
 pub mod embedding_batches;
 pub mod error;
 pub mod index_metadata;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -1255,6 +1255,23 @@ pub fn expected_table_columns() -> &'static [(&'static str, &'static [&'static s
                 "created_at",
             ],
         ),
+        (
+            "download_capabilities",
+            &[
+                "id",
+                "org_id",
+                "user_id",
+                "document_id",
+                "version_id",
+                "purpose",
+                "content_sha256",
+                "content_type",
+                "byte_size",
+                "expires_at",
+                "consumed_at",
+                "created_at",
+            ],
+        ),
     ]
 }
 

--- a/crates/server/src/db/search.rs
+++ b/crates/server/src/db/search.rs
@@ -448,6 +448,269 @@ pub async fn hydrate_chunks_by_identity(
     rows.iter().map(map_hydrated_chunk).collect()
 }
 
+/// Authorized document version row for citation resolve / preview / download.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuthorizedVersionRow {
+    pub org_id: Uuid,
+    pub collection_id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub version_number: i32,
+    pub parent_version_id: Option<Uuid>,
+    /// Version row hash (Markdown hash after promotion — not original upload).
+    pub content_sha256: String,
+    pub original_object_key: String,
+    pub markdown_object_key: Option<String>,
+    pub markdown_artifact_key: Option<String>,
+    pub markdown_artifact_sha256: Option<String>,
+    pub markdown_artifact_content_type: Option<String>,
+    pub markdown_artifact_byte_size: Option<i64>,
+    pub source_filename: Option<String>,
+    pub source_content_type: Option<String>,
+    pub byte_size: Option<i64>,
+    pub document_state: DocumentState,
+    pub deleted_at: Option<DateTime<Utc>>,
+    pub publication_state: PublicationState,
+    pub is_current: bool,
+    pub effective_from: DateTime<Utc>,
+    pub effective_to: Option<DateTime<Utc>>,
+}
+
+/// Immutable Markdown artifact required for citation quote verification / preview.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedMarkdownArtifact {
+    pub object_key: String,
+    pub content_sha256: String,
+    pub content_type: String,
+    pub byte_size: u64,
+}
+
+/// Fresh-authorized chunk load by id for citation resolve (ADR 0002).
+///
+/// Exact citation resolve does **not** require the chunk's index generation to
+/// still be active (cutover/retired generations remain citeable). Fresh ACL,
+/// membership, document state and published version checks still apply.
+pub async fn hydrate_chunk_for_citation(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    chunk_id: Uuid,
+) -> Result<Option<HydratedChunkRow>, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT c.id, c.chunk_identity_sha256, c.org_id, d.collection_id,
+                    c.document_id, c.version_id, dv.version_number, dv.content_sha256,
+                    c.heading_path, c.body, c.page, c.slide, c.sheet,
+                    c.span_start, c.span_end, d.state, d.deleted_at,
+                    dv.publication_state, dv.is_current, dv.effective_from, dv.effective_to,
+                    c.index_metadata_id, im.is_active, im.state AS index_state
+             FROM chunks c
+             JOIN documents d
+               ON d.org_id = c.org_id AND d.id = c.document_id
+             JOIN document_versions dv
+               ON dv.org_id = c.org_id
+              AND dv.document_id = c.document_id
+              AND dv.id = c.version_id
+             JOIN index_metadata im
+               ON im.org_id = c.org_id AND im.id = c.index_metadata_id
+             WHERE c.org_id = $1
+               AND c.id = $2
+               AND EXISTS (
+                 SELECT 1
+                 FROM collections acl_c
+                 JOIN org_memberships acl_m
+                   ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $3
+                 JOIN users acl_u ON acl_u.id = acl_m.user_id
+                 JOIN roles acl_r
+                   ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+                 JOIN role_permissions acl_rp
+                   ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+                 JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
+                 WHERE acl_c.org_id = d.org_id
+                   AND acl_c.id = d.collection_id
+                   AND acl_c.deleted_at IS NULL
+                   AND acl_u.disabled_at IS NULL
+                   AND acl_p.code = CASE WHEN dv.is_current THEN 'qa.query' ELSE 'qa.history' END
+                   AND EXISTS (
+                     SELECT 1
+                     FROM role_permissions query_rp
+                     JOIN permissions query_p ON query_p.id = query_rp.permission_id
+                     WHERE query_rp.org_id = acl_r.org_id
+                       AND query_rp.role_id = acl_r.id
+                       AND query_p.code = 'qa.query'
+                   )
+                   AND (
+                     acl_c.visibility = 'org'
+                     OR acl_c.owner_user_id = $3
+                     OR EXISTS (
+                       SELECT 1 FROM collection_user_access cua
+                       WHERE cua.org_id = acl_c.org_id
+                         AND cua.collection_id = acl_c.id
+                         AND cua.user_id = $3
+                     )
+                   )
+               )
+               AND d.deleted_at IS NULL
+               AND d.state = 'indexed'
+               AND dv.publication_state = 'published'",
+            &[&ctx.org_id(), &chunk_id, &ctx.user_id()],
+        )
+        .await?;
+    row.map(|row| map_hydrated_chunk(&row)).transpose()
+}
+
+/// Fresh-authorized version load for trusted Markdown preview / download mint.
+pub async fn load_authorized_version_for_read(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<Option<AuthorizedVersionRow>, DbError> {
+    let kind = "markdown";
+    let row = txn
+        .query_opt(
+            "SELECT d.org_id, d.collection_id, d.id AS document_id, dv.id AS version_id,
+                    dv.version_number, dv.parent_version_id, dv.content_sha256,
+                    dv.original_object_key, dv.markdown_object_key,
+                    da.object_key AS markdown_artifact_key,
+                    da.content_sha256 AS markdown_artifact_sha256,
+                    da.content_type AS markdown_artifact_content_type,
+                    da.byte_size AS markdown_artifact_byte_size,
+                    dv.source_filename, dv.source_content_type, dv.byte_size,
+                    d.state, d.deleted_at, dv.publication_state, dv.is_current,
+                    dv.effective_from, dv.effective_to
+             FROM documents d
+             JOIN document_versions dv
+               ON dv.org_id = d.org_id
+              AND dv.document_id = d.id
+              AND dv.id = $3
+             LEFT JOIN derived_artifacts da
+               ON da.org_id = dv.org_id
+              AND da.version_id = dv.id
+              AND da.artifact_kind = $4
+             WHERE d.org_id = $1
+               AND d.id = $2
+               AND EXISTS (
+                 SELECT 1
+                 FROM collections acl_c
+                 JOIN org_memberships acl_m
+                   ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = $5
+                 JOIN users acl_u ON acl_u.id = acl_m.user_id
+                 JOIN roles acl_r
+                   ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+                 JOIN role_permissions acl_rp
+                   ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+                 JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
+                 WHERE acl_c.org_id = d.org_id
+                   AND acl_c.id = d.collection_id
+                   AND acl_c.deleted_at IS NULL
+                   AND acl_u.disabled_at IS NULL
+                   AND acl_p.code = CASE WHEN dv.is_current THEN 'qa.query' ELSE 'qa.history' END
+                   AND EXISTS (
+                     SELECT 1
+                     FROM role_permissions query_rp
+                     JOIN permissions query_p ON query_p.id = query_rp.permission_id
+                     WHERE query_rp.org_id = acl_r.org_id
+                       AND query_rp.role_id = acl_r.id
+                       AND query_p.code = 'qa.query'
+                   )
+                   AND (
+                     acl_c.visibility = 'org'
+                     OR acl_c.owner_user_id = $5
+                     OR EXISTS (
+                       SELECT 1 FROM collection_user_access cua
+                       WHERE cua.org_id = acl_c.org_id
+                         AND cua.collection_id = acl_c.id
+                         AND cua.user_id = $5
+                     )
+                   )
+               )
+               AND d.deleted_at IS NULL
+               AND d.state = 'indexed'
+               AND dv.publication_state = 'published'",
+            &[
+                &ctx.org_id(),
+                &document_id,
+                &version_id,
+                &kind,
+                &ctx.user_id(),
+            ],
+        )
+        .await?;
+    row.map(|row| map_authorized_version(&row)).transpose()
+}
+
+/// Fail-closed Markdown artifact identity (derived artifact key/hash/type/size).
+pub fn trusted_markdown_artifact(
+    row: &AuthorizedVersionRow,
+) -> Result<TrustedMarkdownArtifact, DbError> {
+    let object_key = row
+        .markdown_artifact_key
+        .as_deref()
+        .ok_or_else(|| DbError::Config("markdown_artifact_missing".into()))?;
+    let content_sha256 = row
+        .markdown_artifact_sha256
+        .as_deref()
+        .ok_or_else(|| DbError::Config("markdown_artifact_hash_missing".into()))?;
+    let content_type = row
+        .markdown_artifact_content_type
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("text/markdown; charset=utf-8");
+    let byte_size = row
+        .markdown_artifact_byte_size
+        .ok_or_else(|| DbError::Config("markdown_artifact_size_missing".into()))?;
+    let byte_size = u64::try_from(byte_size)
+        .map_err(|_| DbError::Config("markdown_artifact_size_invalid".into()))?;
+    if byte_size == 0 {
+        return Err(DbError::Config("markdown_artifact_size_invalid".into()));
+    }
+    Ok(TrustedMarkdownArtifact {
+        object_key: object_key.to_string(),
+        content_sha256: content_sha256.to_string(),
+        content_type: content_type.to_string(),
+        byte_size,
+    })
+}
+
+fn map_authorized_version(row: &Row) -> Result<AuthorizedVersionRow, DbError> {
+    let state: String = row.get("state");
+    let document_state = DocumentState::parse(&state).map_err(DbError::Config)?;
+    let publication_state: String = row.get("publication_state");
+    let publication_state = match publication_state.as_str() {
+        "draft" => PublicationState::Draft,
+        "published" => PublicationState::Published,
+        other => {
+            return Err(DbError::Config(format!(
+                "unknown publication state: {other}"
+            )));
+        }
+    };
+    Ok(AuthorizedVersionRow {
+        org_id: row.get("org_id"),
+        collection_id: row.get("collection_id"),
+        document_id: row.get("document_id"),
+        version_id: row.get("version_id"),
+        version_number: row.get("version_number"),
+        parent_version_id: row.get("parent_version_id"),
+        content_sha256: row.get("content_sha256"),
+        original_object_key: row.get("original_object_key"),
+        markdown_object_key: row.get("markdown_object_key"),
+        markdown_artifact_key: row.get("markdown_artifact_key"),
+        markdown_artifact_sha256: row.get("markdown_artifact_sha256"),
+        markdown_artifact_content_type: row.get("markdown_artifact_content_type"),
+        markdown_artifact_byte_size: row.get("markdown_artifact_byte_size"),
+        source_filename: row.get("source_filename"),
+        source_content_type: row.get("source_content_type"),
+        byte_size: row.get("byte_size"),
+        document_state,
+        deleted_at: row.get("deleted_at"),
+        publication_state,
+        is_current: row.get("is_current"),
+        effective_from: row.get("effective_from"),
+        effective_to: row.get("effective_to"),
+    })
+}
+
 /// Loads conflict evidence only when both claim sides remain authorized and
 /// published under the resolved version visibility.
 pub async fn load_authorized_conflict_evidence(

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -20,6 +20,7 @@ use crate::config::QuotaSweepConfig;
 use crate::database;
 use crate::db::pool::create_pool;
 use crate::routes;
+use crate::services::download::DownloadFetchBudget;
 use crate::services::quota;
 use crate::state::RuntimeState;
 
@@ -34,6 +35,8 @@ pub struct AppState {
     auth_provider: Option<PasswordAuthProvider>,
     /// Object store adapter (optional when credentials are absent in tests).
     object_store: Option<crate::storage::MinioClient>,
+    /// Process-wide concurrent download byte budget / concurrency limiter.
+    download_budget: Arc<DownloadFetchBudget>,
 }
 
 struct CachedReadiness {
@@ -76,6 +79,7 @@ impl AppState {
             pool,
             auth_provider,
             object_store,
+            download_budget: DownloadFetchBudget::default_production(),
         })
     }
 
@@ -109,6 +113,7 @@ impl AppState {
             pool,
             auth_provider,
             object_store,
+            download_budget: DownloadFetchBudget::for_tests(),
         })
     }
 
@@ -126,6 +131,10 @@ impl AppState {
 
     pub fn object_store(&self) -> Option<&crate::storage::MinioClient> {
         self.object_store.as_ref()
+    }
+
+    pub fn download_budget(&self) -> &Arc<DownloadFetchBudget> {
+        &self.download_budget
     }
 }
 
@@ -166,6 +175,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/v1/health/ready", get(readiness))
         .merge(routes::auth::router())
         .merge(routes::uploads::router(max_upload_bytes))
+        .merge(routes::documents::router())
         .with_state(Arc::new(state))
 }
 

--- a/crates/server/src/routes/documents.rs
+++ b/crates/server/src/routes/documents.rs
@@ -1,0 +1,516 @@
+//! Minimal document citation / preview / download routes (P1B-R02).
+//!
+//! Full collection/document CRUD belongs to P1B-R04. These routes only expose
+//! the R02 service contracts with fresh auth on every call.
+
+use std::fmt;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api::ApiError;
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::db::download_capabilities::DownloadPurpose;
+use crate::http::AppState;
+use crate::services::citation::{self, CitationError, CitationResolveRequest, StableCitation};
+use crate::services::download::{
+    self, CapabilitySigner, DownloadError, DEFAULT_CAPABILITY_TTL, MAX_CAPABILITY_TTL,
+};
+use crate::services::preview::{self, PreviewError};
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/v1/citations/resolve", post(resolve_citations))
+        .route(
+            "/api/v1/documents/{document_id}/versions/{version_id}/preview",
+            get(preview_markdown),
+        )
+        .route(
+            "/api/v1/documents/{document_id}/versions/{version_id}/download-capabilities",
+            post(mint_download_capability),
+        )
+        .route(
+            "/api/v1/download-capabilities/redeem",
+            post(redeem_download_capability),
+        )
+}
+
+/// Wire token field: serializes normally, Debug never prints the raw secret.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+struct RedactedToken(String);
+
+impl fmt::Debug for RedactedToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResolveCitationsBody {
+    citations: Vec<ResolveCitationItem>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResolveCitationItem {
+    chunk_id: Uuid,
+    #[serde(default)]
+    expected_version_id: Option<Uuid>,
+    #[serde(default)]
+    expected_document_id: Option<Uuid>,
+    #[serde(default)]
+    expected_content_sha256: Option<String>,
+    #[serde(default)]
+    expected_quote: Option<String>,
+    #[serde(default)]
+    expected_span_start: Option<usize>,
+    #[serde(default)]
+    expected_span_end: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StableCitationResponse {
+    org_id: Uuid,
+    logical_document_id: Uuid,
+    version_id: Uuid,
+    version_number: i32,
+    content_sha256: String,
+    chunk_id: Uuid,
+    chunk_identity_sha256: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    page: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    slide: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sheet: Option<String>,
+    span_start: usize,
+    span_end: usize,
+    quote: String,
+    effective_from: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effective_to: Option<chrono::DateTime<chrono::Utc>>,
+    is_current: bool,
+    heading: String,
+}
+
+impl From<StableCitation> for StableCitationResponse {
+    fn from(value: StableCitation) -> Self {
+        Self {
+            org_id: value.org_id,
+            logical_document_id: value.logical_document_id,
+            version_id: value.version_id,
+            version_number: value.version_number,
+            content_sha256: value.content_sha256,
+            chunk_id: value.chunk_id,
+            chunk_identity_sha256: value.chunk_identity_sha256,
+            page: value.page,
+            slide: value.slide,
+            sheet: value.sheet,
+            span_start: value.span_start,
+            span_end: value.span_end,
+            quote: value.quote,
+            effective_from: value.effective_from,
+            effective_to: value.effective_to,
+            is_current: value.is_current,
+            heading: value.heading,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ResolveCitationsResponse {
+    citations: Vec<StableCitationResponse>,
+    request_id: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PreviewResponse {
+    document_id: Uuid,
+    version_id: Uuid,
+    version_number: i32,
+    content_sha256: String,
+    markdown_sha256: String,
+    is_current: bool,
+    markdown: String,
+    request_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MintDownloadBody {
+    purpose: String,
+    #[serde(default)]
+    ttl_secs: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MintDownloadResponse {
+    capability_id: Uuid,
+    token: RedactedToken,
+    purpose: String,
+    document_id: Uuid,
+    version_id: Uuid,
+    expires_at: chrono::DateTime<chrono::Utc>,
+    request_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RedeemDownloadBody {
+    token: RedactedToken,
+}
+
+async fn resolve_citations(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Json(body): Json<ResolveCitationsBody>,
+) -> Result<Json<ResolveCitationsResponse>, DocumentRouteError> {
+    let request_id = auth.request_id.clone();
+    if body.citations.is_empty() || body.citations.len() > 40 {
+        return Err(DocumentRouteError::validation(
+            "citations must contain 1..=40 items",
+            request_id,
+        ));
+    }
+    let requests: Vec<CitationResolveRequest> = body
+        .citations
+        .into_iter()
+        .map(|item| CitationResolveRequest {
+            chunk_id: item.chunk_id,
+            expected_version_id: item.expected_version_id,
+            expected_document_id: item.expected_document_id,
+            expected_content_sha256: item.expected_content_sha256,
+            expected_quote: item.expected_quote,
+            expected_span_start: item.expected_span_start,
+            expected_span_end: item.expected_span_end,
+        })
+        .collect();
+    let storage = state
+        .object_store()
+        .ok_or_else(|| DocumentRouteError::Citation(CitationError::Storage, request_id.clone()))?;
+    let citations = citation::resolve_citations(
+        state.pool(),
+        storage,
+        auth.context.org_id(),
+        auth.context.user_id(),
+        &requests,
+    )
+    .await
+    .map_err(|error| DocumentRouteError::Citation(error, request_id.clone()))?;
+    Ok(Json(ResolveCitationsResponse {
+        citations: citations.into_iter().map(Into::into).collect(),
+        request_id,
+    }))
+}
+
+async fn preview_markdown(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path((document_id, version_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<PreviewResponse>, DocumentRouteError> {
+    let request_id = auth.request_id.clone();
+    let storage = state.object_store().ok_or_else(|| {
+        DocumentRouteError::Preview(PreviewError::StorageUnavailable, request_id.clone())
+    })?;
+    let preview = preview::fetch_trusted_markdown(
+        state.pool(),
+        storage,
+        auth.context.org_id(),
+        auth.context.user_id(),
+        document_id,
+        version_id,
+    )
+    .await
+    .map_err(|error| DocumentRouteError::Preview(error, request_id.clone()))?;
+    Ok(Json(PreviewResponse {
+        document_id: preview.document_id,
+        version_id: preview.version_id,
+        version_number: preview.version_number,
+        content_sha256: preview.content_sha256,
+        markdown_sha256: preview.markdown_sha256,
+        is_current: preview.is_current,
+        markdown: preview.markdown,
+        request_id,
+    }))
+}
+
+async fn mint_download_capability(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path((document_id, version_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<MintDownloadBody>,
+) -> Result<Json<MintDownloadResponse>, DocumentRouteError> {
+    let request_id = auth.request_id.clone();
+    let purpose = DownloadPurpose::parse(&body.purpose).map_err(|_| {
+        DocumentRouteError::Download(DownloadError::InvalidPurpose, request_id.clone())
+    })?;
+    let ttl = body
+        .ttl_secs
+        .map(std::time::Duration::from_secs)
+        .unwrap_or(DEFAULT_CAPABILITY_TTL);
+    if ttl > MAX_CAPABILITY_TTL {
+        return Err(DocumentRouteError::Download(
+            DownloadError::InvalidTtl,
+            request_id,
+        ));
+    }
+    let signer = capability_signer(&state)
+        .map_err(|error| DocumentRouteError::Download(error, request_id.clone()))?;
+    let minted = download::mint_download_capability(
+        state.pool(),
+        &signer,
+        auth.context.org_id(),
+        auth.context.user_id(),
+        document_id,
+        version_id,
+        purpose,
+        ttl,
+    )
+    .await
+    .map_err(|error| DocumentRouteError::Download(error, request_id.clone()))?;
+    Ok(Json(MintDownloadResponse {
+        capability_id: minted.capability_id,
+        token: RedactedToken(minted.token.expose().to_string()),
+        purpose: minted.purpose.as_str().into(),
+        document_id: minted.document_id,
+        version_id: minted.version_id,
+        expires_at: minted.expires_at,
+        request_id,
+    }))
+}
+
+async fn redeem_download_capability(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Json(body): Json<RedeemDownloadBody>,
+) -> Result<Response, DocumentRouteError> {
+    let request_id = auth.request_id.clone();
+    if body.token.0.is_empty() || body.token.0.len() > 512 {
+        return Err(DocumentRouteError::Download(
+            DownloadError::InvalidToken,
+            request_id,
+        ));
+    }
+    let storage = state.object_store().ok_or_else(|| {
+        DocumentRouteError::Download(DownloadError::StorageUnavailable, request_id.clone())
+    })?;
+    let signer = capability_signer(&state)
+        .map_err(|error| DocumentRouteError::Download(error, request_id.clone()))?;
+    let artifact = download::redeem_download_capability(
+        state.pool(),
+        storage,
+        &signer,
+        state.download_budget(),
+        auth.context.org_id(),
+        auth.context.user_id(),
+        &body.token.0,
+    )
+    .await
+    .map_err(|error| DocumentRouteError::Download(error, request_id.clone()))?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_str(&artifact.content_type)
+            .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream")),
+    );
+    headers.insert(
+        header::HeaderName::from_static("x-content-sha256"),
+        HeaderValue::from_str(&artifact.content_sha256)
+            .unwrap_or_else(|_| HeaderValue::from_static("")),
+    );
+    headers.insert(
+        header::HeaderName::from_static("x-request-id"),
+        HeaderValue::from_str(&request_id).unwrap_or_else(|_| HeaderValue::from_static("")),
+    );
+    // Defense: never surface object keys; Content-Disposition uses safe filename only.
+    if let Some(filename) = artifact.filename.as_deref() {
+        let safe = filename
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                    ch
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>();
+        if let Ok(value) = HeaderValue::from_str(&format!("attachment; filename=\"{safe}\"")) {
+            headers.insert(header::CONTENT_DISPOSITION, value);
+        }
+    }
+    // Body owns the download budget permit until Hyper finishes / cancels / drops it.
+    let mut response = Response::new(Body::new(artifact.body));
+    *response.status_mut() = StatusCode::OK;
+    *response.headers_mut() = headers;
+    Ok(response)
+}
+
+fn capability_signer(state: &AppState) -> Result<CapabilitySigner, DownloadError> {
+    CapabilitySigner::from_auth_signing_key(state.runtime().config().auth().signing_key.as_ref())
+}
+
+enum DocumentRouteError {
+    Citation(CitationError, String),
+    Preview(PreviewError, String),
+    Download(DownloadError, String),
+    Validation(String, String),
+}
+
+impl DocumentRouteError {
+    fn validation(message: impl Into<String>, request_id: String) -> Self {
+        Self::Validation(message.into(), request_id)
+    }
+}
+
+fn download_status(error: &DownloadError) -> StatusCode {
+    match error {
+        DownloadError::PermissionDenied => StatusCode::FORBIDDEN,
+        DownloadError::NotFound => StatusCode::NOT_FOUND,
+        DownloadError::Expired | DownloadError::Replay | DownloadError::InvalidToken => {
+            StatusCode::GONE
+        }
+        DownloadError::SignerNotConfigured
+        | DownloadError::StorageUnavailable
+        | DownloadError::Busy => StatusCode::SERVICE_UNAVAILABLE,
+        DownloadError::InvalidPurpose | DownloadError::InvalidTtl => StatusCode::BAD_REQUEST,
+        DownloadError::TooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+        DownloadError::Integrity => StatusCode::CONFLICT,
+        DownloadError::Storage | DownloadError::Database => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+impl IntoResponse for DocumentRouteError {
+    fn into_response(self) -> Response {
+        let (status, code, message, request_id) = match self {
+            Self::Citation(error, request_id) => {
+                let status = match error {
+                    CitationError::PermissionDenied => StatusCode::FORBIDDEN,
+                    CitationError::NotFound | CitationError::MarkdownMissing => {
+                        StatusCode::NOT_FOUND
+                    }
+                    CitationError::InvalidRequest => StatusCode::BAD_REQUEST,
+                    CitationError::QuoteMismatch
+                    | CitationError::VersionMismatch
+                    | CitationError::InvalidAnchor
+                    | CitationError::Integrity => StatusCode::CONFLICT,
+                    CitationError::Storage | CitationError::Database => {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    }
+                };
+                (status, error.code(), error.to_string(), request_id)
+            }
+            Self::Preview(error, request_id) => {
+                let status = match error {
+                    PreviewError::PermissionDenied => StatusCode::FORBIDDEN,
+                    PreviewError::NotFound | PreviewError::MarkdownMissing => StatusCode::NOT_FOUND,
+                    PreviewError::StorageUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+                    PreviewError::TooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+                    PreviewError::Integrity | PreviewError::InvalidUtf8 => StatusCode::CONFLICT,
+                    PreviewError::Storage | PreviewError::Database => {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    }
+                };
+                (status, error.code(), error.to_string(), request_id)
+            }
+            Self::Download(error, request_id) => (
+                download_status(&error),
+                error.code(),
+                error.to_string(),
+                request_id,
+            ),
+            Self::Validation(message, request_id) => (
+                StatusCode::BAD_REQUEST,
+                "validation_failed",
+                message,
+                request_id,
+            ),
+        };
+        (
+            status,
+            Json(ApiError {
+                code: code.into(),
+                message,
+                request_id,
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    #[test]
+    fn redeem_body_debug_redacts_token() {
+        let body = RedeemDownloadBody {
+            token: RedactedToken("mhdl1.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.deadbeef".into()),
+        };
+        let debug = format!("{body:?}");
+        assert!(debug.contains("REDACTED"));
+        assert!(!debug.contains("deadbeef"));
+        assert!(!debug.contains("mhdl1"));
+    }
+
+    #[test]
+    fn mint_response_debug_redacts_token() {
+        let response = MintDownloadResponse {
+            capability_id: Uuid::nil(),
+            token: RedactedToken("mhdl1.secret-token-value".into()),
+            purpose: "markdown".into(),
+            document_id: Uuid::nil(),
+            version_id: Uuid::nil(),
+            expires_at: chrono::Utc::now(),
+            request_id: "r".into(),
+        };
+        let debug = format!("{response:?}");
+        assert!(debug.contains("REDACTED"));
+        assert!(!debug.contains("secret-token-value"));
+    }
+
+    #[tokio::test]
+    async fn download_error_mapping_distinguishes_expired_replay_busy() {
+        for (error, status, code) in [
+            (DownloadError::Expired, StatusCode::GONE, "download_expired"),
+            (DownloadError::Replay, StatusCode::GONE, "download_replay"),
+            (
+                DownloadError::Busy,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "download_busy",
+            ),
+            (
+                DownloadError::Integrity,
+                StatusCode::CONFLICT,
+                "download_integrity",
+            ),
+            (
+                DownloadError::TooLarge,
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "download_too_large",
+            ),
+        ] {
+            let response = DocumentRouteError::Download(error, "req-1".into()).into_response();
+            assert_eq!(response.status(), status);
+            let bytes = response.into_body().collect().await.unwrap().to_bytes();
+            let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(json["code"], code);
+            assert_eq!(json["requestId"], "req-1");
+        }
+    }
+}

--- a/crates/server/src/routes/documents.rs
+++ b/crates/server/src/routes/documents.rs
@@ -272,12 +272,14 @@ async fn mint_download_capability(
     let minted = download::mint_download_capability(
         state.pool(),
         &signer,
-        auth.context.org_id(),
-        auth.context.user_id(),
-        document_id,
-        version_id,
-        purpose,
-        ttl,
+        &download::MintDownloadCapabilityRequest {
+            org_id: auth.context.org_id(),
+            user_id: auth.context.user_id(),
+            document_id,
+            version_id,
+            purpose,
+            ttl,
+        },
     )
     .await
     .map_err(|error| DocumentRouteError::Download(error, request_id.clone()))?;

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,4 +1,5 @@
 //! HTTP route modules.
 
 pub mod auth;
+pub mod documents;
 pub mod uploads;

--- a/crates/server/src/services/citation.rs
+++ b/crates/server/src/services/citation.rs
@@ -1,0 +1,485 @@
+//! Version-aware citation anchors and fresh-authorized resolve (P1B-R02 / ADR 0002).
+//!
+//! Quotes are sliced from authoritative trusted Markdown (not chunk.body). Span
+//! offsets are byte offsets into that Markdown. Exact resolve does not require an
+//! active index generation, but always rechecks ACL/membership/document state.
+
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Pool;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::permissions::{resolve_org_context_in_txn, ResolveError};
+use crate::db::error::DbError;
+use crate::db::pool::with_org_txn;
+use crate::db::search::{self, HydratedChunkRow, TrustedMarkdownArtifact};
+use crate::services::deletion::document_reads_suppressed;
+use crate::services::retrieval::{PERMISSION_QA_HISTORY, PERMISSION_QA_QUERY};
+use crate::storage::blob::{BlobStore, ObjectExpectation};
+use crate::storage::keys::{authorize_key_for_version, parse_key_for_org, ObjectNamespace};
+use crate::storage::StorageError;
+
+/// Default bound for loading Markdown while verifying a citation quote.
+pub const CITATION_MARKDOWN_MAX_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Stable citation pin required by ADR 0002.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StableCitation {
+    pub org_id: Uuid,
+    pub logical_document_id: Uuid,
+    pub version_id: Uuid,
+    pub version_number: i32,
+    pub content_sha256: String,
+    pub chunk_id: Uuid,
+    pub chunk_identity_sha256: String,
+    pub page: Option<u32>,
+    pub slide: Option<u32>,
+    pub sheet: Option<String>,
+    pub span_start: usize,
+    pub span_end: usize,
+    pub quote: String,
+    pub effective_from: DateTime<Utc>,
+    pub effective_to: Option<DateTime<Utc>>,
+    pub is_current: bool,
+    pub heading: String,
+}
+
+/// Client/server resolve request. Locators are IDs only — never object keys.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CitationResolveRequest {
+    pub chunk_id: Uuid,
+    pub expected_version_id: Option<Uuid>,
+    pub expected_document_id: Option<Uuid>,
+    pub expected_content_sha256: Option<String>,
+    pub expected_quote: Option<String>,
+    pub expected_span_start: Option<usize>,
+    pub expected_span_end: Option<usize>,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CitationError {
+    #[error("permission denied")]
+    PermissionDenied,
+    #[error("citation not found")]
+    NotFound,
+    #[error("citation quote or span mismatch")]
+    QuoteMismatch,
+    #[error("citation version or hash mismatch")]
+    VersionMismatch,
+    #[error("citation source location is invalid")]
+    InvalidAnchor,
+    #[error("invalid citation request")]
+    InvalidRequest,
+    #[error("trusted markdown is missing")]
+    MarkdownMissing,
+    #[error("citation integrity check failed")]
+    Integrity,
+    #[error("storage error")]
+    Storage,
+    #[error("database error")]
+    Database,
+}
+
+impl CitationError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::PermissionDenied => "citation_permission_denied",
+            Self::NotFound => "citation_not_found",
+            Self::QuoteMismatch => "citation_quote_mismatch",
+            Self::VersionMismatch => "citation_version_mismatch",
+            Self::InvalidAnchor => "citation_invalid_anchor",
+            Self::InvalidRequest => "citation_invalid_request",
+            Self::MarkdownMissing => "citation_markdown_missing",
+            Self::Integrity => "citation_integrity",
+            Self::Storage => "citation_storage",
+            Self::Database => "citation_database",
+        }
+    }
+}
+
+impl From<ResolveError> for CitationError {
+    fn from(_: ResolveError) -> Self {
+        Self::PermissionDenied
+    }
+}
+
+impl From<DbError> for CitationError {
+    fn from(value: DbError) -> Self {
+        match value {
+            DbError::Config(ref msg) if msg.starts_with("markdown_artifact_") => {
+                Self::MarkdownMissing
+            }
+            _ => Self::Database,
+        }
+    }
+}
+
+impl From<StorageError> for CitationError {
+    fn from(value: StorageError) -> Self {
+        match value {
+            StorageError::NotFound => Self::NotFound,
+            StorageError::KeyOrgMismatch
+            | StorageError::MissingScope
+            | StorageError::InvalidKey => Self::PermissionDenied,
+            StorageError::PreconditionFailed | StorageError::ObjectTooLarge => Self::Integrity,
+            _ => Self::Storage,
+        }
+    }
+}
+
+/// Rejects half-open expected span pairs (both-or-none).
+pub fn validate_request_spans(request: &CitationResolveRequest) -> Result<(), CitationError> {
+    match (request.expected_span_start, request.expected_span_end) {
+        (None, None) | (Some(_), Some(_)) => Ok(()),
+        _ => Err(CitationError::InvalidRequest),
+    }
+}
+
+/// Validates PDF/PPTX/XLSX style location fields (page/slide/sheet).
+pub fn validate_source_location(
+    page: Option<u32>,
+    slide: Option<&u32>,
+    sheet: Option<&str>,
+) -> Result<(), CitationError> {
+    if let Some(page) = page {
+        if page == 0 {
+            return Err(CitationError::InvalidAnchor);
+        }
+    }
+    if let Some(slide) = slide {
+        if *slide == 0 {
+            return Err(CitationError::InvalidAnchor);
+        }
+    }
+    if let Some(sheet) = sheet {
+        if sheet.trim().is_empty() || sheet.len() > 256 {
+            return Err(CitationError::InvalidAnchor);
+        }
+    }
+    Ok(())
+}
+
+/// Slices a UTF-8 quote from authoritative Markdown using production spans.
+pub fn quote_from_markdown(
+    markdown: &str,
+    span_start: usize,
+    span_end: usize,
+) -> Result<&str, CitationError> {
+    if span_start >= span_end || span_end > markdown.len() {
+        return Err(CitationError::InvalidAnchor);
+    }
+    if !markdown.is_char_boundary(span_start) || !markdown.is_char_boundary(span_end) {
+        return Err(CitationError::InvalidAnchor);
+    }
+    Ok(&markdown[span_start..span_end])
+}
+
+/// Builds a citation after Markdown quote verification (hermetic).
+pub fn citation_from_markdown_quote(
+    row: &HydratedChunkRow,
+    markdown: &str,
+    markdown_sha256: &str,
+) -> Result<StableCitation, CitationError> {
+    if document_reads_suppressed(row.document_state, row.deleted_at.is_some()) {
+        return Err(CitationError::PermissionDenied);
+    }
+    // Production spans are offsets into the trusted Markdown, not chunk.body.
+    let (span_start, span_end) = match (row.span_start, row.span_end) {
+        (Some(start), Some(end)) if start >= 0 && end >= 0 => (start as usize, end as usize),
+        (None, None) => (0, markdown.len()),
+        _ => return Err(CitationError::InvalidRequest),
+    };
+    let quote = quote_from_markdown(markdown, span_start, span_end)?.to_string();
+    // Chunk body must match the authoritative Markdown span (fail closed).
+    if quote != row.body {
+        return Err(CitationError::Integrity);
+    }
+    if markdown_sha256 != row.content_sha256 {
+        // Published version content_sha256 is the Markdown hash after promotion.
+        return Err(CitationError::Integrity);
+    }
+    let page = row.page.and_then(|value| u32::try_from(value).ok());
+    let slide = row.slide.and_then(|value| u32::try_from(value).ok());
+    validate_source_location(page, slide.as_ref(), row.sheet.as_deref())?;
+    Ok(StableCitation {
+        org_id: row.org_id,
+        logical_document_id: row.document_id,
+        version_id: row.version_id,
+        version_number: row.version_number,
+        content_sha256: row.content_sha256.clone(),
+        chunk_id: row.chunk_id,
+        chunk_identity_sha256: row.chunk_identity_sha256.clone(),
+        page,
+        slide,
+        sheet: row.sheet.clone(),
+        span_start,
+        span_end,
+        quote,
+        effective_from: row.effective_from,
+        effective_to: row.effective_to,
+        is_current: row.is_current,
+        heading: row.heading_path.join(" / "),
+    })
+}
+
+/// Validates optional pins from a prior answer against the resolved citation.
+pub fn validate_citation_pins(
+    citation: &StableCitation,
+    request: &CitationResolveRequest,
+) -> Result<(), CitationError> {
+    if let Some(version_id) = request.expected_version_id {
+        if version_id != citation.version_id {
+            return Err(CitationError::VersionMismatch);
+        }
+    }
+    if let Some(document_id) = request.expected_document_id {
+        if document_id != citation.logical_document_id {
+            return Err(CitationError::VersionMismatch);
+        }
+    }
+    if let Some(hash) = request.expected_content_sha256.as_deref() {
+        if hash != citation.content_sha256 {
+            return Err(CitationError::VersionMismatch);
+        }
+    }
+    if let (Some(start), Some(end)) = (request.expected_span_start, request.expected_span_end) {
+        if start != citation.span_start || end != citation.span_end {
+            return Err(CitationError::QuoteMismatch);
+        }
+    }
+    if let Some(expected_quote) = request.expected_quote.as_deref() {
+        if expected_quote != citation.quote {
+            return Err(CitationError::QuoteMismatch);
+        }
+    }
+    Ok(())
+}
+
+fn require_citation_permissions(
+    ctx: &crate::auth::context::OrgContext,
+    is_current: bool,
+) -> Result<(), CitationError> {
+    if !ctx.has_permission(PERMISSION_QA_QUERY) {
+        return Err(CitationError::PermissionDenied);
+    }
+    if !is_current && !ctx.has_permission(PERMISSION_QA_HISTORY) {
+        return Err(CitationError::PermissionDenied);
+    }
+    if ctx.allowed_collection_ids().is_empty() {
+        return Err(CitationError::PermissionDenied);
+    }
+    Ok(())
+}
+
+async fn load_authorized_markdown<S: BlobStore>(
+    pool: &Pool,
+    storage: &S,
+    ctx: &crate::auth::context::OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<(TrustedMarkdownArtifact, String), CitationError> {
+    let row = with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                search::load_authorized_version_for_read(txn, &ctx, document_id, version_id).await
+            })
+        }
+    })
+    .await?
+    .ok_or(CitationError::NotFound)?;
+    let artifact = search::trusted_markdown_artifact(&row)?;
+    let key = parse_key_for_org(&artifact.object_key, ctx.org_id())?;
+    if key.namespace() != ObjectNamespace::Trusted {
+        return Err(CitationError::PermissionDenied);
+    }
+    authorize_key_for_version(&key, version_id)?;
+    if artifact.byte_size > CITATION_MARKDOWN_MAX_BYTES {
+        return Err(CitationError::Integrity);
+    }
+    let fetched = storage
+        .get_object_bounded(
+            ctx.org_id(),
+            &key,
+            CITATION_MARKDOWN_MAX_BYTES,
+            &ObjectExpectation {
+                content_sha256: &artifact.content_sha256,
+                content_length: artifact.byte_size,
+                content_type: Some(artifact.content_type.as_str()),
+            },
+        )
+        .await?;
+    let markdown =
+        String::from_utf8(fetched.bytes.to_vec()).map_err(|_| CitationError::Integrity)?;
+    Ok((artifact, markdown))
+}
+
+/// Resolves one citation with fresh PostgreSQL authorization and Markdown quote verify.
+pub async fn resolve_citation<S: BlobStore>(
+    pool: &Pool,
+    storage: &S,
+    org_id: Uuid,
+    user_id: Uuid,
+    request: CitationResolveRequest,
+) -> Result<StableCitation, CitationError> {
+    validate_request_spans(&request)?;
+    let ctx = resolve_org_context_in_txn(pool, org_id, user_id).await?;
+    if !ctx.has_permission(PERMISSION_QA_QUERY) {
+        return Err(CitationError::PermissionDenied);
+    }
+    let row = with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        let chunk_id = request.chunk_id;
+        move |txn| {
+            Box::pin(async move { search::hydrate_chunk_for_citation(txn, &ctx, chunk_id).await })
+        }
+    })
+    .await?
+    .ok_or(CitationError::NotFound)?;
+
+    if !ctx.allows_collection(row.collection_id) {
+        return Err(CitationError::PermissionDenied);
+    }
+    require_citation_permissions(&ctx, row.is_current)?;
+
+    let (artifact, markdown) =
+        load_authorized_markdown(pool, storage, &ctx, row.document_id, row.version_id).await?;
+    let citation = citation_from_markdown_quote(&row, &markdown, &artifact.content_sha256)?;
+    if citation.org_id != org_id {
+        return Err(CitationError::PermissionDenied);
+    }
+    validate_citation_pins(&citation, &request)?;
+    Ok(citation)
+}
+
+/// Resolves many citations (multi-document / multi-version) with per-item auth.
+pub async fn resolve_citations<S: BlobStore>(
+    pool: &Pool,
+    storage: &S,
+    org_id: Uuid,
+    user_id: Uuid,
+    requests: &[CitationResolveRequest],
+) -> Result<Vec<StableCitation>, CitationError> {
+    let mut out = Vec::with_capacity(requests.len());
+    for request in requests {
+        out.push(resolve_citation(pool, storage, org_id, user_id, request.clone()).await?);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::{DocumentState, IndexGenerationState, PublicationState};
+    use chrono::TimeZone;
+
+    fn sample_markdown() -> &'static str {
+        "# Mục\n\nMở đầu.\n\nKinh phí phê duyệt là 15 triệu đồng.\n\nKết.\n"
+    }
+
+    fn sample_row(span_start: usize, span_end: usize, body: &str) -> HydratedChunkRow {
+        let org = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let markdown = sample_markdown();
+        let sha = {
+            use sha2::{Digest, Sha256};
+            hex::encode(Sha256::digest(markdown.as_bytes()))
+        };
+        HydratedChunkRow {
+            chunk_id: Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap(),
+            chunk_identity_sha256: "a".repeat(64),
+            org_id: org,
+            collection_id: Uuid::parse_str("55555555-5555-5555-5555-555555555501").unwrap(),
+            document_id: Uuid::parse_str("66666666-6666-6666-6666-666666666601").unwrap(),
+            version_id: Uuid::parse_str("77777777-7777-7777-7777-777777777701").unwrap(),
+            version_number: 2,
+            content_sha256: sha,
+            heading_path: vec!["Mục 1".into(), "Slide 3".into()],
+            body: body.into(),
+            page: Some(4),
+            slide: Some(3),
+            sheet: None,
+            span_start: Some(span_start as i32),
+            span_end: Some(span_end as i32),
+            document_state: DocumentState::Indexed,
+            deleted_at: None,
+            publication_state: PublicationState::Published,
+            is_current: true,
+            effective_from: Utc.with_ymd_and_hms(2024, 8, 1, 0, 0, 0).unwrap(),
+            effective_to: None,
+            index_metadata_id: Uuid::new_v4(),
+            index_generation_active: false,
+            index_generation_state: IndexGenerationState::Retired,
+        }
+    }
+
+    #[test]
+    fn slices_nonzero_vietnamese_span_from_markdown_not_chunk_prefix() {
+        let markdown = sample_markdown();
+        let quote = "Kinh phí phê duyệt là 15 triệu đồng.";
+        let start = markdown.find(quote).unwrap();
+        let end = start + quote.len();
+        assert!(start > 0, "production span must be nonzero into markdown");
+        let row = sample_row(start, end, quote);
+        // Retired generation still builds a citation (exact resolve ignores active).
+        assert!(!row.index_generation_active);
+        assert_eq!(row.index_generation_state, IndexGenerationState::Retired);
+        let citation =
+            citation_from_markdown_quote(&row, markdown, &row.content_sha256.clone()).unwrap();
+        assert_eq!(citation.quote, quote);
+        assert_eq!(citation.span_start, start);
+        assert_eq!(citation.span_end, end);
+    }
+
+    #[test]
+    fn second_chunk_span_does_not_use_first_chunk_body() {
+        let markdown = sample_markdown();
+        let first = "Mở đầu.";
+        let second = "Kết.";
+        let start = markdown.find(second).unwrap();
+        let end = start + second.len();
+        let mut row = sample_row(start, end, second);
+        row.chunk_id = Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").unwrap();
+        // Wrong body (first chunk) must fail closed against Markdown span.
+        row.body = first.into();
+        assert_eq!(
+            citation_from_markdown_quote(&row, markdown, &row.content_sha256),
+            Err(CitationError::Integrity)
+        );
+        row.body = second.into();
+        let citation =
+            citation_from_markdown_quote(&row, markdown, &row.content_sha256.clone()).unwrap();
+        assert_eq!(citation.quote, second);
+    }
+
+    #[test]
+    fn half_open_expected_spans_are_invalid_requests() {
+        let request = CitationResolveRequest {
+            chunk_id: Uuid::new_v4(),
+            expected_version_id: None,
+            expected_document_id: None,
+            expected_content_sha256: None,
+            expected_quote: None,
+            expected_span_start: Some(1),
+            expected_span_end: None,
+        };
+        assert_eq!(
+            validate_request_spans(&request),
+            Err(CitationError::InvalidRequest)
+        );
+    }
+
+    #[test]
+    fn rejects_non_utf8_boundary_spans() {
+        let markdown = "áx"; // 'á' is two UTF-8 bytes; offset 1 is mid-character.
+        assert!(!markdown.is_char_boundary(1));
+        assert!(quote_from_markdown(markdown, 1, markdown.len()).is_err());
+    }
+
+    #[test]
+    fn xlsx_sheet_and_page_anchors_still_validate() {
+        assert!(validate_source_location(Some(2), None, None).is_ok());
+        assert!(validate_source_location(None, Some(&3), None).is_ok());
+        assert!(validate_source_location(None, None, Some("Quý I")).is_ok());
+        assert!(validate_source_location(Some(0), None, None).is_err());
+    }
+}

--- a/crates/server/src/services/download.rs
+++ b/crates/server/src/services/download.rs
@@ -31,8 +31,8 @@ use crate::auth::permissions::{resolve_org_context_in_txn, ResolveError};
 use crate::config::SecretString;
 use crate::db::document_versions;
 use crate::db::download_capabilities::{
-    self, AuthorizedConsumeOutcome, CapabilityLiveness, DownloadCapabilityRow, DownloadPurpose,
-    NewDownloadCapability,
+    self, AuthorizedConsumeBinding, AuthorizedConsumeOutcome, CapabilityLiveness,
+    DownloadCapabilityRow, DownloadPurpose, NewDownloadCapability,
 };
 use crate::db::error::DbError;
 use crate::db::models::DocumentVersion;
@@ -94,7 +94,7 @@ impl fmt::Debug for CapabilityToken {
 
 impl CapabilitySigner {
     pub fn new(key: SecretString) -> Result<Self, DownloadError> {
-        if key.expose().as_bytes().len() < 32 {
+        if key.expose().len() < 32 {
             return Err(DownloadError::SignerNotConfigured);
         }
         Ok(Self { key })
@@ -324,6 +324,17 @@ impl Body for BudgetedDownloadBody {
     }
 }
 
+/// Input for minting a short-lived download capability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MintDownloadCapabilityRequest {
+    pub org_id: Uuid,
+    pub user_id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub purpose: DownloadPurpose,
+    pub ttl: Duration,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MintedDownloadCapability {
     pub capability_id: Uuid,
@@ -335,6 +346,19 @@ pub struct MintedDownloadCapability {
     pub content_type: String,
     pub byte_size: u64,
     pub expires_at: DateTime<Utc>,
+}
+
+/// Fresh ACL + HMAC binding check before fetching download bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DownloadSourceBinding<'a> {
+    org_id: Uuid,
+    user_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    purpose: DownloadPurpose,
+    bound_sha: &'a str,
+    bound_type: &'a str,
+    bound_size: i64,
 }
 
 /// Redeemed download artifact. Body owns the budget permit (not `Clone`).
@@ -552,27 +576,27 @@ pub fn resolve_original_artifact_meta(
 pub async fn mint_download_capability(
     pool: &Pool,
     signer: &CapabilitySigner,
-    org_id: Uuid,
-    user_id: Uuid,
-    document_id: Uuid,
-    version_id: Uuid,
-    purpose: DownloadPurpose,
-    ttl: Duration,
+    request: &MintDownloadCapabilityRequest,
 ) -> Result<MintedDownloadCapability, DownloadError> {
-    if ttl.is_zero() || ttl > MAX_CAPABILITY_TTL {
+    if request.ttl.is_zero() || request.ttl > MAX_CAPABILITY_TTL {
         return Err(DownloadError::InvalidTtl);
     }
-    let ttl_secs = i64::try_from(ttl.as_secs()).map_err(|_| DownloadError::InvalidTtl)?;
+    let ttl_secs = i64::try_from(request.ttl.as_secs()).map_err(|_| DownloadError::InvalidTtl)?;
     if ttl_secs <= 0 {
         return Err(DownloadError::InvalidTtl);
     }
-    let ctx = resolve_org_context_in_txn(pool, org_id, user_id).await?;
+    let ctx = resolve_org_context_in_txn(pool, request.org_id, request.user_id).await?;
     if !ctx.has_permission(PERMISSION_QA_QUERY) {
         return Err(DownloadError::PermissionDenied);
     }
     if ctx.allowed_collection_ids().is_empty() {
         return Err(DownloadError::PermissionDenied);
     }
+
+    let document_id = request.document_id;
+    let version_id = request.version_id;
+    let purpose = request.purpose;
+    let org_id = request.org_id;
 
     let (row, versions) = with_org_txn(pool, &ctx, {
         let ctx = ctx.clone();
@@ -658,19 +682,14 @@ pub async fn mint_download_capability(
 
 async fn authorize_download_source(
     pool: &Pool,
-    org_id: Uuid,
-    user_id: Uuid,
-    document_id: Uuid,
-    version_id: Uuid,
-    purpose: DownloadPurpose,
-    bound_sha: &str,
-    bound_type: &str,
-    bound_size: i64,
+    binding: DownloadSourceBinding<'_>,
 ) -> Result<(String, String, String, u64, Option<String>), DownloadError> {
-    let ctx = resolve_org_context_in_txn(pool, org_id, user_id).await?;
+    let ctx = resolve_org_context_in_txn(pool, binding.org_id, binding.user_id).await?;
     if !ctx.has_permission(PERMISSION_QA_QUERY) {
         return Err(DownloadError::PermissionDenied);
     }
+    let document_id = binding.document_id;
+    let version_id = binding.version_id;
     let (version, versions) = with_org_txn(pool, &ctx, {
         let ctx = ctx.clone();
         move |txn| {
@@ -692,7 +711,7 @@ async fn authorize_download_source(
         return Err(DownloadError::PermissionDenied);
     }
 
-    let (object_key_raw, expected_sha, content_type, byte_size, filename) = match purpose {
+    let (object_key_raw, expected_sha, content_type, byte_size, filename) = match binding.purpose {
         DownloadPurpose::Original => {
             let original = resolve_original_artifact_meta(&versions, &version)?;
             (
@@ -715,9 +734,9 @@ async fn authorize_download_source(
         }
     };
 
-    if expected_sha != bound_sha
-        || content_type != bound_type
-        || i64::try_from(byte_size).ok() != Some(bound_size)
+    if expected_sha != binding.bound_sha
+        || content_type != binding.bound_type
+        || i64::try_from(byte_size).ok() != Some(binding.bound_size)
     {
         return Err(DownloadError::Integrity);
     }
@@ -725,11 +744,11 @@ async fn authorize_download_source(
         return Err(DownloadError::TooLarge);
     }
 
-    let key = parse_key_for_org(&object_key_raw, org_id)?;
-    if purpose == DownloadPurpose::Markdown && key.namespace() != ObjectNamespace::Trusted {
+    let key = parse_key_for_org(&object_key_raw, binding.org_id)?;
+    if binding.purpose == DownloadPurpose::Markdown && key.namespace() != ObjectNamespace::Trusted {
         return Err(DownloadError::PermissionDenied);
     }
-    authorize_key_for_version(&key, version_id)?;
+    authorize_key_for_version(&key, binding.version_id)?;
     Ok((
         object_key_raw,
         expected_sha,
@@ -792,14 +811,16 @@ pub async fn redeem_download_capability<S: BlobStore>(
     let (object_key_raw, _expected_sha, _content_type, byte_size, filename) =
         authorize_download_source(
             pool,
-            org_id,
-            user_id,
-            capability.document_id,
-            capability.version_id,
-            capability.purpose,
-            &capability.content_sha256,
-            &capability.content_type,
-            capability.byte_size,
+            DownloadSourceBinding {
+                org_id,
+                user_id,
+                document_id: capability.document_id,
+                version_id: capability.version_id,
+                purpose: capability.purpose,
+                bound_sha: &capability.content_sha256,
+                bound_type: &capability.content_type,
+                bound_size: capability.byte_size,
+            },
         )
         .await?;
 
@@ -838,30 +859,20 @@ pub async fn redeem_download_capability<S: BlobStore>(
             return Err(DownloadError::PermissionDenied);
         }
     };
-    let expected_document_id = capability.document_id;
-    let expected_version_id = capability.version_id;
-    let expected_purpose = capability.purpose;
-    let expected_sha = capability.content_sha256.clone();
-    let expected_type = capability.content_type.clone();
-    let expected_size = capability.byte_size;
+    let expected = AuthorizedConsumeBinding {
+        capability_id,
+        document_id: capability.document_id,
+        version_id: capability.version_id,
+        purpose: capability.purpose,
+        content_sha256: capability.content_sha256.clone(),
+        content_type: capability.content_type.clone(),
+        byte_size: capability.byte_size,
+    };
     let outcome = with_org_txn(pool, &ctx, {
         let ctx = ctx.clone();
-        let expected_sha = expected_sha.clone();
-        let expected_type = expected_type.clone();
         move |txn| {
             Box::pin(async move {
-                download_capabilities::consume_authorized_or_classify(
-                    txn,
-                    &ctx,
-                    capability_id,
-                    expected_document_id,
-                    expected_version_id,
-                    expected_purpose,
-                    &expected_sha,
-                    &expected_type,
-                    expected_size,
-                )
-                .await
+                download_capabilities::consume_authorized_or_classify(txn, &ctx, &expected).await
             })
         }
     })
@@ -977,39 +988,43 @@ mod tests {
         }
     }
 
-    fn version(
+    struct VersionFixture<'a> {
         id: Uuid,
         parent: Option<Uuid>,
         number: i32,
-        original_key: &str,
+        original_key: &'a str,
         content_sha256: String,
-        markdown_key: Option<&str>,
-        content_type: &str,
+        markdown_key: Option<&'a str>,
+        content_type: &'a str,
         byte_size: i64,
-    ) -> DocumentVersion {
-        DocumentVersion {
-            id,
-            org_id: Uuid::new_v4(),
-            document_id: Uuid::new_v4(),
-            version_number: number,
-            parent_version_id: parent,
-            publication_state: if markdown_key.is_some() {
-                PublicationState::Published
-            } else {
-                PublicationState::Draft
-            },
-            is_current: markdown_key.is_some(),
-            content_sha256,
-            original_object_key: original_key.into(),
-            markdown_object_key: markdown_key.map(str::to_string),
-            source_filename: Some("source.pdf".into()),
-            source_content_type: Some(content_type.into()),
-            byte_size: Some(byte_size),
-            effective_from: Utc::now(),
-            effective_to: None,
-            change_summary: None,
-            created_by_user_id: Uuid::new_v4(),
-            created_at: Utc::now(),
+    }
+
+    impl VersionFixture<'_> {
+        fn build(self) -> DocumentVersion {
+            DocumentVersion {
+                id: self.id,
+                org_id: Uuid::new_v4(),
+                document_id: Uuid::new_v4(),
+                version_number: self.number,
+                parent_version_id: self.parent,
+                publication_state: if self.markdown_key.is_some() {
+                    PublicationState::Published
+                } else {
+                    PublicationState::Draft
+                },
+                is_current: self.markdown_key.is_some(),
+                content_sha256: self.content_sha256,
+                original_object_key: self.original_key.into(),
+                markdown_object_key: self.markdown_key.map(str::to_string),
+                source_filename: Some("source.pdf".into()),
+                source_content_type: Some(self.content_type.into()),
+                byte_size: Some(self.byte_size),
+                effective_from: Utc::now(),
+                effective_to: None,
+                change_summary: None,
+                created_by_user_id: Uuid::new_v4(),
+                created_at: Utc::now(),
+            }
         }
     }
 
@@ -1021,26 +1036,28 @@ mod tests {
         let original_sha = "aa".repeat(32);
         let markdown_sha = "bb".repeat(32);
         let versions = vec![
-            version(
-                source_id,
-                None,
-                1,
+            VersionFixture {
+                id: source_id,
+                parent: None,
+                number: 1,
                 original_key,
-                original_sha.clone(),
-                None,
-                "application/pdf",
-                2048,
-            ),
-            version(
-                published_id,
-                Some(source_id),
-                2,
+                content_sha256: original_sha.clone(),
+                markdown_key: None,
+                content_type: "application/pdf",
+                byte_size: 2048,
+            }
+            .build(),
+            VersionFixture {
+                id: published_id,
+                parent: Some(source_id),
+                number: 2,
                 original_key,
-                markdown_sha.clone(),
-                Some("trusted/aa/bb/cc"),
-                "text/markdown; charset=utf-8",
-                100,
-            ),
+                content_sha256: markdown_sha.clone(),
+                markdown_key: Some("trusted/aa/bb/cc"),
+                content_type: "text/markdown; charset=utf-8",
+                byte_size: 100,
+            }
+            .build(),
         ];
         let published = AuthorizedVersionRow {
             org_id: versions[1].org_id,

--- a/crates/server/src/services/download.rs
+++ b/crates/server/src/services/download.rs
@@ -1,0 +1,1205 @@
+//! Short-lived, single-purpose download capabilities (P1B-R02 / ADR 0007).
+//!
+//! Capabilities are HMAC-bound to org/user/document/version/purpose/hash/type/size
+//! and recorded in PostgreSQL for expiry + replay protection. Original downloads
+//! resolve authoritative upload metadata via the reconciliation parent-source model
+//! (promoted versions store Markdown hash/size on the published row).
+//!
+//! Mint/consume expiry uses PostgreSQL `clock_timestamp()`. Redeem fetches under a
+//! process-wide byte budget **before** atomic consume so Busy/storage/integrity
+//! leave the token retryable. The response body owns the budget permit until the
+//! HTTP body completes, is cancelled, or is dropped.
+
+use std::fmt;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use base64::Engine;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Pool;
+use http_body::{Body, Frame};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use uuid::Uuid;
+
+use crate::auth::permissions::{resolve_org_context_in_txn, ResolveError};
+use crate::config::SecretString;
+use crate::db::document_versions;
+use crate::db::download_capabilities::{
+    self, AuthorizedConsumeOutcome, CapabilityLiveness, DownloadCapabilityRow, DownloadPurpose,
+    NewDownloadCapability,
+};
+use crate::db::error::DbError;
+use crate::db::models::DocumentVersion;
+use crate::db::pool::with_org_txn;
+use crate::db::search::{self, AuthorizedVersionRow};
+use crate::services::preview::{trusted_markdown_artifact_from_version, PreviewError};
+use crate::services::reconciliation::authoritative_original_source;
+use crate::services::retrieval::{PERMISSION_QA_HISTORY, PERMISSION_QA_QUERY};
+use crate::storage::blob::{canonicalize_content_type, BlobStore, ObjectExpectation};
+use crate::storage::keys::{authorize_key_for_version, parse_key_for_org, ObjectNamespace};
+use crate::storage::StorageError;
+
+const CAPABILITY_DOMAIN: &[u8] = b"markhand-download-cap-v1";
+const TOKEN_PREFIX: &str = "mhdl1";
+/// Default short TTL for a single-purpose download capability.
+pub const DEFAULT_CAPABILITY_TTL: Duration = Duration::from_secs(60);
+/// Hard upper bound so clients cannot mint long-lived download grants.
+pub const MAX_CAPABILITY_TTL: Duration = Duration::from_secs(300);
+/// Absolute download stream bound (defense in depth vs upload policy).
+pub const DOWNLOAD_MAX_BYTES: u64 = 200 * 1024 * 1024;
+/// Process-wide in-flight download byte budget (slightly above one max object).
+pub const DEFAULT_DOWNLOAD_BUDGET_BYTES: u64 = 256 * 1024 * 1024;
+/// Max concurrent bounded download fetches per process.
+pub const DEFAULT_DOWNLOAD_CONCURRENCY: usize = 4;
+
+/// HMAC signer for download capability tokens (secrets never appear in Debug).
+#[derive(Clone)]
+pub struct CapabilitySigner {
+    key: SecretString,
+}
+
+impl fmt::Debug for CapabilitySigner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CapabilitySigner")
+            .field("key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Opaque capability token — Debug never prints the raw secret material.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CapabilityToken(SecretString);
+
+impl CapabilityToken {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(SecretString::new(value.into()))
+    }
+
+    pub fn expose(&self) -> &str {
+        self.0.expose()
+    }
+}
+
+impl fmt::Debug for CapabilityToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CapabilityToken([REDACTED])")
+    }
+}
+
+impl CapabilitySigner {
+    pub fn new(key: SecretString) -> Result<Self, DownloadError> {
+        if key.expose().as_bytes().len() < 32 {
+            return Err(DownloadError::SignerNotConfigured);
+        }
+        Ok(Self { key })
+    }
+
+    pub fn from_auth_signing_key(key: Option<&SecretString>) -> Result<Self, DownloadError> {
+        let key = key.ok_or(DownloadError::SignerNotConfigured)?;
+        Self::new(key.clone())
+    }
+
+    fn sign_bytes(&self, message: &[u8]) -> [u8; 32] {
+        hmac_sha256(self.key.expose().as_bytes(), message)
+    }
+
+    pub fn sign_capability(&self, row: &DownloadCapabilityRow) -> CapabilityToken {
+        let mac = self.sign_bytes(&canonical_message(row));
+        let mac_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(mac);
+        CapabilityToken::new(format!("{TOKEN_PREFIX}.{}.{mac_b64}", row.id))
+    }
+
+    pub fn verify_token(
+        &self,
+        token: &CapabilityToken,
+        row: &DownloadCapabilityRow,
+    ) -> Result<(), DownloadError> {
+        let expected = self.sign_capability(row);
+        if !constant_time_eq(token.expose().as_bytes(), expected.expose().as_bytes()) {
+            return Err(DownloadError::InvalidToken);
+        }
+        Ok(())
+    }
+}
+
+/// Invalid [`DownloadFetchBudget`] configuration (never panics in constructors).
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DownloadBudgetConfigError {
+    #[error("download budget max bytes must be non-zero and <= download max")]
+    InvalidMaxBytes,
+    #[error("download budget concurrency must be in 1..=Semaphore::MAX_PERMITS")]
+    InvalidConcurrency,
+}
+
+/// Process-wide limiter so concurrent redeems cannot allocate unbounded RAM.
+#[derive(Debug)]
+pub struct DownloadFetchBudget {
+    max_in_flight_bytes: u64,
+    in_flight: AtomicU64,
+    slots: Arc<Semaphore>,
+}
+
+/// RAII permit that releases concurrency slot + reserved bytes on drop.
+/// Not `Clone` — cloning would bypass the budget.
+pub struct DownloadFetchPermit {
+    budget: Arc<DownloadFetchBudget>,
+    reserved: u64,
+    _slot: OwnedSemaphorePermit,
+}
+
+impl fmt::Debug for DownloadFetchPermit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DownloadFetchPermit")
+            .field("reserved", &self.reserved)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for DownloadFetchPermit {
+    fn drop(&mut self) {
+        self.budget
+            .in_flight
+            .fetch_sub(self.reserved, Ordering::AcqRel);
+    }
+}
+
+impl DownloadFetchBudget {
+    /// Validated constructor. Rejects zero / oversized byte budgets and
+    /// concurrency outside `1..=Semaphore::MAX_PERMITS` (Tokio panics above that).
+    pub fn try_new(
+        max_in_flight_bytes: u64,
+        max_concurrent: usize,
+    ) -> Result<Arc<Self>, DownloadBudgetConfigError> {
+        // Reject 0 and values that cannot reserve even one max object usefully,
+        // plus absurd u64::MAX-scale configs that break checked arithmetic headroom.
+        if max_in_flight_bytes == 0 || max_in_flight_bytes == u64::MAX {
+            return Err(DownloadBudgetConfigError::InvalidMaxBytes);
+        }
+        if max_concurrent == 0 || max_concurrent > Semaphore::MAX_PERMITS {
+            return Err(DownloadBudgetConfigError::InvalidConcurrency);
+        }
+        Ok(Arc::new(Self {
+            max_in_flight_bytes,
+            in_flight: AtomicU64::new(0),
+            slots: Arc::new(Semaphore::new(max_concurrent)),
+        }))
+    }
+
+    pub fn default_production() -> Arc<Self> {
+        Self::try_new(DEFAULT_DOWNLOAD_BUDGET_BYTES, DEFAULT_DOWNLOAD_CONCURRENCY)
+            .expect("compiled-in production download budget is valid")
+    }
+
+    /// Generous limits for hermetic service tests (still exercises acquire/release).
+    pub fn for_tests() -> Arc<Self> {
+        Self::try_new(DEFAULT_DOWNLOAD_BUDGET_BYTES.saturating_mul(4), 32)
+            .expect("compiled-in test download budget is valid")
+    }
+
+    pub async fn acquire(
+        self: &Arc<Self>,
+        bytes: u64,
+    ) -> Result<DownloadFetchPermit, DownloadError> {
+        if bytes == 0 || bytes > DOWNLOAD_MAX_BYTES {
+            return Err(DownloadError::TooLarge);
+        }
+        // Fail-fast: never park the request waiting for a slot (Busy must be retryable).
+        let slot = self
+            .slots
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| DownloadError::Busy)?;
+        loop {
+            let current = self.in_flight.load(Ordering::Acquire);
+            let Some(next) = current.checked_add(bytes) else {
+                drop(slot);
+                return Err(DownloadError::Busy);
+            };
+            if next > self.max_in_flight_bytes {
+                drop(slot);
+                return Err(DownloadError::Busy);
+            }
+            match self.in_flight.compare_exchange(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Ok(DownloadFetchPermit {
+                        budget: Arc::clone(self),
+                        reserved: bytes,
+                        _slot: slot,
+                    });
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+
+    pub fn in_flight_bytes(&self) -> u64 {
+        self.in_flight.load(Ordering::Acquire)
+    }
+}
+
+/// HTTP body that owns a [`DownloadFetchPermit`] until fully polled, cancelled, or dropped.
+/// Not `Clone` — cloning would release the permit early while bytes still stream.
+pub struct BudgetedDownloadBody {
+    full: Bytes,
+    offset: usize,
+    chunk_size: usize,
+    permit: Option<DownloadFetchPermit>,
+}
+
+impl BudgetedDownloadBody {
+    pub fn new(bytes: Bytes, permit: DownloadFetchPermit) -> Self {
+        Self {
+            full: bytes,
+            offset: 0,
+            chunk_size: usize::MAX,
+            permit: Some(permit),
+        }
+    }
+
+    /// Test helper: emit the body in small frames so callers can observe held budget.
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = chunk_size.max(1);
+        self
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.full
+    }
+
+    pub fn len(&self) -> usize {
+        self.full.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.full.is_empty()
+    }
+
+    pub fn permit_held(&self) -> bool {
+        self.permit.is_some()
+    }
+}
+
+impl fmt::Debug for BudgetedDownloadBody {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BudgetedDownloadBody")
+            .field("len", &self.full.len())
+            .field("offset", &self.offset)
+            .field("permit_held", &self.permit.is_some())
+            .finish()
+    }
+}
+
+impl Body for BudgetedDownloadBody {
+    type Data = Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        if this.offset >= this.full.len() {
+            // Completed stream: release budget immediately (Drop is a backstop).
+            this.permit.take();
+            return Poll::Ready(None);
+        }
+        let end = this
+            .offset
+            .saturating_add(this.chunk_size)
+            .min(this.full.len());
+        let chunk = this.full.slice(this.offset..end);
+        this.offset = end;
+        Poll::Ready(Some(Ok(Frame::data(chunk))))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MintedDownloadCapability {
+    pub capability_id: Uuid,
+    pub token: CapabilityToken,
+    pub purpose: DownloadPurpose,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub content_sha256: String,
+    pub content_type: String,
+    pub byte_size: u64,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Redeemed download artifact. Body owns the budget permit (not `Clone`).
+pub struct DownloadArtifact {
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub purpose: DownloadPurpose,
+    pub content_sha256: String,
+    pub content_type: String,
+    pub filename: Option<String>,
+    /// Zero-copy body; owns [`DownloadFetchPermit`] until stream end/cancel/drop.
+    pub body: BudgetedDownloadBody,
+}
+
+impl fmt::Debug for DownloadArtifact {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DownloadArtifact")
+            .field("document_id", &self.document_id)
+            .field("version_id", &self.version_id)
+            .field("purpose", &self.purpose)
+            .field("content_sha256", &self.content_sha256)
+            .field("content_type", &self.content_type)
+            .field("filename", &self.filename)
+            .field("body", &self.body)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OriginalArtifactMeta {
+    pub object_key: String,
+    pub content_sha256: String,
+    pub content_type: String,
+    pub byte_size: u64,
+    pub source_filename: Option<String>,
+    pub source_version_id: Uuid,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DownloadError {
+    #[error("permission denied")]
+    PermissionDenied,
+    #[error("download source not found")]
+    NotFound,
+    #[error("download capability expired")]
+    Expired,
+    #[error("download capability already used")]
+    Replay,
+    #[error("download capability token is invalid")]
+    InvalidToken,
+    #[error("download capability signer is not configured")]
+    SignerNotConfigured,
+    #[error("invalid download purpose")]
+    InvalidPurpose,
+    #[error("invalid capability ttl")]
+    InvalidTtl,
+    #[error("storage unavailable")]
+    StorageUnavailable,
+    #[error("storage error")]
+    Storage,
+    #[error("integrity check failed")]
+    Integrity,
+    #[error("object exceeds download size bound")]
+    TooLarge,
+    #[error("download capacity busy")]
+    Busy,
+    #[error("database error")]
+    Database,
+}
+
+impl DownloadError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::PermissionDenied => "download_permission_denied",
+            Self::NotFound => "download_not_found",
+            Self::Expired => "download_expired",
+            Self::Replay => "download_replay",
+            Self::InvalidToken => "download_invalid_token",
+            Self::SignerNotConfigured => "download_signer_unavailable",
+            Self::InvalidPurpose => "download_invalid_purpose",
+            Self::InvalidTtl => "download_invalid_ttl",
+            Self::StorageUnavailable => "download_storage_unavailable",
+            Self::Storage => "download_storage",
+            Self::Integrity => "download_integrity",
+            Self::TooLarge => "download_too_large",
+            Self::Busy => "download_busy",
+            Self::Database => "download_database",
+        }
+    }
+}
+
+impl From<ResolveError> for DownloadError {
+    fn from(_: ResolveError) -> Self {
+        Self::PermissionDenied
+    }
+}
+
+impl From<DbError> for DownloadError {
+    fn from(_: DbError) -> Self {
+        Self::Database
+    }
+}
+
+impl From<StorageError> for DownloadError {
+    fn from(value: StorageError) -> Self {
+        match value {
+            StorageError::NotFound => Self::NotFound,
+            StorageError::KeyOrgMismatch
+            | StorageError::MissingScope
+            | StorageError::InvalidKey => Self::PermissionDenied,
+            StorageError::ObjectTooLarge => Self::TooLarge,
+            StorageError::PreconditionFailed => Self::Integrity,
+            _ => Self::Storage,
+        }
+    }
+}
+
+impl From<PreviewError> for DownloadError {
+    fn from(value: PreviewError) -> Self {
+        match value {
+            PreviewError::PermissionDenied => Self::PermissionDenied,
+            PreviewError::NotFound | PreviewError::MarkdownMissing => Self::NotFound,
+            PreviewError::Integrity | PreviewError::InvalidUtf8 => Self::Integrity,
+            PreviewError::TooLarge => Self::TooLarge,
+            PreviewError::StorageUnavailable => Self::StorageUnavailable,
+            PreviewError::Storage => Self::Storage,
+            PreviewError::Database => Self::Database,
+        }
+    }
+}
+
+fn canonical_message(row: &DownloadCapabilityRow) -> Vec<u8> {
+    let mut out = Vec::with_capacity(320);
+    out.extend_from_slice(CAPABILITY_DOMAIN);
+    out.push(b'|');
+    out.extend_from_slice(row.id.as_bytes());
+    out.push(b'|');
+    out.extend_from_slice(row.org_id.as_bytes());
+    out.push(b'|');
+    out.extend_from_slice(row.user_id.as_bytes());
+    out.push(b'|');
+    out.extend_from_slice(row.document_id.as_bytes());
+    out.push(b'|');
+    out.extend_from_slice(row.version_id.as_bytes());
+    out.push(b'|');
+    out.extend_from_slice(row.purpose.as_str().as_bytes());
+    out.push(b'|');
+    out.extend_from_slice(row.content_sha256.as_bytes());
+    out.push(b'|');
+    out.extend_from_slice(row.content_type.as_bytes());
+    out.push(b'|');
+    out.extend_from_slice(row.byte_size.to_string().as_bytes());
+    out.push(b'|');
+    out.extend_from_slice(row.expires_at.timestamp().to_string().as_bytes());
+    out
+}
+
+fn parse_capability_token(raw: &str) -> Result<(Uuid, CapabilityToken), DownloadError> {
+    let mut parts = raw.split('.');
+    let prefix = parts.next().ok_or(DownloadError::InvalidToken)?;
+    let id = parts.next().ok_or(DownloadError::InvalidToken)?;
+    let mac = parts.next().ok_or(DownloadError::InvalidToken)?;
+    if parts.next().is_some() || prefix != TOKEN_PREFIX || mac.is_empty() {
+        return Err(DownloadError::InvalidToken);
+    }
+    let id = Uuid::parse_str(id).map_err(|_| DownloadError::InvalidToken)?;
+    Ok((id, CapabilityToken::new(raw.to_string())))
+}
+
+fn normalize_stored_content_type(raw: &str) -> Result<String, DownloadError> {
+    canonicalize_content_type(raw).ok_or(DownloadError::Integrity)
+}
+
+fn liveness_error(live: CapabilityLiveness) -> Result<(), DownloadError> {
+    match live {
+        CapabilityLiveness::Open => Ok(()),
+        CapabilityLiveness::Expired => Err(DownloadError::Expired),
+        CapabilityLiveness::Replay => Err(DownloadError::Replay),
+        CapabilityLiveness::NotFound => Err(DownloadError::NotFound),
+    }
+}
+
+/// Resolve original upload identity for a published version (reconciliation model).
+pub fn resolve_original_artifact_meta(
+    versions: &[DocumentVersion],
+    published: &AuthorizedVersionRow,
+) -> Result<OriginalArtifactMeta, DownloadError> {
+    let source = authoritative_original_source(versions, &published.original_object_key)
+        .ok_or(DownloadError::NotFound)?;
+    let byte_size = source
+        .byte_size
+        .ok_or(DownloadError::NotFound)
+        .and_then(|value| u64::try_from(value).map_err(|_| DownloadError::Integrity))?;
+    if byte_size == 0 || byte_size > DOWNLOAD_MAX_BYTES {
+        return Err(DownloadError::TooLarge);
+    }
+    let content_type = normalize_stored_content_type(
+        source
+            .source_content_type
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("application/octet-stream"),
+    )?;
+    Ok(OriginalArtifactMeta {
+        object_key: source.original_object_key.clone(),
+        content_sha256: source.content_sha256.clone(),
+        content_type,
+        byte_size,
+        source_filename: source.source_filename.clone(),
+        source_version_id: source.id,
+    })
+}
+
+/// Mints a short-lived capability after fresh authorization. Never returns object keys.
+pub async fn mint_download_capability(
+    pool: &Pool,
+    signer: &CapabilitySigner,
+    org_id: Uuid,
+    user_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    purpose: DownloadPurpose,
+    ttl: Duration,
+) -> Result<MintedDownloadCapability, DownloadError> {
+    if ttl.is_zero() || ttl > MAX_CAPABILITY_TTL {
+        return Err(DownloadError::InvalidTtl);
+    }
+    let ttl_secs = i64::try_from(ttl.as_secs()).map_err(|_| DownloadError::InvalidTtl)?;
+    if ttl_secs <= 0 {
+        return Err(DownloadError::InvalidTtl);
+    }
+    let ctx = resolve_org_context_in_txn(pool, org_id, user_id).await?;
+    if !ctx.has_permission(PERMISSION_QA_QUERY) {
+        return Err(DownloadError::PermissionDenied);
+    }
+    if ctx.allowed_collection_ids().is_empty() {
+        return Err(DownloadError::PermissionDenied);
+    }
+
+    let (row, versions) = with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row =
+                    search::load_authorized_version_for_read(txn, &ctx, document_id, version_id)
+                        .await?;
+                let versions = document_versions::list_by_document(txn, &ctx, document_id).await?;
+                Ok((row, versions))
+            })
+        }
+    })
+    .await?;
+    let row = row.ok_or(DownloadError::NotFound)?;
+
+    if row.org_id != org_id || !ctx.allows_collection(row.collection_id) {
+        return Err(DownloadError::PermissionDenied);
+    }
+    if !row.is_current && !ctx.has_permission(PERMISSION_QA_HISTORY) {
+        return Err(DownloadError::PermissionDenied);
+    }
+
+    let (content_sha256, content_type, byte_size) = match purpose {
+        DownloadPurpose::Original => {
+            let original = resolve_original_artifact_meta(&versions, &row)?;
+            (
+                original.content_sha256,
+                original.content_type,
+                i64::try_from(original.byte_size).map_err(|_| DownloadError::Integrity)?,
+            )
+        }
+        DownloadPurpose::Markdown => {
+            let artifact = trusted_markdown_artifact_from_version(&row)?;
+            (
+                artifact.content_sha256,
+                normalize_stored_content_type(&artifact.content_type)?,
+                i64::try_from(artifact.byte_size).map_err(|_| DownloadError::Integrity)?,
+            )
+        }
+    };
+
+    let capability_id = Uuid::new_v4();
+    let stored = with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        let content_sha256 = content_sha256.clone();
+        let content_type = content_type.clone();
+        move |txn| {
+            Box::pin(async move {
+                download_capabilities::insert(
+                    txn,
+                    &ctx,
+                    NewDownloadCapability {
+                        id: capability_id,
+                        document_id,
+                        version_id,
+                        purpose,
+                        content_sha256: &content_sha256,
+                        content_type: &content_type,
+                        byte_size,
+                        ttl_secs,
+                    },
+                )
+                .await
+            })
+        }
+    })
+    .await?;
+
+    let token = signer.sign_capability(&stored);
+    Ok(MintedDownloadCapability {
+        capability_id: stored.id,
+        token,
+        purpose,
+        document_id,
+        version_id,
+        content_sha256: stored.content_sha256,
+        content_type: stored.content_type,
+        byte_size: u64::try_from(stored.byte_size).unwrap_or(0),
+        expires_at: stored.expires_at,
+    })
+}
+
+async fn authorize_download_source(
+    pool: &Pool,
+    org_id: Uuid,
+    user_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    purpose: DownloadPurpose,
+    bound_sha: &str,
+    bound_type: &str,
+    bound_size: i64,
+) -> Result<(String, String, String, u64, Option<String>), DownloadError> {
+    let ctx = resolve_org_context_in_txn(pool, org_id, user_id).await?;
+    if !ctx.has_permission(PERMISSION_QA_QUERY) {
+        return Err(DownloadError::PermissionDenied);
+    }
+    let (version, versions) = with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let version =
+                    search::load_authorized_version_for_read(txn, &ctx, document_id, version_id)
+                        .await?;
+                let versions = document_versions::list_by_document(txn, &ctx, document_id).await?;
+                Ok((version, versions))
+            })
+        }
+    })
+    .await?;
+    let version = version.ok_or(DownloadError::PermissionDenied)?;
+    if !version.is_current && !ctx.has_permission(PERMISSION_QA_HISTORY) {
+        return Err(DownloadError::PermissionDenied);
+    }
+    if !ctx.allows_collection(version.collection_id) {
+        return Err(DownloadError::PermissionDenied);
+    }
+
+    let (object_key_raw, expected_sha, content_type, byte_size, filename) = match purpose {
+        DownloadPurpose::Original => {
+            let original = resolve_original_artifact_meta(&versions, &version)?;
+            (
+                original.object_key,
+                original.content_sha256,
+                original.content_type,
+                original.byte_size,
+                original.source_filename,
+            )
+        }
+        DownloadPurpose::Markdown => {
+            let artifact = trusted_markdown_artifact_from_version(&version)?;
+            (
+                artifact.object_key,
+                artifact.content_sha256,
+                normalize_stored_content_type(&artifact.content_type)?,
+                artifact.byte_size,
+                Some("preview.md".into()),
+            )
+        }
+    };
+
+    if expected_sha != bound_sha
+        || content_type != bound_type
+        || i64::try_from(byte_size).ok() != Some(bound_size)
+    {
+        return Err(DownloadError::Integrity);
+    }
+    if byte_size > DOWNLOAD_MAX_BYTES {
+        return Err(DownloadError::TooLarge);
+    }
+
+    let key = parse_key_for_org(&object_key_raw, org_id)?;
+    if purpose == DownloadPurpose::Markdown && key.namespace() != ObjectNamespace::Trusted {
+        return Err(DownloadError::PermissionDenied);
+    }
+    authorize_key_for_version(&key, version_id)?;
+    Ok((
+        object_key_raw,
+        expected_sha,
+        content_type,
+        byte_size,
+        filename,
+    ))
+}
+
+/// Redeems a capability exactly once. Fetch + verify happen **before** consume so
+/// Busy/storage/integrity leave the token retryable. Only the consume winner returns a body.
+pub async fn redeem_download_capability<S: BlobStore>(
+    pool: &Pool,
+    storage: &S,
+    signer: &CapabilitySigner,
+    budget: &Arc<DownloadFetchBudget>,
+    org_id: Uuid,
+    user_id: Uuid,
+    token_raw: &str,
+) -> Result<DownloadArtifact, DownloadError> {
+    if token_raw.is_empty() || token_raw.len() > 512 {
+        return Err(DownloadError::InvalidToken);
+    }
+    let (capability_id, token) = parse_capability_token(token_raw)?;
+
+    // 1) Fresh auth + load/verify capability (no consume yet).
+    let ctx = resolve_org_context_in_txn(pool, org_id, user_id).await?;
+    if !ctx.has_permission(PERMISSION_QA_QUERY) {
+        return Err(DownloadError::PermissionDenied);
+    }
+    let capability = with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(
+                async move { download_capabilities::get_by_id(txn, &ctx, capability_id).await },
+            )
+        }
+    })
+    .await?
+    .ok_or(DownloadError::NotFound)?;
+
+    if capability.user_id != user_id || capability.org_id != org_id {
+        return Err(DownloadError::PermissionDenied);
+    }
+    signer.verify_token(&token, &capability)?;
+
+    // Soft liveness (DB clock) — avoid expensive fetch when already dead.
+    let live = with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                download_capabilities::classify_liveness(txn, &ctx, capability_id).await
+            })
+        }
+    })
+    .await?;
+    liveness_error(live)?;
+
+    // 2) Fresh ACL for the bound document/version.
+    let (object_key_raw, _expected_sha, _content_type, byte_size, filename) =
+        authorize_download_source(
+            pool,
+            org_id,
+            user_id,
+            capability.document_id,
+            capability.version_id,
+            capability.purpose,
+            &capability.content_sha256,
+            &capability.content_type,
+            capability.byte_size,
+        )
+        .await?;
+
+    let key = parse_key_for_org(&object_key_raw, org_id)?;
+
+    // 3) Acquire budget, then bounded fetch+verify (token still open on failure).
+    let permit = budget.acquire(byte_size).await?;
+    let fetched = match storage
+        .get_object_bounded(
+            org_id,
+            &key,
+            DOWNLOAD_MAX_BYTES.min(byte_size),
+            &ObjectExpectation {
+                content_sha256: &capability.content_sha256,
+                content_length: byte_size,
+                content_type: Some(capability.content_type.as_str()),
+            },
+        )
+        .await
+    {
+        Ok(fetched) => fetched,
+        Err(error) => {
+            drop(permit);
+            return Err(DownloadError::from(error));
+        }
+    };
+
+    // 4) Single atomic auth+consume at the DB (FOR UPDATE + conditional UPDATE WHERE EXISTS).
+    //    Post-fetch OrgContext re-resolve alone is not sufficient — revoke/delete must be
+    //    evaluated in the same statement that sets consumed_at.
+    let ctx = match resolve_org_context_in_txn(pool, org_id, user_id).await {
+        Ok(ctx) => ctx,
+        Err(_) => {
+            drop(fetched);
+            drop(permit);
+            return Err(DownloadError::PermissionDenied);
+        }
+    };
+    let expected_document_id = capability.document_id;
+    let expected_version_id = capability.version_id;
+    let expected_purpose = capability.purpose;
+    let expected_sha = capability.content_sha256.clone();
+    let expected_type = capability.content_type.clone();
+    let expected_size = capability.byte_size;
+    let outcome = with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        let expected_sha = expected_sha.clone();
+        let expected_type = expected_type.clone();
+        move |txn| {
+            Box::pin(async move {
+                download_capabilities::consume_authorized_or_classify(
+                    txn,
+                    &ctx,
+                    capability_id,
+                    expected_document_id,
+                    expected_version_id,
+                    expected_purpose,
+                    &expected_sha,
+                    &expected_type,
+                    expected_size,
+                )
+                .await
+            })
+        }
+    })
+    .await?;
+
+    let consumed = match outcome {
+        AuthorizedConsumeOutcome::Consumed(row) => row,
+        AuthorizedConsumeOutcome::Expired => {
+            drop(fetched);
+            drop(permit);
+            return Err(DownloadError::Expired);
+        }
+        AuthorizedConsumeOutcome::Replay => {
+            // Concurrent loser: drop bytes + permit; winner alone returns a body.
+            drop(fetched);
+            drop(permit);
+            return Err(DownloadError::Replay);
+        }
+        AuthorizedConsumeOutcome::PermissionDenied => {
+            // Auth failed under the lock — token left open (retryable); no body.
+            drop(fetched);
+            drop(permit);
+            return Err(DownloadError::PermissionDenied);
+        }
+        AuthorizedConsumeOutcome::NotFound => {
+            drop(fetched);
+            drop(permit);
+            return Err(DownloadError::NotFound);
+        }
+    };
+
+    if consumed.content_sha256 != capability.content_sha256
+        || consumed.content_type != capability.content_type
+        || consumed.byte_size != capability.byte_size
+    {
+        drop(fetched);
+        drop(permit);
+        return Err(DownloadError::Integrity);
+    }
+
+    Ok(DownloadArtifact {
+        document_id: consumed.document_id,
+        version_id: consumed.version_id,
+        purpose: consumed.purpose,
+        content_sha256: consumed.content_sha256,
+        content_type: consumed.content_type,
+        filename,
+        body: BudgetedDownloadBody::new(fetched.bytes, permit),
+    })
+}
+
+/// HMAC-SHA256 without adding a direct `hmac` dependency.
+pub fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    const BLOCK: usize = 64;
+    let mut key_block = [0u8; BLOCK];
+    if key.len() > BLOCK {
+        let digested = Sha256::digest(key);
+        key_block[..32].copy_from_slice(&digested);
+    } else {
+        key_block[..key.len()].copy_from_slice(key);
+    }
+    let mut ipad = [0x36u8; BLOCK];
+    let mut opad = [0x5cu8; BLOCK];
+    for i in 0..BLOCK {
+        ipad[i] ^= key_block[i];
+        opad[i] ^= key_block[i];
+    }
+    let mut inner = Sha256::new();
+    inner.update(ipad);
+    inner.update(message);
+    let inner_hash = inner.finalize();
+    let mut outer = Sha256::new();
+    outer.update(opad);
+    outer.update(inner_hash);
+    let digest = outer.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (left, right) in a.iter().zip(b.iter()) {
+        diff |= left ^ right;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::{DocumentState, PublicationState};
+    use chrono::TimeZone;
+    use http_body_util::BodyExt;
+
+    fn sample_row() -> DownloadCapabilityRow {
+        DownloadCapabilityRow {
+            id: Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap(),
+            org_id: Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap(),
+            user_id: Uuid::parse_str("22222222-2222-2222-2222-222222222201").unwrap(),
+            document_id: Uuid::parse_str("66666666-6666-6666-6666-666666666601").unwrap(),
+            version_id: Uuid::parse_str("77777777-7777-7777-7777-777777777701").unwrap(),
+            purpose: DownloadPurpose::Markdown,
+            content_sha256: "ab".repeat(32),
+            content_type: "text/markdown; charset=utf-8".into(),
+            byte_size: 128,
+            expires_at: Utc.with_ymd_and_hms(2030, 1, 1, 0, 0, 0).unwrap(),
+            consumed_at: None,
+            created_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        }
+    }
+
+    fn version(
+        id: Uuid,
+        parent: Option<Uuid>,
+        number: i32,
+        original_key: &str,
+        content_sha256: String,
+        markdown_key: Option<&str>,
+        content_type: &str,
+        byte_size: i64,
+    ) -> DocumentVersion {
+        DocumentVersion {
+            id,
+            org_id: Uuid::new_v4(),
+            document_id: Uuid::new_v4(),
+            version_number: number,
+            parent_version_id: parent,
+            publication_state: if markdown_key.is_some() {
+                PublicationState::Published
+            } else {
+                PublicationState::Draft
+            },
+            is_current: markdown_key.is_some(),
+            content_sha256,
+            original_object_key: original_key.into(),
+            markdown_object_key: markdown_key.map(str::to_string),
+            source_filename: Some("source.pdf".into()),
+            source_content_type: Some(content_type.into()),
+            byte_size: Some(byte_size),
+            effective_from: Utc::now(),
+            effective_to: None,
+            change_summary: None,
+            created_by_user_id: Uuid::new_v4(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn original_meta_uses_parent_upload_not_promoted_markdown_hash() {
+        let source_id = Uuid::new_v4();
+        let published_id = Uuid::new_v4();
+        let original_key = "quarantine/aa/bb";
+        let original_sha = "aa".repeat(32);
+        let markdown_sha = "bb".repeat(32);
+        let versions = vec![
+            version(
+                source_id,
+                None,
+                1,
+                original_key,
+                original_sha.clone(),
+                None,
+                "application/pdf",
+                2048,
+            ),
+            version(
+                published_id,
+                Some(source_id),
+                2,
+                original_key,
+                markdown_sha.clone(),
+                Some("trusted/aa/bb/cc"),
+                "text/markdown; charset=utf-8",
+                100,
+            ),
+        ];
+        let published = AuthorizedVersionRow {
+            org_id: versions[1].org_id,
+            collection_id: Uuid::new_v4(),
+            document_id: versions[1].document_id,
+            version_id: published_id,
+            version_number: 2,
+            parent_version_id: Some(source_id),
+            content_sha256: markdown_sha.clone(),
+            original_object_key: original_key.into(),
+            markdown_object_key: Some("trusted/aa/bb/cc".into()),
+            markdown_artifact_key: Some("trusted/aa/bb/cc".into()),
+            markdown_artifact_sha256: Some(markdown_sha),
+            markdown_artifact_content_type: Some("text/markdown; charset=utf-8".into()),
+            markdown_artifact_byte_size: Some(100),
+            source_filename: Some("source.pdf".into()),
+            source_content_type: Some("text/markdown; charset=utf-8".into()),
+            byte_size: Some(100),
+            document_state: DocumentState::Indexed,
+            deleted_at: None,
+            publication_state: PublicationState::Published,
+            is_current: true,
+            effective_from: Utc::now(),
+            effective_to: None,
+        };
+        let original = resolve_original_artifact_meta(&versions, &published).unwrap();
+        assert_eq!(original.content_sha256, original_sha);
+        assert_eq!(original.byte_size, 2048);
+        assert_eq!(original.content_type, "application/pdf");
+        assert_eq!(original.source_version_id, source_id);
+    }
+
+    #[test]
+    fn capability_token_debug_is_redacted_and_binds_type_size() {
+        let signer =
+            CapabilitySigner::new(SecretString::new("unit-test-download-signing-key-32b!"))
+                .unwrap();
+        let row = sample_row();
+        let token = signer.sign_capability(&row);
+        assert!(format!("{token:?}").contains("REDACTED"));
+        assert!(!format!("{token:?}").contains(token.expose()));
+        assert!(signer.verify_token(&token, &row).is_ok());
+
+        let mut other = row.clone();
+        other.byte_size = 999;
+        assert_eq!(
+            signer.verify_token(&token, &other),
+            Err(DownloadError::InvalidToken)
+        );
+        other = row.clone();
+        other.content_type = "application/pdf".into();
+        assert_eq!(
+            signer.verify_token(&token, &other),
+            Err(DownloadError::InvalidToken)
+        );
+    }
+
+    #[test]
+    fn token_does_not_embed_object_key_or_bucket() {
+        let signer =
+            CapabilitySigner::new(SecretString::new("unit-test-download-signing-key-32b!"))
+                .unwrap();
+        let token = signer.sign_capability(&sample_row());
+        assert!(!token.expose().contains("trusted/"));
+        assert!(!token.expose().contains("minio"));
+        assert!(!token.expose().contains("bucket"));
+    }
+
+    #[test]
+    fn budget_try_new_rejects_invalid_config() {
+        assert_eq!(
+            DownloadFetchBudget::try_new(0, 1).err(),
+            Some(DownloadBudgetConfigError::InvalidMaxBytes)
+        );
+        assert_eq!(
+            DownloadFetchBudget::try_new(1_024, 0).err(),
+            Some(DownloadBudgetConfigError::InvalidConcurrency)
+        );
+        assert_eq!(
+            DownloadFetchBudget::try_new(1_024, Semaphore::MAX_PERMITS.saturating_add(1)).err(),
+            Some(DownloadBudgetConfigError::InvalidConcurrency)
+        );
+        assert!(DownloadFetchBudget::try_new(1_024, 2).is_ok());
+    }
+
+    #[tokio::test]
+    async fn download_budget_rejects_when_bytes_exhausted_checked_add() {
+        assert_eq!(
+            DownloadFetchBudget::try_new(u64::MAX, 1).err(),
+            Some(DownloadBudgetConfigError::InvalidMaxBytes)
+        );
+        let budget = DownloadFetchBudget::try_new(1_024, 2).unwrap();
+        let a = budget.acquire(800).await.unwrap();
+        assert_eq!(budget.in_flight_bytes(), 800);
+        assert_eq!(budget.acquire(400).await.err(), Some(DownloadError::Busy));
+
+        // Fill exact max so next reservation uses checked_add and exceeds budget.
+        let near = DownloadFetchBudget::try_new(DOWNLOAD_MAX_BYTES, 2).unwrap();
+        let p1 = near.acquire(DOWNLOAD_MAX_BYTES).await.unwrap();
+        assert_eq!(
+            near.acquire(1).await.err(),
+            Some(DownloadError::Busy),
+            "checked_add path must reject when next would exceed budget"
+        );
+
+        // Overflow edge: current near u64::MAX - bytes.
+        let overflow_budget = DownloadFetchBudget::try_new(u64::MAX - 1, 2).unwrap();
+        // Reserve DOWNLOAD_MAX_BYTES, then attempt another that would overflow if using wrapping add.
+        let p2 = overflow_budget.acquire(DOWNLOAD_MAX_BYTES).await.unwrap();
+        // Manually poison in_flight to Max - 10 to exercise checked_add overflow branch.
+        overflow_budget
+            .in_flight
+            .store(u64::MAX - 10, Ordering::Release);
+        assert_eq!(
+            overflow_budget.acquire(32).await.err(),
+            Some(DownloadError::Busy)
+        );
+        // Reset before drop so Drop's fetch_sub does not underflow the test counter.
+        overflow_budget
+            .in_flight
+            .store(DOWNLOAD_MAX_BYTES, Ordering::Release);
+
+        drop(a);
+        drop(p1);
+        drop(p2);
+        assert_eq!(budget.in_flight_bytes(), 0);
+        let _b = budget.acquire(400).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn budgeted_body_holds_permit_until_consumed_or_dropped() {
+        let budget = DownloadFetchBudget::try_new(1_024, 2).unwrap();
+        let permit = budget.acquire(16).await.unwrap();
+        let mut body = BudgetedDownloadBody::new(Bytes::from_static(b"0123456789abcdef"), permit)
+            .with_chunk_size(4);
+        assert!(body.permit_held());
+        assert_eq!(budget.in_flight_bytes(), 16);
+
+        let frame = std::future::poll_fn(|cx| Pin::new(&mut body).poll_frame(cx))
+            .await
+            .expect("frame present")
+            .expect("infallible body");
+        assert_eq!(frame.into_data().expect("data frame").as_ref(), b"0123");
+        assert!(body.permit_held(), "slow body must keep budget mid-stream");
+        assert_eq!(budget.in_flight_bytes(), 16);
+
+        // Cancellation / drop before completion releases budget.
+        drop(body);
+        assert_eq!(budget.in_flight_bytes(), 0);
+
+        let permit = budget.acquire(16).await.unwrap();
+        let body = BudgetedDownloadBody::new(Bytes::from_static(b"0123456789abcdef"), permit)
+            .with_chunk_size(8);
+        let collected = body.collect().await.unwrap().to_bytes();
+        assert_eq!(collected.as_ref(), b"0123456789abcdef");
+        assert_eq!(
+            budget.in_flight_bytes(),
+            0,
+            "full consume must release permit"
+        );
+    }
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -2,13 +2,16 @@
 
 pub mod artifacts;
 pub mod chunking;
+pub mod citation;
 pub mod claims;
 pub mod conversion;
 pub mod deletion;
 pub mod document_state;
+pub mod download;
 pub mod embedding;
 pub mod index_signature;
 pub mod indexing;
+pub mod preview;
 pub mod promotion;
 pub mod quota;
 pub mod reconciliation;

--- a/crates/server/src/services/preview.rs
+++ b/crates/server/src/services/preview.rs
@@ -1,0 +1,251 @@
+//! Trusted Markdown preview fetch with fresh authorization (P1B-R02).
+//!
+//! Object keys and bucket names are never accepted from clients. The server loads
+//! derived-artifact key/hash/type/size from PostgreSQL, HEADs, then bounded-reads.
+
+use deadpool_postgres::Pool;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::auth::permissions::{resolve_org_context_in_txn, ResolveError};
+use crate::db::error::DbError;
+use crate::db::pool::with_org_txn;
+use crate::db::search::{self, AuthorizedVersionRow, TrustedMarkdownArtifact};
+use crate::services::deletion::document_reads_suppressed;
+use crate::services::retrieval::{PERMISSION_QA_HISTORY, PERMISSION_QA_QUERY};
+use crate::storage::blob::{BlobStore, ObjectExpectation};
+use crate::storage::keys::{authorize_key_for_version, parse_key_for_org, ObjectNamespace};
+use crate::storage::StorageError;
+
+/// Small preview cap — full originals use download capabilities instead.
+pub const PREVIEW_MAX_BYTES: u64 = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedMarkdownPreview {
+    pub org_id: Uuid,
+    pub document_id: Uuid,
+    pub version_id: Uuid,
+    pub version_number: i32,
+    pub content_sha256: String,
+    pub markdown_sha256: String,
+    pub is_current: bool,
+    pub markdown: String,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PreviewError {
+    #[error("permission denied")]
+    PermissionDenied,
+    #[error("preview not found")]
+    NotFound,
+    #[error("markdown artifact is missing")]
+    MarkdownMissing,
+    #[error("markdown integrity check failed")]
+    Integrity,
+    #[error("markdown is not utf-8")]
+    InvalidUtf8,
+    #[error("markdown exceeds preview size bound")]
+    TooLarge,
+    #[error("storage unavailable")]
+    StorageUnavailable,
+    #[error("storage error")]
+    Storage,
+    #[error("database error")]
+    Database,
+}
+
+impl PreviewError {
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::PermissionDenied => "preview_permission_denied",
+            Self::NotFound => "preview_not_found",
+            Self::MarkdownMissing => "preview_markdown_missing",
+            Self::Integrity => "preview_integrity",
+            Self::InvalidUtf8 => "preview_invalid_utf8",
+            Self::TooLarge => "preview_too_large",
+            Self::StorageUnavailable => "preview_storage_unavailable",
+            Self::Storage => "preview_storage",
+            Self::Database => "preview_database",
+        }
+    }
+}
+
+impl From<ResolveError> for PreviewError {
+    fn from(_: ResolveError) -> Self {
+        Self::PermissionDenied
+    }
+}
+
+impl From<DbError> for PreviewError {
+    fn from(value: DbError) -> Self {
+        match value {
+            DbError::Config(ref msg) if msg.starts_with("markdown_artifact_") => {
+                Self::MarkdownMissing
+            }
+            _ => Self::Database,
+        }
+    }
+}
+
+impl From<StorageError> for PreviewError {
+    fn from(value: StorageError) -> Self {
+        match value {
+            StorageError::NotFound => Self::NotFound,
+            StorageError::KeyOrgMismatch
+            | StorageError::MissingScope
+            | StorageError::InvalidKey => Self::PermissionDenied,
+            StorageError::ObjectTooLarge => Self::TooLarge,
+            StorageError::PreconditionFailed => Self::Integrity,
+            _ => Self::Storage,
+        }
+    }
+}
+
+/// Fail-closed derived Markdown artifact (no key/hash fallback).
+pub fn trusted_markdown_artifact_from_version(
+    row: &AuthorizedVersionRow,
+) -> Result<TrustedMarkdownArtifact, PreviewError> {
+    if document_reads_suppressed(row.document_state, row.deleted_at.is_some()) {
+        return Err(PreviewError::PermissionDenied);
+    }
+    search::trusted_markdown_artifact(row).map_err(PreviewError::from)
+}
+
+/// Fetches trusted Markdown for preview. Client-supplied keys/buckets are ignored.
+pub async fn fetch_trusted_markdown<S: BlobStore>(
+    pool: &Pool,
+    storage: &S,
+    org_id: Uuid,
+    user_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<TrustedMarkdownPreview, PreviewError> {
+    let ctx = resolve_org_context_in_txn(pool, org_id, user_id).await?;
+    if !ctx.has_permission(PERMISSION_QA_QUERY) {
+        return Err(PreviewError::PermissionDenied);
+    }
+    if ctx.allowed_collection_ids().is_empty() {
+        return Err(PreviewError::PermissionDenied);
+    }
+
+    let row = with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                search::load_authorized_version_for_read(txn, &ctx, document_id, version_id).await
+            })
+        }
+    })
+    .await?
+    .ok_or(PreviewError::NotFound)?;
+
+    if row.org_id != org_id || !ctx.allows_collection(row.collection_id) {
+        return Err(PreviewError::PermissionDenied);
+    }
+    if !row.is_current && !ctx.has_permission(PERMISSION_QA_HISTORY) {
+        return Err(PreviewError::PermissionDenied);
+    }
+
+    let artifact = trusted_markdown_artifact_from_version(&row)?;
+    if artifact.byte_size > PREVIEW_MAX_BYTES {
+        return Err(PreviewError::TooLarge);
+    }
+    let key = parse_key_for_org(&artifact.object_key, org_id)?;
+    if key.namespace() != ObjectNamespace::Trusted {
+        return Err(PreviewError::PermissionDenied);
+    }
+    authorize_key_for_version(&key, version_id)?;
+
+    let fetched = storage
+        .get_object_bounded(
+            org_id,
+            &key,
+            PREVIEW_MAX_BYTES,
+            &ObjectExpectation {
+                content_sha256: &artifact.content_sha256,
+                content_length: artifact.byte_size,
+                content_type: Some(artifact.content_type.as_str()),
+            },
+        )
+        .await?;
+    let markdown =
+        String::from_utf8(fetched.bytes.to_vec()).map_err(|_| PreviewError::InvalidUtf8)?;
+
+    Ok(TrustedMarkdownPreview {
+        org_id,
+        document_id: row.document_id,
+        version_id: row.version_id,
+        version_number: row.version_number,
+        content_sha256: row.content_sha256,
+        markdown_sha256: fetched.content_sha256,
+        is_current: row.is_current,
+        markdown,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::{DocumentState, PublicationState};
+    use chrono::{TimeZone, Utc};
+
+    fn sample_version() -> AuthorizedVersionRow {
+        AuthorizedVersionRow {
+            org_id: Uuid::new_v4(),
+            collection_id: Uuid::new_v4(),
+            document_id: Uuid::new_v4(),
+            version_id: Uuid::new_v4(),
+            version_number: 1,
+            parent_version_id: Some(Uuid::new_v4()),
+            content_sha256: "a".repeat(64),
+            original_object_key: "quarantine/aa/bb".into(),
+            markdown_object_key: Some("trusted/aa/bb/cc".into()),
+            markdown_artifact_key: Some("trusted/aa/bb/cc".into()),
+            markdown_artifact_sha256: Some("b".repeat(64)),
+            markdown_artifact_content_type: Some("text/markdown; charset=utf-8".into()),
+            markdown_artifact_byte_size: Some(128),
+            source_filename: Some("policy.pdf".into()),
+            source_content_type: Some("text/markdown; charset=utf-8".into()),
+            byte_size: Some(128),
+            document_state: DocumentState::Indexed,
+            deleted_at: None,
+            publication_state: PublicationState::Published,
+            is_current: true,
+            effective_from: Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+            effective_to: None,
+        }
+    }
+
+    #[test]
+    fn requires_derived_artifact_hash_and_size() {
+        let row = sample_version();
+        let artifact = trusted_markdown_artifact_from_version(&row).unwrap();
+        assert_eq!(artifact.content_sha256, "b".repeat(64));
+        assert_eq!(artifact.byte_size, 128);
+
+        let mut missing_hash = sample_version();
+        missing_hash.markdown_artifact_sha256 = None;
+        assert_eq!(
+            trusted_markdown_artifact_from_version(&missing_hash),
+            Err(PreviewError::MarkdownMissing)
+        );
+
+        let mut fallback_only = sample_version();
+        fallback_only.markdown_artifact_key = None;
+        // markdown_object_key alone is not enough without immutable artifact hash/size.
+        assert_eq!(
+            trusted_markdown_artifact_from_version(&fallback_only),
+            Err(PreviewError::MarkdownMissing)
+        );
+    }
+
+    #[test]
+    fn tombstoned_version_cannot_preview() {
+        let mut row = sample_version();
+        row.document_state = DocumentState::Tombstoned;
+        assert_eq!(
+            trusted_markdown_artifact_from_version(&row),
+            Err(PreviewError::PermissionDenied)
+        );
+    }
+}

--- a/crates/server/src/storage/blob.rs
+++ b/crates/server/src/storage/blob.rs
@@ -1,0 +1,441 @@
+//! Bounded object fetch API for preview / citation / download (P1B-R02).
+//!
+//! Callers supply authoritative size/hash/type expectations from PostgreSQL before
+//! allocating. Implementations HEAD first and stream with an incremental hash.
+//! Content-type is canonicalized (type/subtype + params lowercased) before compare.
+//! Length short/truncation is a precondition/integrity failure; only exceeding the
+//! authorized cap yields [`StorageError::ObjectTooLarge`].
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::storage::error::StorageError;
+use crate::storage::keys::{authorize_key_for_org, ObjectKey};
+use crate::storage::minio::MinioClient;
+
+/// HEAD/metadata observed before a bounded GET.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectHead {
+    pub content_length: u64,
+    pub content_sha256: Option<String>,
+    pub content_type: Option<String>,
+}
+
+/// Bytes returned by a bounded GET after size/hash checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchedObject {
+    pub bytes: Bytes,
+    pub content_sha256: String,
+    pub content_length: u64,
+    pub content_type: Option<String>,
+}
+
+/// Authoritative expectation from PostgreSQL (fail closed on mismatch).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectExpectation<'a> {
+    pub content_sha256: &'a str,
+    pub content_length: u64,
+    pub content_type: Option<&'a str>,
+}
+
+/// Canonical MIME comparison form: `type/subtype` lowercased; parameters sorted
+/// by name, names/values lowercased, quotes stripped.
+pub fn canonicalize_content_type(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.len() > 255 {
+        return None;
+    }
+    let mut parts = trimmed.split(';');
+    let base = parts.next()?.trim();
+    if base.is_empty() || !base.contains('/') || base.contains(' ') {
+        return None;
+    }
+    let mut out = base.to_ascii_lowercase();
+    let mut params = Vec::new();
+    for param in parts {
+        let param = param.trim();
+        if param.is_empty() {
+            continue;
+        }
+        let (name, value) = match param.split_once('=') {
+            Some((name, value)) => (name.trim(), value.trim().trim_matches('"')),
+            None => (param, ""),
+        };
+        if name.is_empty() {
+            return None;
+        }
+        params.push((name.to_ascii_lowercase(), value.to_ascii_lowercase()));
+    }
+    params.sort_by(|left, right| left.0.cmp(&right.0));
+    for (name, value) in params {
+        out.push_str("; ");
+        out.push_str(&name);
+        if !value.is_empty() {
+            out.push('=');
+            out.push_str(&value);
+        }
+    }
+    Some(out)
+}
+
+pub fn content_types_equivalent(left: &str, right: &str) -> bool {
+    match (
+        canonicalize_content_type(left),
+        canonicalize_content_type(right),
+    ) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
+/// Validates HEAD length/hash against an authorized expectation and byte cap.
+/// Content-type is enforced after the body is observed (response or stored meta).
+pub fn validate_head_against_expectation(
+    head: &ObjectHead,
+    max_bytes: u64,
+    expected: &ObjectExpectation<'_>,
+) -> Result<(), StorageError> {
+    if expected.content_length == 0 || expected.content_length > max_bytes {
+        return Err(StorageError::ObjectTooLarge);
+    }
+    if head.content_length > max_bytes {
+        return Err(StorageError::ObjectTooLarge);
+    }
+    if head.content_length != expected.content_length {
+        return Err(StorageError::PreconditionFailed);
+    }
+    if let Some(stored_hash) = head.content_sha256.as_deref() {
+        if stored_hash != expected.content_sha256 {
+            return Err(StorageError::PreconditionFailed);
+        }
+    }
+    Ok(())
+}
+
+/// Incremental bounded reader used by Memory + MinIO paths (unit-tested without MinIO).
+#[derive(Debug)]
+pub struct BoundedAccumulator {
+    max_bytes: u64,
+    expected_len: u64,
+    hasher: Sha256,
+    total: u64,
+    out: Vec<u8>,
+}
+
+impl BoundedAccumulator {
+    pub fn begin(max_bytes: u64, expected_len: u64) -> Result<Self, StorageError> {
+        if expected_len == 0 || expected_len > max_bytes {
+            return Err(StorageError::ObjectTooLarge);
+        }
+        Ok(Self {
+            max_bytes,
+            expected_len,
+            hasher: Sha256::new(),
+            total: 0,
+            out: Vec::with_capacity(expected_len.min(max_bytes) as usize),
+        })
+    }
+
+    pub fn push(&mut self, chunk: &[u8]) -> Result<(), StorageError> {
+        let next = self.total.saturating_add(chunk.len() as u64);
+        if next > self.max_bytes {
+            return Err(StorageError::ObjectTooLarge);
+        }
+        if next > self.expected_len {
+            return Err(StorageError::PreconditionFailed);
+        }
+        self.total = next;
+        self.hasher.update(chunk);
+        self.out.extend_from_slice(chunk);
+        Ok(())
+    }
+
+    pub fn finish(
+        self,
+        expected: &ObjectExpectation<'_>,
+        observed_content_type: Option<String>,
+    ) -> Result<FetchedObject, StorageError> {
+        if self.total != self.expected_len || self.total != expected.content_length {
+            return Err(StorageError::PreconditionFailed);
+        }
+        let content_sha256 = hex::encode(self.hasher.finalize());
+        if content_sha256 != expected.content_sha256 {
+            return Err(StorageError::PreconditionFailed);
+        }
+        if let Some(expected_type) = expected.content_type {
+            let Some(actual) = observed_content_type.as_deref() else {
+                return Err(StorageError::PreconditionFailed);
+            };
+            if !content_types_equivalent(expected_type, actual) {
+                return Err(StorageError::PreconditionFailed);
+            }
+        }
+        Ok(FetchedObject {
+            bytes: Bytes::from(self.out),
+            content_sha256,
+            content_length: self.total,
+            content_type: observed_content_type,
+        })
+    }
+}
+
+/// Org-bound blob reads used by citation/preview/download.
+pub trait BlobStore: Send + Sync {
+    fn head_object(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+    ) -> impl std::future::Future<Output = Result<ObjectHead, StorageError>> + Send;
+
+    fn get_object_bounded(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        max_bytes: u64,
+        expected: &ObjectExpectation<'_>,
+    ) -> impl std::future::Future<Output = Result<FetchedObject, StorageError>> + Send;
+}
+
+impl BlobStore for MinioClient {
+    async fn head_object(&self, org_id: Uuid, key: &ObjectKey) -> Result<ObjectHead, StorageError> {
+        self.head_object_meta(org_id, key).await
+    }
+
+    async fn get_object_bounded(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        max_bytes: u64,
+        expected: &ObjectExpectation<'_>,
+    ) -> Result<FetchedObject, StorageError> {
+        MinioClient::get_object_bounded(self, org_id, key, max_bytes, expected).await
+    }
+}
+
+/// In-memory blob store for hermetic citation/preview/download tests.
+#[derive(Clone, Default)]
+pub struct MemoryBlobStore {
+    inner: Arc<Mutex<HashMap<String, MemoryObject>>>,
+}
+
+#[derive(Clone)]
+struct MemoryObject {
+    org_id: Uuid,
+    bytes: Bytes,
+    content_sha256: String,
+    content_type: Option<String>,
+}
+
+impl MemoryBlobStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn put(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        bytes: impl Into<Bytes>,
+        content_type: Option<&str>,
+    ) -> Result<(), StorageError> {
+        authorize_key_for_org(key, org_id)?;
+        let bytes = bytes.into();
+        let content_sha256 = hex::encode(Sha256::digest(&bytes));
+        self.inner.lock().expect("memory blob store lock").insert(
+            key.as_str(),
+            MemoryObject {
+                org_id,
+                bytes,
+                content_sha256,
+                content_type: content_type.map(str::to_string),
+            },
+        );
+        Ok(())
+    }
+}
+
+impl BlobStore for MemoryBlobStore {
+    async fn head_object(&self, org_id: Uuid, key: &ObjectKey) -> Result<ObjectHead, StorageError> {
+        authorize_key_for_org(key, org_id)?;
+        let guard = self.inner.lock().expect("memory blob store lock");
+        let object = guard.get(&key.as_str()).ok_or(StorageError::NotFound)?;
+        if object.org_id != org_id {
+            return Err(StorageError::OwnershipConflict);
+        }
+        Ok(ObjectHead {
+            content_length: object.bytes.len() as u64,
+            content_sha256: Some(object.content_sha256.clone()),
+            content_type: object.content_type.clone(),
+        })
+    }
+
+    async fn get_object_bounded(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        max_bytes: u64,
+        expected: &ObjectExpectation<'_>,
+    ) -> Result<FetchedObject, StorageError> {
+        let head = self.head_object(org_id, key).await?;
+        validate_head_against_expectation(&head, max_bytes, expected)?;
+        let guard = self.inner.lock().expect("memory blob store lock");
+        let object = guard.get(&key.as_str()).ok_or(StorageError::NotFound)?;
+        if object.org_id != org_id {
+            return Err(StorageError::OwnershipConflict);
+        }
+        let mut acc = BoundedAccumulator::begin(max_bytes, expected.content_length)?;
+        acc.push(&object.bytes)?;
+        acc.finish(expected, object.content_type.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::keys::{quarantine_key, trusted_key};
+
+    #[test]
+    fn canonicalize_content_type_normalizes_case_and_param_order() {
+        assert_eq!(
+            canonicalize_content_type("Text/Markdown; Charset=\"UTF-8\"; x=1").as_deref(),
+            Some("text/markdown; charset=utf-8; x=1")
+        );
+        assert!(content_types_equivalent(
+            "text/markdown; charset=utf-8",
+            "Text/Markdown; Charset=UTF-8"
+        ));
+        assert!(!content_types_equivalent(
+            "text/markdown",
+            "application/pdf"
+        ));
+    }
+
+    #[test]
+    fn bounded_accumulator_short_read_is_precondition_not_too_large() {
+        let sha = hex::encode(Sha256::digest(b"abcd"));
+        let expected = ObjectExpectation {
+            content_sha256: &sha,
+            content_length: 4,
+            content_type: Some("text/plain"),
+        };
+        let mut acc = BoundedAccumulator::begin(64, 4).unwrap();
+        acc.push(b"ab").unwrap();
+        assert_eq!(
+            acc.finish(&expected, Some("text/plain".into())),
+            Err(StorageError::PreconditionFailed)
+        );
+    }
+
+    #[test]
+    fn bounded_accumulator_over_cap_is_object_too_large() {
+        let mut acc = BoundedAccumulator::begin(4, 4).unwrap();
+        assert_eq!(acc.push(b"abcde"), Err(StorageError::ObjectTooLarge));
+        assert!(matches!(
+            BoundedAccumulator::begin(4, 8),
+            Err(StorageError::ObjectTooLarge)
+        ));
+    }
+
+    #[test]
+    fn bounded_accumulator_type_mismatch_is_precondition() {
+        let body = Bytes::from_static(b"hello");
+        let sha = hex::encode(Sha256::digest(&body));
+        let expected = ObjectExpectation {
+            content_sha256: &sha,
+            content_length: body.len() as u64,
+            content_type: Some("application/pdf"),
+        };
+        let mut acc = BoundedAccumulator::begin(64, expected.content_length).unwrap();
+        acc.push(&body).unwrap();
+        assert_eq!(
+            acc.finish(&expected, Some("text/plain".into())),
+            Err(StorageError::PreconditionFailed)
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_store_enforces_type_short_and_oversize() {
+        let store = MemoryBlobStore::new();
+        let org = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let key = quarantine_key(org, Uuid::new_v4(), None).unwrap();
+        let body = Bytes::from_static(b"hello-bytes");
+        store
+            .put(org, &key, body.clone(), Some("text/plain"))
+            .unwrap();
+        let sha = hex::encode(Sha256::digest(&body));
+        let fetched = store
+            .get_object_bounded(
+                org,
+                &key,
+                64,
+                &ObjectExpectation {
+                    content_sha256: &sha,
+                    content_length: body.len() as u64,
+                    content_type: Some("Text/Plain"),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(fetched.bytes, body);
+
+        assert!(matches!(
+            store
+                .get_object_bounded(
+                    org,
+                    &key,
+                    4,
+                    &ObjectExpectation {
+                        content_sha256: &sha,
+                        content_length: body.len() as u64,
+                        content_type: None,
+                    },
+                )
+                .await,
+            Err(StorageError::ObjectTooLarge)
+        ));
+        assert!(matches!(
+            store
+                .get_object_bounded(
+                    org,
+                    &key,
+                    64,
+                    &ObjectExpectation {
+                        content_sha256: &sha,
+                        content_length: body.len() as u64,
+                        content_type: Some("application/pdf"),
+                    },
+                )
+                .await,
+            Err(StorageError::PreconditionFailed)
+        ));
+        assert!(matches!(
+            store
+                .get_object_bounded(
+                    org,
+                    &key,
+                    64,
+                    &ObjectExpectation {
+                        content_sha256: &sha,
+                        content_length: (body.len() as u64) + 1,
+                        content_type: Some("text/plain"),
+                    },
+                )
+                .await,
+            Err(StorageError::PreconditionFailed)
+        ));
+        assert!(matches!(
+            store.head_object(other, &key).await,
+            Err(StorageError::KeyOrgMismatch)
+        ));
+        let trusted = trusted_key(org, Uuid::new_v4(), Uuid::new_v4(), None).unwrap();
+        assert!(matches!(
+            store.head_object(org, &trusted).await,
+            Err(StorageError::NotFound)
+        ));
+    }
+}

--- a/crates/server/src/storage/error.rs
+++ b/crates/server/src/storage/error.rs
@@ -31,6 +31,8 @@ pub enum StorageError {
     Transport,
     #[error("storage backend rejected the request")]
     Backend,
+    #[error("object exceeds authorized size bound")]
+    ObjectTooLarge,
 }
 
 impl StorageError {
@@ -48,6 +50,7 @@ impl StorageError {
             Self::CollectionMismatch => "storage_collection_mismatch",
             Self::Transport => "storage_transport",
             Self::Backend => "storage_backend",
+            Self::ObjectTooLarge => "storage_object_too_large",
         }
     }
 }

--- a/crates/server/src/storage/minio.rs
+++ b/crates/server/src/storage/minio.rs
@@ -566,6 +566,78 @@ impl MinioClient {
         Ok(metadata_map(&head))
     }
 
+    /// HEAD with authoritative length/hash/type for bounded reads.
+    pub async fn head_object_meta(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+    ) -> Result<crate::storage::blob::ObjectHead, StorageError> {
+        authorize_key_for_org(key, org_id)?;
+        let (head, _) = self.head_for_org(org_id, key).await?;
+        let meta = metadata_map(&head);
+        let content_length = head
+            .content_length
+            .and_then(|len| u64::try_from(len).ok())
+            .or_else(|| {
+                meta.get("content-length-bytes")
+                    .and_then(|value| value.parse().ok())
+            })
+            .ok_or(StorageError::Backend)?;
+        Ok(crate::storage::blob::ObjectHead {
+            content_length,
+            content_sha256: meta.get("content-sha256").cloned(),
+            content_type: meta
+                .get("content-type")
+                .cloned()
+                .or_else(|| head.content_type.clone()),
+        })
+    }
+
+    /// Stream-get an object after HEAD, enforcing `max_bytes` and PG expectations
+    /// before/while allocating. Uses an incremental SHA-256 over the stream.
+    pub async fn get_object_bounded(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        max_bytes: u64,
+        expected: &crate::storage::blob::ObjectExpectation<'_>,
+    ) -> Result<crate::storage::blob::FetchedObject, StorageError> {
+        use crate::storage::blob::{validate_head_against_expectation, BoundedAccumulator};
+        let head = self.head_object_meta(org_id, key).await?;
+        validate_head_against_expectation(&head, max_bytes, expected)?;
+        let path = key.as_str();
+        let url = self
+            .with_s3_timeout(self.bucket.presign_get(path, 300, None), |_| {
+                StorageError::Transport
+            })
+            .await?;
+        let response = timeout(self.operation_timeout, self.http_client.get(url).send())
+            .await
+            .map_err(|_| StorageError::Transport)?
+            .map_err(|_| StorageError::Transport)?;
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        // Prefer response Content-Type; fall back to HEAD. `finish` enforces
+        // canonical MIME equivalence when the caller supplied an expectation.
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
+            .or(head.content_type);
+        let mut acc = BoundedAccumulator::begin(max_bytes, expected.content_length)?;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream
+            .try_next()
+            .await
+            .map_err(|_| StorageError::Transport)?
+        {
+            acc.push(&chunk)?;
+        }
+        acc.finish(expected, content_type)
+    }
+
     async fn verify_stored_org(&self, org_id: Uuid, key: &ObjectKey) -> Result<(), StorageError> {
         let _ = self.head_for_org(org_id, key).await?;
         Ok(())

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -4,12 +4,17 @@
 //! operator collection drops require a distinct admin API key and an explicit
 //! import of `crate::storage::qdrant::{QdrantAdminClient, QdrantAdminApiKey}`.
 
+pub mod blob;
 pub mod error;
 pub mod keys;
 pub mod minio;
 pub mod qdrant;
 pub mod url_safety;
 
+pub use blob::{
+    canonicalize_content_type, content_types_equivalent, validate_head_against_expectation,
+    BlobStore, BoundedAccumulator, FetchedObject, MemoryBlobStore, ObjectExpectation, ObjectHead,
+};
 pub use error::StorageError;
 pub use keys::{
     authorize_key_for_org, authorize_key_for_version, parse_key_for_org, quarantine_key,

--- a/crates/server/tests/citation_preview_download.rs
+++ b/crates/server/tests/citation_preview_download.rs
@@ -12,8 +12,8 @@ use fileconv_server::auth::context::OrgContext;
 use fileconv_server::config::SecretString;
 use fileconv_server::database::apply_migrations;
 use fileconv_server::db::download_capabilities::{
-    classify_liveness, consume_authorized_or_classify, AuthorizedConsumeOutcome,
-    CapabilityLiveness, DownloadCapabilityRow, DownloadPurpose,
+    classify_liveness, consume_authorized_or_classify, AuthorizedConsumeBinding,
+    AuthorizedConsumeOutcome, CapabilityLiveness, DownloadCapabilityRow, DownloadPurpose,
 };
 use fileconv_server::db::pool::{apply_org_context, create_pool, with_org_txn};
 use fileconv_server::services::citation::{
@@ -21,7 +21,7 @@ use fileconv_server::services::citation::{
 };
 use fileconv_server::services::download::{
     mint_download_capability, redeem_download_capability, CapabilitySigner, DownloadError,
-    DownloadFetchBudget, DEFAULT_CAPABILITY_TTL,
+    DownloadFetchBudget, MintDownloadCapabilityRequest, DEFAULT_CAPABILITY_TTL,
 };
 use fileconv_server::services::preview::{fetch_trusted_markdown, PreviewError};
 use fileconv_server::services::retrieval::{PERMISSION_QA_HISTORY, PERMISSION_QA_QUERY};
@@ -302,10 +302,9 @@ async fn seed_tenant(
         [ids.collection],
     )
     .unwrap();
-    let markdown_len = markdown.as_bytes().len() as i64;
+    let markdown_len = markdown.len() as i64;
     let original_len = original_bytes.len() as i64;
     with_org_txn(pool, &ctx, {
-        let ids = ids;
         let markdown_sha = markdown_sha.clone();
         let original_sha = original_sha.clone();
         let original_key_str = original_key.as_str();
@@ -588,12 +587,14 @@ async fn citation_preview_download_happy_path_with_memory_store() {
     let minted = mint_download_capability(
         &pool,
         &signer,
-        tenant.ids.org,
-        tenant.ids.user,
-        tenant.ids.document,
-        tenant.ids.published_version,
-        DownloadPurpose::Original,
-        DEFAULT_CAPABILITY_TTL,
+        &MintDownloadCapabilityRequest {
+            org_id: tenant.ids.org,
+            user_id: tenant.ids.user,
+            document_id: tenant.ids.document,
+            version_id: tenant.ids.published_version,
+            purpose: DownloadPurpose::Original,
+            ttl: DEFAULT_CAPABILITY_TTL,
+        },
     )
     .await
     .expect("mint original");
@@ -658,12 +659,14 @@ async fn two_tenants_idor_is_permission_denied_not_database() {
     let minted = mint_download_capability(
         &pool,
         &signer,
-        a.ids.org,
-        a.ids.user,
-        a.ids.document,
-        a.ids.published_version,
-        DownloadPurpose::Markdown,
-        DEFAULT_CAPABILITY_TTL,
+        &MintDownloadCapabilityRequest {
+            org_id: a.ids.org,
+            user_id: a.ids.user,
+            document_id: a.ids.document,
+            version_id: a.ids.published_version,
+            purpose: DownloadPurpose::Markdown,
+            ttl: DEFAULT_CAPABILITY_TTL,
+        },
     )
     .await
     .expect("mint");
@@ -729,12 +732,14 @@ async fn concurrent_redeem_allows_only_one_winner() {
     let minted = mint_download_capability(
         &pool,
         &signer,
-        tenant.ids.org,
-        tenant.ids.user,
-        tenant.ids.document,
-        tenant.ids.published_version,
-        DownloadPurpose::Markdown,
-        DEFAULT_CAPABILITY_TTL,
+        &MintDownloadCapabilityRequest {
+            org_id: tenant.ids.org,
+            user_id: tenant.ids.user,
+            document_id: tenant.ids.document,
+            version_id: tenant.ids.published_version,
+            purpose: DownloadPurpose::Markdown,
+            ttl: DEFAULT_CAPABILITY_TTL,
+        },
     )
     .await
     .expect("mint");
@@ -775,13 +780,7 @@ async fn concurrent_redeem_allows_only_one_winner() {
             let outcome = consume_authorized_or_classify(
                 &txn,
                 &ctx,
-                capability.id,
-                capability.document_id,
-                capability.version_id,
-                capability.purpose,
-                &capability.content_sha256,
-                &capability.content_type,
-                capability.byte_size,
+                &AuthorizedConsumeBinding::from_row(&capability),
             )
             .await
             .expect("consume_authorized_or_classify");
@@ -966,12 +965,14 @@ async fn mint_rejects_oversized_ttl() {
     let denied = mint_download_capability(
         &pool,
         &signer,
-        tenant.ids.org,
-        tenant.ids.user,
-        tenant.ids.document,
-        tenant.ids.published_version,
-        DownloadPurpose::Original,
-        Duration::from_secs(10_000),
+        &MintDownloadCapabilityRequest {
+            org_id: tenant.ids.org,
+            user_id: tenant.ids.user,
+            document_id: tenant.ids.document,
+            version_id: tenant.ids.published_version,
+            purpose: DownloadPurpose::Original,
+            ttl: Duration::from_secs(10_000),
+        },
     )
     .await;
     assert_eq!(denied, Err(DownloadError::InvalidTtl));
@@ -1018,12 +1019,14 @@ async fn disabled_user_and_membership_removal_deny_services() {
     let disabled = mint_download_capability(
         &pool,
         &signer,
-        tenant.ids.org,
-        tenant.ids.user,
-        tenant.ids.document,
-        tenant.ids.published_version,
-        DownloadPurpose::Markdown,
-        DEFAULT_CAPABILITY_TTL,
+        &MintDownloadCapabilityRequest {
+            org_id: tenant.ids.org,
+            user_id: tenant.ids.user,
+            document_id: tenant.ids.document,
+            version_id: tenant.ids.published_version,
+            purpose: DownloadPurpose::Markdown,
+            ttl: DEFAULT_CAPABILITY_TTL,
+        },
     )
     .await;
     assert_eq!(disabled, Err(DownloadError::PermissionDenied));
@@ -1179,7 +1182,7 @@ async fn qa_history_revoke_denies_non_current_version() {
         let version = tenant.ids.published_version;
         let user = tenant.ids.user;
         let markdown_sha = tenant.markdown_sha.clone();
-        let markdown_len = tenant.markdown.as_bytes().len() as i64;
+        let markdown_len = tenant.markdown.len() as i64;
         move |txn| {
             Box::pin(async move {
                 let successor = Uuid::new_v4();
@@ -1322,12 +1325,14 @@ async fn capability_expiry_boundary_is_expired_not_replay() {
     let minted = mint_download_capability(
         &pool,
         &signer,
-        tenant.ids.org,
-        tenant.ids.user,
-        tenant.ids.document,
-        tenant.ids.published_version,
-        DownloadPurpose::Markdown,
-        Duration::from_secs(1),
+        &MintDownloadCapabilityRequest {
+            org_id: tenant.ids.org,
+            user_id: tenant.ids.user,
+            document_id: tenant.ids.document,
+            version_id: tenant.ids.published_version,
+            purpose: DownloadPurpose::Markdown,
+            ttl: Duration::from_secs(1),
+        },
     )
     .await
     .expect("mint ttl=1s");
@@ -1426,12 +1431,14 @@ async fn content_type_mismatch_on_redeem_is_integrity() {
     let minted = mint_download_capability(
         &pool,
         &signer,
-        tenant.ids.org,
-        tenant.ids.user,
-        tenant.ids.document,
-        tenant.ids.published_version,
-        DownloadPurpose::Original,
-        DEFAULT_CAPABILITY_TTL,
+        &MintDownloadCapabilityRequest {
+            org_id: tenant.ids.org,
+            user_id: tenant.ids.user,
+            document_id: tenant.ids.document,
+            version_id: tenant.ids.published_version,
+            purpose: DownloadPurpose::Original,
+            ttl: DEFAULT_CAPABILITY_TTL,
+        },
     )
     .await
     .expect("mint");
@@ -1512,12 +1519,14 @@ async fn busy_budget_keeps_token_retryable() {
     let minted = mint_download_capability(
         &pool,
         &signer,
-        tenant.ids.org,
-        tenant.ids.user,
-        tenant.ids.document,
-        tenant.ids.published_version,
-        DownloadPurpose::Original,
-        DEFAULT_CAPABILITY_TTL,
+        &MintDownloadCapabilityRequest {
+            org_id: tenant.ids.org,
+            user_id: tenant.ids.user,
+            document_id: tenant.ids.document,
+            version_id: tenant.ids.published_version,
+            purpose: DownloadPurpose::Original,
+            ttl: DEFAULT_CAPABILITY_TTL,
+        },
     )
     .await
     .expect("mint");
@@ -1627,12 +1636,14 @@ async fn barrier_acl_revoke_before_consume_denies_without_burning_token() {
     let minted = mint_download_capability(
         &pool,
         &signer,
-        tenant.ids.org,
-        tenant.ids.user,
-        tenant.ids.document,
-        tenant.ids.published_version,
-        DownloadPurpose::Markdown,
-        DEFAULT_CAPABILITY_TTL,
+        &MintDownloadCapabilityRequest {
+            org_id: tenant.ids.org,
+            user_id: tenant.ids.user,
+            document_id: tenant.ids.document,
+            version_id: tenant.ids.published_version,
+            purpose: DownloadPurpose::Markdown,
+            ttl: DEFAULT_CAPABILITY_TTL,
+        },
     )
     .await
     .expect("mint");
@@ -1767,12 +1778,14 @@ async fn barrier_document_delete_before_consume_denies_without_body() {
     let minted = mint_download_capability(
         &pool,
         &signer,
-        tenant.ids.org,
-        tenant.ids.user,
-        tenant.ids.document,
-        tenant.ids.published_version,
-        DownloadPurpose::Original,
-        DEFAULT_CAPABILITY_TTL,
+        &MintDownloadCapabilityRequest {
+            org_id: tenant.ids.org,
+            user_id: tenant.ids.user,
+            document_id: tenant.ids.document,
+            version_id: tenant.ids.published_version,
+            purpose: DownloadPurpose::Original,
+            ttl: DEFAULT_CAPABILITY_TTL,
+        },
     )
     .await
     .expect("mint");
@@ -1871,12 +1884,14 @@ async fn wrong_user_consume_is_permission_denied_not_expired_oracle() {
     let minted = mint_download_capability(
         &pool,
         &signer,
-        owner.ids.org,
-        owner.ids.user,
-        owner.ids.document,
-        owner.ids.published_version,
-        DownloadPurpose::Markdown,
-        DEFAULT_CAPABILITY_TTL,
+        &MintDownloadCapabilityRequest {
+            org_id: owner.ids.org,
+            user_id: owner.ids.user,
+            document_id: owner.ids.document,
+            version_id: owner.ids.published_version,
+            purpose: DownloadPurpose::Markdown,
+            ttl: DEFAULT_CAPABILITY_TTL,
+        },
     )
     .await
     .expect("mint");
@@ -1980,27 +1995,9 @@ async fn wrong_user_consume_is_permission_denied_not_expired_oracle() {
     .unwrap();
     let classified = with_org_txn(&pool, &peer_ctx, {
         let ctx = peer_ctx.clone();
-        let id = minted.capability_id;
-        let document = owner.ids.document;
-        let version = owner.ids.published_version;
-        let sha = row.content_sha256.clone();
-        let ctype = row.content_type.clone();
-        let size = row.byte_size;
+        let expected = AuthorizedConsumeBinding::from_row(&row);
         move |txn| {
-            Box::pin(async move {
-                fileconv_server::db::download_capabilities::consume_authorized_or_classify(
-                    txn,
-                    &ctx,
-                    id,
-                    document,
-                    version,
-                    DownloadPurpose::Markdown,
-                    &sha,
-                    &ctype,
-                    size,
-                )
-                .await
-            })
+            Box::pin(async move { consume_authorized_or_classify(txn, &ctx, &expected).await })
         }
     })
     .await

--- a/crates/server/tests/citation_preview_download.rs
+++ b/crates/server/tests/citation_preview_download.rs
@@ -1,0 +1,2015 @@
+//! Integration tests for citation / preview / download (P1B-R02) after review fixes.
+//!
+//! Hermetic unit coverage lives under `services/{citation,preview,download}` and
+//! `storage::blob`. Live PostgreSQL tests require `MARKHAND_TEST_DATABASE_URL` and
+//! exercise MemoryBlobStore (no MinIO) for real fetch/redeem paths.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use chrono::{TimeZone, Utc};
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::config::SecretString;
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::download_capabilities::{
+    classify_liveness, consume_authorized_or_classify, AuthorizedConsumeOutcome,
+    CapabilityLiveness, DownloadCapabilityRow, DownloadPurpose,
+};
+use fileconv_server::db::pool::{apply_org_context, create_pool, with_org_txn};
+use fileconv_server::services::citation::{
+    resolve_citation, CitationError, CitationResolveRequest,
+};
+use fileconv_server::services::download::{
+    mint_download_capability, redeem_download_capability, CapabilitySigner, DownloadError,
+    DownloadFetchBudget, DEFAULT_CAPABILITY_TTL,
+};
+use fileconv_server::services::preview::{fetch_trusted_markdown, PreviewError};
+use fileconv_server::services::retrieval::{PERMISSION_QA_HISTORY, PERMISSION_QA_QUERY};
+use fileconv_server::storage::keys::{quarantine_key, trusted_key, ObjectKey};
+use fileconv_server::storage::MemoryBlobStore;
+use fileconv_server::storage::{BlobStore, ObjectExpectation, ObjectHead, StorageError};
+use sha2::{Digest, Sha256};
+use tokio::sync::{oneshot, Barrier};
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+/// Blocks **after** a successful inner fetch so revoke/delete races are truly post-fetch.
+struct GateBlobStore {
+    inner: MemoryBlobStore,
+    fetched: Mutex<Option<oneshot::Sender<()>>>,
+    release: Mutex<Option<oneshot::Receiver<()>>>,
+}
+
+impl GateBlobStore {
+    fn new(
+        inner: MemoryBlobStore,
+        fetched: oneshot::Sender<()>,
+        release: oneshot::Receiver<()>,
+    ) -> Self {
+        Self {
+            inner,
+            fetched: Mutex::new(Some(fetched)),
+            release: Mutex::new(Some(release)),
+        }
+    }
+}
+
+impl BlobStore for GateBlobStore {
+    async fn head_object(&self, org_id: Uuid, key: &ObjectKey) -> Result<ObjectHead, StorageError> {
+        self.inner.head_object(org_id, key).await
+    }
+
+    async fn get_object_bounded(
+        &self,
+        org_id: Uuid,
+        key: &ObjectKey,
+        max_bytes: u64,
+        expected: &ObjectExpectation<'_>,
+    ) -> Result<fileconv_server::storage::FetchedObject, StorageError> {
+        let object = self
+            .inner
+            .get_object_bounded(org_id, key, max_bytes, expected)
+            .await?;
+        // Signal only after bytes are in hand (post-fetch), then wait for test side.
+        let fetched = self.fetched.lock().expect("gate lock").take();
+        if let Some(tx) = fetched {
+            let _ = tx.send(());
+        }
+        let release = self.release.lock().expect("gate lock").take();
+        if let Some(rx) = release {
+            let _ = rx.await;
+        }
+        Ok(object)
+    }
+}
+
+fn test_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => None,
+    }
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect_raw_result(database_url: &str) -> Result<tokio_postgres::Client, String> {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .map_err(|error| format!("connect failed for {database_url}: {error}"))?;
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    Ok(client)
+}
+
+async fn database_exists(admin_url: &str, db_name: &str) -> Result<bool, String> {
+    let admin = connect_raw_result(admin_url).await?;
+    let row = admin
+        .query_opt("SELECT 1 FROM pg_database WHERE datname = $1", &[&db_name])
+        .await
+        .map_err(|error| format!("pg_database lookup for {db_name}: {error}"))?;
+    Ok(row.is_some())
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    /// Taken on cleanup so `Drop` and async `drop` each run at most once.
+    db_name: Option<String>,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let suffix = Uuid::new_v4().simple();
+        let db_name = format!("markhand_r02_{suffix}");
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect_raw_result(&admin_url)
+            .await
+            .expect("admin connect for CREATE DATABASE");
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: Some(db_name.clone()),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    /// Terminate backends, then `DROP DATABASE … WITH (FORCE)` in a **separate**
+    /// statement (DROP cannot run inside a multi-statement transaction block).
+    async fn cleanup_async(admin_url: &str, db_name: &str) -> Result<(), String> {
+        let admin = connect_raw_result(admin_url).await?;
+        admin
+            .execute(
+                "SELECT pg_terminate_backend(pid)
+                 FROM pg_stat_activity
+                 WHERE datname = $1 AND pid <> pg_backend_pid()",
+                &[&db_name],
+            )
+            .await
+            .map_err(|error| format!("terminate backends for {db_name}: {error}"))?;
+        // Separate simple query — never batched with terminate.
+        admin
+            .batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{db_name}\" WITH (FORCE)"
+            ))
+            .await
+            .map_err(|error| format!("DROP DATABASE {db_name}: {error}"))?;
+        Ok(())
+    }
+
+    /// Drop-safe cleanup: always runs on a **dedicated OS thread** with its own
+    /// Tokio runtime. Never uses `block_in_place` / the parent handle — that
+    /// double-panics on `current_thread` runtimes during panic unwind.
+    fn cleanup_blocking(admin_url: &str, db_name: &str) -> Result<(), String> {
+        let admin_url = admin_url.to_string();
+        let db_name = db_name.to_string();
+        std::thread::Builder::new()
+            .name("ephemeral-db-cleanup".into())
+            .spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|error| format!("runtime for cleanup: {error}"))?;
+                rt.block_on(Self::cleanup_async(&admin_url, &db_name))
+            })
+            .map_err(|error| format!("spawn cleanup thread: {error}"))?
+            .join()
+            .map_err(|_| "cleanup thread panicked".to_string())?
+    }
+
+    async fn drop(mut self) -> Result<(), String> {
+        let Some(db_name) = self.db_name.take() else {
+            return Ok(());
+        };
+        Self::cleanup_async(&self.admin_url, &db_name).await
+    }
+}
+
+impl Drop for EphemeralDb {
+    fn drop(&mut self) {
+        let Some(db_name) = self.db_name.take() else {
+            return;
+        };
+        if let Err(error) = Self::cleanup_blocking(&self.admin_url, &db_name) {
+            // Best-effort on panic paths; never panic here (would abort the process).
+            eprintln!("EphemeralDb Drop cleanup failed for {db_name}: {error}");
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TenantIds {
+    org: Uuid,
+    user: Uuid,
+    collection: Uuid,
+    role: Uuid,
+    document: Uuid,
+    source_version: Uuid,
+    published_version: Uuid,
+    chunk_first: Uuid,
+    chunk_second: Uuid,
+    index_meta: Uuid,
+    original_object: Uuid,
+    markdown_object: Uuid,
+}
+
+struct SeededTenant {
+    ids: TenantIds,
+    markdown: String,
+    markdown_sha: String,
+    original_bytes: Vec<u8>,
+    original_sha: String,
+    quote_start: usize,
+    quote_end: usize,
+    quote: String,
+    second_start: usize,
+    second_end: usize,
+    second_quote: String,
+}
+
+async fn seed_tenant(
+    pool: &deadpool_postgres::Pool,
+    store: &MemoryBlobStore,
+    collection_visibility: &str,
+) -> SeededTenant {
+    let ids = TenantIds {
+        org: Uuid::new_v4(),
+        user: Uuid::new_v4(),
+        collection: Uuid::new_v4(),
+        role: Uuid::new_v4(),
+        document: Uuid::new_v4(),
+        source_version: Uuid::new_v4(),
+        published_version: Uuid::new_v4(),
+        chunk_first: Uuid::new_v4(),
+        chunk_second: Uuid::new_v4(),
+        index_meta: Uuid::new_v4(),
+        original_object: Uuid::new_v4(),
+        markdown_object: Uuid::new_v4(),
+    };
+    let markdown =
+        "# Mục\n\nMở đầu.\n\nKinh phí phê duyệt là 15 triệu đồng.\n\nKết thúc phiên bản.\n"
+            .to_string();
+    let quote = "Kinh phí phê duyệt là 15 triệu đồng.".to_string();
+    let quote_start = markdown.find(&quote).expect("quote in markdown");
+    let quote_end = quote_start + quote.len();
+    assert!(quote_start > 0);
+    let second_quote = "Kết thúc phiên bản.".to_string();
+    let second_start = markdown.find(&second_quote).expect("second quote");
+    let second_end = second_start + second_quote.len();
+    let markdown_sha = hex::encode(Sha256::digest(markdown.as_bytes()));
+    let original_bytes = b"%PDF-1.4 original-upload-bytes".to_vec();
+    let original_sha = hex::encode(Sha256::digest(&original_bytes));
+    let original_key = quarantine_key(ids.org, ids.original_object, Some("doc.pdf")).unwrap();
+    let markdown_key =
+        trusted_key(ids.org, ids.published_version, ids.markdown_object, None).unwrap();
+    store
+        .put(
+            ids.org,
+            &original_key,
+            original_bytes.clone(),
+            Some("application/pdf"),
+        )
+        .unwrap();
+    store
+        .put(
+            ids.org,
+            &markdown_key,
+            markdown.as_bytes().to_vec(),
+            Some("text/markdown; charset=utf-8"),
+        )
+        .unwrap();
+
+    let ctx = OrgContext::try_new(
+        ids.org,
+        ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [ids.collection],
+    )
+    .unwrap();
+    let markdown_len = markdown.as_bytes().len() as i64;
+    let original_len = original_bytes.len() as i64;
+    with_org_txn(pool, &ctx, {
+        let ids = ids;
+        let markdown_sha = markdown_sha.clone();
+        let original_sha = original_sha.clone();
+        let original_key_str = original_key.as_str();
+        let markdown_key_str = markdown_key.as_str();
+        let quote = quote.clone();
+        let second_quote = second_quote.clone();
+        let visibility = collection_visibility.to_string();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO orgs (id, slug, name) VALUES ($1, $2, $3)",
+                    &[&ids.org, &format!("org-{}", ids.org), &"org"],
+                )
+                .await?;
+                let email = format!("{}@example.test", ids.user);
+                txn.execute(
+                    "INSERT INTO users (id, email, display_name, password_hash)
+                     VALUES ($1, $2, 'u', 'test-hash')",
+                    &[&ids.user, &email],
+                )
+                .await?;
+                // Separate collection owner so ACL revoke via user_access is meaningful.
+                let owner_user = Uuid::new_v4();
+                txn.execute(
+                    "INSERT INTO users (id, email, display_name, password_hash)
+                     VALUES ($1, $2, 'owner', 'test-hash')",
+                    &[&owner_user, &format!("{owner_user}@example.test")],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'owner'), ($1, $3, 'owner')",
+                    &[&ids.org, &ids.user, &owner_user],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO roles (id, org_id, code, name, is_system)
+                     VALUES ($1, $2, 'owner', 'Owner', true)",
+                    &[&ids.role, &ids.org],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     SELECT $1, $2, id FROM permissions
+                     WHERE code IN ('qa.query', 'qa.history')",
+                    &[&ids.org, &ids.role],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO collections (
+                        id, org_id, name, slug, owner_user_id, visibility
+                     ) VALUES ($1, $2, 'c', $3, $4, $5)",
+                    &[
+                        &ids.collection,
+                        &ids.org,
+                        &format!("c-{}", ids.collection),
+                        &owner_user,
+                        &visibility,
+                    ],
+                )
+                .await?;
+                if visibility == "private" {
+                    txn.execute(
+                        "INSERT INTO collection_user_access (
+                            id, org_id, collection_id, user_id, access_level
+                         ) VALUES ($1, $2, $3, $4, 'read')",
+                        &[&Uuid::new_v4(), &ids.org, &ids.collection, &ids.user],
+                    )
+                    .await?;
+                }
+                txn.execute(
+                    "INSERT INTO documents (
+                        id, org_id, collection_id, title, state, created_by_user_id
+                     ) VALUES ($1, $2, $3, 'doc', 'indexed', $4)",
+                    &[&ids.document, &ids.org, &ids.collection, &ids.user],
+                )
+                .await?;
+                // Source/upload version carries original hash/size/type.
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state, is_current,
+                        content_sha256, original_object_key, source_filename, source_content_type,
+                        byte_size, effective_from, created_by_user_id
+                     ) VALUES (
+                        $1,$2,$3,1,'draft',false,$4,$5,'doc.pdf','application/pdf',$6,
+                        '2024-01-01Z',$7
+                     )",
+                    &[
+                        &ids.source_version,
+                        &ids.org,
+                        &ids.document,
+                        &original_sha,
+                        &original_key_str,
+                        &original_len,
+                        &ids.user,
+                    ],
+                )
+                .await?;
+                // Published version reuses original key but stores Markdown hash/size.
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, parent_version_id,
+                        publication_state, is_current, content_sha256, original_object_key,
+                        markdown_object_key, source_filename, source_content_type, byte_size,
+                        effective_from, created_by_user_id
+                     ) VALUES (
+                        $1,$2,$3,2,$4,'published',true,$5,$6,$7,'doc.pdf',
+                        'text/markdown; charset=utf-8',$8,'2024-06-01Z',$9
+                     )",
+                    &[
+                        &ids.published_version,
+                        &ids.org,
+                        &ids.document,
+                        &ids.source_version,
+                        &markdown_sha,
+                        &original_key_str,
+                        &markdown_key_str,
+                        &markdown_len,
+                        &ids.user,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE documents SET current_version_id = $1 WHERE id = $2",
+                    &[&ids.published_version, &ids.document],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO derived_artifacts (
+                        id, org_id, document_id, version_id, artifact_kind, object_key,
+                        content_sha256, content_type, byte_size
+                     ) VALUES (
+                        $1,$2,$3,$4,'markdown',$5,$6,'text/markdown; charset=utf-8',$7
+                     )",
+                    &[
+                        &Uuid::new_v4(),
+                        &ids.org,
+                        &ids.document,
+                        &ids.published_version,
+                        &markdown_key_str,
+                        &markdown_sha,
+                        &markdown_len,
+                    ],
+                )
+                .await?;
+                // Retired generation — exact citation must still resolve.
+                txn.execute(
+                    "INSERT INTO index_metadata (
+                        id, org_id, collection_id, index_signature_sha256,
+                        embedding_family, embedding_revision, dimensions,
+                        runtime_path, generation, is_active, state
+                     ) VALUES (
+                        $1,$2,$3,$4,'f','r',8,'local-hash',1,false,'retired'
+                     )",
+                    &[&ids.index_meta, &ids.org, &ids.collection, &"c".repeat(64)],
+                )
+                .await?;
+                let identity1 = format!("{:064x}", 1u8);
+                let identity2 = format!("{:064x}", 2u8);
+                txn.execute(
+                    "INSERT INTO chunks (
+                        id, org_id, document_id, version_id, ordinal, heading_path, body,
+                        body_text_version, chunk_identity_sha256, index_metadata_id,
+                        index_signature, page, slide, sheet, span_start, span_end, tsv
+                     ) VALUES
+                     ($1,$2,$3,$4,0,ARRAY['Mục','Slide 3'],$5,'v1',$6,$7,$8,2,3,NULL,$9,$10,
+                      to_tsvector('simple',$5)),
+                     ($11,$2,$3,$4,1,ARRAY['Mục'],$12,'v1',$13,$7,$8,NULL,NULL,NULL,$14,$15,
+                      to_tsvector('simple',$12))",
+                    &[
+                        &ids.chunk_first,
+                        &ids.org,
+                        &ids.document,
+                        &ids.published_version,
+                        &quote,
+                        &identity1,
+                        &ids.index_meta,
+                        &"c".repeat(64),
+                        &(quote_start as i32),
+                        &(quote_end as i32),
+                        &ids.chunk_second,
+                        &second_quote,
+                        &identity2,
+                        &(second_start as i32),
+                        &(second_end as i32),
+                    ],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed tenant");
+
+    SeededTenant {
+        ids,
+        markdown,
+        markdown_sha,
+        original_bytes,
+        original_sha,
+        quote_start,
+        quote_end,
+        quote,
+        second_start,
+        second_end,
+        second_quote,
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn citation_preview_download_happy_path_with_memory_store() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let signer =
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap();
+
+    let citation = resolve_citation(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        CitationResolveRequest {
+            chunk_id: tenant.ids.chunk_first,
+            expected_version_id: Some(tenant.ids.published_version),
+            expected_document_id: Some(tenant.ids.document),
+            expected_content_sha256: Some(tenant.markdown_sha.clone()),
+            expected_quote: Some(tenant.quote.clone()),
+            expected_span_start: Some(tenant.quote_start),
+            expected_span_end: Some(tenant.quote_end),
+        },
+    )
+    .await
+    .expect("citation from retired generation + markdown span");
+    assert_eq!(citation.quote, tenant.quote);
+    assert!(citation.span_start > 0);
+    assert_eq!(citation.page, Some(2));
+    assert_eq!(citation.slide, Some(3));
+
+    let second = resolve_citation(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        CitationResolveRequest {
+            chunk_id: tenant.ids.chunk_second,
+            expected_version_id: None,
+            expected_document_id: None,
+            expected_content_sha256: None,
+            expected_quote: Some(tenant.second_quote.clone()),
+            expected_span_start: Some(tenant.second_start),
+            expected_span_end: Some(tenant.second_end),
+        },
+    )
+    .await
+    .expect("second chunk");
+    assert_eq!(second.quote, tenant.second_quote);
+    assert_ne!(second.span_start, citation.span_start);
+
+    let preview = fetch_trusted_markdown(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+    )
+    .await
+    .expect("preview");
+    assert_eq!(preview.markdown, tenant.markdown);
+    assert_eq!(preview.markdown_sha256, tenant.markdown_sha);
+
+    let minted = mint_download_capability(
+        &pool,
+        &signer,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+        DownloadPurpose::Original,
+        DEFAULT_CAPABILITY_TTL,
+    )
+    .await
+    .expect("mint original");
+    assert_eq!(minted.content_sha256, tenant.original_sha);
+    assert_eq!(minted.content_type, "application/pdf");
+    assert_eq!(minted.byte_size, tenant.original_bytes.len() as u64);
+
+    let budget = DownloadFetchBudget::for_tests();
+    let artifact = redeem_download_capability(
+        &pool,
+        &store,
+        &signer,
+        &budget,
+        tenant.ids.org,
+        tenant.ids.user,
+        minted.token.expose(),
+    )
+    .await
+    .expect("redeem original");
+    assert_eq!(artifact.body.as_bytes(), tenant.original_bytes.as_slice());
+    assert_eq!(artifact.content_type, "application/pdf");
+    assert!(
+        artifact.body.permit_held(),
+        "budget permit must stay held until body is consumed/dropped"
+    );
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn two_tenants_idor_is_permission_denied_not_database() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let a = seed_tenant(&pool, &store, "org").await;
+    let b = seed_tenant(&pool, &store, "org").await;
+    let signer =
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap();
+
+    let preview_cross = fetch_trusted_markdown(
+        &pool,
+        &store,
+        b.ids.org,
+        b.ids.user,
+        a.ids.document,
+        a.ids.published_version,
+    )
+    .await;
+    assert!(
+        matches!(
+            preview_cross,
+            Err(PreviewError::PermissionDenied | PreviewError::NotFound)
+        ),
+        "cross-tenant preview must not surface Database: {preview_cross:?}"
+    );
+
+    let minted = mint_download_capability(
+        &pool,
+        &signer,
+        a.ids.org,
+        a.ids.user,
+        a.ids.document,
+        a.ids.published_version,
+        DownloadPurpose::Markdown,
+        DEFAULT_CAPABILITY_TTL,
+    )
+    .await
+    .expect("mint");
+    let budget = DownloadFetchBudget::for_tests();
+    let redeem_cross = redeem_download_capability(
+        &pool,
+        &store,
+        &signer,
+        &budget,
+        b.ids.org,
+        b.ids.user,
+        minted.token.expose(),
+    )
+    .await;
+    assert!(
+        matches!(
+            redeem_cross,
+            Err(DownloadError::PermissionDenied | DownloadError::NotFound)
+        ),
+        "cross-tenant redeem must not surface Database: {redeem_cross:?}"
+    );
+
+    let cite_cross = resolve_citation(
+        &pool,
+        &store,
+        b.ids.org,
+        b.ids.user,
+        CitationResolveRequest {
+            chunk_id: a.ids.chunk_first,
+            expected_version_id: None,
+            expected_document_id: None,
+            expected_content_sha256: None,
+            expected_quote: None,
+            expected_span_start: None,
+            expected_span_end: None,
+        },
+    )
+    .await;
+    assert!(
+        matches!(
+            cite_cross,
+            Err(CitationError::PermissionDenied | CitationError::NotFound)
+        ),
+        "cross-tenant citation must not surface Database: {cite_cross:?}"
+    );
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn concurrent_redeem_allows_only_one_winner() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = Arc::new(create_pool(&ephemeral.url).expect("pool"));
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let signer =
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap();
+    let minted = mint_download_capability(
+        &pool,
+        &signer,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+        DownloadPurpose::Markdown,
+        DEFAULT_CAPABILITY_TTL,
+    )
+    .await
+    .expect("mint");
+
+    let ctx = OrgContext::try_new(
+        tenant.ids.org,
+        tenant.ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [tenant.ids.collection],
+    )
+    .unwrap();
+    let capability = with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        let id = minted.capability_id;
+        move |txn| {
+            Box::pin(async move {
+                fileconv_server::db::download_capabilities::get_by_id(txn, &ctx, id).await
+            })
+        }
+    })
+    .await
+    .expect("load capability")
+    .expect("capability row");
+
+    // Two prepared org transactions rendezvous immediately before
+    // `consume_authorized_or_classify` (FOR UPDATE) — deterministic SQL lock
+    // contention without any production service hook.
+    let barrier = Arc::new(Barrier::new(2));
+    let run = |pool: Arc<deadpool_postgres::Pool>,
+               ctx: OrgContext,
+               capability: DownloadCapabilityRow,
+               barrier: Arc<Barrier>| {
+        tokio::spawn(async move {
+            let mut client = pool.get().await.expect("checkout");
+            let txn = client.transaction().await.expect("begin");
+            apply_org_context(&txn, &ctx).await.expect("RLS GUCs");
+            barrier.wait().await;
+            let outcome = consume_authorized_or_classify(
+                &txn,
+                &ctx,
+                capability.id,
+                capability.document_id,
+                capability.version_id,
+                capability.purpose,
+                &capability.content_sha256,
+                &capability.content_type,
+                capability.byte_size,
+            )
+            .await
+            .expect("consume_authorized_or_classify");
+            txn.commit().await.expect("commit");
+            outcome
+        })
+    };
+
+    let t1 = run(
+        pool.clone(),
+        ctx.clone(),
+        capability.clone(),
+        barrier.clone(),
+    );
+    let t2 = run(pool.clone(), ctx.clone(), capability.clone(), barrier);
+    let r1 = t1.await.expect("join1");
+    let r2 = t2.await.expect("join2");
+    let wins = matches!(r1, AuthorizedConsumeOutcome::Consumed(_)) as u8
+        + matches!(r2, AuthorizedConsumeOutcome::Consumed(_)) as u8;
+    let replays = matches!(r1, AuthorizedConsumeOutcome::Replay) as u8
+        + matches!(r2, AuthorizedConsumeOutcome::Replay) as u8;
+    assert_eq!(wins, 1, "exactly one consume must succeed: {r1:?} / {r2:?}");
+    assert_eq!(
+        replays, 1,
+        "the other consume must be Replay: {r1:?} / {r2:?}"
+    );
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn ephemeral_db_drop_cleans_up_after_panic_on_current_thread() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+
+    let captured = Arc::new(Mutex::new(None::<(String, String)>));
+    let captured_for_task = captured.clone();
+    let join = tokio::task::spawn(async move {
+        let ephemeral = EphemeralDb::create(&base_url).await;
+        *captured_for_task.lock().expect("capture lock") = Some((
+            ephemeral.admin_url.clone(),
+            ephemeral
+                .db_name
+                .clone()
+                .expect("ephemeral db name before panic"),
+        ));
+        panic!("intentional panic to exercise EphemeralDb::Drop");
+    });
+    let join_err = join.await.expect_err("spawned task must panic");
+    assert!(
+        join_err.is_panic(),
+        "expected panic unwind, got: {join_err:?}"
+    );
+
+    let (admin_url, db_name) = captured
+        .lock()
+        .expect("capture lock")
+        .clone()
+        .expect("ephemeral identity captured before panic");
+    // Drop ran during task unwind on this current_thread runtime; process must
+    // still be alive and the ephemeral database must be gone.
+    let exists = database_exists(&admin_url, &db_name)
+        .await
+        .expect("database_exists");
+    assert!(
+        !exists,
+        "ephemeral DB {db_name} must be dropped after panic-path Drop"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn acl_revoke_and_history_revoke_deny_fresh_resolve() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "private").await;
+    let ctx = OrgContext::try_new(
+        tenant.ids.org,
+        tenant.ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [tenant.ids.collection],
+    )
+    .unwrap();
+
+    // ACL revoke: remove collection_user_access on private collection.
+    with_org_txn(&pool, &ctx, {
+        let org = tenant.ids.org;
+        let collection = tenant.ids.collection;
+        let user = tenant.ids.user;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "DELETE FROM collection_user_access
+                     WHERE org_id = $1 AND collection_id = $2 AND user_id = $3",
+                    &[&org, &collection, &user],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("revoke acl");
+
+    let denied = fetch_trusted_markdown(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+    )
+    .await;
+    assert!(
+        matches!(
+            denied,
+            Err(PreviewError::PermissionDenied | PreviewError::NotFound)
+        ),
+        "ACL revoke must deny preview: {denied:?}"
+    );
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn half_open_span_is_invalid_request() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let err = resolve_citation(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        CitationResolveRequest {
+            chunk_id: tenant.ids.chunk_first,
+            expected_version_id: None,
+            expected_document_id: None,
+            expected_content_sha256: None,
+            expected_quote: None,
+            expected_span_start: Some(tenant.quote_start),
+            expected_span_end: None,
+        },
+    )
+    .await;
+    assert_eq!(err, Err(CitationError::InvalidRequest));
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[test]
+fn hermetic_effective_time_pin_shape() {
+    let at = Utc.with_ymd_and_hms(2024, 2, 15, 0, 0, 0).unwrap();
+    assert_eq!(at.timestamp(), 1_707_955_200);
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn mint_rejects_oversized_ttl() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let signer =
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap();
+    let denied = mint_download_capability(
+        &pool,
+        &signer,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+        DownloadPurpose::Original,
+        Duration::from_secs(10_000),
+    )
+    .await;
+    assert_eq!(denied, Err(DownloadError::InvalidTtl));
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn disabled_user_and_membership_removal_deny_services() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let signer =
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap();
+    let ctx = OrgContext::try_new(
+        tenant.ids.org,
+        tenant.ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [tenant.ids.collection],
+    )
+    .unwrap();
+
+    with_org_txn(&pool, &ctx, {
+        let user = tenant.ids.user;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE users SET disabled_at = clock_timestamp() WHERE id = $1",
+                    &[&user],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("disable user");
+
+    let disabled = mint_download_capability(
+        &pool,
+        &signer,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+        DownloadPurpose::Markdown,
+        DEFAULT_CAPABILITY_TTL,
+    )
+    .await;
+    assert_eq!(disabled, Err(DownloadError::PermissionDenied));
+
+    // Re-enable, then remove membership.
+    with_org_txn(&pool, &ctx, {
+        let org = tenant.ids.org;
+        let user = tenant.ids.user;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE users SET disabled_at = NULL WHERE id = $1",
+                    &[&user],
+                )
+                .await?;
+                txn.execute(
+                    "DELETE FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+                    &[&org, &user],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("remove membership");
+
+    let no_member = fetch_trusted_markdown(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+    )
+    .await;
+    assert!(
+        matches!(
+            no_member,
+            Err(PreviewError::PermissionDenied | PreviewError::NotFound)
+        ),
+        "membership removal must deny: {no_member:?}"
+    );
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn document_deletion_denies_preview_and_citation() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let ctx = OrgContext::try_new(
+        tenant.ids.org,
+        tenant.ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [tenant.ids.collection],
+    )
+    .unwrap();
+
+    with_org_txn(&pool, &ctx, {
+        let org = tenant.ids.org;
+        let document = tenant.ids.document;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE documents
+                     SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&org, &document],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("soft-delete document");
+
+    let preview = fetch_trusted_markdown(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+    )
+    .await;
+    assert!(
+        matches!(
+            preview,
+            Err(PreviewError::PermissionDenied | PreviewError::NotFound)
+        ),
+        "deleted document must deny preview: {preview:?}"
+    );
+
+    let citation = resolve_citation(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        CitationResolveRequest {
+            chunk_id: tenant.ids.chunk_first,
+            expected_version_id: None,
+            expected_document_id: None,
+            expected_content_sha256: None,
+            expected_quote: None,
+            expected_span_start: None,
+            expected_span_end: None,
+        },
+    )
+    .await;
+    assert!(
+        matches!(
+            citation,
+            Err(CitationError::PermissionDenied | CitationError::NotFound)
+        ),
+        "deleted document must deny citation: {citation:?}"
+    );
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn qa_history_revoke_denies_non_current_version() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let ctx = OrgContext::try_new(
+        tenant.ids.org,
+        tenant.ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [tenant.ids.collection],
+    )
+    .unwrap();
+
+    // Supersede published version with a new current row so the original becomes history.
+    with_org_txn(&pool, &ctx, {
+        let org = tenant.ids.org;
+        let document = tenant.ids.document;
+        let version = tenant.ids.published_version;
+        let user = tenant.ids.user;
+        let markdown_sha = tenant.markdown_sha.clone();
+        let markdown_len = tenant.markdown.as_bytes().len() as i64;
+        move |txn| {
+            Box::pin(async move {
+                let successor = Uuid::new_v4();
+                let now: chrono::DateTime<chrono::Utc> =
+                    txn.query_one("SELECT clock_timestamp()", &[]).await?.get(0);
+                txn.execute(
+                    "UPDATE document_versions
+                     SET is_current = false, effective_to = $2
+                     WHERE id = $1",
+                    &[&version, &now],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, parent_version_id,
+                        publication_state, is_current, content_sha256, original_object_key,
+                        markdown_object_key, source_filename, source_content_type, byte_size,
+                        effective_from, created_by_user_id
+                     )
+                     SELECT $1, org_id, document_id, version_number + 1, id,
+                            'published', true, $2, original_object_key, markdown_object_key,
+                            source_filename, source_content_type, $3, $4, $5
+                     FROM document_versions WHERE id = $6",
+                    &[
+                        &successor,
+                        &markdown_sha,
+                        &markdown_len,
+                        &now,
+                        &user,
+                        &version,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "UPDATE documents
+                     SET current_version_id = $1, updated_at = clock_timestamp()
+                     WHERE org_id = $2 AND id = $3",
+                    &[&successor, &org, &document],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("supersede to create historical version");
+
+    let allowed = fetch_trusted_markdown(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+    )
+    .await;
+    assert!(
+        allowed.is_ok(),
+        "qa.history should allow historical: {allowed:?}"
+    );
+
+    with_org_txn(&pool, &ctx, {
+        let org = tenant.ids.org;
+        let role = tenant.ids.role;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "DELETE FROM role_permissions
+                     WHERE org_id = $1 AND role_id = $2
+                       AND permission_id = (SELECT id FROM permissions WHERE code = 'qa.history')",
+                    &[&org, &role],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("revoke qa.history");
+
+    let denied = fetch_trusted_markdown(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+    )
+    .await;
+    assert!(
+        matches!(
+            denied,
+            Err(PreviewError::PermissionDenied | PreviewError::NotFound)
+        ),
+        "qa.history revoke must deny historical preview: {denied:?}"
+    );
+
+    let cite = resolve_citation(
+        &pool,
+        &store,
+        tenant.ids.org,
+        tenant.ids.user,
+        CitationResolveRequest {
+            chunk_id: tenant.ids.chunk_first,
+            expected_version_id: None,
+            expected_document_id: None,
+            expected_content_sha256: None,
+            expected_quote: None,
+            expected_span_start: None,
+            expected_span_end: None,
+        },
+    )
+    .await;
+    assert!(
+        matches!(
+            cite,
+            Err(CitationError::PermissionDenied | CitationError::NotFound)
+        ),
+        "qa.history revoke must deny historical citation: {cite:?}"
+    );
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn capability_expiry_boundary_is_expired_not_replay() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let signer =
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap();
+    let budget = DownloadFetchBudget::for_tests();
+
+    let minted = mint_download_capability(
+        &pool,
+        &signer,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+        DownloadPurpose::Markdown,
+        Duration::from_secs(1),
+    )
+    .await
+    .expect("mint ttl=1s");
+
+    // Force expiry with DB clock (avoid sleeping on wall clock drift).
+    let ctx = OrgContext::try_new(
+        tenant.ids.org,
+        tenant.ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [tenant.ids.collection],
+    )
+    .unwrap();
+    with_org_txn(&pool, &ctx, {
+        let id = minted.capability_id;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE download_capabilities
+                     SET created_at = clock_timestamp() - interval '10 seconds',
+                         expires_at = clock_timestamp() - interval '1 second'
+                     WHERE id = $1",
+                    &[&id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("force expiry");
+
+    // Re-sign is required because HMAC binds expires_at; load row and resign.
+    let row = with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        let id = minted.capability_id;
+        move |txn| {
+            Box::pin(async move {
+                fileconv_server::db::download_capabilities::get_by_id(txn, &ctx, id).await
+            })
+        }
+    })
+    .await
+    .expect("load")
+    .expect("row");
+    let token = signer.sign_capability(&row);
+
+    let expired = redeem_download_capability(
+        &pool,
+        &store,
+        &signer,
+        &budget,
+        tenant.ids.org,
+        tenant.ids.user,
+        token.expose(),
+    )
+    .await;
+    assert!(
+        matches!(expired, Err(DownloadError::Expired)),
+        "expiry boundary must be Expired, not Replay: {expired:?}"
+    );
+
+    // Second redeem of the same expired token remains Expired (not Replay).
+    let expired_again = redeem_download_capability(
+        &pool,
+        &store,
+        &signer,
+        &budget,
+        tenant.ids.org,
+        tenant.ids.user,
+        token.expose(),
+    )
+    .await;
+    assert!(
+        matches!(expired_again, Err(DownloadError::Expired)),
+        "{expired_again:?}"
+    );
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn content_type_mismatch_on_redeem_is_integrity() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let signer =
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap();
+    let budget = DownloadFetchBudget::for_tests();
+
+    let minted = mint_download_capability(
+        &pool,
+        &signer,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+        DownloadPurpose::Original,
+        DEFAULT_CAPABILITY_TTL,
+    )
+    .await
+    .expect("mint");
+
+    // Overwrite stored object with wrong content-type; hash/size unchanged.
+    let original_key =
+        quarantine_key(tenant.ids.org, tenant.ids.original_object, Some("doc.pdf")).unwrap();
+    store
+        .put(
+            tenant.ids.org,
+            &original_key,
+            tenant.original_bytes.clone(),
+            Some("text/plain"),
+        )
+        .unwrap();
+
+    let mismatched = redeem_download_capability(
+        &pool,
+        &store,
+        &signer,
+        &budget,
+        tenant.ids.org,
+        tenant.ids.user,
+        minted.token.expose(),
+    )
+    .await;
+    assert!(
+        matches!(mismatched, Err(DownloadError::Integrity)),
+        "{mismatched:?}"
+    );
+
+    // Integrity must leave the token retryable — restore type and redeem again.
+    store
+        .put(
+            tenant.ids.org,
+            &original_key,
+            tenant.original_bytes.clone(),
+            Some("application/pdf"),
+        )
+        .unwrap();
+    let retry = redeem_download_capability(
+        &pool,
+        &store,
+        &signer,
+        &budget,
+        tenant.ids.org,
+        tenant.ids.user,
+        minted.token.expose(),
+    )
+    .await
+    .expect("integrity failure must not burn token");
+    assert_eq!(retry.body.as_bytes(), tenant.original_bytes.as_slice());
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn busy_budget_keeps_token_retryable() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &store, "org").await;
+    let signer =
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap();
+    // Tiny budget: one held reservation blocks the redeem fetch.
+    let budget =
+        DownloadFetchBudget::try_new(tenant.original_bytes.len() as u64, 1).expect("tiny budget");
+    let blocker = budget
+        .acquire(tenant.original_bytes.len() as u64)
+        .await
+        .expect("hold budget");
+
+    let minted = mint_download_capability(
+        &pool,
+        &signer,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+        DownloadPurpose::Original,
+        DEFAULT_CAPABILITY_TTL,
+    )
+    .await
+    .expect("mint");
+
+    let busy = redeem_download_capability(
+        &pool,
+        &store,
+        &signer,
+        &budget,
+        tenant.ids.org,
+        tenant.ids.user,
+        minted.token.expose(),
+    )
+    .await;
+    assert!(matches!(busy, Err(DownloadError::Busy)), "{busy:?}");
+    drop(blocker);
+
+    let retry = redeem_download_capability(
+        &pool,
+        &store,
+        &signer,
+        &budget,
+        tenant.ids.org,
+        tenant.ids.user,
+        minted.token.expose(),
+    )
+    .await
+    .expect("Busy must not burn token");
+    assert_eq!(retry.body.as_bytes(), tenant.original_bytes.as_slice());
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+async fn memory_blob_content_type_and_length_semantics_hermetic() {
+    let store = MemoryBlobStore::new();
+    let org = Uuid::new_v4();
+    let key = quarantine_key(org, Uuid::new_v4(), None).unwrap();
+    let body = b"payload-bytes".to_vec();
+    let sha = hex::encode(Sha256::digest(&body));
+    store
+        .put(org, &key, body.clone(), Some("application/pdf"))
+        .unwrap();
+
+    assert!(matches!(
+        store
+            .get_object_bounded(
+                org,
+                &key,
+                64,
+                &ObjectExpectation {
+                    content_sha256: &sha,
+                    content_length: body.len() as u64,
+                    content_type: Some("text/plain"),
+                },
+            )
+            .await,
+        Err(StorageError::PreconditionFailed)
+    ));
+    assert!(matches!(
+        store
+            .get_object_bounded(
+                org,
+                &key,
+                64,
+                &ObjectExpectation {
+                    content_sha256: &sha,
+                    content_length: (body.len() as u64) + 3,
+                    content_type: Some("application/pdf"),
+                },
+            )
+            .await,
+        Err(StorageError::PreconditionFailed)
+    ));
+    assert!(matches!(
+        store
+            .get_object_bounded(
+                org,
+                &key,
+                4,
+                &ObjectExpectation {
+                    content_sha256: &sha,
+                    content_length: body.len() as u64,
+                    content_type: Some("application/pdf"),
+                },
+            )
+            .await,
+        Err(StorageError::ObjectTooLarge)
+    ));
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn barrier_acl_revoke_before_consume_denies_without_burning_token() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = Arc::new(create_pool(&ephemeral.url).expect("pool"));
+    let memory = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &memory, "private").await;
+    let signer = Arc::new(
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap(),
+    );
+    let budget = DownloadFetchBudget::for_tests();
+    let minted = mint_download_capability(
+        &pool,
+        &signer,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+        DownloadPurpose::Markdown,
+        DEFAULT_CAPABILITY_TTL,
+    )
+    .await
+    .expect("mint");
+
+    let (fetched_tx, fetched_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let gate = Arc::new(GateBlobStore::new(memory, fetched_tx, release_rx));
+
+    let pool_r = pool.clone();
+    let gate_r = gate.clone();
+    let signer_r = signer.clone();
+    let budget_r = budget.clone();
+    let token = minted.token.expose().to_string();
+    let org = tenant.ids.org;
+    let user = tenant.ids.user;
+    let redeem = tokio::spawn(async move {
+        redeem_download_capability(
+            &pool_r,
+            gate_r.as_ref(),
+            &signer_r,
+            &budget_r,
+            org,
+            user,
+            &token,
+        )
+        .await
+    });
+
+    fetched_rx.await.expect("fetch reached storage gate");
+    let ctx = OrgContext::try_new(
+        tenant.ids.org,
+        tenant.ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [tenant.ids.collection],
+    )
+    .unwrap();
+    with_org_txn(&pool, &ctx, {
+        let org = tenant.ids.org;
+        let collection = tenant.ids.collection;
+        let user = tenant.ids.user;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "DELETE FROM collection_user_access
+                     WHERE org_id = $1 AND collection_id = $2 AND user_id = $3",
+                    &[&org, &collection, &user],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("revoke ACL while redeem is past fetch, before consume");
+    release_tx.send(()).expect("release gate");
+
+    let denied = redeem.await.expect("join redeem");
+    assert!(
+        matches!(
+            denied,
+            Err(DownloadError::PermissionDenied | DownloadError::NotFound)
+        ),
+        "ACL revoke at consume must deny body: {denied:?}"
+    );
+
+    let live = with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        let id = minted.capability_id;
+        move |txn| Box::pin(async move { classify_liveness(txn, &ctx, id).await })
+    })
+    .await
+    .expect("liveness");
+    assert_eq!(
+        live,
+        CapabilityLiveness::Open,
+        "auth failure must leave token retryable, not Replay"
+    );
+
+    // Restore ACL — same token must succeed (proves consume did not fire).
+    with_org_txn(&pool, &ctx, {
+        let org = tenant.ids.org;
+        let collection = tenant.ids.collection;
+        let user = tenant.ids.user;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO collection_user_access (
+                        id, org_id, collection_id, user_id, access_level
+                     ) VALUES ($1, $2, $3, $4, 'read')",
+                    &[&Uuid::new_v4(), &org, &collection, &user],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("restore ACL");
+
+    let retry_store = gate.inner.clone();
+    let retry = redeem_download_capability(
+        &pool,
+        &retry_store,
+        &signer,
+        &budget,
+        tenant.ids.org,
+        tenant.ids.user,
+        minted.token.expose(),
+    )
+    .await
+    .expect("retry after ACL restore");
+    assert_eq!(retry.body.as_bytes(), tenant.markdown.as_bytes());
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn barrier_document_delete_before_consume_denies_without_body() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = Arc::new(create_pool(&ephemeral.url).expect("pool"));
+    let memory = MemoryBlobStore::new();
+    let tenant = seed_tenant(&pool, &memory, "org").await;
+    let signer = Arc::new(
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap(),
+    );
+    let budget = DownloadFetchBudget::for_tests();
+    let minted = mint_download_capability(
+        &pool,
+        &signer,
+        tenant.ids.org,
+        tenant.ids.user,
+        tenant.ids.document,
+        tenant.ids.published_version,
+        DownloadPurpose::Original,
+        DEFAULT_CAPABILITY_TTL,
+    )
+    .await
+    .expect("mint");
+
+    let (fetched_tx, fetched_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    let gate = Arc::new(GateBlobStore::new(memory, fetched_tx, release_rx));
+
+    let pool_r = pool.clone();
+    let gate_r = gate.clone();
+    let signer_r = signer.clone();
+    let budget_r = budget.clone();
+    let token = minted.token.expose().to_string();
+    let org = tenant.ids.org;
+    let user = tenant.ids.user;
+    let redeem = tokio::spawn(async move {
+        redeem_download_capability(
+            &pool_r,
+            gate_r.as_ref(),
+            &signer_r,
+            &budget_r,
+            org,
+            user,
+            &token,
+        )
+        .await
+    });
+
+    fetched_rx.await.expect("fetch gate");
+    let ctx = OrgContext::try_new(
+        tenant.ids.org,
+        tenant.ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [tenant.ids.collection],
+    )
+    .unwrap();
+    with_org_txn(&pool, &ctx, {
+        let org = tenant.ids.org;
+        let document = tenant.ids.document;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE documents
+                     SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND id = $2",
+                    &[&org, &document],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("soft-delete during redeem window");
+    release_tx.send(()).expect("release");
+
+    let denied = redeem.await.expect("join");
+    assert!(
+        matches!(
+            denied,
+            Err(DownloadError::PermissionDenied | DownloadError::NotFound)
+        ),
+        "document delete at consume must not return body: {denied:?}"
+    );
+    assert!(
+        !matches!(denied, Err(DownloadError::Replay | DownloadError::Expired)),
+        "must not burn/classify as replay/expired after delete race"
+    );
+
+    let live = with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        let id = minted.capability_id;
+        move |txn| Box::pin(async move { classify_liveness(txn, &ctx, id).await })
+    })
+    .await
+    .expect("liveness");
+    assert_eq!(live, CapabilityLiveness::Open);
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn wrong_user_consume_is_permission_denied_not_expired_oracle() {
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    apply_migrations(&ephemeral.url).await.expect("migrate");
+    let pool = create_pool(&ephemeral.url).expect("pool");
+    let store = MemoryBlobStore::new();
+    let owner = seed_tenant(&pool, &store, "org").await;
+    let signer =
+        CapabilitySigner::new(SecretString::new("integration-download-signing-key-32b!")).unwrap();
+    let budget = DownloadFetchBudget::for_tests();
+    let minted = mint_download_capability(
+        &pool,
+        &signer,
+        owner.ids.org,
+        owner.ids.user,
+        owner.ids.document,
+        owner.ids.published_version,
+        DownloadPurpose::Markdown,
+        DEFAULT_CAPABILITY_TTL,
+    )
+    .await
+    .expect("mint");
+
+    // Same-org peer (not the capability owner) — IDOR must not learn Expired.
+    let peer = Uuid::new_v4();
+    let owner_ctx = OrgContext::try_new(
+        owner.ids.org,
+        owner.ids.user,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [owner.ids.collection],
+    )
+    .unwrap();
+    with_org_txn(&pool, &owner_ctx, {
+        let org = owner.ids.org;
+        let role = owner.ids.role;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO users (id, email, display_name, password_hash)
+                     VALUES ($1, $2, 'peer', 'test-hash')",
+                    &[&peer, &format!("{peer}@example.test")],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'owner')",
+                    &[&org, &peer],
+                )
+                .await?;
+                // Peer shares the same role row already granted qa.* via seed.
+                let _ = role;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("add peer");
+
+    with_org_txn(&pool, &owner_ctx, {
+        let id = minted.capability_id;
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE download_capabilities
+                     SET created_at = clock_timestamp() - interval '10 seconds',
+                         expires_at = clock_timestamp() - interval '1 second'
+                     WHERE id = $1",
+                    &[&id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("expire");
+    let row = with_org_txn(&pool, &owner_ctx, {
+        let ctx = owner_ctx.clone();
+        let id = minted.capability_id;
+        move |txn| {
+            Box::pin(async move {
+                fileconv_server::db::download_capabilities::get_by_id(txn, &ctx, id).await
+            })
+        }
+    })
+    .await
+    .expect("load")
+    .expect("row");
+    let token = signer.sign_capability(&row);
+
+    let probe = redeem_download_capability(
+        &pool,
+        &store,
+        &signer,
+        &budget,
+        owner.ids.org,
+        peer,
+        token.expose(),
+    )
+    .await;
+    assert!(
+        matches!(
+            probe,
+            Err(DownloadError::PermissionDenied | DownloadError::NotFound)
+        ),
+        "wrong user must not learn Expired/Replay: {probe:?}"
+    );
+    assert!(
+        !matches!(probe, Err(DownloadError::Expired | DownloadError::Replay)),
+        "IDOR oracle: {probe:?}"
+    );
+
+    // Direct atomic consume classify (same txn semantics) for peer.
+    let peer_ctx = OrgContext::try_new(
+        owner.ids.org,
+        peer,
+        [PERMISSION_QA_QUERY, PERMISSION_QA_HISTORY],
+        [owner.ids.collection],
+    )
+    .unwrap();
+    let classified = with_org_txn(&pool, &peer_ctx, {
+        let ctx = peer_ctx.clone();
+        let id = minted.capability_id;
+        let document = owner.ids.document;
+        let version = owner.ids.published_version;
+        let sha = row.content_sha256.clone();
+        let ctype = row.content_type.clone();
+        let size = row.byte_size;
+        move |txn| {
+            Box::pin(async move {
+                fileconv_server::db::download_capabilities::consume_authorized_or_classify(
+                    txn,
+                    &ctx,
+                    id,
+                    document,
+                    version,
+                    DownloadPurpose::Markdown,
+                    &sha,
+                    &ctype,
+                    size,
+                )
+                .await
+            })
+        }
+    })
+    .await
+    .expect("classify");
+    assert_eq!(
+        classified,
+        fileconv_server::db::download_capabilities::AuthorizedConsumeOutcome::PermissionDenied,
+        "peer must not observe Expired via consume classify"
+    );
+
+    ephemeral.drop().await.expect("ephemeral cleanup");
+}

--- a/crates/server/tests/schema_migrations.rs
+++ b/crates/server/tests/schema_migrations.rs
@@ -39,6 +39,7 @@ const BUSINESS_TABLES: &[&str] = &[
     "usage_counters",
     "quota_reservations",
     "audit_log",
+    "download_capabilities",
 ];
 
 const GLOBAL_TABLES: &[&str] = &["orgs", "users", "permissions"];

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -205,10 +205,18 @@ ghi trong issue đã `Done`.
 
 ### P1B-R02 — Citation, preview và download authorization
 
+- **Status:** Review — services `{citation,preview,download}` + bounded `BlobStore`/
+  `MemoryBlobStore`; citation quotes from trusted Markdown spans; original download
+  uses reconciliation parent-source metadata; exact citation ignores index generation
+  activity; live PG + memory-store acceptance in `tests/citation_preview_download.rs`.
+  Mark Done after coordinator review/merge.
 - **Plan:** Stable anchor pin logical document/version number/version ID/content hash/
   effective time/current flag; fresh auth per resolve; trusted Markdown fetch; short
   single-purpose download capability.
-- **Files:** `services/{citation,preview,download}.rs`, document routes.
+- **Files:** `services/{citation,preview,download}.rs`, `routes/documents.rs`,
+  `storage/blob.rs`, `db/{search,download_capabilities}.rs`,
+  `migrations/0018_expand_download_capabilities.sql`,
+  `migrations/0019_expand_download_capability_clock.sql`.
 - **Depends:** F05/F06/R01.
 - **Acceptance/tests:** Quote/hash/version/anchor valid; historical permission + fresh
   ACL; delete/suspend/removal deny; IDOR, expiry/replay, multi-document/multi-version,

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "df1e51308172f6f0";
+    const ROADMAP_SOURCE_HASH = "23a1ad4df147c9ab";
     const phases = [
       {
         "id": "phase-f",
@@ -1192,7 +1192,7 @@
           [
             "P1B-R02",
             "Citation, preview và download authorization",
-            "blocked"
+            "review"
           ],
           [
             "P1B-R03",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Implements P1B-R02 citation resolution, trusted Markdown preview, and short-lived single-use downloads with fresh PostgreSQL authorization.

This is stacked on the P1B-R01 hardening branch; rebase the PR onto `master` after that dependency merges.

## Scope

- Stable version-aware citation anchors with trusted Markdown hash/span/quote verification.
- Fresh authorization for citation, preview, and download, including historical `qa.history` checks.
- Bounded blob reads with MIME/size/hash validation and memory-budgeted download bodies.
- HMAC-bound, single-purpose capabilities with DB-clock expiry, atomic replay protection, and authorization checked in the consume statement.
- Minimal document routes for resolve/preview/mint/redeem.
- Additive capability migrations and comprehensive PostgreSQL/storage regressions.

## Evidence

- [x] Tests: complete `cargo test -p fileconv-server` suite passes.
- [x] Live acceptance: 16 R02 PostgreSQL tests and 8 migration/RLS tests pass locally.
- [x] Lint: strict server all-target Clippy passes with warnings denied.
- [x] Mandatory preflight: rustfmt, locked metadata, dependency policy, migration manifest, roadmap, and diff checks pass.
- [x] Manual/migration evidence: repeated ephemeral migration runs leave zero leaked test databases.

## Boundary and security review

- [x] Dependency boundary check passed.
- [x] Tenant/ACL impact reviewed: final capability consume rechecks active user, membership, permissions, ACL, document/version state, and immutable bindings atomically.
- [x] Sensitive logging/secret/egress impact reviewed: capability tokens have redacted Debug; no bucket credentials or raw object keys are exposed.
- [x] Security review trigger checked: iterative Grok implementation and GPT-5.6 Sol xHigh review reached APPROVE with zero findings; final Clippy refactor was reviewed separately and approved.

## Follow-up

- [x] Docs, migrations, roadmap, and route contracts updated.
- [ ] Mark P1B-R02 Done only after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8539-2448-79bf-bb28-1135cc995007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8539-2448-79bf-bb28-1135cc995007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

