### PR TITLE
test(core): unit test FormatKind::from_path (#285)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -360,6 +360,66 @@ fn title_from_markdown(markdown: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+
+    fn assert_format(path: &str, expected: FormatKind) {
+        assert_eq!(
+            FormatKind::from_path(Path::new(path)),
+            expected,
+            "đường dẫn {path:?} phải map tới {expected:?}"
+        );
+    }
+
+    /// from_path phải khớp đuôi file với FormatKind
+    #[test]
+    fn format_kind_from_path_maps_extensions() {
+        let cases: &[(&str, FormatKind)] = &[
+            // Office
+            ("report.pdf", FormatKind::Pdf),
+            ("REPORT.PDF", FormatKind::Pdf),
+            ("slides.pptx", FormatKind::Pptx),
+            ("doc.docx", FormatKind::Docx),
+            // Spreadsheet
+            ("a.xlsx", FormatKind::Xlsx),
+            ("b.xls", FormatKind::Xlsx),
+            ("c.xlsb", FormatKind::Xlsx),
+            ("d.ods", FormatKind::Xlsx),
+            ("e.csv", FormatKind::Csv),
+            // Web / text
+            ("page.html", FormatKind::Html),
+            ("page.htm", FormatKind::Html),
+            ("notes.txt", FormatKind::Text),
+            ("readme.md", FormatKind::Text),
+            ("app.log", FormatKind::Text),
+            ("long.markdown", FormatKind::Text),
+            // Image / audio (mẫu)
+            ("scan.png", FormatKind::Image),
+            ("photo.JPG", FormatKind::Image),
+            ("clip.mp3", FormatKind::Audio),
+            ("voice.wav", FormatKind::Audio),
+            // Unknown
+            ("Makefile", FormatKind::Unknown),
+            ("legacy.doc", FormatKind::Unknown), // .doc chưa hỗ trợ — không sniff magic-byte
+            ("archive.zip", FormatKind::Unknown),
+            ("file.tar.gz", FormatKind::Unknown), // chỉ lấy đuôi cuối "gz"
+        ];
+        for (path, expected) in cases {
+            assert_format(path, *expected);
+        }
+    }
+
+    /// Mọi đuôi trong `supported_extensions` phải được `from_path` nhận (không Unknown).
+    #[test]
+    fn supported_extensions_matches_from_path() {
+        for ext in FormatKind::supported_extensions() {
+            let path = format!("file.{ext}");
+            assert_ne!(
+                FormatKind::from_path(Path::new(&path)),
+                FormatKind::Unknown,
+                "đuôi {ext:?} có trong supported_extensions nhưng from_path trả Unknown"
+            );
+        }
+    }
 
     #[test]
     fn legacy_converter_options_exhaustive_literal_still_compiles() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -362,6 +362,47 @@ mod tests {
     use super::*;
     use std::path::Path;
 
+    /// Bảng đuôi → FormatKind; phải khớp `FormatKind::from_path` và `supported_extensions`.
+    const FROM_PATH_EXTENSION_CASES: &[(&str, FormatKind)] = &[
+        ("pdf", FormatKind::Pdf),
+        ("docx", FormatKind::Docx),
+        ("pptx", FormatKind::Pptx),
+        ("xlsx", FormatKind::Xlsx),
+        ("xls", FormatKind::Xlsx),
+        ("xlsb", FormatKind::Xlsx),
+        ("ods", FormatKind::Xlsx),
+        ("csv", FormatKind::Csv),
+        ("html", FormatKind::Html),
+        ("htm", FormatKind::Html),
+        ("txt", FormatKind::Text),
+        ("log", FormatKind::Text),
+        ("md", FormatKind::Text),
+        ("markdown", FormatKind::Text),
+        ("png", FormatKind::Image),
+        ("jpg", FormatKind::Image),
+        ("jpeg", FormatKind::Image),
+        ("webp", FormatKind::Image),
+        ("bmp", FormatKind::Image),
+        ("tif", FormatKind::Image),
+        ("tiff", FormatKind::Image),
+        ("gif", FormatKind::Image),
+        ("wav", FormatKind::Audio),
+        ("mp3", FormatKind::Audio),
+        ("m4a", FormatKind::Audio),
+        ("flac", FormatKind::Audio),
+        ("ogg", FormatKind::Audio),
+    ];
+
+    fn expected_kind_for_ext(ext: &str) -> FormatKind {
+        FROM_PATH_EXTENSION_CASES
+            .iter()
+            .find(|(e, _)| *e == ext)
+            .map(|(_, k)| *k)
+            .unwrap_or_else(|| {
+                panic!("thiếu entry cho đuôi {ext:?} trong FROM_PATH_EXTENSION_CASES")
+            })
+    }
+
     fn assert_format(path: &str, expected: FormatKind) {
         assert_eq!(
             FormatKind::from_path(Path::new(path)),
@@ -373,50 +414,41 @@ mod tests {
     /// from_path phải khớp đuôi file với FormatKind
     #[test]
     fn format_kind_from_path_maps_extensions() {
-        let cases: &[(&str, FormatKind)] = &[
-            // Office
-            ("report.pdf", FormatKind::Pdf),
-            ("REPORT.PDF", FormatKind::Pdf),
-            ("slides.pptx", FormatKind::Pptx),
-            ("doc.docx", FormatKind::Docx),
-            // Spreadsheet
-            ("a.xlsx", FormatKind::Xlsx),
-            ("b.xls", FormatKind::Xlsx),
-            ("c.xlsb", FormatKind::Xlsx),
-            ("d.ods", FormatKind::Xlsx),
-            ("e.csv", FormatKind::Csv),
-            // Web / text
-            ("page.html", FormatKind::Html),
-            ("page.htm", FormatKind::Html),
-            ("notes.txt", FormatKind::Text),
-            ("readme.md", FormatKind::Text),
-            ("app.log", FormatKind::Text),
-            ("long.markdown", FormatKind::Text),
-            // Image / audio (mẫu)
-            ("scan.png", FormatKind::Image),
-            ("photo.JPG", FormatKind::Image),
-            ("clip.mp3", FormatKind::Audio),
-            ("voice.wav", FormatKind::Audio),
-            // Unknown
-            ("Makefile", FormatKind::Unknown),
-            ("legacy.doc", FormatKind::Unknown), // .doc chưa hỗ trợ — không sniff magic-byte
-            ("archive.zip", FormatKind::Unknown),
-            ("file.tar.gz", FormatKind::Unknown), // chỉ lấy đuôi cuối "gz"
-        ];
-        for (path, expected) in cases {
-            assert_format(path, *expected);
+        for (ext, expected) in FROM_PATH_EXTENSION_CASES {
+            assert_format(&format!("file.{ext}"), *expected);
         }
+
+        // Case insensitivity (to_ascii_lowercase trên đuôi)
+        assert_format("REPORT.PDF", FormatKind::Pdf);
+        assert_format("photo.JPG", FormatKind::Image);
+
+        // Path::extension chỉ nhìn tên file cuối, không phụ thuộc thư mục
+        assert_format("docs/a/report.pdf", FormatKind::Pdf);
+
+        // Unknown / đuôi lạ
+        assert_format("Makefile", FormatKind::Unknown);
+        assert_format("legacy.doc", FormatKind::Unknown); // .doc chưa hỗ trợ — không sniff magic-byte
+        assert_format("archive.zip", FormatKind::Unknown);
+        assert_format("file.tar.gz", FormatKind::Unknown); // chỉ lấy đuôi cuối "gz"
+        assert_format("file.", FormatKind::Unknown); // Path::extension → None
     }
 
-    /// Mọi đuôi trong `supported_extensions` phải được `from_path` nhận (không Unknown).
+    /// Mọi đuôi trong `supported_extensions` phải map đúng FormatKind (không chỉ ≠ Unknown).
     #[test]
     fn supported_extensions_matches_from_path() {
         for ext in FormatKind::supported_extensions() {
-            let path = format!("file.{ext}");
-            assert_ne!(
-                FormatKind::from_path(Path::new(&path)),
-                FormatKind::Unknown,
-                "đuôi {ext:?} có trong supported_extensions nhưng from_path trả Unknown"
+            let expected = expected_kind_for_ext(ext);
+            assert_eq!(
+                FormatKind::from_path(Path::new(&format!("file.{ext}"))),
+                expected,
+                "đuôi {ext:?} phải map tới {expected:?}"
+            );
+        }
+
+        for (ext, _) in FROM_PATH_EXTENSION_CASES {
+            assert!(
+                FormatKind::supported_extensions().contains(ext),
+                "đuôi {ext:?} có trong FROM_PATH_EXTENSION_CASES nhưng thiếu trong supported_extensions"
             );
         }
     }


### PR DESCRIPTION
## Tóm tắt
Thêm unit test cho `FormatKind::from_path` — router định dạng của core.

Closes #285

## Thay đổi
- Bảng case-driven trong `crates/core/src/lib.rs` (`mod tests`)
- Test đồng bộ `supported_extensions` với `from_path`
- Không đổi mapping production

## Vì sao không sniff magic-byte?
1. **Tăng độ phức tạp** — cần bảng signature, xử lý edge case, duy trì khi thêm định dạng.
2. **File đơn giản không có magic-byte** — ví dụ `.txt`, `.csv`, `.md` là text thuần; sniffing không giúp gì.
3. **False positive** — nhiều định dạng Office (`.docx`, `.pptx`, `.xlsx`) là file ZIP bên trong; signature `PK` dễ **nhầm với `.zip`**, route sai converter.
4. **Tăng chi phí** — mỗi lần `convert_path` / `probe` phải mở/đọc file thay vì chỉ parse path; chậm hơn trên watch worker / MCP gọi hàng loạt.

**Đánh đổi:** file đặt tên sai đuôi → `Unknown`.

## Test plan
- [x] `cargo test -p fileconv-core from_path`
- [x] `cargo fmt --all -- --check`
