### PR TITLE
Make P1B integration gates blocking and lifecycle-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,11 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       CARGO_INCREMENTAL: "0"
       RUST_BACKTRACE: "1"
-      # Same dev-only credentials as deploy/dev/compose.yml defaults /
-      # deploy/dev/.env.example — MARKHAND_TEST_DATABASE_URL intentionally
-      # uses the Postgres bootstrap superuser (not markhand_app, which
-      # bootstrap-server-role.sh creates NOCREATEDB) because the tests
-      # themselves CREATE/DROP an ephemeral database per test via
-      # EphemeralDb::create() + apply_migrations().
+      # Dual-role DB URLs (deploy/dev/compose.yml defaults):
+      # - admin/superuser: CREATE/DROP ephemeral databases + migrate
+      # - markhand_app: application pool for FORCE RLS / tenant assertions
       MARKHAND_TEST_DATABASE_URL: postgresql://markhand:markhand_dev_only@127.0.0.1:54329/markhand
+      MARKHAND_TEST_APP_DATABASE_URL: postgresql://markhand_app:markhand_app_dev_only@127.0.0.1:54329/markhand
       MARKHAND_TEST_MINIO_ENDPOINT: http://127.0.0.1:9000
       MARKHAND_TEST_MINIO_ACCESS_KEY: markhand
       MARKHAND_TEST_MINIO_SECRET_KEY: markhand_dev_only
@@ -191,20 +189,17 @@ jobs:
             "${COMPOSE[@]}" logs minio >&2 || true
             exit 1
           fi
+      - name: Bootstrap non-superuser markhand_app role
+        run: bash deploy/scripts/bootstrap-server-role.sh
       - name: Rust DB-backed integration tests (fileconv-server, --include-ignored)
         id: integration_tests
-        # ADVISORY (non-blocking) for now. Running the previously never-executed
-        # #[ignore] DB-backed suite revealed a backlog of pre-existing failures
-        # (real index-worker bugs; RLS-probe tests that need the non-superuser
-        # markhand_app role, not the compose superuser which bypasses FORCE RLS).
-        # Real deterministic defects the suite caught are fixed on the branch; the
-        # rest is owning-team/test-infra work that must not block unrelated merges.
-        # Step-level continue-on-error keeps the job (and its required check) green
-        # while the step still runs and surfaces failures in the log. (Job-level
-        # continue-on-error was insufficient — the workflow passed but this check
-        # itself still reported failure and blocked.) Remove once the suite is green.
-        continue-on-error: true
-        run: cargo test -p fileconv-server -- --include-ignored
+        # Blocking gate. Skip the live E2E opt-in test so missing MARKHAND_E2E
+        # stays an honest not_run (#[ignore] + --skip), not a soft-return pass.
+        # Use cargo --no-fail-fast so one red binary still surfaces the full backlog.
+        run: >-
+          cargo test -p fileconv-server --no-fail-fast --
+          --include-ignored
+          --skip e2e_live_vertical_slice
       - name: Dump service logs on failure
         if: steps.integration_tests.outcome == 'failure'
         run: docker compose -f deploy/dev/compose.yml logs --tail=200

--- a/crates/server/migrations/0022_expand_lifecycle_refresh_job.sql
+++ b/crates/server/migrations/0022_expand_lifecycle_refresh_job.sql
@@ -1,0 +1,21 @@
+-- Phase: 1B
+-- Owner: storage-owner
+-- Change: expand
+-- Lock/data risk: widens jobs.job_type CHECK only; no row rewrite.
+-- Rollback compatibility: reject new enqueues; existing lifecycle_refresh rows
+--                         would need draining before restoring the old CHECK.
+-- Durable lifecycle-refresh jobs refresh Qdrant is_current/is_effective markers
+-- after version promotion without replaying superseded index jobs.
+
+ALTER TABLE jobs
+    DROP CONSTRAINT IF EXISTS jobs_job_type_check;
+
+ALTER TABLE jobs
+    ADD CONSTRAINT jobs_job_type_check CHECK (job_type IN (
+        'convert',
+        'index',
+        'delete',
+        'reconcile',
+        'embedding_batch',
+        'lifecycle_refresh'
+    ));

--- a/crates/server/migrations/manifest.json
+++ b/crates/server/migrations/manifest.json
@@ -21,6 +21,7 @@
     "0018_expand_download_capability_redemptions.sql": "fe660678523878cb62c174116545de3cb9b5037ff9db19590e6c3c312dc682d0",
     "0019_expand_ops_fences_jobs_system.sql": "90bc4c28bd5804aed1739fa484df7eb0f32d909713fe3e08a9fcd331d5fc451f",
     "0020_expand_hash_semantics_readiness_ops.sql": "d36f471ff4c8f91e0b11d91dce605f6a84b7216004649e45d4e8ff34282dd02c",
-    "0021_expand_audit_intent_outcome.sql": "378f6056970172cc7fa5bbd1491c67415ec4e0fc4707e295bffb20de57a09fae"
+    "0021_expand_audit_intent_outcome.sql": "378f6056970172cc7fa5bbd1491c67415ec4e0fc4707e295bffb20de57a09fae",
+    "0022_expand_lifecycle_refresh_job.sql": "0f5801b4ffae224c8a46a76b8c1004b6e22281c137310e8e4a7741fe826b6475"
   }
 }

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -90,6 +90,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0021_expand_audit_intent_outcome.sql",
         include_str!("../migrations/0021_expand_audit_intent_outcome.sql"),
     ),
+    (
+        "0022_expand_lifecycle_refresh_job.sql",
+        include_str!("../migrations/0022_expand_lifecycle_refresh_job.sql"),
+    ),
 ];
 
 /// Embedded migration sources in apply order (name, SQL). Used by integration tests.

--- a/crates/server/src/db/chunks.rs
+++ b/crates/server/src/db/chunks.rs
@@ -217,6 +217,71 @@ pub async fn count_by_version(
     Ok(row.get(0))
 }
 
+/// Counts chunks for one version bound to a specific index generation.
+pub async fn count_by_version_and_generation(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    version_id: Uuid,
+    index_metadata_id: Uuid,
+) -> Result<i64, DbError> {
+    let row = txn
+        .query_one(
+            "SELECT count(*)::bigint
+             FROM chunks
+             WHERE org_id = $1
+               AND version_id = $2
+               AND index_metadata_id = $3",
+            &[&ctx.org_id(), &version_id, &index_metadata_id],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
+/// Returns every distinct index generation that has durable chunks for a version.
+pub async fn list_generations_for_version(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    version_id: Uuid,
+) -> Result<Vec<Uuid>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT DISTINCT index_metadata_id
+             FROM chunks
+             WHERE org_id = $1 AND version_id = $2
+             ORDER BY index_metadata_id",
+            &[&ctx.org_id(), &version_id],
+        )
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|row| row.get::<_, Uuid>("index_metadata_id"))
+        .collect())
+}
+
+/// Loads chunk identity digests for one version bound to a generation.
+pub async fn list_identities_by_version_and_generation(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    version_id: Uuid,
+    index_metadata_id: Uuid,
+) -> Result<Vec<String>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT chunk_identity_sha256
+             FROM chunks
+             WHERE org_id = $1
+               AND version_id = $2
+               AND index_metadata_id = $3
+             ORDER BY ordinal, id",
+            &[&ctx.org_id(), &version_id, &index_metadata_id],
+        )
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|row| row.get::<_, String>("chunk_identity_sha256"))
+        .collect())
+}
+
 /// Loads one immutable ordinal range for a particular vector generation.
 pub async fn list_generation_range(
     txn: &Transaction<'_>,

--- a/crates/server/src/db/document_versions.rs
+++ b/crates/server/src/db/document_versions.rs
@@ -394,12 +394,16 @@ pub async fn list_by_document(
     rows.iter().map(map_version).collect()
 }
 
+/// Promotes `version_id` to current when needed.
+///
+/// Returns `Some(previous_version_id)` when a different version was demoted in
+/// this transaction (caller should durably enqueue lifecycle refresh).
 pub async fn promote_current_if_needed(
     txn: &Transaction<'_>,
     ctx: &OrgContext,
     document: &Document,
     version_id: Uuid,
-) -> Result<(), DbError> {
+) -> Result<Option<Uuid>, DbError> {
     let row = txn
         .query_one(
             "SELECT is_current
@@ -412,7 +416,7 @@ pub async fn promote_current_if_needed(
     let already_current: bool = row.get("is_current");
     if already_current {
         return if document.current_version_id == Some(version_id) {
-            Ok(())
+            Ok(None)
         } else {
             Err(DbError::StaleState {
                 expected: version_id.to_string(),
@@ -429,6 +433,20 @@ pub async fn promote_current_if_needed(
             observed: document.state.to_string(),
         });
     }
+
+    let previous = txn
+        .query_opt(
+            "SELECT id
+             FROM document_versions
+             WHERE org_id = $1
+               AND document_id = $2
+               AND is_current
+             FOR UPDATE",
+            &[&ctx.org_id(), &document.id],
+        )
+        .await?
+        .map(|row| row.get::<_, Uuid>("id"))
+        .filter(|id| *id != version_id);
 
     let effective_to = txn
         .query_one("SELECT clock_timestamp()", &[])
@@ -469,7 +487,7 @@ pub async fn promote_current_if_needed(
             observed: "missing_or_changed".into(),
         });
     }
-    Ok(())
+    Ok(previous)
 }
 
 fn is_eligible_for_conversion_promotion(document: &Document) -> bool {

--- a/crates/server/src/db/embedding_batches.rs
+++ b/crates/server/src/db/embedding_batches.rs
@@ -352,6 +352,59 @@ pub async fn document_batches_complete(
     ))
 }
 
+/// True when every embedding batch for this generation/version succeeded.
+///
+/// Unlike [`document_batches_complete`], this intentionally ignores the parent
+/// index job status so a reset/replayed index lease can still observe that the
+/// version's vectors were already materialized.
+pub async fn embedding_batches_succeeded_for_version(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    index_metadata_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<bool, DbError> {
+    let row = txn
+        .query_one(
+            "SELECT count(*)::bigint > 0 AS has_batches,
+                    COALESCE(bool_and(status = 'succeeded'), false) AS all_succeeded
+             FROM embedding_batches
+             WHERE org_id = $1
+               AND index_metadata_id = $2
+               AND document_id = $3
+               AND version_id = $4",
+            &[&ctx.org_id(), &index_metadata_id, &document_id, &version_id],
+        )
+        .await?;
+    Ok(row.get::<_, bool>("has_batches") && row.get::<_, bool>("all_succeeded"))
+}
+
+/// True when the generation backfill row for this document/version is terminal
+/// `backfilled` (used for empty documents that have no embedding batches).
+pub async fn generation_backfill_is_backfilled(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    index_metadata_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+) -> Result<bool, DbError> {
+    let row = txn
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM index_generation_backfills
+                WHERE org_id = $1
+                  AND index_metadata_id = $2
+                  AND document_id = $3
+                  AND version_id = $4
+                  AND status = 'backfilled'
+             )",
+            &[&ctx.org_id(), &index_metadata_id, &document_id, &version_id],
+        )
+        .await?;
+    Ok(row.get(0))
+}
+
 pub async fn generation_backfill_complete(
     txn: &Transaction<'_>,
     ctx: &OrgContext,

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -498,6 +498,7 @@ pub enum JobType {
     Delete,
     Reconcile,
     EmbeddingBatch,
+    LifecycleRefresh,
 }
 
 impl JobType {
@@ -508,6 +509,7 @@ impl JobType {
             Self::Delete => "delete",
             Self::Reconcile => "reconcile",
             Self::EmbeddingBatch => "embedding_batch",
+            Self::LifecycleRefresh => "lifecycle_refresh",
         }
     }
 
@@ -518,6 +520,7 @@ impl JobType {
             "delete" => Ok(Self::Delete),
             "reconcile" => Ok(Self::Reconcile),
             "embedding_batch" => Ok(Self::EmbeddingBatch),
+            "lifecycle_refresh" => Ok(Self::LifecycleRefresh),
             other => Err(format!("unknown job type: {other}")),
         }
     }

--- a/crates/server/src/jobs/mod.rs
+++ b/crates/server/src/jobs/mod.rs
@@ -45,6 +45,8 @@ pub struct JobPayload {
     pub index_metadata_id: Option<Uuid>,
     /// Parent conversion job for an independent reconciliation job.
     pub cleanup_target_job_id: Option<Uuid>,
+    /// Newer version that superseded `version_id` (lifecycle refresh).
+    pub related_version_id: Option<Uuid>,
 }
 
 impl JobPayload {
@@ -74,6 +76,7 @@ impl From<JobPayloadV1> for JobPayload {
             batch_id: None,
             index_metadata_id: None,
             cleanup_target_job_id: None,
+            related_version_id: None,
         }
     }
 }

--- a/crates/server/src/services/indexing.rs
+++ b/crates/server/src/services/indexing.rs
@@ -320,6 +320,24 @@ pub async fn index_version(
     }
     heartbeat_once(db_pool, ctx, input).await?;
 
+    // Replay short-circuit: when PG chunks + embedding batches (or empty
+    // backfill) are already durable for this generation, do not re-enqueue
+    // embedding work. Lifecycle markers for superseded versions are refreshed
+    // by durable `lifecycle_refresh` jobs enqueued at promotion time — not by
+    // replaying the old index job.
+    if version_index_materialized(
+        db_pool,
+        ctx,
+        metadata.id,
+        document_id,
+        version_id,
+        prepared_chunks.len(),
+    )
+    .await?
+    {
+        return Ok(IndexVersionOutcome::AlreadyIndexed);
+    }
+
     if is_current {
         match document.state {
             DocumentState::Converted => {
@@ -1456,6 +1474,51 @@ impl IndexingError {
     pub fn is_retryable_job_failure(&self) -> bool {
         !matches!(self, Self::Job(JobError::LeaseLost))
     }
+}
+
+/// Returns true when this version's index output for `metadata_id` is already
+/// durable: chunk rows match `expected_chunks`, and either embedding batches all
+/// succeeded (non-empty) or the generation backfill is `backfilled` (empty).
+async fn version_index_materialized(
+    db_pool: &Pool,
+    ctx: &OrgContext,
+    metadata_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    expected_chunks: usize,
+) -> Result<bool, IndexingError> {
+    with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let chunk_count =
+                    chunks::count_by_version_and_generation(txn, &ctx, version_id, metadata_id)
+                        .await?;
+                if chunk_count as usize != expected_chunks {
+                    return Ok(false);
+                }
+                if expected_chunks == 0 {
+                    return Ok(embedding_batches::generation_backfill_is_backfilled(
+                        txn,
+                        &ctx,
+                        metadata_id,
+                        document_id,
+                        version_id,
+                    )
+                    .await?);
+                }
+                Ok(embedding_batches::embedding_batches_succeeded_for_version(
+                    txn,
+                    &ctx,
+                    metadata_id,
+                    document_id,
+                    version_id,
+                )
+                .await?)
+            })
+        }
+    })
+    .await
 }
 
 /// Compensates just-upserted batch vectors with an exact-point-id, document-scoped delete.

--- a/crates/server/src/services/lifecycle.rs
+++ b/crates/server/src/services/lifecycle.rs
@@ -1,0 +1,266 @@
+//! Durable Qdrant lifecycle-refresh jobs after version promotion.
+
+use deadpool_postgres::Pool;
+use serde_json::json;
+use thiserror::Error;
+use tokio_postgres::Transaction;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{Job, JobStatus, JobType};
+use crate::db::pool::with_org_txn_typed;
+use crate::db::{chunks, documents, index_metadata, jobs as repo};
+use crate::jobs::{self, EnqueueJob, EnqueueOutcome, JobError, JobPayload};
+use crate::services::index_signature::collection_name_for_digest;
+use crate::storage::error::StorageError;
+use crate::storage::qdrant::{point_id_from_org_collection_and_chunk, QdrantClient, VectorScope};
+
+#[derive(Debug, Error)]
+pub enum LifecycleError {
+    #[error("database error")]
+    Db(#[from] DbError),
+    #[error("job error")]
+    Job(#[from] JobError),
+    #[error("storage error")]
+    Storage(#[from] StorageError),
+    #[error("lifecycle refresh payload is invalid")]
+    InvalidPayload,
+    #[error("claimed lifecycle job is missing a lease token")]
+    MissingLease,
+}
+
+impl LifecycleError {
+    pub fn safe_job_error(&self) -> &'static str {
+        match self {
+            Self::Db(_) => "lifecycle database error",
+            Self::Job(_) => "lifecycle job error",
+            Self::Storage(_) => "lifecycle storage error",
+            Self::InvalidPayload => "lifecycle payload invalid",
+            Self::MissingLease => "lifecycle missing lease",
+        }
+    }
+
+    pub fn is_retryable_job_failure(&self) -> bool {
+        matches!(self, Self::Db(_) | Self::Storage(_) | Self::Job(_))
+    }
+}
+
+pub fn lifecycle_refresh_idempotency_key(
+    generation_id: Uuid,
+    previous_version_id: Uuid,
+    new_version_id: Uuid,
+) -> String {
+    format!("lifecycle_refresh:{generation_id}:{previous_version_id}:{new_version_id}")
+}
+
+/// Enqueues one idempotent filter-only lifecycle refresh per materialized
+/// generation of the demoted version (same promotion transaction).
+///
+/// When the previous version has no durable chunks yet, returns an empty list
+/// — never invents work from the active generation.
+pub async fn enqueue_refresh_within_txn(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    collection_id: Uuid,
+    previous_version_id: Uuid,
+    new_version_id: Uuid,
+) -> Result<Vec<EnqueueOutcome>, JobError> {
+    let generation_ids =
+        chunks::list_generations_for_version(txn, ctx, previous_version_id).await?;
+    let mut outcomes = Vec::with_capacity(generation_ids.len());
+    for generation_id in generation_ids {
+        let metadata = index_metadata::find_by_id(txn, ctx, generation_id)
+            .await?
+            .ok_or_else(|| {
+                JobError::Database(DbError::Config(format!(
+                    "lifecycle generation missing: {generation_id}"
+                )))
+            })?;
+        let job_collection_id = metadata.collection_id.unwrap_or(collection_id);
+        let payload = JobPayload {
+            document_id: Some(document_id),
+            version_id: Some(previous_version_id),
+            related_version_id: Some(new_version_id),
+            collection_id: Some(job_collection_id),
+            index_metadata_id: Some(generation_id),
+            ..JobPayload::default()
+        };
+        let outcome = jobs::enqueue_within_txn(
+            txn,
+            ctx,
+            EnqueueJob::new(
+                JobType::LifecycleRefresh,
+                payload,
+                lifecycle_refresh_idempotency_key(
+                    generation_id,
+                    previous_version_id,
+                    new_version_id,
+                ),
+            ),
+        )
+        .await?;
+        outcomes.push(outcome);
+    }
+    Ok(outcomes)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LifecycleSnapshot {
+    org_id: Uuid,
+    collection_id: Uuid,
+    version_id: Uuid,
+    is_current: bool,
+    is_effective: bool,
+}
+
+/// Re-reads version state under the document lock, then applies a filter-only
+/// Qdrant payload update. Retries converge: a later claim re-reads PG and
+/// rewrites markers without depending on superseded index-job replay.
+pub async fn refresh_version_lifecycle(
+    db_pool: &Pool,
+    qdrant: &QdrantClient,
+    ctx: &OrgContext,
+    job: &Job,
+    lease_token: &str,
+    attempts: i32,
+) -> Result<(), LifecycleError> {
+    if job.lease_owner.as_deref() != Some(lease_token) {
+        return Err(LifecycleError::MissingLease);
+    }
+    let payload = jobs::decode_job_payload(job.payload_version, job.payload.clone())?;
+    let document_id = payload.document_id.ok_or(LifecycleError::InvalidPayload)?;
+    let version_id = payload.version_id.ok_or(LifecycleError::InvalidPayload)?;
+    let index_metadata_id = payload
+        .index_metadata_id
+        .ok_or(LifecycleError::InvalidPayload)?;
+    let collection_id = payload
+        .collection_id
+        .ok_or(LifecycleError::InvalidPayload)?;
+    let job_id = job.id;
+    let lease_token = lease_token.to_string();
+
+    let (snapshot, identities, signature) = with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let lease_token = lease_token.clone();
+        move |txn| {
+            Box::pin(async move {
+                verify_claimed_job(txn, &ctx, job_id, &lease_token, attempts).await?;
+                let _document = documents::get_by_id_for_update(txn, &ctx, document_id).await?;
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                let version =
+                    crate::db::document_versions::find_by_id(txn, &ctx, document_id, version_id)
+                        .await?
+                        .ok_or(LifecycleError::InvalidPayload)?;
+                let metadata = index_metadata::find_by_id(txn, &ctx, index_metadata_id)
+                    .await?
+                    .ok_or(LifecycleError::InvalidPayload)?;
+                let identities = chunks::list_identities_by_version_and_generation(
+                    txn,
+                    &ctx,
+                    version_id,
+                    index_metadata_id,
+                )
+                .await?;
+                let generation_collection =
+                    metadata.collection_id.unwrap_or(document.collection_id);
+                let snapshot = LifecycleSnapshot {
+                    org_id: ctx.org_id(),
+                    collection_id: generation_collection,
+                    version_id,
+                    is_current: document.current_version_id == Some(version_id),
+                    is_effective: version.effective_to.is_none(),
+                };
+                if snapshot.collection_id != collection_id {
+                    return Err(LifecycleError::InvalidPayload);
+                }
+                Ok((snapshot, identities, metadata.index_signature_sha256))
+            })
+        }
+    })
+    .await?;
+
+    if !identities.is_empty() {
+        let collection_name = collection_name_for_digest(&signature)?;
+        let scope = VectorScope::new(snapshot.org_id, [snapshot.collection_id]);
+        let point_ids = identities
+            .iter()
+            .map(|identity| {
+                point_id_from_org_collection_and_chunk(
+                    snapshot.org_id,
+                    snapshot.collection_id,
+                    identity,
+                )
+            })
+            .collect::<Result<Vec<_>, StorageError>>()?;
+        let version_filter = [json!({
+            "key": "version_id",
+            "match": { "value": snapshot.version_id.to_string() }
+        })];
+        qdrant
+            .set_payload_fields(
+                &collection_name,
+                &scope,
+                &point_ids,
+                &json!({
+                    "is_current": snapshot.is_current,
+                    "is_effective": snapshot.is_effective,
+                }),
+                &version_filter,
+            )
+            .await?;
+    }
+
+    // Re-read under the document lock; if promotion raced, fail retryably so
+    // the durable job converges on the latest PG state without losing work.
+    let still_matches = with_org_txn_typed(db_pool, ctx, {
+        let ctx = ctx.clone();
+        let lease_token = lease_token.clone();
+        move |txn| {
+            Box::pin(async move {
+                verify_claimed_job(txn, &ctx, job_id, &lease_token, attempts).await?;
+                let _document = documents::get_by_id_for_update(txn, &ctx, document_id).await?;
+                let document = documents::get_by_id(txn, &ctx, document_id).await?;
+                let version =
+                    crate::db::document_versions::find_by_id(txn, &ctx, document_id, version_id)
+                        .await?
+                        .ok_or(LifecycleError::InvalidPayload)?;
+                let is_current = document.current_version_id == Some(version_id);
+                let is_effective = version.effective_to.is_none();
+                Ok::<bool, LifecycleError>(
+                    is_current == snapshot.is_current && is_effective == snapshot.is_effective,
+                )
+            })
+        }
+    })
+    .await?;
+    if !still_matches {
+        return Err(LifecycleError::Db(DbError::StaleState {
+            expected: format!(
+                "current={} effective={}",
+                snapshot.is_current, snapshot.is_effective
+            ),
+            observed: "changed_under_refresh".into(),
+        }));
+    }
+
+    Ok(())
+}
+
+async fn verify_claimed_job(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    job_id: Uuid,
+    lease_token: &str,
+    attempts: i32,
+) -> Result<Job, LifecycleError> {
+    repo::get_by_id_for_update(txn, ctx, job_id)
+        .await?
+        .filter(|job| {
+            job.status == JobStatus::Leased
+                && job.lease_owner.as_deref() == Some(lease_token)
+                && job.attempts == attempts
+        })
+        .ok_or(LifecycleError::Job(JobError::LeaseLost))
+}

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -13,6 +13,7 @@ pub mod download;
 pub mod embedding;
 pub mod index_signature;
 pub mod indexing;
+pub mod lifecycle;
 pub mod ops_fence;
 pub mod preview;
 pub mod promotion;

--- a/crates/server/src/services/promotion.rs
+++ b/crates/server/src/services/promotion.rs
@@ -15,6 +15,7 @@ use crate::db::models::{ArtifactKind, DocumentVersion, Job, JobStatus, ResourceK
 use crate::db::{documents, pool, quota as quota_repo};
 use crate::jobs::{self, CheckpointPayload, EventPayload, JobError};
 use crate::services::conversion::{checkpoint_with_step, ConversionIdentity, ConversionStep};
+use crate::services::lifecycle;
 use crate::services::quota::QuotaError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -172,13 +173,24 @@ pub async fn promote_conversion(
                 }
 
                 if created || version.is_current {
-                    document_versions::promote_current_if_needed(
+                    if let Some(previous_version_id) = document_versions::promote_current_if_needed(
                         txn,
                         &ctx,
                         &document,
                         promoted_version_id,
                     )
-                    .await?;
+                    .await?
+                    {
+                        lifecycle::enqueue_refresh_within_txn(
+                            txn,
+                            &ctx,
+                            input.source.document_id,
+                            document.collection_id,
+                            previous_version_id,
+                            promoted_version_id,
+                        )
+                        .await?;
+                    }
                 }
                 maybe_fault(input.fault, PromotionFault::AfterPointerSwap)?;
 

--- a/crates/server/src/storage/qdrant.rs
+++ b/crates/server/src/storage/qdrant.rs
@@ -462,6 +462,44 @@ impl QdrantClient {
         Ok(hits)
     }
 
+    /// Overwrite selected payload fields via filter only (no body `points`).
+    ///
+    /// The filter always includes mandatory org/collection scope, `has_id` for
+    /// the exact point set, plus any caller extras (e.g. `version_id`). Used to
+    /// refresh lifecycle markers without re-embedding.
+    pub async fn set_payload_fields(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        point_ids: &[Uuid],
+        fields: &Value,
+        extra_must: &[Value],
+    ) -> Result<(), StorageError> {
+        scope.validate()?;
+        if point_ids.is_empty() {
+            return Ok(());
+        }
+        let body = set_payload_fields_body(scope, point_ids, fields, extra_must)?;
+        let url = format!(
+            "{}/collections/{}/points/payload?wait=true",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let response = self
+            .authed(self.http.post(&url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if response.status().as_u16() == 404 {
+            return Ok(());
+        }
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        Ok(())
+    }
+
     /// Delete points matching the mandatory org/collection filter (and optional extra).
     pub async fn delete_by_scope(
         &self,
@@ -819,6 +857,29 @@ fn distance_matches(existing: &str, expected: &str) -> bool {
     existing.eq_ignore_ascii_case(expected)
 }
 
+/// Builds the filter-only set-payload body (never includes a top-level `points`).
+pub(crate) fn set_payload_fields_body(
+    scope: &VectorScope,
+    point_ids: &[Uuid],
+    fields: &Value,
+    extra_must: &[Value],
+) -> Result<Value, StorageError> {
+    if !fields.is_object() {
+        return Err(StorageError::PreconditionFailed);
+    }
+    let mut must = mandatory_filter_must(scope);
+    must.extend(extra_must.iter().cloned());
+    let ids: Vec<Value> = point_ids
+        .iter()
+        .map(|id| Value::String(id.to_string()))
+        .collect();
+    must.push(json!({ "has_id": ids }));
+    Ok(json!({
+        "payload": fields,
+        "filter": { "must": must },
+    }))
+}
+
 fn mandatory_filter(scope: &VectorScope) -> Value {
     json!({ "must": mandatory_filter_must(scope) })
 }
@@ -902,6 +963,52 @@ fn parse_point_id(value: &Value) -> Result<Uuid, StorageError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn set_payload_body_is_filter_only_with_has_id_and_version() {
+        let org = Uuid::new_v4();
+        let collection = Uuid::new_v4();
+        let version = Uuid::new_v4();
+        let point = Uuid::new_v4();
+        let body = set_payload_fields_body(
+            &VectorScope::new(org, [collection]),
+            &[point],
+            &json!({ "is_current": false }),
+            &[json!({
+                "key": "version_id",
+                "match": { "value": version.to_string() }
+            })],
+        )
+        .expect("body");
+        assert!(
+            body.get("points").is_none(),
+            "set_payload must not send body points"
+        );
+        let must = body
+            .pointer("/filter/must")
+            .and_then(Value::as_array)
+            .expect("must filter");
+        assert!(
+            must.iter().any(|clause| clause.get("has_id").is_some()),
+            "has_id required in must"
+        );
+        assert!(
+            must.iter()
+                .any(|clause| { clause.get("key").and_then(Value::as_str) == Some("version_id") }),
+            "version_id required in must"
+        );
+        assert!(
+            must.iter()
+                .any(|clause| clause.get("key").and_then(Value::as_str) == Some("org_id")),
+            "org_id required in must"
+        );
+        assert!(
+            must.iter().any(|clause| {
+                clause.get("key").and_then(Value::as_str) == Some("collection_id")
+            }),
+            "collection_id required in must"
+        );
+    }
 
     #[test]
     fn empty_scope_is_rejected() {

--- a/crates/server/src/workers/convert.rs
+++ b/crates/server/src/workers/convert.rs
@@ -666,6 +666,7 @@ impl ConvertWorker {
                 batch_id: None,
                 index_metadata_id: None,
                 cleanup_target_job_id: Some(parent_job.id),
+                related_version_id: None,
             },
             format!("convert.cleanup:{}", parent_job.id),
         );

--- a/crates/server/src/workers/index.rs
+++ b/crates/server/src/workers/index.rs
@@ -1,5 +1,9 @@
 //! Durable index job worker.
 
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
 use deadpool_postgres::Pool;
@@ -14,6 +18,7 @@ use crate::db::models::{Job, JobStatus, JobType};
 use crate::jobs::{self, JobError};
 use crate::services::embedding::ApprovedEmbeddingRuntime;
 use crate::services::indexing::{self, IndexVersionInput, IndexVersionOutcome, IndexingError};
+use crate::services::lifecycle::{self, LifecycleError};
 use crate::storage::minio::MinioClient;
 use crate::storage::qdrant::QdrantClient;
 
@@ -68,6 +73,8 @@ pub struct IndexWorker {
     config: IndexWorkerConfig,
     approved_signature: Option<String>,
     embedding_plan: EmbeddingPlan,
+    /// Alternates Index ↔ LifecycleRefresh claim preference (ConvertWorker pattern).
+    next_claim_prefers_lifecycle: Arc<AtomicBool>,
 }
 
 impl IndexWorker {
@@ -122,23 +129,40 @@ impl IndexWorker {
             config,
             approved_signature,
             embedding_plan,
+            next_claim_prefers_lifecycle: Arc::new(AtomicBool::new(false)),
         })
     }
 
     pub async fn run_once(&self, ctx: &OrgContext) -> Result<IndexWorkerRun, IndexWorkerError> {
-        let jobs = jobs::claim_type(
-            &self.db_pool,
-            ctx,
-            JobType::Index,
-            &self.config.worker_id,
-            DEFAULT_CLAIM_LIMIT,
-            self.config.lease_ttl,
-        )
-        .await?;
-        let Some(job) = jobs.into_iter().next() else {
-            return Ok(IndexWorkerRun::NoJob);
+        // Fairness: alternate Index ↔ LifecycleRefresh so a continuous index
+        // backlog cannot starve demoted-version lifecycle refresh.
+        let claim_order = if self
+            .next_claim_prefers_lifecycle
+            .fetch_xor(true, Ordering::Relaxed)
+        {
+            [JobType::LifecycleRefresh, JobType::Index]
+        } else {
+            [JobType::Index, JobType::LifecycleRefresh]
         };
-        self.process_claimed_job(ctx, job).await
+        for job_type in claim_order {
+            let jobs = jobs::claim_type(
+                &self.db_pool,
+                ctx,
+                job_type,
+                &self.config.worker_id,
+                DEFAULT_CLAIM_LIMIT,
+                self.config.lease_ttl,
+            )
+            .await?;
+            if let Some(job) = jobs.into_iter().next() {
+                return if job.job_type == JobType::LifecycleRefresh {
+                    self.process_lifecycle_job(ctx, job).await
+                } else {
+                    self.process_claimed_job(ctx, job).await
+                };
+            }
+        }
+        Ok(IndexWorkerRun::NoJob)
     }
 
     /// Returns the immutable embedding plan used to resolve target generations
@@ -230,6 +254,68 @@ impl IndexWorker {
         }
     }
 
+    async fn process_lifecycle_job(
+        &self,
+        ctx: &OrgContext,
+        job: Job,
+    ) -> Result<IndexWorkerRun, IndexWorkerError> {
+        let lease_token = job
+            .lease_owner
+            .as_deref()
+            .ok_or(IndexWorkerError::MissingLease)?
+            .to_string();
+        let attempts = job.attempts;
+        let deadline = TokioInstant::now() + self.config.max_job_duration;
+        let result = timeout_at(
+            deadline,
+            lifecycle::refresh_version_lifecycle(
+                &self.db_pool,
+                &self.qdrant,
+                ctx,
+                &job,
+                &lease_token,
+                attempts,
+            ),
+        )
+        .await;
+        match result {
+            Ok(Ok(())) => {
+                match jobs::complete(&self.db_pool, ctx, job.id, &lease_token, attempts).await {
+                    Ok(completed) => Ok(IndexWorkerRun::Completed {
+                        job_id: completed.id,
+                        chunks: 0,
+                    }),
+                    Err(JobError::LeaseLost) => Ok(IndexWorkerRun::LeaseLost { job_id: job.id }),
+                    Err(error) => Err(IndexWorkerError::Job(error)),
+                }
+            }
+            Ok(Err(LifecycleError::Job(JobError::LeaseLost))) => {
+                Ok(IndexWorkerRun::LeaseLost { job_id: job.id })
+            }
+            Ok(Err(error)) if error.is_retryable_job_failure() => {
+                self.fail_lifecycle_claimed(
+                    ctx,
+                    &job,
+                    &lease_token,
+                    attempts,
+                    error.safe_job_error(),
+                )
+                .await
+            }
+            Ok(Err(error)) => Err(IndexWorkerError::Lifecycle(error)),
+            Err(_) => {
+                self.fail_lifecycle_claimed(
+                    ctx,
+                    &job,
+                    &lease_token,
+                    attempts,
+                    IndexWorkerError::JobTimedOut.safe_job_error(),
+                )
+                .await
+            }
+        }
+    }
+
     async fn fail_claimed(
         &self,
         ctx: &OrgContext,
@@ -251,6 +337,33 @@ impl IndexWorker {
             Err(error) => Err(IndexWorkerError::Indexing(error)),
         }
     }
+
+    async fn fail_lifecycle_claimed(
+        &self,
+        ctx: &OrgContext,
+        job: &Job,
+        lease_token: &str,
+        attempts: i32,
+        last_error: &str,
+    ) -> Result<IndexWorkerRun, IndexWorkerError> {
+        match jobs::fail(
+            &self.db_pool,
+            ctx,
+            job.id,
+            lease_token,
+            attempts,
+            last_error,
+        )
+        .await
+        {
+            Ok(failed) => Ok(IndexWorkerRun::Failed {
+                job_id: failed.id,
+                terminal: failed.status == JobStatus::DeadLetter,
+            }),
+            Err(JobError::LeaseLost) => Ok(IndexWorkerRun::LeaseLost { job_id: job.id }),
+            Err(error) => Err(IndexWorkerError::Job(error)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -267,6 +380,8 @@ pub enum IndexWorkerError {
     Job(#[from] JobError),
     #[error("indexing error")]
     Indexing(#[from] IndexingError),
+    #[error("lifecycle error")]
+    Lifecycle(#[from] LifecycleError),
     #[error("claimed job is missing a lease token")]
     MissingLease,
     #[error("worker heartbeat interval must be <= one third of lease ttl")]
@@ -294,6 +409,7 @@ impl IndexWorkerError {
         match self {
             Self::Job(_) => "index job error",
             Self::Indexing(error) => error.safe_job_error(),
+            Self::Lifecycle(error) => error.safe_job_error(),
             Self::MissingLease => "index missing lease",
             Self::InvalidHeartbeatConfig => "index heartbeat config invalid",
             Self::InvalidMaxJobDuration => "index max job duration invalid",

--- a/crates/server/tests/auth.rs
+++ b/crates/server/tests/auth.rs
@@ -91,14 +91,20 @@ impl EphemeralDb {
 
     async fn drop(self) {
         let admin = connect_raw(&self.admin_url).await;
-        let _ = admin
+        admin
             .batch_execute(&format!(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity                  WHERE datname = '{}' AND pid <> pg_backend_pid()",
+                self.db_name
             ))
-            .await;
+            .await
+            .unwrap_or_else(|error| panic!("terminate backends failed: {error}"));
+        admin
+            .batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+                self.db_name
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("DROP DATABASE WITH (FORCE) failed: {error}"));
     }
 }
 

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -1,0 +1,187 @@
+//! Shared helpers for DB-backed server integration tests.
+//!
+//! Dual-role layout:
+//! - `MARKHAND_TEST_DATABASE_URL` — bootstrap role with `CREATEDB` (compose superuser)
+//! - `MARKHAND_TEST_APP_DATABASE_URL` — non-superuser `markhand_app` for FORCE RLS
+#![allow(dead_code)] // not every integration binary uses every helper
+
+use deadpool_postgres::Pool;
+use fileconv_server::database::apply_migrations;
+use fileconv_server::db::pool::{create_pool, create_pool_with_max_size};
+use tokio_postgres::NoTls;
+use uuid::Uuid;
+
+pub fn admin_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!(
+                "skipped: MARKHAND_TEST_DATABASE_URL unset — integration tests require PostgreSQL"
+            );
+            None
+        }
+    }
+}
+
+pub fn app_database_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_APP_DATABASE_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!(
+                "skipped: MARKHAND_TEST_APP_DATABASE_URL unset — FORCE RLS assertions require markhand_app"
+            );
+            None
+        }
+    }
+}
+
+pub fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+pub async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("connect failed for {database_url}: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+/// Drop an ephemeral database with an independent `WITH (FORCE)` statement.
+///
+/// Failures propagate so suites cannot silently leave prefix databases behind.
+pub async fn drop_database_force(admin_maintenance_url: &str, db_name: &str) -> Result<(), String> {
+    let admin = connect_raw(admin_maintenance_url).await;
+    admin
+        .batch_execute(&format!(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+             WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+        ))
+        .await
+        .map_err(|error| format!("terminate backends for {db_name}: {error}"))?;
+    admin
+        .batch_execute(&format!(
+            "DROP DATABASE IF EXISTS \"{db_name}\" WITH (FORCE)"
+        ))
+        .await
+        .map_err(|error| format!("DROP DATABASE {db_name} WITH (FORCE): {error}"))?;
+    Ok(())
+}
+
+/// Ephemeral database created by the admin role, with the app role granted and
+/// used for the application pool so FORCE RLS is actually enforced.
+pub struct DualRoleEphemeralDb {
+    admin_maintenance_url: String,
+    db_name: String,
+    pub admin_db_url: String,
+    pub app_url: String,
+}
+
+impl DualRoleEphemeralDb {
+    pub fn db_name(&self) -> &str {
+        &self.db_name
+    }
+
+    pub async fn create(admin_base_url: &str, app_base_url: &str) -> Self {
+        let db_name = format!("markhand_it_{}", Uuid::new_v4().simple());
+        let admin_maintenance_url = rewrite_database_url(admin_base_url, "postgres");
+        let admin = connect_raw(&admin_maintenance_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        admin
+            .batch_execute(&format!(
+                "GRANT CONNECT ON DATABASE \"{db_name}\" TO markhand_app"
+            ))
+            .await
+            .expect("GRANT CONNECT to markhand_app");
+
+        let admin_db_url = rewrite_database_url(admin_base_url, &db_name);
+        let app_url = rewrite_database_url(app_base_url, &db_name);
+
+        // Migrate as the bootstrap role (CREATE EXTENSION / ownership), then
+        // grant the non-superuser app role DML + EXECUTE so FORCE RLS applies.
+        apply_migrations(&admin_db_url)
+            .await
+            .expect("apply migrations");
+        let admin_on_db = connect_raw(&admin_db_url).await;
+        admin_on_db
+            .batch_execute(
+                "GRANT USAGE ON SCHEMA public TO markhand_app;
+                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO markhand_app;
+                 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO markhand_app;
+                 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO markhand_app;",
+            )
+            .await
+            .expect("grant app role privileges on ephemeral database");
+
+        Self {
+            admin_maintenance_url,
+            db_name,
+            admin_db_url,
+            app_url,
+        }
+    }
+
+    pub async fn drop(self) {
+        drop_database_force(&self.admin_maintenance_url, &self.db_name)
+            .await
+            .unwrap_or_else(|error| panic!("ephemeral database cleanup failed: {error}"));
+    }
+}
+
+pub async fn boot_app_pool(
+    admin_base_url: &str,
+    app_base_url: &str,
+) -> (DualRoleEphemeralDb, Pool) {
+    let ephemeral = DualRoleEphemeralDb::create(admin_base_url, app_base_url).await;
+    let pool = create_pool(&ephemeral.app_url).expect("create app-role pool");
+    (ephemeral, pool)
+}
+
+pub async fn boot_app_pool_with_max_size(
+    admin_base_url: &str,
+    app_base_url: &str,
+    max_size: usize,
+) -> (DualRoleEphemeralDb, Pool) {
+    let ephemeral = DualRoleEphemeralDb::create(admin_base_url, app_base_url).await;
+    let pool = create_pool_with_max_size(&ephemeral.app_url, max_size)
+        .expect("create sized app-role pool");
+    (ephemeral, pool)
+}
+
+/// Assert the pool connection is `markhand_app` without superuser/bypassrls.
+pub async fn assert_markhand_app_role(pool: &Pool) {
+    let client = pool.get().await.expect("app pool client");
+    let row = client
+        .query_one(
+            "SELECT current_user::text AS current_user,
+                    rolsuper,
+                    rolbypassrls
+             FROM pg_roles
+             WHERE rolname = current_user",
+            &[],
+        )
+        .await
+        .expect("role probe");
+    let current_user: String = row.get("current_user");
+    let rolsuper: bool = row.get("rolsuper");
+    let rolbypassrls: bool = row.get("rolbypassrls");
+    assert_eq!(current_user, "markhand_app");
+    assert!(!rolsuper, "markhand_app must not be superuser");
+    assert!(!rolbypassrls, "markhand_app must not bypass RLS");
+}

--- a/crates/server/tests/deletion_reconcile.rs
+++ b/crates/server/tests/deletion_reconcile.rs
@@ -683,14 +683,20 @@ impl EphemeralDb {
 
     async fn drop(self) {
         let admin = connect_raw(&self.admin_url).await;
-        let _ = admin
+        admin
             .batch_execute(&format!(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity                  WHERE datname = '{}' AND pid <> pg_backend_pid()",
+                self.db_name
             ))
-            .await;
+            .await
+            .unwrap_or_else(|error| panic!("terminate backends failed: {error}"));
+        admin
+            .batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+                self.db_name
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("DROP DATABASE WITH (FORCE) failed: {error}"));
     }
 }
 

--- a/crates/server/tests/e2e_release_suite.rs
+++ b/crates/server/tests/e2e_release_suite.rs
@@ -2,6 +2,8 @@
 //!
 //! Default `cargo test` must not claim a green live E2E. The live suite is
 //! `#[ignore]` and only runs with `--ignored` under `MARKHAND_E2E=1`.
+//! Integration CI that uses `--include-ignored` must `--skip e2e_live_vertical_slice`
+//! so absence of the live opt-in stays an honest not_run, not a fake pass.
 
 #[test]
 fn e2e_suite_default_is_not_run() {
@@ -33,15 +35,11 @@ fn e2e_suite_default_is_not_run() {
 #[test]
 #[ignore = "live Compose POC vertical slice; run with --ignored and MARKHAND_E2E=1"]
 fn e2e_live_vertical_slice() {
-    // Opt-in operator gate: only exercised under MARKHAND_E2E=1. Absent the flag
-    // (e.g. the rust-integration CI job that runs `--include-ignored` with a live
-    // database but no live-evidence opt-in), skip gracefully instead of failing —
-    // mirroring the DB-gated tests' `else { return }` idiom, per this suite's own
-    // "only runs with --ignored under MARKHAND_E2E=1" contract.
-    if std::env::var("MARKHAND_E2E").ok().as_deref() != Some("1") {
-        eprintln!("e2e_live_vertical_slice: skipped (set MARKHAND_E2E=1 for the live suite)");
-        return;
-    }
+    assert_eq!(
+        std::env::var("MARKHAND_E2E").ok().as_deref(),
+        Some("1"),
+        "e2e_live_vertical_slice requires MARKHAND_E2E=1; CI must --skip this test under plain --include-ignored"
+    );
     let database = std::env::var("MARKHAND_TEST_DATABASE_URL")
         .expect("MARKHAND_E2E=1 requires MARKHAND_TEST_DATABASE_URL");
     assert!(

--- a/crates/server/tests/index_worker.rs
+++ b/crates/server/tests/index_worker.rs
@@ -3,22 +3,30 @@
 //! These tests require PostgreSQL, MinIO, and Qdrant. They use a local
 //! OpenAI-compatible mock for embeddings and are explicitly ignored unless
 //! the live storage environment is configured.
+//!
+//! Database access runs as non-superuser `markhand_app` (FORCE RLS).
+
+mod common;
 
 use bytes::Bytes;
+use common::{
+    admin_database_url, app_database_url, assert_markhand_app_role, boot_app_pool,
+    DualRoleEphemeralDb,
+};
 use deadpool_postgres::Pool;
 use fileconv_knowledge::embedding::{EmbeddingPlan, ProviderDeployment, RUNTIME_VLLM_LOCAL};
 use fileconv_server::auth::context::OrgContext;
 use fileconv_server::config::{MinioConfig, Profile, SecretString};
-use fileconv_server::database::apply_migrations;
 use fileconv_server::db::collections::{self, NewCollection};
 use fileconv_server::db::documents::{self, NewDocument};
 use fileconv_server::db::models::{ArtifactKind, CollectionVisibility, DocumentState};
 use fileconv_server::db::orgs;
-use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::db::pool::with_org_txn;
 use fileconv_server::jobs::{self, EventPayload, CURRENT_EVENT_PAYLOAD_VERSION};
 use fileconv_server::services::chunking::prepare_chunks;
 use fileconv_server::services::embedding::ApprovedEmbeddingRuntime;
 use fileconv_server::services::indexing::IndexingOutboxSink;
+use fileconv_server::services::lifecycle;
 use fileconv_server::storage::minio::{MinioClient, ObjectIdentityMeta};
 use fileconv_server::storage::qdrant::{
     point_id_from_org_collection_and_chunk, ChunkPointPayload, QdrantClient, UpsertPoint,
@@ -37,15 +45,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
-use tokio_postgres::NoTls;
 use uuid::Uuid;
-
-fn test_database_url() -> Result<String, String> {
-    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
-        Ok(url) if !url.trim().is_empty() => Ok(url),
-        _ => Err("MARKHAND_TEST_DATABASE_URL is required".into()),
-    }
-}
 
 fn test_minio_client() -> Result<MinioClient, String> {
     let endpoint = match std::env::var("MARKHAND_TEST_MINIO_ENDPOINT") {
@@ -211,68 +211,8 @@ fn read_http_request(stream: &mut TcpStream) -> Vec<u8> {
     }
 }
 
-fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
-    let (without_query, query) = match base_url.split_once('?') {
-        Some((head, tail)) => (head, Some(tail)),
-        None => (base_url, None),
-    };
-    let prefix = without_query
-        .rsplit_once('/')
-        .map(|(head, _)| head)
-        .expect("database URL must include a path");
-    match query {
-        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
-        None => format!("{prefix}/{database_name}"),
-    }
-}
-
-async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
-    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
-        .await
-        .unwrap_or_else(|error| panic!("database connection failed: {error}"));
-    tokio::spawn(async move {
-        let _ = connection.await;
-    });
-    client
-}
-
-struct EphemeralDb {
-    admin_url: String,
-    db_name: String,
-    url: String,
-}
-
-impl EphemeralDb {
-    async fn create(base_url: &str) -> Self {
-        let db_name = format!("markhand_index_worker_{}", Uuid::new_v4().simple());
-        let admin_url = rewrite_database_url(base_url, "postgres");
-        let admin = connect_raw(&admin_url).await;
-        admin
-            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
-            .await
-            .expect("CREATE DATABASE");
-        Self {
-            admin_url,
-            db_name: db_name.clone(),
-            url: rewrite_database_url(base_url, &db_name),
-        }
-    }
-
-    async fn drop(self) {
-        let admin = connect_raw(&self.admin_url).await;
-        let _ = admin
-            .batch_execute(&format!(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
-            ))
-            .await;
-    }
-}
-
 struct LiveEnv {
-    db: EphemeralDb,
+    db: DualRoleEphemeralDb,
     pool: Pool,
     storage: MinioClient,
     qdrant: QdrantClient,
@@ -281,32 +221,85 @@ struct LiveEnv {
 
 impl LiveEnv {
     async fn boot() -> Result<Self, String> {
-        let base_url = test_database_url()?;
+        let admin_url = admin_database_url()
+            .ok_or_else(|| "MARKHAND_TEST_DATABASE_URL is required".to_string())?;
+        let app_url = app_database_url()
+            .ok_or_else(|| "MARKHAND_TEST_APP_DATABASE_URL is required".to_string())?;
         let storage = test_minio_client()?;
         let qdrant = test_qdrant_client()?;
         storage
             .ensure_bucket()
             .await
             .map_err(|error| format!("ensure test bucket: {error}"))?;
-        let db = EphemeralDb::create(&base_url).await;
-        apply_migrations(&db.url)
-            .await
-            .map_err(|error| format!("apply test migrations: {error}"))?;
-        let pool = create_pool(&db.url).map_err(|error| format!("create test pool: {error}"))?;
+        let (db, pool) = boot_app_pool(&admin_url, &app_url).await;
+        assert_markhand_app_role(&pool).await;
         let ctx = OrgContext::try_new(Uuid::new_v4(), Uuid::new_v4(), ["doc.upload"], [])
             .map_err(|error| format!("create test org context: {error}"))?;
-        Ok(Self {
+        let env = Self {
             db,
             pool,
             storage,
             qdrant,
             ctx,
-        })
+        };
+        assert_cross_org_raw_query_is_zero(&env).await;
+        Ok(env)
     }
 
     async fn drop(self) {
         self.db.drop().await;
     }
+}
+
+async fn assert_cross_org_raw_query_is_zero(env: &LiveEnv) {
+    let other = OrgContext::try_new(Uuid::new_v4(), Uuid::new_v4(), ["doc.upload"], [])
+        .expect("other org context");
+    let other_collection = Uuid::new_v4();
+    with_org_txn(&env.pool, &other, {
+        let ctx = other.clone();
+        move |txn| {
+            Box::pin(async move {
+                orgs::ensure_exists(txn, &ctx, "other-org", "Other Org").await?;
+                orgs::ensure_user(txn, &ctx, ctx.user_id(), "other@example.test", "Other").await?;
+                orgs::ensure_membership(txn, &ctx).await?;
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: other_collection,
+                        name: "other",
+                        slug: "other",
+                        description: None,
+                        visibility: CollectionVisibility::Private,
+                    },
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed other org");
+    let visible: i64 = with_org_txn(&env.pool, &env.ctx, {
+        let other_org = other.org_id();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint FROM collections WHERE org_id = $1",
+                        &[&other_org],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("cross-org probe");
+    assert_eq!(
+        visible, 0,
+        "app-role FORCE RLS must hide other-org rows from raw queries"
+    );
 }
 
 async fn seed_converted_document(
@@ -579,6 +572,20 @@ async fn seed_promoted_current_version(
                     &[&ctx.org_id(), &document_id, &version_id],
                 )
                 .await?;
+                // Same durable enqueue path production promotion uses: lifecycle
+                // refresh for the demoted version in the pointer-swap transaction.
+                lifecycle::enqueue_refresh_within_txn(
+                    txn,
+                    &ctx,
+                    document_id,
+                    collection_id,
+                    previous_version_id,
+                    version_id,
+                )
+                .await
+                .map_err(|error| {
+                    fileconv_server::db::error::DbError::Config(format!("{error:?}"))
+                })?;
                 let payload = EventPayload {
                     job_id: None,
                     document_id: Some(document_id),
@@ -690,6 +697,212 @@ async fn index_job_count(env: &LiveEnv) -> i64 {
     })
     .await
     .expect("index job count")
+}
+
+async fn lifecycle_job_count(env: &LiveEnv) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM jobs
+                         WHERE org_id = $1 AND job_type = 'lifecycle_refresh'",
+                        &[&ctx.org_id()],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("lifecycle job count")
+}
+
+async fn lifecycle_job_succeeded_count(env: &LiveEnv) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM jobs
+                         WHERE org_id = $1
+                           AND job_type = 'lifecycle_refresh'
+                           AND status = 'succeeded'",
+                        &[&ctx.org_id()],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("lifecycle succeeded count")
+}
+
+async fn lifecycle_job_generation_ids(env: &LiveEnv) -> Vec<Uuid> {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let rows = txn
+                    .query(
+                        "SELECT DISTINCT (payload->>'index_metadata_id')::uuid AS generation_id
+                         FROM jobs
+                         WHERE org_id = $1 AND job_type = 'lifecycle_refresh'
+                         ORDER BY generation_id",
+                        &[&ctx.org_id()],
+                    )
+                    .await?;
+                Ok(rows
+                    .iter()
+                    .map(|row| row.get::<_, Uuid>("generation_id"))
+                    .collect::<Vec<_>>())
+            })
+        }
+    })
+    .await
+    .expect("lifecycle generation ids")
+}
+
+async fn lifecycle_pending_count(env: &LiveEnv) -> i64 {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint
+                         FROM jobs
+                         WHERE org_id = $1
+                           AND job_type = 'lifecycle_refresh'
+                           AND status = 'pending'",
+                        &[&ctx.org_id()],
+                    )
+                    .await?;
+                Ok(row.get(0))
+            })
+        }
+    })
+    .await
+    .expect("lifecycle pending count")
+}
+
+/// Materializes version chunks under a second (inactive) generation so promotion
+/// enqueues one lifecycle job per generation.
+async fn materialize_second_generation_for_version(
+    env: &LiveEnv,
+    collection_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    markdown: &str,
+) -> Uuid {
+    let chunks = prepare_chunks(document_id, version_id, markdown, "");
+    let second_generation = Uuid::new_v4();
+    let second_collection = Uuid::new_v4();
+    let signature = "f".repeat(64);
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                // Second collection + inactive generation (distinct Qdrant routing key).
+                let collection_name = format!("Second Gen {second_collection}");
+                let collection_slug = format!("second-gen-{second_collection}");
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: second_collection,
+                        name: &collection_name,
+                        slug: &collection_slug,
+                        description: None,
+                        visibility: CollectionVisibility::Private,
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO index_metadata (
+                        id, org_id, collection_id, index_signature_sha256, embedding_family,
+                        embedding_revision, dimensions, runtime_path, generation, is_active, state
+                     ) VALUES (
+                        $1, $2, $3, $4, 'test', 'r1', 8, 'vllm-local', 1, false, 'retired'
+                     )",
+                    &[
+                        &second_generation,
+                        &ctx.org_id(),
+                        &second_collection,
+                        &signature,
+                    ],
+                )
+                .await?;
+                for (ordinal, chunk) in chunks.iter().enumerate() {
+                    let ordinal = i32::try_from(ordinal).expect("ordinal");
+                    txn.execute(
+                        "INSERT INTO chunks (
+                            id, org_id, document_id, version_id, ordinal, body,
+                            chunk_identity_sha256, index_metadata_id, index_signature, tsv
+                         ) VALUES (
+                            $1, $2, $3, $4, $5, $6, $7, $8, $9,
+                            to_tsvector('simple', $6)
+                         )",
+                        &[
+                            &Uuid::new_v4(),
+                            &ctx.org_id(),
+                            &document_id,
+                            &version_id,
+                            &ordinal,
+                            &chunk.body,
+                            &chunk.chunk_identity,
+                            &second_generation,
+                            &signature,
+                        ],
+                    )
+                    .await?;
+                }
+                let _ = collection_id;
+                Ok(second_generation)
+            })
+        }
+    })
+    .await
+    .expect("materialize second generation")
+}
+
+async fn reset_lifecycle_job_to_pending(env: &LiveEnv) {
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE jobs
+                     SET status = 'pending', lease_owner = NULL, lease_expires_at = NULL,
+                         heartbeat_at = NULL, available_at = clock_timestamp(),
+                         finished_at = NULL, last_error = NULL, updated_at = clock_timestamp()
+                     WHERE org_id = $1 AND job_type = 'lifecycle_refresh'",
+                    &[&ctx.org_id()],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("reset lifecycle job");
+}
+
+async fn drain_index_and_lifecycle(env: &LiveEnv, worker: &IndexWorker) {
+    for _ in 0..16 {
+        match worker.run_once(&env.ctx).await.expect("drain run") {
+            IndexWorkerRun::NoJob => return,
+            IndexWorkerRun::Completed { .. }
+            | IndexWorkerRun::Failed { .. }
+            | IndexWorkerRun::LeaseLost { .. } => {}
+        }
+    }
+    panic!("index/lifecycle worker did not drain");
 }
 
 async fn chunk_count(env: &LiveEnv, version_id: Uuid) -> i64 {
@@ -1040,17 +1253,6 @@ async fn live_index_worker_indexes_converted_document() {
 #[tokio::test]
 #[ignore = "requires MARKHAND_TEST_DATABASE_URL, MARKHAND_TEST_MINIO_*, and MARKHAND_TEST_QDRANT_URL"]
 async fn live_index_worker_replay_is_idempotent() {
-    // QUARANTINED — opt in with MARKHAND_INDEX_WORKER_LIVE=1.
-    // This surfaces a real, unfixed index-worker bug (pre-existing; never ran in CI
-    // until the rust-integration job): replaying an already-indexed version does not
-    // yield IndexVersionOutcome::AlreadyIndexed, so run_once returns chunks>0 instead
-    // of the expected Completed { chunks: 0 }. Gated (not deleted) so the integration
-    // gate stays green for the rest of the suite while the indexing owner fixes the
-    // AlreadyIndexed detection in indexing::index_version. Remove the gate with the fix.
-    if std::env::var("MARKHAND_INDEX_WORKER_LIVE").ok().as_deref() != Some("1") {
-        eprintln!("skipped: quarantined known-failing (replay idempotency); set MARKHAND_INDEX_WORKER_LIVE=1 to run");
-        return;
-    }
     let env = match LiveEnv::boot().await {
         Ok(env) => env,
         Err(error) => {
@@ -1135,19 +1337,8 @@ async fn live_index_worker_signature_mismatch_fails_closed() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL, MARKHAND_TEST_MINIO_*, and MARKHAND_TEST_QDRANT_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL, MARKHAND_TEST_MINIO_*, and MARKHAND_TEST_QDRANT_URL"]
 async fn live_index_worker_stale_version_does_not_mark_current_indexed() {
-    // QUARANTINED — opt in with MARKHAND_INDEX_WORKER_LIVE=1.
-    // This surfaces a real, unfixed index-worker bug (pre-existing; never ran in CI
-    // until the rust-integration job): a stale/superseded version's Qdrant points are
-    // not written with is_current=false && is_effective=false, so the staleness-flag
-    // assertion fails. Gated (not deleted) so the integration gate stays green for the
-    // rest of the suite while the indexing owner fixes the point-payload staleness
-    // marking. Remove the gate with the fix.
-    if std::env::var("MARKHAND_INDEX_WORKER_LIVE").ok().as_deref() != Some("1") {
-        eprintln!("skipped: quarantined known-failing (stale-version flags); set MARKHAND_INDEX_WORKER_LIVE=1 to run");
-        return;
-    }
     let env = match LiveEnv::boot().await {
         Ok(env) => env,
         Err(error) => {
@@ -1174,21 +1365,27 @@ async fn live_index_worker_stale_version_does_not_mark_current_indexed() {
         DocumentState::Indexed
     );
 
+    // Natural A→B: promote B (durably enqueues lifecycle_refresh for A) without
+    // resetting A's succeeded index job. Fairness may claim lifecycle before
+    // index B, so drain both job types then embeddings.
     let version_b =
         seed_promoted_current_version(&env, document_id, collection_id, version_a, markdown_b)
             .await;
-    reset_index_job_for_version(&env, version_a).await;
+    assert_eq!(lifecycle_job_count(&env).await, 1);
     relay(&env, &embedding_plan).await;
-
-    let stale_run = worker.run_once(&env.ctx).await.expect("stale run");
-    assert!(matches!(
-        stale_run,
-        IndexWorkerRun::Completed { chunks, .. } if chunks == prepare_chunks(document_id, version_a, markdown_a, "").len()
-    ));
+    drain_index_and_lifecycle(&env, &worker).await;
+    run_embedding_jobs(&env, &embedding_worker).await;
+    drain_index_and_lifecycle(&env, &worker).await;
     assert_eq!(
         document_state(&env, document_id).await,
-        DocumentState::Converted
+        DocumentState::Indexed
     );
+    assert_eq!(lifecycle_job_succeeded_count(&env).await, 1);
+    assert_eq!(
+        chunk_count(&env, version_b).await,
+        prepare_chunks(document_id, version_b, markdown_b, "").len() as i64
+    );
+
     let points_a = fetched_points(
         &env,
         &embedding_plan,
@@ -1202,17 +1399,6 @@ async fn live_index_worker_stale_version_does_not_mark_current_indexed() {
     assert!(points_a
         .iter()
         .all(|(_, payload)| !payload.is_current && !payload.is_effective));
-
-    let current_run = worker.run_once(&env.ctx).await.expect("current run");
-    assert!(matches!(
-        current_run,
-        IndexWorkerRun::Completed { chunks, .. } if chunks == prepare_chunks(document_id, version_b, markdown_b, "").len()
-    ));
-    run_embedding_jobs(&env, &embedding_worker).await;
-    assert_eq!(
-        document_state(&env, document_id).await,
-        DocumentState::Indexed
-    );
     let points_b = fetched_points(
         &env,
         &embedding_plan,
@@ -1284,6 +1470,560 @@ async fn live_index_worker_resumes_from_indexing_state() {
     assert_eq!(
         document_state(&env, document_id).await,
         DocumentState::Indexed
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL, MARKHAND_TEST_MINIO_*, and MARKHAND_TEST_QDRANT_URL"]
+async fn live_qdrant_set_payload_mixed_scope_ids_only_target_changes() {
+    let env = match LiveEnv::boot().await {
+        Ok(env) => env,
+        Err(error) => {
+            eprintln!("skipped: {error}");
+            return;
+        }
+    };
+    let embedding_plan = test_embedding_plan("http://embedding.test/v1");
+    let signature = embedding_plan.index_signature(8).unwrap();
+    let collection_name = env
+        .qdrant
+        .ensure_collection_for_signature(&signature)
+        .await
+        .expect("ensure collection");
+
+    let org = env.ctx.org_id();
+    let other_org = Uuid::new_v4();
+    let collection = Uuid::new_v4();
+    let other_collection = Uuid::new_v4();
+    let document = Uuid::new_v4();
+    let version_target = Uuid::new_v4();
+    let version_other = Uuid::new_v4();
+    let id_target = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let id_other_version = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let id_other_collection = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    let id_other_org = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    let point_target =
+        point_id_from_org_collection_and_chunk(org, collection, id_target).expect("target");
+    let point_other_version =
+        point_id_from_org_collection_and_chunk(org, collection, id_other_version)
+            .expect("other version");
+    let point_other_collection =
+        point_id_from_org_collection_and_chunk(org, other_collection, id_other_collection)
+            .expect("other collection");
+    let point_other_org =
+        point_id_from_org_collection_and_chunk(other_org, collection, id_other_org)
+            .expect("other org");
+    let vector = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    let points = [
+        (org, collection, id_target, document, version_target),
+        (org, collection, id_other_version, document, version_other),
+        (
+            org,
+            other_collection,
+            id_other_collection,
+            document,
+            version_target,
+        ),
+        (
+            other_org,
+            collection,
+            id_other_org,
+            document,
+            version_target,
+        ),
+    ];
+    for (scope_org, scope_col, identity, document_id, version_id) in points {
+        env.qdrant
+            .upsert_points(
+                &collection_name,
+                &VectorScope::new(scope_org, [scope_col]),
+                &[UpsertPoint {
+                    chunk_identity: identity.into(),
+                    vector: vector.clone(),
+                    payload: ChunkPointPayload {
+                        org_id: scope_org,
+                        collection_id: scope_col,
+                        document_id,
+                        version_id,
+                        chunk_id: identity.into(),
+                        ordinal: 0,
+                        is_current: true,
+                        is_effective: true,
+                        index_generation: 1,
+                    },
+                }],
+            )
+            .await
+            .expect("upsert mixed-scope point");
+    }
+
+    // Mixed has_id set: only target must change when org/collection/version filter holds.
+    // Dropping version_id would flip same-org/collection other-version; body `points`
+    // without filter would flip foreign IDs — both regressions fail this assertion.
+    let mixed_ids = [
+        point_target,
+        point_other_version,
+        point_other_collection,
+        point_other_org,
+    ];
+    env.qdrant
+        .set_payload_fields(
+            &collection_name,
+            &VectorScope::new(org, [collection]),
+            &mixed_ids,
+            &json!({ "is_current": false, "is_effective": false }),
+            &[json!({
+                "key": "version_id",
+                "match": { "value": version_target.to_string() }
+            })],
+        )
+        .await
+        .expect("mixed-scope filter-only update");
+
+    let target = env
+        .qdrant
+        .get_points(
+            &collection_name,
+            &VectorScope::new(org, [collection]),
+            &[point_target],
+        )
+        .await
+        .expect("get target");
+    assert_eq!(target.len(), 1);
+    assert!(!target[0].1.is_current && !target[0].1.is_effective);
+
+    let other_version = env
+        .qdrant
+        .get_points(
+            &collection_name,
+            &VectorScope::new(org, [collection]),
+            &[point_other_version],
+        )
+        .await
+        .expect("get other version");
+    assert!(
+        other_version[0].1.is_current && other_version[0].1.is_effective,
+        "other version must stay current when version filter is present"
+    );
+
+    let other_collection_pts = env
+        .qdrant
+        .get_points(
+            &collection_name,
+            &VectorScope::new(org, [other_collection]),
+            &[point_other_collection],
+        )
+        .await
+        .expect("get other collection");
+    assert!(other_collection_pts[0].1.is_current && other_collection_pts[0].1.is_effective);
+
+    let other_org_pts = env
+        .qdrant
+        .get_points(
+            &collection_name,
+            &VectorScope::new(other_org, [collection]),
+            &[point_other_org],
+        )
+        .await
+        .expect("get other org");
+    assert!(other_org_pts[0].1.is_current && other_org_pts[0].1.is_effective);
+    env.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL, MARKHAND_TEST_MINIO_*, and MARKHAND_TEST_QDRANT_URL"]
+async fn live_lifecycle_refresh_retries_converge_without_losing_work() {
+    let env = match LiveEnv::boot().await {
+        Ok(env) => env,
+        Err(error) => {
+            eprintln!("skipped: {error}");
+            return;
+        }
+    };
+    let provider = MockEmbeddingProvider::start();
+    let embedding_plan = test_embedding_plan(provider.base_url());
+    let markdown_a = sample_markdown();
+    let markdown_b = "# Chương II\n\nBản retry.\n\n## Điều 3\n\nNội dung.\n";
+    let (document_id, version_a, collection_id) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown_a).await;
+    relay(&env, &embedding_plan).await;
+    let worker = index_worker(&env, None, embedding_plan.clone()).expect("worker");
+    assert!(matches!(
+        worker.run_once(&env.ctx).await.expect("index a"),
+        IndexWorkerRun::Completed { .. }
+    ));
+    let embedding_worker = embedding_worker(&env, &provider).expect("embedding worker");
+    run_embedding_jobs(&env, &embedding_worker).await;
+    let _version_b =
+        seed_promoted_current_version(&env, document_id, collection_id, version_a, markdown_b)
+            .await;
+    relay(&env, &embedding_plan).await;
+    drain_index_and_lifecycle(&env, &worker).await;
+    run_embedding_jobs(&env, &embedding_worker).await;
+    drain_index_and_lifecycle(&env, &worker).await;
+    assert_eq!(lifecycle_job_succeeded_count(&env).await, 1);
+
+    // Corrupt markers, then re-queue the same durable lifecycle job and converge.
+    let points_a = fetched_points(
+        &env,
+        &embedding_plan,
+        collection_id,
+        document_id,
+        version_a,
+        markdown_a,
+    )
+    .await;
+    let point_ids = points_a.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+    let signature = embedding_plan.index_signature(8).unwrap();
+    let collection_name = env
+        .qdrant
+        .ensure_collection_for_signature(&signature)
+        .await
+        .expect("collection");
+    env.qdrant
+        .set_payload_fields(
+            &collection_name,
+            &VectorScope::new(env.ctx.org_id(), [collection_id]),
+            &point_ids,
+            &json!({ "is_current": true, "is_effective": true }),
+            &[json!({
+                "key": "version_id",
+                "match": { "value": version_a.to_string() }
+            })],
+        )
+        .await
+        .expect("corrupt markers");
+    reset_lifecycle_job_to_pending(&env).await;
+    assert!(matches!(
+        worker.run_once(&env.ctx).await.expect("lifecycle retry"),
+        IndexWorkerRun::Completed { chunks: 0, .. }
+    ));
+    let repaired = fetched_points(
+        &env,
+        &embedding_plan,
+        collection_id,
+        document_id,
+        version_a,
+        markdown_a,
+    )
+    .await;
+    assert!(repaired
+        .iter()
+        .all(|(_, payload)| !payload.is_current && !payload.is_effective));
+    assert_eq!(lifecycle_job_count(&env).await, 1);
+    env.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL, MARKHAND_TEST_MINIO_*, and MARKHAND_TEST_QDRANT_URL"]
+async fn live_replay_a_races_promotion_b_under_barrier() {
+    let env = match LiveEnv::boot().await {
+        Ok(env) => env,
+        Err(error) => {
+            eprintln!("skipped: {error}");
+            return;
+        }
+    };
+    let provider = MockEmbeddingProvider::start();
+    let embedding_plan = test_embedding_plan(provider.base_url());
+    let markdown_a = sample_markdown();
+    let markdown_b = "# Chương II\n\nBản race.\n\n## Điều 3\n\nNội dung race.\n";
+    let (document_id, version_a, collection_id) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown_a).await;
+    relay(&env, &embedding_plan).await;
+    let worker = Arc::new(index_worker(&env, None, embedding_plan.clone()).expect("worker"));
+    assert!(matches!(
+        worker.run_once(&env.ctx).await.expect("index a"),
+        IndexWorkerRun::Completed { .. }
+    ));
+    let embedding_worker = embedding_worker(&env, &provider).expect("embedding worker");
+    run_embedding_jobs(&env, &embedding_worker).await;
+
+    // Race: replay superseded A vs promoting B (lifecycle enqueue) at a barrier.
+    reset_index_job_for_version(&env, version_a).await;
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let barrier_replay = barrier.clone();
+    let worker_replay = worker.clone();
+    let ctx_replay = env.ctx.clone();
+    let replay = tokio::spawn(async move {
+        barrier_replay.wait().await;
+        worker_replay.run_once(&ctx_replay).await
+    });
+    barrier.wait().await;
+    let version_b =
+        seed_promoted_current_version(&env, document_id, collection_id, version_a, markdown_b)
+            .await;
+    let replay_outcome = replay.await.expect("join replay").expect("replay run");
+    assert!(matches!(
+        replay_outcome,
+        IndexWorkerRun::Completed { .. } | IndexWorkerRun::NoJob | IndexWorkerRun::LeaseLost { .. }
+    ));
+    relay(&env, &embedding_plan).await;
+    drain_index_and_lifecycle(&env, &worker).await;
+    run_embedding_jobs(&env, &embedding_worker).await;
+    drain_index_and_lifecycle(&env, &worker).await;
+
+    let points_a = fetched_points(
+        &env,
+        &embedding_plan,
+        collection_id,
+        document_id,
+        version_a,
+        markdown_a,
+    )
+    .await;
+    let points_b = fetched_points(
+        &env,
+        &embedding_plan,
+        collection_id,
+        document_id,
+        version_b,
+        markdown_b,
+    )
+    .await;
+    assert!(!points_a.is_empty());
+    assert!(points_a
+        .iter()
+        .all(|(_, payload)| !payload.is_current && !payload.is_effective));
+    assert!(!points_b.is_empty());
+    assert!(points_b
+        .iter()
+        .all(|(_, payload)| payload.is_current && payload.is_effective));
+    assert_eq!(
+        document_state(&env, document_id).await,
+        DocumentState::Indexed
+    );
+    env.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL, MARKHAND_TEST_MINIO_*, and MARKHAND_TEST_QDRANT_URL"]
+async fn live_promotion_enqueues_lifecycle_per_materialized_generation() {
+    let env = match LiveEnv::boot().await {
+        Ok(env) => env,
+        Err(error) => {
+            eprintln!("skipped: {error}");
+            return;
+        }
+    };
+    let provider = MockEmbeddingProvider::start();
+    let embedding_plan = test_embedding_plan(provider.base_url());
+    let markdown_a = sample_markdown();
+    let markdown_b = "# Chương II\n\nHai generation.\n\n## Điều 3\n\nNội dung.\n";
+    let (document_id, version_a, collection_id) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown_a).await;
+    relay(&env, &embedding_plan).await;
+    let worker = index_worker(&env, None, embedding_plan.clone()).expect("worker");
+    assert!(matches!(
+        worker.run_once(&env.ctx).await.expect("index a"),
+        IndexWorkerRun::Completed { .. }
+    ));
+    let embedding_worker = embedding_worker(&env, &provider).expect("embedding worker");
+    run_embedding_jobs(&env, &embedding_worker).await;
+
+    let second_generation = materialize_second_generation_for_version(
+        &env,
+        collection_id,
+        document_id,
+        version_a,
+        markdown_a,
+    )
+    .await;
+    let second_collection = with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT collection_id FROM index_metadata
+                         WHERE org_id = $1 AND id = $2",
+                        &[&ctx.org_id(), &second_generation],
+                    )
+                    .await?;
+                Ok(row.get::<_, Uuid>("collection_id"))
+            })
+        }
+    })
+    .await
+    .expect("second collection");
+
+    let second_signature = "f".repeat(64);
+    let collection_name =
+        fileconv_server::services::index_signature::collection_name_for_digest(&second_signature)
+            .expect("collection name");
+    env.qdrant
+        .ensure_collection_for_digest(&second_signature, 8, true)
+        .await
+        .expect("ensure second qdrant collection");
+
+    let chunks = prepare_chunks(document_id, version_a, markdown_a, "");
+    let vector = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    for chunk in &chunks {
+        env.qdrant
+            .upsert_points(
+                &collection_name,
+                &VectorScope::new(env.ctx.org_id(), [second_collection]),
+                &[UpsertPoint {
+                    chunk_identity: chunk.chunk_identity.clone(),
+                    vector: vector.clone(),
+                    payload: ChunkPointPayload {
+                        org_id: env.ctx.org_id(),
+                        collection_id: second_collection,
+                        document_id,
+                        version_id: version_a,
+                        chunk_id: chunk.chunk_identity.clone(),
+                        ordinal: u64::try_from(chunk.ordinal).expect("ordinal"),
+                        is_current: true,
+                        is_effective: true,
+                        index_generation: 1,
+                    },
+                }],
+            )
+            .await
+            .expect("upsert second gen point");
+    }
+
+    let version_b =
+        seed_promoted_current_version(&env, document_id, collection_id, version_a, markdown_b)
+            .await;
+    assert_eq!(lifecycle_job_count(&env).await, 2);
+    let generations = lifecycle_job_generation_ids(&env).await;
+    assert_eq!(generations.len(), 2);
+    assert!(generations.contains(&second_generation));
+
+    with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let outcomes = lifecycle::enqueue_refresh_within_txn(
+                    txn,
+                    &ctx,
+                    document_id,
+                    collection_id,
+                    version_a,
+                    version_b,
+                )
+                .await
+                .map_err(|error| {
+                    fileconv_server::db::error::DbError::Config(format!("{error:?}"))
+                })?;
+                assert_eq!(outcomes.len(), 2);
+                assert!(outcomes.iter().all(|outcome| !outcome.created));
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("idempotent re-enqueue");
+    assert_eq!(lifecycle_job_count(&env).await, 2);
+
+    relay(&env, &embedding_plan).await;
+    drain_index_and_lifecycle(&env, &worker).await;
+    run_embedding_jobs(&env, &embedding_worker).await;
+    drain_index_and_lifecycle(&env, &worker).await;
+    assert_eq!(lifecycle_job_succeeded_count(&env).await, 2);
+
+    let points_primary = fetched_points(
+        &env,
+        &embedding_plan,
+        collection_id,
+        document_id,
+        version_a,
+        markdown_a,
+    )
+    .await;
+    assert!(points_primary
+        .iter()
+        .all(|(_, payload)| !payload.is_current && !payload.is_effective));
+
+    let second_ids = chunks
+        .iter()
+        .map(|chunk| {
+            point_id_from_org_collection_and_chunk(
+                env.ctx.org_id(),
+                second_collection,
+                &chunk.chunk_identity,
+            )
+            .expect("id")
+        })
+        .collect::<Vec<_>>();
+    let points_second = env
+        .qdrant
+        .get_points(
+            &collection_name,
+            &VectorScope::new(env.ctx.org_id(), [second_collection]),
+            &second_ids,
+        )
+        .await
+        .expect("second gen points");
+    assert!(!points_second.is_empty());
+    assert!(points_second
+        .iter()
+        .all(|(_, payload)| !payload.is_current && !payload.is_effective));
+    env.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL, MARKHAND_TEST_MINIO_*, and MARKHAND_TEST_QDRANT_URL"]
+async fn live_index_worker_fairness_claims_lifecycle_within_two_run_once() {
+    let env = match LiveEnv::boot().await {
+        Ok(env) => env,
+        Err(error) => {
+            eprintln!("skipped: {error}");
+            return;
+        }
+    };
+    let provider = MockEmbeddingProvider::start();
+    let embedding_plan = test_embedding_plan(provider.base_url());
+    let markdown_a = sample_markdown();
+    let markdown_b = "# Chương II\n\nFairness.\n\n## Điều 3\n\nNội dung.\n";
+    let markdown_c = "# Chương III\n\nBacklog.\n\n## Điều 4\n\nThêm index.\n";
+
+    let (document_a, version_a, collection_a) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown_a).await;
+    relay(&env, &embedding_plan).await;
+    let worker = index_worker(&env, None, embedding_plan.clone()).expect("worker");
+    assert!(matches!(
+        worker.run_once(&env.ctx).await.expect("index a"),
+        IndexWorkerRun::Completed { .. }
+    ));
+    let embedding_worker = embedding_worker(&env, &provider).expect("embedding worker");
+    run_embedding_jobs(&env, &embedding_worker).await;
+
+    let _version_b =
+        seed_promoted_current_version(&env, document_a, collection_a, version_a, markdown_b).await;
+    let (_document_c, _version_c, _collection_c) =
+        seed_converted_document(&env.pool, &env.storage, &env.ctx, markdown_c).await;
+    relay(&env, &embedding_plan).await;
+    assert!(lifecycle_pending_count(&env).await >= 1);
+    let index_pending_before = with_org_txn(&env.pool, &env.ctx, {
+        let ctx = env.ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let row = txn
+                    .query_one(
+                        "SELECT count(*)::bigint FROM jobs
+                         WHERE org_id = $1 AND job_type = 'index' AND status = 'pending'",
+                        &[&ctx.org_id()],
+                    )
+                    .await?;
+                Ok(row.get::<_, i64>(0))
+            })
+        }
+    })
+    .await
+    .expect("index pending");
+    assert!(
+        index_pending_before >= 2,
+        "need continuous index backlog, got {index_pending_before}"
+    );
+
+    worker.run_once(&env.ctx).await.expect("run_once 1");
+    worker.run_once(&env.ctx).await.expect("run_once 2");
+    assert!(
+        lifecycle_pending_count(&env).await < lifecycle_job_count(&env).await,
+        "lifecycle must be claimed within 2 run_once despite index backlog"
     );
     env.drop().await;
 }

--- a/crates/server/tests/jobs.rs
+++ b/crates/server/tests/jobs.rs
@@ -86,14 +86,20 @@ impl EphemeralDb {
 
     async fn drop(self) {
         let admin = connect_raw(&self.admin_url).await;
-        let _ = admin
+        admin
             .batch_execute(&format!(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity                  WHERE datname = '{}' AND pid <> pg_backend_pid()",
+                self.db_name
             ))
-            .await;
+            .await
+            .unwrap_or_else(|error| panic!("terminate backends failed: {error}"));
+        admin
+            .batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+                self.db_name
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("DROP DATABASE WITH (FORCE) failed: {error}"));
     }
 }
 

--- a/crates/server/tests/quota.rs
+++ b/crates/server/tests/quota.rs
@@ -1,104 +1,32 @@
 //! Live PostgreSQL tests for P1B-I02 atomic quota admission.
 //!
-//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` is unset. These tests use the
-//! non-superuser app role and the same tenant transaction helper as production.
+//! Skips cleanly when dual-role URLs are unset. Uses non-superuser
+//! `markhand_app` so FORCE RLS tenant isolation assertions are meaningful.
+
+mod common;
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use common::{admin_database_url, app_database_url, boot_app_pool, DualRoleEphemeralDb};
 use deadpool_postgres::Pool;
 use fileconv_server::auth::context::OrgContext;
-use fileconv_server::database::apply_migrations;
 use fileconv_server::db::models::{ReservationStatus, ResourceKind};
 use fileconv_server::db::orgs;
-use fileconv_server::db::pool::{create_pool, with_org_txn};
+use fileconv_server::db::pool::with_org_txn;
 use fileconv_server::db::quota as db_quota;
 use fileconv_server::services::quota::{
     self, apply_quota_headers, QuotaDenial, QuotaError, QuotaSettlement, QuotaSnapshot,
 };
 use tokio::sync::oneshot;
-use tokio_postgres::NoTls;
 use uuid::Uuid;
 
-fn test_database_url() -> Option<String> {
-    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
-        Ok(url) if !url.trim().is_empty() => Some(url),
-        _ => {
-            eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
-            None
-        }
-    }
-}
-
-fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
-    let (without_query, query) = match base_url.split_once('?') {
-        Some((head, tail)) => (head, Some(tail)),
-        None => (base_url, None),
-    };
-    let prefix = without_query
-        .rsplit_once('/')
-        .map(|(head, _)| head)
-        .expect("database URL must include a path");
-    match query {
-        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
-        None => format!("{prefix}/{database_name}"),
-    }
-}
-
-async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
-    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
-        .await
-        .unwrap_or_else(|error| panic!("connect failed for {database_url}: {error}"));
-    tokio::spawn(async move {
-        let _ = connection.await;
-    });
-    client
-}
-
-struct EphemeralDb {
-    admin_url: String,
-    db_name: String,
-    url: String,
-}
-
-impl EphemeralDb {
-    async fn create(base_url: &str) -> Self {
-        let db_name = format!("markhand_quota_{}", Uuid::new_v4().simple());
-        let admin_url = rewrite_database_url(base_url, "postgres");
-        let admin = connect_raw(&admin_url).await;
-        admin
-            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
-            .await
-            .expect("CREATE DATABASE");
-        Self {
-            admin_url,
-            db_name: db_name.clone(),
-            url: rewrite_database_url(base_url, &db_name),
-        }
-    }
-
-    async fn drop(self) {
-        let admin = connect_raw(&self.admin_url).await;
-        let _ = admin
-            .batch_execute(&format!(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
-            ))
-            .await;
-    }
-}
-
-async fn boot_pool(base_url: &str) -> (EphemeralDb, Pool) {
-    let ephemeral = EphemeralDb::create(base_url).await;
-    apply_migrations(&ephemeral.url)
-        .await
-        .expect("apply migrations");
-    let pool = create_pool(&ephemeral.url).expect("pool");
-    (ephemeral, pool)
+async fn boot_pool() -> Option<(DualRoleEphemeralDb, Pool)> {
+    let admin = admin_database_url()?;
+    let app = app_database_url()?;
+    Some(boot_app_pool(&admin, &app).await)
 }
 
 fn ctx(org: Uuid, user: Uuid) -> OrgContext {
@@ -243,12 +171,11 @@ async fn force_expire(pool: &Pool, context: &OrgContext, key: &str) {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn concurrent_reserve_does_not_over_reserve() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let pool = Arc::new(pool);
     let context = seed_org_with_quota(
         &pool,
@@ -303,12 +230,11 @@ async fn concurrent_reserve_does_not_over_reserve() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn terminal_settlement_is_idempotent_and_typed() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let context = seed_org_with_quota(
         &pool,
         Uuid::new_v4(),
@@ -411,12 +337,11 @@ async fn terminal_settlement_is_idempotent_and_typed() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn idempotency_key_retries_create_one_reservation() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let pool = Arc::new(pool);
     let context = seed_org_with_quota(
         &pool,
@@ -492,12 +417,11 @@ async fn idempotency_key_retries_create_one_reservation() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn mismatched_and_terminal_key_reuse_is_rejected() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let context = seed_org_with_quota(
         &pool,
         Uuid::new_v4(),
@@ -614,12 +538,11 @@ async fn mismatched_and_terminal_key_reuse_is_rejected() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn concurrent_finalize_and_refund_do_not_double_apply() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let pool = Arc::new(pool);
     let context = seed_org_with_quota(
         &pool,
@@ -675,12 +598,11 @@ async fn concurrent_finalize_and_refund_do_not_double_apply() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn upload_two_resource_settlement_is_atomic() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let context = seed_org_with_quota(
         &pool,
         Uuid::new_v4(),
@@ -726,12 +648,11 @@ async fn upload_two_resource_settlement_is_atomic() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn concurrent_jobs_admission_respects_limit() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let pool = Arc::new(pool);
     let context = seed_org_with_quota(
         &pool,
@@ -783,12 +704,11 @@ async fn concurrent_jobs_admission_respects_limit() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn expired_crash_reservation_does_not_block_and_sweeps() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let context = seed_org_with_quota(
         &pool,
         Uuid::new_v4(),
@@ -855,12 +775,11 @@ async fn expired_crash_reservation_does_not_block_and_sweeps() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn finalize_waiting_on_quota_lock_uses_fresh_post_lock_clock() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let context = seed_org_with_quota(
         &pool,
         Uuid::new_v4(),
@@ -965,12 +884,11 @@ async fn finalize_waiting_on_quota_lock_uses_fresh_post_lock_clock() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn overflow_paths_reject_without_wrap_or_panic() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let context = seed_org_with_quota(
         &pool,
         Uuid::new_v4(),
@@ -1039,12 +957,11 @@ async fn overflow_paths_reject_without_wrap_or_panic() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn quota_rows_are_org_scoped_by_predicate_and_rls() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let org_a = Uuid::new_v4();
     let org_b = Uuid::new_v4();
     let ctx_a = seed_org_with_quota(

--- a/crates/server/tests/readiness_force_rls.rs
+++ b/crates/server/tests/readiness_force_rls.rs
@@ -1,55 +1,334 @@
 //! Cross-org readiness aggregates under FORCE RLS (P1B-R06).
 //!
-//! Requires `MARKHAND_TEST_DATABASE_URL` pointing at a migrated database where
-//! the app role is `markhand_app` (or the connected role can EXECUTE the
-//! SECURITY DEFINER helpers). Skips when unset.
+//! Requires dual-role URLs: admin (`MARKHAND_TEST_DATABASE_URL`) to create an
+//! ephemeral DB and seed rows, and `markhand_app` (`MARKHAND_TEST_APP_DATABASE_URL`)
+//! for FORCE RLS probes + SECURITY DEFINER helpers.
 
-use fileconv_server::database::{apply_migrations, check_connection};
+mod common;
 
-fn database_url() -> Option<String> {
-    std::env::var("MARKHAND_TEST_DATABASE_URL")
-        .ok()
-        .filter(|u| {
-            !u.is_empty() && (u.starts_with("postgres://") || u.starts_with("postgresql://"))
-        })
+use common::{
+    admin_database_url, app_database_url, assert_markhand_app_role, boot_app_pool, connect_raw,
+    drop_database_force, rewrite_database_url, DualRoleEphemeralDb,
+};
+use uuid::Uuid;
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL (markhand_app)"]
+async fn app_role_sees_two_org_generation_consistency_via_definer() {
+    let Some(admin_url) = admin_database_url() else {
+        return;
+    };
+    let Some(app_url) = app_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_app_pool(&admin_url, &app_url).await;
+    assert_markhand_app_role(&pool).await;
+
+    let org_a = Uuid::new_v4();
+    let org_b = Uuid::new_v4();
+    let org_c = Uuid::new_v4();
+    let collection_a = Uuid::new_v4();
+    let collection_b = Uuid::new_v4();
+    let collection_c = Uuid::new_v4();
+    let gen_a = Uuid::new_v4();
+    let gen_b = Uuid::new_v4();
+    let gen_b_new = Uuid::new_v4();
+    let gen_c = Uuid::new_v4();
+    let sig_b = "b".repeat(64);
+    let sig_c = "c".repeat(64);
+
+    let admin = connect_raw(&ephemeral.admin_db_url).await;
+    // Org A active@b, org B active@c → consistent(b) false until B matches.
+    admin
+        .batch_execute(&format!(
+            "
+            INSERT INTO orgs (id, slug, name) VALUES
+              ('{org_a}', 'ready-a', 'Ready A'),
+              ('{org_b}', 'ready-b', 'Ready B');
+            INSERT INTO users (id, email, display_name) VALUES
+              ('{org_a}', 'a@example.test', 'A'),
+              ('{org_b}', 'b@example.test', 'B');
+            INSERT INTO collections (
+                id, org_id, name, slug, owner_user_id, visibility
+            ) VALUES
+              ('{collection_a}', '{org_a}', 'Ready A', 'ready-a', '{org_a}', 'private'),
+              ('{collection_b}', '{org_b}', 'Ready B', 'ready-b', '{org_b}', 'private');
+            INSERT INTO index_metadata (
+                id, org_id, collection_id, index_signature_sha256, embedding_family,
+                embedding_revision, dimensions, runtime_path, generation, is_active, state
+            ) VALUES
+              ('{gen_a}', '{org_a}', '{collection_a}', '{sig_b}', 'test',
+               'r1', 8, 'vllm-local', 1, true, 'active'),
+              ('{gen_b}', '{org_b}', '{collection_b}', '{sig_c}', 'test',
+               'r1', 8, 'vllm-local', 1, true, 'active');
+            "
+        ))
+        .await
+        .expect("seed readiness generations");
+
+    let app = connect_raw(&ephemeral.app_url).await;
+    let role: String = app
+        .query_one("SELECT current_user::text", &[])
+        .await
+        .expect("current_user")
+        .get(0);
+    assert_eq!(role, "markhand_app");
+
+    // Direct table reads without app.org_id GUC must see zero rows under FORCE RLS.
+    let direct_generations: i64 = app
+        .query_one("SELECT count(*)::bigint FROM index_metadata", &[])
+        .await
+        .expect("direct generation count")
+        .get(0);
+    assert_eq!(
+        direct_generations, 0,
+        "FORCE RLS hides index_metadata without GUC"
+    );
+    let direct_fences: i64 = app
+        .query_one("SELECT count(*)::bigint FROM ops_fences", &[])
+        .await
+        .expect("direct fence count")
+        .get(0);
+    assert_eq!(direct_fences, 0, "FORCE RLS hides ops_fences without GUC");
+    let direct_jobs: i64 = app
+        .query_one("SELECT count(*)::bigint FROM jobs", &[])
+        .await
+        .expect("direct jobs count")
+        .get(0);
+    assert_eq!(direct_jobs, 0, "FORCE RLS hides jobs without GUC");
+
+    let mismatched: bool = app
+        .query_one("SELECT markhand_index_generation_consistent($1)", &[&sig_b])
+        .await
+        .expect("A=b B=c → consistent(b)")
+        .get(0);
+    assert!(
+        !mismatched,
+        "org A sig b + org B sig c must report false for expected b"
+    );
+
+    // Signature is immutable — retire B@c and insert B@b.
+    admin
+        .batch_execute(&format!(
+            "
+            UPDATE index_metadata SET is_active = false, state = 'retired'
+             WHERE id = '{gen_b}';
+            INSERT INTO index_metadata (
+                id, org_id, collection_id, index_signature_sha256, embedding_family,
+                embedding_revision, dimensions, runtime_path, generation, is_active, state
+            ) VALUES (
+                '{gen_b_new}', '{org_b}', '{collection_b}', '{sig_b}', 'test',
+                'r1', 8, 'vllm-local', 2, true, 'active'
+            );
+            "
+        ))
+        .await
+        .expect("align B to signature b");
+
+    let aligned: bool = app
+        .query_one("SELECT markhand_index_generation_consistent($1)", &[&sig_b])
+        .await
+        .expect("aligned A+B")
+        .get(0);
+    assert!(aligned, "after B→b, consistent(b) must be true");
+
+    // Contract: org with index_metadata but no matching active generation → false.
+    admin
+        .batch_execute(&format!(
+            "
+            INSERT INTO orgs (id, slug, name) VALUES ('{org_c}', 'ready-c', 'Ready C');
+            INSERT INTO users (id, email, display_name)
+             VALUES ('{org_c}', 'c@example.test', 'C');
+            INSERT INTO collections (
+                id, org_id, name, slug, owner_user_id, visibility
+            ) VALUES (
+                '{collection_c}', '{org_c}', 'Ready C', 'ready-c', '{org_c}', 'private'
+            );
+            INSERT INTO index_metadata (
+                id, org_id, collection_id, index_signature_sha256, embedding_family,
+                embedding_revision, dimensions, runtime_path, generation, is_active, state
+            ) VALUES (
+                '{gen_c}', '{org_c}', '{collection_c}', '{sig_b}', 'test',
+                'r1', 8, 'vllm-local', 1, false, 'retired'
+            );
+            "
+        ))
+        .await
+        .expect("seed org C without active generation");
+
+    let missing_active: bool = app
+        .query_one("SELECT markhand_index_generation_consistent($1)", &[&sig_b])
+        .await
+        .expect("missing active")
+        .get(0);
+    assert!(
+        !missing_active,
+        "org with only retired generation must report false"
+    );
+
+    admin
+        .batch_execute(&format!(
+            "UPDATE index_metadata SET is_active = true, state = 'active'
+             WHERE id = '{gen_c}'"
+        ))
+        .await
+        .expect("activate C");
+
+    let consistent: bool = app
+        .query_one("SELECT markhand_index_generation_consistent($1)", &[&sig_b])
+        .await
+        .expect("all orgs active@b")
+        .get(0);
+    assert!(
+        consistent,
+        "after C gains active@b, consistent(b) must be true"
+    );
+
+    let fence_before: bool = app
+        .query_one("SELECT markhand_any_blocking_fence_active()", &[])
+        .await
+        .expect("fence before")
+        .get(0);
+    assert!(!fence_before, "no blocking fence initially");
+
+    admin
+        .batch_execute(
+            "INSERT INTO ops_fences (name, reason, active)
+             VALUES ('restore', 'readiness-test', true)
+             ON CONFLICT (name) DO UPDATE
+             SET reason = EXCLUDED.reason, active = true, cleared_at = NULL",
+        )
+        .await
+        .expect("activate fence");
+    let fence_active: bool = app
+        .query_one("SELECT markhand_any_blocking_fence_active()", &[])
+        .await
+        .expect("fence active")
+        .get(0);
+    assert!(fence_active, "blocking fence must report true");
+
+    admin
+        .batch_execute(
+            "UPDATE ops_fences
+             SET active = false, cleared_at = clock_timestamp()
+             WHERE name = 'restore'",
+        )
+        .await
+        .expect("clear fence");
+    let fence_cleared: bool = app
+        .query_one("SELECT markhand_any_blocking_fence_active()", &[])
+        .await
+        .expect("fence cleared")
+        .get(0);
+    assert!(!fence_cleared, "cleared fence must report false");
+
+    let reconcile_before: bool = app
+        .query_one("SELECT markhand_any_reconcile_running()", &[])
+        .await
+        .expect("reconcile before")
+        .get(0);
+    assert!(!reconcile_before, "no reconcile job initially");
+
+    admin
+        .batch_execute(&format!(
+            "INSERT INTO jobs (
+                id, org_id, job_type, status, idempotency_key, document_id, version_id, payload
+             ) VALUES (
+                '{job}', '{org_a}', 'reconcile', 'running', 'ready-reconcile',
+                NULL, NULL, '{{}}'::jsonb
+             )",
+            job = Uuid::new_v4()
+        ))
+        .await
+        .expect("seed reconcile job");
+    let reconcile_running: bool = app
+        .query_one("SELECT markhand_any_reconcile_running()", &[])
+        .await
+        .expect("reconcile running")
+        .get(0);
+    assert!(reconcile_running, "running reconcile must report true");
+
+    admin
+        .batch_execute(
+            "UPDATE jobs SET status = 'succeeded', finished_at = clock_timestamp()
+             WHERE job_type = 'reconcile' AND status = 'running'",
+        )
+        .await
+        .expect("finish reconcile");
+    let reconcile_done: bool = app
+        .query_one("SELECT markhand_any_reconcile_running()", &[])
+        .await
+        .expect("reconcile done")
+        .get(0);
+    assert!(!reconcile_done, "finished reconcile must report false");
+
+    ephemeral.drop().await;
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL with markhand_app role"]
-async fn app_role_sees_two_org_generation_consistency_via_definer() {
-    let Some(url) = database_url() else {
-        eprintln!("skipped: MARKHAND_TEST_DATABASE_URL unset");
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL (markhand_app)"]
+async fn ephemeral_drop_database_with_force_removes_pg_database() {
+    let Some(admin_url) = admin_database_url() else {
         return;
     };
-    apply_migrations(&url).await.expect("migrations");
-    check_connection(&url).await.expect("connect");
-
-    let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
-        .await
-        .expect("pg connect");
-    tokio::spawn(async move {
-        let _ = connection.await;
-    });
-
-    // Functions must be callable without setting app.org_id (cross-org aggregate).
-    let ok: bool = client
+    let Some(app_url) = app_database_url() else {
+        return;
+    };
+    let ephemeral = DualRoleEphemeralDb::create(&admin_url, &app_url).await;
+    let db_name = ephemeral.db_name().to_string();
+    let maintenance = rewrite_database_url(&admin_url, "postgres");
+    let admin = connect_raw(&maintenance).await;
+    let present: bool = admin
         .query_one(
-            "SELECT markhand_index_generation_consistent($1)",
-            &[&"a".repeat(64)],
+            "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)",
+            &[&db_name],
         )
         .await
-        .expect("definer callable")
+        .expect("pg_database present")
         .get(0);
-    let _ = ok;
-    let fence: bool = client
-        .query_one("SELECT markhand_any_blocking_fence_active()", &[])
+    assert!(present, "created ephemeral DB must appear in pg_database");
+
+    ephemeral.drop().await;
+
+    let admin = connect_raw(&maintenance).await;
+    let absent: bool = admin
+        .query_one(
+            "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)",
+            &[&db_name],
+        )
         .await
-        .expect("fence definer")
+        .expect("pg_database absent probe")
         .get(0);
-    let reconcile: bool = client
-        .query_one("SELECT markhand_any_reconcile_running()", &[])
+    assert!(
+        !absent,
+        "DROP DATABASE WITH (FORCE) must remove pg_database row"
+    );
+
+    let leftovers: i64 = admin
+        .query_one(
+            "SELECT count(*)::bigint FROM pg_database WHERE datname = $1",
+            &[&db_name],
+        )
         .await
-        .expect("reconcile definer")
+        .expect("leftover count")
         .get(0);
-    let _ = (fence, reconcile);
+    assert_eq!(leftovers, 0);
+
+    let bare_name = format!("markhand_it_{}", Uuid::new_v4().simple());
+    admin
+        .batch_execute(&format!("CREATE DATABASE \"{bare_name}\""))
+        .await
+        .expect("CREATE DATABASE bare");
+    drop_database_force(&maintenance, &bare_name)
+        .await
+        .expect("direct drop_database_force");
+    let gone: bool = admin
+        .query_one(
+            "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)",
+            &[&bare_name],
+        )
+        .await
+        .expect("bare gone")
+        .get(0);
+    assert!(!gone);
 }

--- a/crates/server/tests/repositories.rs
+++ b/crates/server/tests/repositories.rs
@@ -1,110 +1,38 @@
 //! Integration tests for OrgContext, repositories, RLS, and document state machine.
 //!
-//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` is unset (same pattern as
-//! `schema_migrations.rs`). Uses the non-superuser `markhand_app` role so FORCE
-//! RLS genuinely applies.
+//! Skips cleanly when dual-role URLs are unset. Uses the non-superuser
+//! `markhand_app` role so FORCE RLS genuinely applies.
+
+mod common;
 
 use std::sync::Arc;
 use std::time::Duration;
 
+use common::{
+    admin_database_url, app_database_url, boot_app_pool, boot_app_pool_with_max_size,
+    DualRoleEphemeralDb,
+};
 use deadpool_postgres::Pool;
 use fileconv_server::auth::context::{OrgContext, OrgContextError};
-use fileconv_server::database::apply_migrations;
 use fileconv_server::db::collections::{self, NewCollection};
 use fileconv_server::db::documents::{self, NewDocument};
 use fileconv_server::db::error::DbError;
 use fileconv_server::db::models::{CollectionVisibility, DocumentState};
 use fileconv_server::db::orgs;
-use fileconv_server::db::pool::{
-    apply_org_context, create_pool, create_pool_with_max_size, with_org_txn,
-};
+use fileconv_server::db::pool::{apply_org_context, with_org_txn};
 use fileconv_server::services::document_state;
-use tokio_postgres::NoTls;
 use uuid::Uuid;
 
-fn test_database_url() -> Option<String> {
-    match std::env::var("MARKHAND_TEST_DATABASE_URL") {
-        Ok(url) if !url.trim().is_empty() => Some(url),
-        _ => {
-            eprintln!(
-                "skipped: MARKHAND_TEST_DATABASE_URL unset — repository integration tests require PostgreSQL"
-            );
-            None
-        }
-    }
+async fn boot_pool() -> Option<(DualRoleEphemeralDb, Pool)> {
+    let admin = admin_database_url()?;
+    let app = app_database_url()?;
+    Some(boot_app_pool(&admin, &app).await)
 }
 
-fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
-    let (without_query, query) = match base_url.split_once('?') {
-        Some((head, tail)) => (head, Some(tail)),
-        None => (base_url, None),
-    };
-    let prefix = without_query
-        .rsplit_once('/')
-        .map(|(head, _)| head)
-        .expect("database URL must include a path");
-    match query {
-        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
-        None => format!("{prefix}/{database_name}"),
-    }
-}
-
-fn admin_database_url(base_url: &str) -> String {
-    rewrite_database_url(base_url, "postgres")
-}
-
-async fn connect_raw(database_url: &str) -> tokio_postgres::Client {
-    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
-        .await
-        .unwrap_or_else(|error| panic!("connect failed for {database_url}: {error}"));
-    tokio::spawn(async move {
-        let _ = connection.await;
-    });
-    client
-}
-
-struct EphemeralDb {
-    admin_url: String,
-    db_name: String,
-    url: String,
-}
-
-impl EphemeralDb {
-    async fn create(base_url: &str) -> Self {
-        let db_name = format!("markhand_it_{}", Uuid::new_v4().simple());
-        let admin_url = admin_database_url(base_url);
-        let admin = connect_raw(&admin_url).await;
-        admin
-            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
-            .await
-            .expect("CREATE DATABASE");
-        Self {
-            admin_url,
-            db_name: db_name.clone(),
-            url: rewrite_database_url(base_url, &db_name),
-        }
-    }
-
-    async fn drop(self) {
-        let admin = connect_raw(&self.admin_url).await;
-        let _ = admin
-            .batch_execute(&format!(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
-            ))
-            .await;
-    }
-}
-
-async fn boot_pool(base_url: &str) -> (EphemeralDb, Pool) {
-    let ephemeral = EphemeralDb::create(base_url).await;
-    apply_migrations(&ephemeral.url)
-        .await
-        .expect("apply migrations");
-    let pool = create_pool(&ephemeral.url).expect("create pool");
-    (ephemeral, pool)
+async fn boot_pool_sized(max_size: usize) -> Option<(DualRoleEphemeralDb, Pool)> {
+    let admin = admin_database_url()?;
+    let app = app_database_url()?;
+    Some(boot_app_pool_with_max_size(&admin, &app, max_size).await)
 }
 
 fn make_ctx(org: Uuid, user: Uuid) -> OrgContext {
@@ -179,12 +107,11 @@ fn org_context_fail_closed_on_empty_scope() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn cross_org_deny_via_predicate_and_rls() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
 
     let org_a = Uuid::new_v4();
     let user_a = Uuid::new_v4();
@@ -289,17 +216,12 @@ async fn cross_org_deny_via_predicate_and_rls() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn pool_does_not_leak_tenant_gucs() {
-    let Some(base_url) = test_database_url() else {
+    // Max size 1 forces the same physical backend connection to be reused.
+    let Some((ephemeral, pool)) = boot_pool_sized(1).await else {
         return;
     };
-    // Max size 1 forces the same physical backend connection to be reused.
-    let ephemeral = EphemeralDb::create(&base_url).await;
-    apply_migrations(&ephemeral.url)
-        .await
-        .expect("apply migrations");
-    let pool = create_pool_with_max_size(&ephemeral.url, 1).expect("pool size 1");
 
     let org_a = Uuid::new_v4();
     let user_a = Uuid::new_v4();
@@ -439,12 +361,11 @@ async fn pool_does_not_leak_tenant_gucs() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn document_state_machine_legal_illegal_and_concurrent() {
-    let Some(base_url) = test_database_url() else {
+    let Some((ephemeral, pool)) = boot_pool().await else {
         return;
     };
-    let (ephemeral, pool) = boot_pool(&base_url).await;
     let pool = Arc::new(pool);
 
     let org = Uuid::new_v4();

--- a/crates/server/tests/retrieval.rs
+++ b/crates/server/tests/retrieval.rs
@@ -76,14 +76,20 @@ impl EphemeralDb {
 
     async fn drop(self) {
         let admin = connect_raw(&self.admin_url).await;
-        let _ = admin
+        admin
             .batch_execute(&format!(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity                  WHERE datname = '{}' AND pid <> pg_backend_pid()",
+                self.db_name
             ))
-            .await;
+            .await
+            .unwrap_or_else(|error| panic!("terminate backends failed: {error}"));
+        admin
+            .batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+                self.db_name
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("DROP DATABASE WITH (FORCE) failed: {error}"));
     }
 }
 

--- a/crates/server/tests/schema_migrations.rs
+++ b/crates/server/tests/schema_migrations.rs
@@ -2,7 +2,11 @@
 //!
 //! Skips gracefully when `MARKHAND_TEST_DATABASE_URL` is unset so CI without a
 //! database stays green. Local runs must set the URL and exercise real Postgres.
+//! FORCE RLS assertions require `MARKHAND_TEST_APP_DATABASE_URL` (`markhand_app`).
 
+mod common;
+
+use common::{app_database_url, boot_app_pool};
 use fileconv_server::database::{apply_migrations, embedded_migrations, migration_checksum};
 use fileconv_server::db::models::expected_table_columns;
 use std::collections::BTreeSet;
@@ -113,14 +117,21 @@ impl EphemeralDb {
 
     async fn drop(self) {
         let admin = connect(&self.admin_url).await;
-        let _ = admin
+        admin
             .batch_execute(&format!(
                 "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
+                 WHERE datname = '{}' AND pid <> pg_backend_pid()",
+                self.db_name
             ))
-            .await;
+            .await
+            .unwrap_or_else(|error| panic!("terminate backends failed: {error}"));
+        admin
+            .batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+                self.db_name
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("DROP DATABASE WITH (FORCE) failed: {error}"));
     }
 }
 
@@ -922,14 +933,23 @@ async fn concurrent_publish_and_lineage_as_of() {
 }
 
 #[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn rls_all_tenant_tables_and_pool_context_reset() {
-    let Some(base_url) = test_database_url() else {
+    let Some(admin_url) = test_database_url() else {
         return;
     };
-    let ephemeral = EphemeralDb::create(&base_url).await;
-    apply_migrations(&ephemeral.url).await.unwrap();
-    let mut client = connect(&ephemeral.url).await;
+    let Some(app_url) = app_database_url() else {
+        return;
+    };
+    // FORCE RLS is a no-op for the compose superuser; assert as markhand_app.
+    let (ephemeral, _pool) = boot_app_pool(&admin_url, &app_url).await;
+    let mut client = connect(&ephemeral.app_url).await;
+    let role: String = client
+        .query_one("SELECT current_user", &[])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(role, "markhand_app");
 
     let org_a = Uuid::parse_str(POC_ORG).unwrap();
     let org_b = Uuid::new_v4();

--- a/crates/server/tests/uploads.rs
+++ b/crates/server/tests/uploads.rs
@@ -203,14 +203,20 @@ impl EphemeralDb {
 
     async fn drop(self) {
         let admin = connect_raw(&self.admin_url).await;
-        let _ = admin
+        admin
             .batch_execute(&format!(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity                  WHERE datname = '{}' AND pid <> pg_backend_pid()",
+                self.db_name
             ))
-            .await;
+            .await
+            .unwrap_or_else(|error| panic!("terminate backends failed: {error}"));
+        admin
+            .batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+                self.db_name
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("DROP DATABASE WITH (FORCE) failed: {error}"));
     }
 }
 

--- a/crates/server/tests/worker.rs
+++ b/crates/server/tests/worker.rs
@@ -167,14 +167,20 @@ impl EphemeralDb {
 
     async fn drop(self) {
         let admin = connect_raw(&self.admin_url).await;
-        let _ = admin
+        admin
             .batch_execute(&format!(
-                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
-                 WHERE datname = '{}' AND pid <> pg_backend_pid(); \
-                 DROP DATABASE IF EXISTS \"{}\"",
-                self.db_name, self.db_name
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity                  WHERE datname = '{}' AND pid <> pg_backend_pid()",
+                self.db_name
             ))
-            .await;
+            .await
+            .unwrap_or_else(|error| panic!("terminate backends failed: {error}"));
+        admin
+            .batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+                self.db_name
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("DROP DATABASE WITH (FORCE) failed: {error}"));
     }
 }
 
@@ -396,6 +402,7 @@ async fn enqueue_convert(
                 batch_id: None,
                 index_metadata_id: None,
                 cleanup_target_job_id: None,
+                related_version_id: None,
             },
             format!("convert-{version_id}"),
         ),
@@ -1337,6 +1344,7 @@ async fn live_convert_worker_fault_injection_rolls_back_and_retries_promotion() 
                     batch_id: None,
                     index_metadata_id: None,
                     cleanup_target_job_id: None,
+                    related_version_id: None,
                 },
                 format!("convert-fault-{fault:?}-{version_id}"),
             ),
@@ -1526,6 +1534,7 @@ async fn live_convert_worker_reconciliation_cleans_terminal_parent_leak() {
             batch_id: None,
             index_metadata_id: None,
             cleanup_target_job_id: None,
+            related_version_id: None,
         },
         format!("convert-terminal-cleanup-{version_id}"),
     );
@@ -1627,6 +1636,7 @@ async fn live_convert_worker_reconciliation_runs_with_pending_convert_work() {
                 batch_id: None,
                 index_metadata_id: None,
                 cleanup_target_job_id: None,
+                related_version_id: None,
             },
             format!("convert-fair-first-{version_id}"),
         ),
@@ -1647,6 +1657,7 @@ async fn live_convert_worker_reconciliation_runs_with_pending_convert_work() {
                 batch_id: None,
                 index_metadata_id: None,
                 cleanup_target_job_id: None,
+                related_version_id: None,
             },
             format!("convert-fair-second-{version_id}"),
         ),
@@ -1667,6 +1678,7 @@ async fn live_convert_worker_reconciliation_runs_with_pending_convert_work() {
                 batch_id: None,
                 index_metadata_id: None,
                 cleanup_target_job_id: None,
+                related_version_id: None,
             },
             format!("convert-fair-cleanup-parent-{version_id}"),
         ),
@@ -1690,6 +1702,7 @@ async fn live_convert_worker_reconciliation_runs_with_pending_convert_work() {
                 batch_id: None,
                 index_metadata_id: None,
                 cleanup_target_job_id: Some(parent.id),
+                related_version_id: None,
             },
             format!("convert.cleanup:{}", parent.id),
         ),
@@ -1864,6 +1877,7 @@ async fn live_convert_worker_reclaim_style_retry_keeps_committed_attempt_object_
                 batch_id: None,
                 index_metadata_id: None,
                 cleanup_target_job_id: None,
+                related_version_id: None,
             },
             format!("convert-reclaim-race-{version_id}"),
         ),
@@ -1972,6 +1986,7 @@ async fn live_convert_worker_barrier_reclaim_promote_before_old_compensation_kee
                 batch_id: None,
                 index_metadata_id: None,
                 cleanup_target_job_id: None,
+                related_version_id: None,
             },
             format!("convert-barrier-reclaim-{version_id}"),
         ),
@@ -2712,6 +2727,7 @@ while True:
                     batch_id: None,
                     index_metadata_id: None,
                     cleanup_target_job_id: None,
+                    related_version_id: None,
                 },
                 format!("convert-resource-{name}-{version_id}"),
             ),

--- a/crates/server/tests/worker.rs
+++ b/crates/server/tests/worker.rs
@@ -722,6 +722,51 @@ async fn make_job_available(pool: &Pool, ctx: &OrgContext, job_id: Uuid) {
     .expect("make job available");
 }
 
+async fn force_lease_expired(pool: &Pool, ctx: &OrgContext, job_id: Uuid) {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "UPDATE jobs
+                     SET lease_expires_at = clock_timestamp() - interval '1 second'
+                     WHERE org_id = $1 AND id = $2",
+                    &[&ctx.org_id(), &job_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("force lease expired");
+}
+
+async fn reclaim_job_to_pending(pool: &Pool, ctx: &OrgContext, job_id: Uuid) -> Job {
+    const MAX_ATTEMPTS: usize = 40;
+    for attempt in 0..MAX_ATTEMPTS {
+        force_lease_expired(pool, ctx, job_id).await;
+        let reclaimed = jobs::reclaim_expired(pool, ctx, 10, Duration::from_secs(1))
+            .await
+            .expect("reclaim expired");
+        if let Some(job) = reclaimed.into_iter().find(|job| job.id == job_id) {
+            assert_eq!(
+                job.status,
+                JobStatus::Pending,
+                "reclaimed job must return to pending for retry"
+            );
+            make_job_available(pool, ctx, job_id).await;
+            return get_job(pool, ctx, job_id).await;
+        }
+        tokio::time::sleep(Duration::from_millis(25 * (attempt as u64 + 1))).await;
+    }
+    let job = get_job(pool, ctx, job_id).await;
+    panic!(
+        "job {job_id} was not reclaimed to pending within retry budget; status={:?}",
+        job.status
+    );
+}
+
 async fn version_inherits_document_collection(
     pool: &Pool,
     ctx: &OrgContext,
@@ -2018,13 +2063,9 @@ async fn live_convert_worker_barrier_reclaim_promote_before_old_compensation_kee
         .await
         .expect("key A exists after stage"));
 
-    tokio::time::sleep(Duration::from_millis(1200)).await;
-    let reclaimed = jobs::reclaim_expired(&pool, &ctx, 10, Duration::from_secs(1))
-        .await
-        .expect("reclaim expired");
-    assert_eq!(reclaimed.len(), 1);
-    assert_eq!(reclaimed[0].id, job.id);
-    make_job_available(&pool, &ctx, job.id).await;
+    let reclaimed = reclaim_job_to_pending(&pool, &ctx, job.id).await;
+    assert_eq!(reclaimed.id, job.id);
+    assert_eq!(reclaimed.status, JobStatus::Pending);
 
     let worker_b = ConvertWorker::new(
         pool.clone(),
@@ -2032,10 +2073,14 @@ async fn live_convert_worker_barrier_reclaim_promote_before_old_compensation_kee
         stub_worker_config(ECHO_INPUT_SCRIPT, 50),
     )
     .expect("worker b");
-    assert!(matches!(
-        worker_b.run_once(&ctx).await.expect("worker b promote"),
-        ConvertWorkerRun::Completed { job_id, .. } if job_id == job.id
-    ));
+    let worker_b_result = worker_b.run_once(&ctx).await.expect("worker b promote");
+    assert!(
+        matches!(
+            &worker_b_result,
+            ConvertWorkerRun::Completed { job_id, .. } if *job_id == job.id
+        ),
+        "worker b promote: {worker_b_result:?}"
+    );
     let committed_key = first_markdown_artifact_key(&pool, &ctx, document_id).await;
     assert_ne!(committed_key, key_a.as_str());
     let committed = fileconv_server::storage::parse_key_for_org(&committed_key, ctx.org_id())

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -37,7 +37,12 @@ ghi trong issue đã `Done`.
 
 ### P1B-F02 — POC deployment và isolation scaffold
 
-- **Status:** Done — Docker boot + sandbox preflight evidence in `bench/markhand_web/reports/poc-f02-boot.md` (API ready, workers healthy, convert preflight ok, format smoke).
+- **Status:** In progress — #281 fixed the broken `python-slim-bookworm` digest in
+  `deploy/poc/images.lock.json` and added digest-length guards; compose/Dockerfiles
+  remain on master. Gap: `bench/markhand_web/reports/poc-f02-boot.md` is explicitly
+  **hand-authored / [Unverified]** (no machine-captured logs or `docker inspect`
+  artifacts). Do not claim Done until `deploy/scripts/poc-boot-evidence.sh` is
+  re-run on a standard Docker host and raw evidence is committed.
 - **Plan:** Pinned API/converter/index images, compose services, health/init, non-root,
   read-only, tmpfs, dropped caps, converter no-egress, resource/secret limits.
 - **Files:** `deploy/{Dockerfile.server,Dockerfile.worker,compose.poc.yml,.env.example}`,
@@ -164,7 +169,15 @@ ghi trong issue đã `Done`.
 
 ### P1B-I06 — Chunk/embedding/index worker
 
-- **Status:** done — merged to `master` (orchestrated branch, lifecycle fixes through `3af4c79`).
+- **Status:** Done — Sol R2 evidence green: multi-generation
+  `lifecycle_refresh` (one idempotent job per materialized generation; no
+  active-generation fallback); Index↔LifecycleRefresh claim fairness
+  (ConvertWorker atomic pattern); mixed-scope filter-only Qdrant update (has_id
+  + org/collection/version, no body `points`). LiveEnv dual-role
+  (`markhand_app`). Local:
+  `cargo test -p fileconv-server --test index_worker -- --include-ignored`
+  → 10 ok (natural A→B, multi-gen demote + idempotent replay, fairness ≤2
+  `run_once`, mixed-scope, race, retry).
 - **Plan:** Core chunking + knowledge identity/signature chứa `version_id`; PG
   chunks/FTS; separate embedding batches; Qdrant payload version/effective/current;
   extract typed claim key/value/unit/scope; incremental conflict candidate outbox;
@@ -172,13 +185,19 @@ ghi trong issue đã `Done`.
 - **Files:** `workers/{index,embedding}.rs`, `services/{chunking,embedding,indexing}.rs`.
 - **Depends:** I03/I05/F06 + G0-RET/G0-CAP/G1A.
 - **Acceptance/tests:** Approved signature; ≤1 replay batch; no duplicate; mismatch
-  before publish; golden/mock/backpressure/kill/consistency tests.
+  before publish; golden/mock/backpressure/kill/consistency tests;
+  `live_index_worker_replay_is_idempotent`;
+  `live_index_worker_stale_version_does_not_mark_current_indexed`.
 - **Security/migration:** Local approved embedding only; new signature=new generation.
   **Out:** user-selected models.
 
 ### P1B-I07 — Tombstone delete và reconcile
 
-- **Status:** done — merged to `master` via PR #245
+- **Status:** Done — merged via PR #245; #282 fixed reconcile audit `request_id`
+  length so `live_reconcile_repairs_orphan_vectors` /
+  `live_reconcile_dead_letter_staging_gc` pass under rust-integration. ADR 0015
+  (purge retention semantics) remains Proposed — wording follow-up only, not a
+  blocker for the delete/reconcile acceptance matrix already covered by live tests.
 - **Plan:** PG tombstone first; idempotent vector/object cleanup; dry-run/repair
   missing/orphan/stale across three stores.
 - **Files:** `workers/{delete,reconcile}.rs`, `services/{deletion,reconciliation}.rs`.
@@ -276,13 +295,13 @@ ghi trong issue đã `Done`.
 
 ### P1B-R06 — OpenAPI, rate limit và readiness
 
-- **Status:** In progress — SECURITY DEFINER readiness aggregates
-  (`markhand_index_generation_consistent` / fence/reconcile) under FORCE RLS;
-  baseline `/api/v1` IP middleware (health exempt); hard-cap rejects unseen keys
-  without insert; OpenAPI requestBody/response/multipart/SSE expanded + client
-  regenerated. Gap: live two-org app-role readiness DB proof
-  (`tests/readiness_force_rls.rs` ignored); trusted-proxy soak; full route schema
-  parity still deepening.
+- **Status:** In progress — dual-role FORCE RLS evidence closed:
+  `tests/readiness_force_rls.rs` as `markhand_app` proves direct rows without
+  GUC = 0 and SECURITY DEFINER transitions (A=b/B=c → false; B→b → true;
+  missing active generation → false; fence/reconcile true/false). Also:
+  baseline `/api/v1` IP middleware (health exempt); hard-cap rejects unseen keys;
+  OpenAPI requestBody/response/multipart/SSE expanded + client regenerated.
+  Gap: trusted-proxy soak; full route schema parity still deepening.
 - **Plan:** Complete OpenAPI/fixtures; request IDs; CORS; IP auth/user limits; quota
   metadata; live/ready/start checks.
 - **Files:** `api/openapi.rs`, OpenAPI YAML, `middleware/**`, `routes/health.rs`,

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "27e82bb906cdff3f";
+    const ROADMAP_SOURCE_HASH = "194b4d10cd49e71e";
     const phases = [
       {
         "id": "phase-f",
@@ -1127,7 +1127,7 @@
           [
             "P1B-F02",
             "POC deployment và isolation scaffold",
-            "done"
+            "in_progress"
           ],
           [
             "P1B-F03",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Makes the Phase 1B integration gate blocking and fixes the I06 lifecycle defects exposed by the live suite.

## Scope

- Add durable per-generation lifecycle-refresh jobs when a new document version is promoted
- Demote stale Qdrant payloads with tenant/collection/version-scoped filter-only updates
- Guarantee fair progress between index and lifecycle-refresh queues
- Run integration tests through a non-superuser, non-BYPASSRLS `markhand_app` role
- Remove index-worker quarantine and CI soft-fail behavior
- Strengthen two-org readiness, mixed-scope Qdrant and ephemeral database cleanup tests
- Replace a fixed-sleep convert-worker reclaim barrier with deterministic expire/reclaim polling
- Downgrade F02 until machine-captured boot evidence exists; update I06/R06 evidence accurately

## Evidence

- [x] Tests: exact blocking integration command passed, including 10 index-worker and 2 readiness live tests
- [x] Tests: full server suite, strict server/knowledge clippy and formatter passed
- [x] Tests: convert-worker barrier passed locally and under 40 parallel Composer stress iterations after the first CI run exposed a heartbeat race
- [x] Manual/benchmark/migration evidence: migration manifest, locked metadata, dependency policy, architecture and roadmap checks passed

## Boundary and security review

- [x] Dependency boundary check passed.
- [x] Tenant/ACL impact reviewed; live tests assert `markhand_app` is neither superuser nor BYPASSRLS.
- [x] Sensitive logging/secret/egress impact reviewed, or N/A.
- [x] Security review trigger checked.

## Follow-up

- [x] Catalog and roadmap updated for F02/I06/I07/R06.
- [ ] Capture machine-generated F02 boot evidence.
- [ ] Complete R06 trusted-proxy soak and full OpenAPI schema parity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f89aa-4a19-7164-a591-28ec18a7c940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f89aa-4a19-7164-a591-28ec18a7c940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

