### PR TITLE
Web wave 0 remainder and wave 1: client, SSE, mocks, login shell, scope-safe org switch

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,6 +1,16 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './App';
+import { installMockFetch, resetMockState, uninstallMockFetch } from './mocks';
+
+const DEMO_EMAIL = 'demo@markhand.test';
+const DEMO_PASSWORD = 'demo-password';
+
+function fillAndSubmitLogin(email: string, password: string) {
+  fireEvent.change(screen.getByLabelText('Email'), { target: { value: email } });
+  fireEvent.change(screen.getByLabelText('Mật khẩu'), { target: { value: password } });
+  fireEvent.click(screen.getByRole('button', { name: 'Đăng nhập' }));
+}
 
 describe('App', () => {
   afterEach(() => {
@@ -57,13 +67,19 @@ describe('App', () => {
     expect(screen.getByRole('heading', { name: 'Trợ giúp Markhand' })).toBeVisible();
   });
 
-  it('renders the library page for a deep-linked collection path', () => {
+  it('redirects a deep-linked protected route to /login when anonymous, preserving it as ?next=', async () => {
     window.history.pushState(null, '', '/library/col-42');
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
 
     render(<App />);
 
-    expect(screen.getByRole('heading', { name: 'Bộ sưu tập col-42' })).toBeVisible();
+    await waitFor(() =>
+      expect(window.location.pathname + window.location.search).toBe(
+        '/login?next=%2Flibrary%2Fcol-42',
+      ),
+    );
+    expect(screen.getByRole('heading', { name: 'Đăng nhập vào Markhand' })).toBeVisible();
+    expect(screen.queryByRole('heading', { name: 'Bộ sưu tập col-42' })).not.toBeInTheDocument();
   });
 
   it('shows a not-found page for an unknown path and links back home', () => {
@@ -75,5 +91,98 @@ describe('App', () => {
     expect(screen.getByRole('heading', { name: 'Không tìm thấy trang' })).toBeVisible();
     fireEvent.click(screen.getByRole('link', { name: 'Về trang chính' }));
     expect(window.location.pathname).toBe('/');
+  });
+});
+
+describe('App / authenticated shell (P2-05 guard matrix + login/logout)', () => {
+  beforeEach(() => {
+    installMockFetch();
+    resetMockState();
+  });
+
+  afterEach(() => {
+    cleanup();
+    uninstallMockFetch();
+    window.sessionStorage.clear();
+    window.history.pushState(null, '', '/');
+  });
+
+  it('logs in through the real mock server, lands on the intended deep-linked route, and shows session/org in the topbar', async () => {
+    window.history.pushState(null, '', '/library/col-42');
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Đăng nhập vào Markhand' })).toBeVisible(),
+    );
+    expect(window.location.search).toBe('?next=%2Flibrary%2Fcol-42');
+
+    fillAndSubmitLogin(DEMO_EMAIL, DEMO_PASSWORD);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Bộ sưu tập col-42' })).toBeVisible(),
+    );
+    expect(screen.getByText('Demo User', { exact: false })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Đăng xuất' })).toBeVisible();
+  });
+
+  it('rejects the wrong password and never renders the protected shell', async () => {
+    window.history.pushState(null, '', '/library');
+    render(<App />);
+    await waitFor(() => expect(window.location.pathname).toBe('/login'));
+
+    fillAndSubmitLogin(DEMO_EMAIL, 'not-the-password');
+
+    await waitFor(() => expect(screen.getByText('Email hoặc mật khẩu không đúng.')).toBeVisible());
+    expect(window.location.pathname).toBe('/login');
+    expect(screen.queryByRole('button', { name: 'Đăng xuất' })).not.toBeInTheDocument();
+  });
+
+  it('logs out back to /login without leaving a half-authenticated shell', async () => {
+    window.history.pushState(null, '', '/library');
+    render(<App />);
+    await waitFor(() => expect(window.location.pathname).toBe('/login'));
+
+    fillAndSubmitLogin(DEMO_EMAIL, DEMO_PASSWORD);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Đăng xuất' })).toBeVisible());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Đăng xuất' }));
+
+    await waitFor(() => expect(window.location.pathname).toBe('/login'));
+    expect(screen.queryByRole('button', { name: 'Đăng xuất' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Đăng nhập vào Markhand' })).toBeVisible();
+  });
+
+  it('renders an in-shell notice — not the admin page, not a redirect — for a signed-in user without member.manage', async () => {
+    window.history.pushState(null, '', '/admin/members');
+    render(<App />);
+    await waitFor(() => expect(window.location.pathname).toBe('/login'));
+
+    fillAndSubmitLogin(DEMO_EMAIL, DEMO_PASSWORD);
+
+    await waitFor(() => expect(screen.getByText(/không có quyền/)).toBeVisible());
+    expect(
+      screen.queryByRole('heading', { name: 'Thành viên và vai trò' }),
+    ).not.toBeInTheDocument();
+    // Still on the admin URL — this is a render decision, the server remains the authority.
+    expect(window.location.pathname).toBe('/admin/members');
+  });
+
+  it('restores the session on unmount/remount without forcing a re-login (real page-reload-from-a-fresh-client case is covered in auth/AuthContext.test.tsx)', async () => {
+    window.history.pushState(null, '', '/library');
+    render(<App />);
+    await waitFor(() => expect(window.location.pathname).toBe('/login'));
+    fillAndSubmitLogin(DEMO_EMAIL, DEMO_PASSWORD);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Đăng xuất' })).toBeVisible());
+
+    // `App.tsx` always uses the shared `apiClient` singleton, so unmounting
+    // and remounting here does not clear its in-memory tokens the way an
+    // actual page reload (a brand-new JS heap) would — this only asserts the
+    // shell doesn't second-guess a still-valid persisted session on remount.
+    cleanup();
+    window.history.pushState(null, '', '/library');
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Đăng xuất' })).toBeVisible());
+    expect(window.location.pathname).toBe('/library');
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchReadiness, type ConnectionState } from './api/health';
-import { AuthProvider } from './auth/AuthContext';
+import { AuthProvider, useAuth } from './auth/AuthContext';
+import { ProtectedRoute, PublicOnlyRoute } from './auth/RouteGuard';
+import { Button } from './components/ui';
 import { RouteLink } from './components/RouteLink';
 import {
   AdminMembersPage,
@@ -11,7 +13,17 @@ import {
   QaPage,
 } from './pages';
 import { RouterProvider, useRouter } from './state/RouterProvider';
+import { ScopeProvider } from './state/ScopeProvider';
 import type { RouteName } from './types/routes';
+
+/**
+ * Real permission constants from plans/markhand-web/phase-1c-multi-org-security.md
+ * §P1C.2 — `member.manage` gates the members admin page. There is no
+ * documented constant yet for the usage/quota admin page (P2-12/1C haven't
+ * shipped one), so that route only requires "signed in" below rather than
+ * guessing a permission name the server may not agree with.
+ */
+const MEMBER_MANAGE_PERMISSION = 'member.manage';
 
 const navItems: Array<{ route: RouteName; to: string; label: string }> = [
   { route: 'login', to: '/login', label: 'Đăng nhập' },
@@ -43,15 +55,35 @@ function RouteOutlet() {
   const { match } = useRouter();
   switch (match.name) {
     case 'login':
-      return <LoginPage />;
+      return (
+        <PublicOnlyRoute>
+          <LoginPage />
+        </PublicOnlyRoute>
+      );
     case 'library':
-      return <LibraryPage collectionId={match.params.collectionId} />;
+      return (
+        <ProtectedRoute>
+          <LibraryPage collectionId={match.params.collectionId} />
+        </ProtectedRoute>
+      );
     case 'qa':
-      return <QaPage collectionId={match.params.collectionId} />;
+      return (
+        <ProtectedRoute>
+          <QaPage collectionId={match.params.collectionId} />
+        </ProtectedRoute>
+      );
     case 'adminMembers':
-      return <AdminMembersPage />;
+      return (
+        <ProtectedRoute permission={MEMBER_MANAGE_PERMISSION}>
+          <AdminMembersPage />
+        </ProtectedRoute>
+      );
     case 'adminUsage':
-      return <AdminUsagePage />;
+      return (
+        <ProtectedRoute>
+          <AdminUsagePage />
+        </ProtectedRoute>
+      );
     case 'help':
       return <HelpPage />;
     case 'notFound':
@@ -71,10 +103,50 @@ function RouteOutlet() {
 export function App() {
   return (
     <RouterProvider>
-      <AuthProvider>
-        <AppShell />
-      </AuthProvider>
+      <ScopeProvider>
+        <AuthProvider>
+          <AppShell />
+        </AuthProvider>
+      </ScopeProvider>
     </RouterProvider>
+  );
+}
+
+/**
+ * Session/org visibility for the shell (plan requirement: "session/org/role
+ * hiển thị rõ"). There is no single "role" the API returns — only
+ * `permissions[]` (see AuthContext.tsx) — so this surfaces the org and the
+ * permission count/list instead of inventing a role label.
+ */
+function AuthStatus() {
+  const { session, logout } = useAuth();
+  const { navigate } = useRouter();
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  if (session.status !== 'authenticated') return null;
+
+  async function handleLogout() {
+    setLoggingOut(true);
+    try {
+      await logout();
+    } finally {
+      setLoggingOut(false);
+      navigate('/login');
+    }
+  }
+
+  return (
+    <div className="session-status" role="status">
+      <span
+        className="session-identity"
+        title={`Quyền: ${session.permissions.join(', ') || '(không có)'}`}
+      >
+        {session.displayName} <span className="session-org">· org {session.orgId}</span>
+      </span>
+      <Button variant="ghost" size="sm" loading={loggingOut} onClick={() => void handleLogout()}>
+        Đăng xuất
+      </Button>
+    </div>
   );
 }
 
@@ -133,6 +205,7 @@ function AppShell() {
           <span>Markhand</span>
         </RouteLink>
         <PrimaryNav />
+        <AuthStatus />
         <span className={`connection-dot ${connection.kind}`} aria-hidden="true" />
         <span className="connection-label" role="status">
           {connection.kind === 'checking' && 'Đang kiểm tra máy chủ'}

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createApiClient } from './client';
+import { HttpApiError, NetworkError, isAbortError } from './errors';
+import type { SessionTokens } from './session';
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(body === undefined ? null : JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+function noContentResponse(status = 204): Response {
+  return new Response(null, { status });
+}
+
+function bearerOf(init: RequestInit | undefined): string | undefined {
+  const headers = init?.headers as Record<string, string> | undefined;
+  return headers?.Authorization;
+}
+
+function validTokens(overrides: Partial<SessionTokens> = {}): SessionTokens {
+  return {
+    accessToken: 'old-token',
+    refreshToken: 'refresh-1',
+    tokenType: 'Bearer',
+    expiresIn: 3600,
+    orgId: 'org-1',
+    userId: 'user-1',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('request()', () => {
+  it('prefixes business routes with /api/v1 and injects a bearer access token', async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      expect(String(input)).toBe('/api/v1/collections');
+      expect(bearerOf(init)).toBe('Bearer old-token');
+      return jsonResponse(200, { items: [], page: { hasMore: false } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+
+    const result = await client.request('get', '/collections');
+    expect(result).toEqual({ items: [], page: { hasMore: false } });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries exactly once after a 401 with a freshly refreshed token, and does not loop on a persistent 401', async () => {
+    let refreshCalls = 0;
+    let businessCallsWithNewToken = 0;
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/v1/auth/refresh') {
+        refreshCalls++;
+        return jsonResponse(
+          200,
+          validTokens({ accessToken: 'new-token', refreshToken: 'refresh-2' }),
+        );
+      }
+      if (url === '/api/v1/collections') {
+        if (bearerOf(init) === 'Bearer new-token') businessCallsWithNewToken++;
+        return jsonResponse(401, { code: 'unauthorized', message: 'expired', requestId: 'r' });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+
+    await expect(client.request('get', '/collections')).rejects.toMatchObject({ status: 401 });
+    expect(refreshCalls).toBe(1);
+    expect(businessCallsWithNewToken).toBe(1);
+    // 1 initial (old token) + 1 refresh + 1 retry (new token) = 3, never a second refresh.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('single-flights the refresh across N concurrent requests that each hit a 401, and all N succeed with the new token', async () => {
+    let refreshCalls = 0;
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/v1/auth/refresh') {
+        refreshCalls++;
+        return jsonResponse(
+          200,
+          validTokens({ accessToken: 'new-token', refreshToken: 'refresh-2' }),
+        );
+      }
+      if (url === '/api/v1/collections') {
+        if (bearerOf(init) === 'Bearer new-token') {
+          return jsonResponse(200, { items: [], page: { hasMore: false } });
+        }
+        return jsonResponse(401, { code: 'unauthorized', message: 'expired', requestId: 'r' });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+
+    const results = await Promise.all([
+      client.request('get', '/collections'),
+      client.request('get', '/collections'),
+      client.request('get', '/collections'),
+      client.request('get', '/collections'),
+    ]);
+
+    for (const result of results) {
+      expect(result).toEqual({ items: [], page: { hasMore: false } });
+    }
+    expect(refreshCalls).toBe(1);
+  });
+
+  it('rejects every concurrent request and fires onSessionLost exactly once when the refresh itself fails', async () => {
+    let refreshCalls = 0;
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url === '/api/v1/auth/refresh') {
+        refreshCalls++;
+        return jsonResponse(401, {
+          code: 'invalid_refresh_token',
+          message: 'expired',
+          requestId: 'r',
+        });
+      }
+      if (url === '/api/v1/collections') {
+        return jsonResponse(401, { code: 'unauthorized', message: 'expired', requestId: 'r' });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+    const lost = vi.fn();
+    client.tokenProvider.onSessionLost(lost);
+
+    const results = await Promise.allSettled([
+      client.request('get', '/collections'),
+      client.request('get', '/collections'),
+      client.request('get', '/collections'),
+    ]);
+
+    for (const result of results) {
+      expect(result.status).toBe('rejected');
+    }
+    expect(refreshCalls).toBe(1);
+    expect(lost).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces 429 quota metadata instead of swallowing it', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(
+        429,
+        {
+          code: 'rate_limited',
+          message: 'Too many requests',
+          requestId: 'r',
+          details: { retryAfterSeconds: 4, scope: 'user', quota: 'rate_limit' },
+        },
+        { 'Retry-After': '4' },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+
+    const error = await client.request('get', '/collections').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(HttpApiError);
+    const httpError = error as HttpApiError;
+    expect(httpError.status).toBe(429);
+    expect(httpError.rateLimit).toEqual({
+      retryAfterSeconds: 4,
+      scope: 'user',
+      quota: 'rate_limit',
+    });
+  });
+
+  it('propagates AbortError without wrapping it, and does not attempt a refresh retry', async () => {
+    const fetchMock = vi.fn(async (_input: string | URL, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        throw new DOMException('The operation was aborted.', 'AbortError');
+      }
+      return jsonResponse(200, {});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const error = await client
+      .request('get', '/collections', { signal: controller.signal })
+      .catch((e: unknown) => e);
+    expect(isAbortError(error)).toBe(true);
+    expect(error).not.toBeInstanceOf(NetworkError);
+    // Only the one aborted attempt — no refresh call was ever triggered.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps a raw fetch failure as NetworkError rather than an unhandled rejection', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+
+    const error = await client.request('get', '/collections').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(NetworkError);
+    expect((error as NetworkError).cause).toBeInstanceOf(TypeError);
+  });
+
+  it('substitutes path params and serializes query params', async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      expect(String(input)).toBe('/api/v1/collections/col-1/documents?limit=10');
+      return jsonResponse(200, { items: [], page: { hasMore: false } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+
+    await client.request('get', '/collections/{collectionId}/documents', {
+      params: { path: { collectionId: 'col-1' }, query: { limit: 10 } },
+    });
+  });
+});
+
+describe('login()', () => {
+  it('installs the returned tokens so a subsequent request is authenticated with them', async () => {
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/v1/auth/login') {
+        return jsonResponse(200, validTokens({ accessToken: 'from-login' }));
+      }
+      if (url === '/api/v1/auth/me') {
+        if (bearerOf(init) === 'Bearer from-login') {
+          return jsonResponse(200, {
+            userId: 'u',
+            orgId: 'o',
+            email: 'a@b.com',
+            displayName: 'A',
+            permissions: [],
+            allowedCollectionIds: [],
+            sessionId: 's',
+          });
+        }
+        return jsonResponse(401, { code: 'unauthorized', message: 'no', requestId: 'r' });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    const tokens = await client.login({ email: 'a@b.com', password: 'secret' });
+    expect(tokens.accessToken).toBe('from-login');
+
+    const me = await client.me();
+    expect(me.email).toBe('a@b.com');
+  });
+});
+
+describe('logout()', () => {
+  it('skips the network call and resolves when there is no session', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    await expect(client.logout()).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('always clears the local session, even when the server call fails', async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      if (String(input) === '/api/v1/auth/logout') {
+        throw new TypeError('Failed to fetch');
+      }
+      throw new Error('unexpected call');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+
+    await expect(client.logout()).rejects.toBeInstanceOf(NetworkError);
+    expect(client.sessionManager.hasSession()).toBe(false);
+  });
+
+  it('clears the session on a successful 204 and does not call it again for a second logout', async () => {
+    const fetchMock = vi.fn(async () => noContentResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = createApiClient({ baseUrl: '' });
+    client.sessionManager.setTokens(validTokens());
+
+    await client.logout();
+    expect(client.sessionManager.hasSession()).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await client.logout();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no refresh token left, no second network call
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,0 +1,292 @@
+// Typed HTTP client for the Markhand API. Every request/response shape comes
+// from `generated/contract.ts` (regenerated from the server's OpenAPI doc) —
+// nothing here hand-declares a type that file already exports.
+//
+// Responsibilities (see plans/markhand-web/phase-2-web-spa.md §P2.2):
+//   - typed request/response against `paths`/`components`;
+//   - bearer injection + single-flight refresh-on-401 (delegated to `session.ts`);
+//   - normalized `{code,message,requestId,details?}` errors (delegated to `errors.ts`);
+//   - 429 quota metadata surfaced, not swallowed;
+//   - request cancellation via `AbortSignal`.
+//
+// Business routes are served under `/api/v1` even though the paths in
+// `contract.ts` (and the OpenAPI doc itself, `servers: [{url: /api/v1}]`)
+// omit that prefix; the server mounts every route in this file with it
+// (verified in crates/server/src/routes/*.rs, e.g. `/api/v1/auth/login`).
+import type { components, paths } from './generated/contract';
+import { NetworkError, isAbortError, normalizeErrorResponse } from './errors';
+import {
+  createSessionManager,
+  type SessionManager,
+  type SessionTokens,
+  type TokenProvider,
+} from './session';
+
+const API_PREFIX = '/api/v1';
+
+type HttpMethod = 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch' | 'trace';
+
+/** Paths declared in the OpenAPI contract. */
+export type ApiPath = keyof paths;
+/**
+ * HTTP methods the contract actually declares for a given path. Every method
+ * key is always present on `paths[P]` (e.g. `get?: never`), so filtering by
+ * key name alone (`keyof paths[P]`) would accept every method for every
+ * path; the unsupported ones are excluded here by checking that the value
+ * isn't the `undefined` an unset optional method resolves to.
+ */
+export type MethodOf<P extends ApiPath> = {
+  [M in HttpMethod]: paths[P][M] extends undefined ? never : M;
+}[HttpMethod];
+type OperationOf<P extends ApiPath, M extends MethodOf<P>> = paths[P][M];
+
+type JsonRequestBodyOf<Op> = Op extends {
+  requestBody?: { content: { 'application/json': infer B } };
+}
+  ? B
+  : never;
+
+// Response status codes are numeric literal keys in the generated contract
+// (`200: {...}`), not string keys, so the "2xx" test coerces to a template
+// literal (`${K}`) before pattern-matching against `2${string}`.
+type SuccessResponseOf<Op> = Op extends { responses: infer R }
+  ? {
+      [K in keyof R]: K extends number
+        ? `${K}` extends `2${string}`
+          ? R[K] extends { content: { 'application/json': infer J } }
+            ? J
+            : void
+          : never
+        : never;
+    }[keyof R]
+  : never;
+
+type PathParamsOf<P extends ApiPath, M extends MethodOf<P>> =
+  OperationOf<P, M> extends { parameters: { path: infer PP } } ? PP : undefined;
+
+type QueryParamsOf<P extends ApiPath, M extends MethodOf<P>> =
+  OperationOf<P, M> extends { parameters: { query?: infer QP } } ? QP : undefined;
+
+// `params` (and, transitively, `params.path`) is only required at the call
+// site when the operation actually declares a path parameter — e.g.
+// `request('get', '/collections/{collectionId}', ...)` must pass
+// `params.path.collectionId`, while `request('get', '/auth/me')` needs no
+// third argument at all. Body requiredness is not similarly enforced (see
+// `JsonRequestBodyOf`) — a documented gap, not an oversight.
+type ParamsFieldFor<P extends ApiPath, M extends MethodOf<P>> =
+  PathParamsOf<P, M> extends undefined
+    ? { path?: undefined; query?: QueryParamsOf<P, M> }
+    : { path: PathParamsOf<P, M>; query?: QueryParamsOf<P, M> };
+
+type BaseRequestOptions<P extends ApiPath, M extends MethodOf<P>> = {
+  body?: JsonRequestBodyOf<OperationOf<P, M>>;
+  signal?: AbortSignal;
+};
+
+export type RequestOptions<P extends ApiPath, M extends MethodOf<P>> =
+  PathParamsOf<P, M> extends undefined
+    ? BaseRequestOptions<P, M> & { params?: ParamsFieldFor<P, M> }
+    : BaseRequestOptions<P, M> & { params: ParamsFieldFor<P, M> };
+
+/** Whether `request()`'s third argument can be omitted for a given path/method (no required path params). */
+type RequestOptionsArg<P extends ApiPath, M extends MethodOf<P>> =
+  PathParamsOf<P, M> extends undefined
+    ? [options?: RequestOptions<P, M>]
+    : [options: RequestOptions<P, M>];
+
+function substitutePath(template: string, pathParams: Record<string, unknown> | undefined): string {
+  if (!pathParams) return template;
+  return template.replace(/\{([^}]+)\}/g, (match, name: string) => {
+    if (!(name in pathParams)) return match;
+    return encodeURIComponent(String(pathParams[name]));
+  });
+}
+
+function buildQueryString(query: Record<string, unknown> | undefined): string {
+  if (!query) return '';
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null) continue;
+    search.set(key, String(value));
+  }
+  const asString = search.toString();
+  return asString.length > 0 ? `?${asString}` : '';
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  return (text.length > 0 ? JSON.parse(text) : undefined) as T;
+}
+
+export interface ApiClientOptions {
+  /** Overrides `VITE_MARKHAND_API_BASE_URL`; mainly for tests. */
+  baseUrl?: string;
+  /** Overrides the default expiry skew passed to the session manager; mainly for tests. */
+  expirySkewMs?: number;
+}
+
+export interface ApiClient {
+  /** Typed request against any path/method the OpenAPI contract declares. Requires a valid session. */
+  request<P extends ApiPath, M extends MethodOf<P>>(
+    method: M,
+    path: P,
+    ...options: RequestOptionsArg<P, M>
+  ): Promise<SuccessResponseOf<OperationOf<P, M>>>;
+  /** `POST /auth/login`. On success, installs the returned tokens into the session. */
+  login(
+    credentials: components['schemas']['LoginRequest'],
+    signal?: AbortSignal,
+  ): Promise<SessionTokens>;
+  /**
+   * `POST /auth/logout`. Best-effort: the local session is always cleared,
+   * even if the server call fails (network error or the refresh token was
+   * already invalid) — logout should always take effect client-side. Any
+   * such failure is still thrown so the caller can surface it if it wants.
+   */
+  logout(signal?: AbortSignal): Promise<void>;
+  /** `GET /auth/me`. Authenticated; participates in refresh-on-401 like any other request. */
+  me(signal?: AbortSignal): Promise<components['schemas']['MeResponse']>;
+  /** The `TokenProvider` seam handed to the SSE agent's code and to auth UI. */
+  tokenProvider: TokenProvider;
+  /** Escape hatch for auth UI/tests that need session control beyond the `TokenProvider` seam. */
+  sessionManager: SessionManager;
+}
+
+export function createApiClient(options: ApiClientOptions = {}): ApiClient {
+  const baseUrl =
+    (options.baseUrl ?? import.meta.env.VITE_MARKHAND_API_BASE_URL)?.replace(/\/$/, '') ?? '';
+
+  async function rawFetch(path: string, init: RequestInit): Promise<Response> {
+    try {
+      return await fetch(`${baseUrl}${API_PREFIX}${path}`, init);
+    } catch (cause) {
+      if (isAbortError(cause)) throw cause;
+      throw new NetworkError('Network request failed', { cause });
+    }
+  }
+
+  async function refreshViaHttp(refreshToken: string): Promise<SessionTokens> {
+    const body: components['schemas']['RefreshTokenRequest'] = { refreshToken };
+    const response = await rawFetch('/auth/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) throw await normalizeErrorResponse(response);
+    return parseJsonResponse<SessionTokens>(response);
+  }
+
+  const sessionManager = createSessionManager(refreshViaHttp, {
+    expirySkewMs: options.expirySkewMs,
+  });
+
+  /**
+   * Runs one attempt of an authenticated request, retrying exactly once
+   * after a single `refreshNow()` if the first attempt came back 401 — never
+   * more than once, so a persistently-rejecting server surfaces as a normal
+   * 401 `HttpApiError` instead of looping.
+   */
+  async function authedFetch(
+    method: string,
+    path: string,
+    init: { body?: unknown; signal?: AbortSignal },
+  ): Promise<Response> {
+    const attempt = async (): Promise<Response> => {
+      const token = await sessionManager.getAccessToken();
+      const headers: Record<string, string> = {
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+      };
+      if (init.body !== undefined) headers['Content-Type'] = 'application/json';
+      return rawFetch(path, {
+        method,
+        headers,
+        body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+        signal: init.signal,
+      });
+    };
+
+    const first = await attempt();
+    if (first.status !== 401) return first;
+    await sessionManager.refreshNow();
+    return attempt();
+  }
+
+  async function request<P extends ApiPath, M extends MethodOf<P>>(
+    method: M,
+    path: P,
+    ...rest: RequestOptionsArg<P, M>
+  ): Promise<SuccessResponseOf<OperationOf<P, M>>> {
+    const reqOptions: RequestOptions<P, M> = rest[0] ?? ({} as RequestOptions<P, M>);
+    const url =
+      substitutePath(
+        path as string,
+        reqOptions.params?.path as Record<string, unknown> | undefined,
+      ) + buildQueryString(reqOptions.params?.query as Record<string, unknown> | undefined);
+    const response = await authedFetch(method.toUpperCase(), url, {
+      body: reqOptions.body,
+      signal: reqOptions.signal,
+    });
+    if (!response.ok) throw await normalizeErrorResponse(response);
+    if (response.status === 204 || response.status === 205) {
+      return undefined as SuccessResponseOf<OperationOf<P, M>>;
+    }
+    return parseJsonResponse<SuccessResponseOf<OperationOf<P, M>>>(response);
+  }
+
+  async function login(
+    credentials: components['schemas']['LoginRequest'],
+    signal?: AbortSignal,
+  ): Promise<SessionTokens> {
+    const response = await rawFetch('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(credentials),
+      signal,
+    });
+    if (!response.ok) throw await normalizeErrorResponse(response);
+    const tokens = await parseJsonResponse<SessionTokens>(response);
+    sessionManager.setTokens(tokens);
+    return tokens;
+  }
+
+  async function logout(signal?: AbortSignal): Promise<void> {
+    const refreshToken = sessionManager.getRefreshTokenForLogout();
+    if (!refreshToken) {
+      sessionManager.clear();
+      return;
+    }
+    try {
+      const body: components['schemas']['RefreshTokenRequest'] = { refreshToken };
+      const response = await rawFetch('/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(body),
+        signal,
+      });
+      if (!response.ok) throw await normalizeErrorResponse(response);
+    } finally {
+      sessionManager.clear();
+    }
+  }
+
+  async function me(signal?: AbortSignal): Promise<components['schemas']['MeResponse']> {
+    return request('get', '/auth/me', { signal });
+  }
+
+  return {
+    request,
+    login,
+    logout,
+    me,
+    tokenProvider: sessionManager,
+    sessionManager,
+  };
+}
+
+/** Ready-to-use singleton for app code; tests should prefer `createApiClient()` for isolation. */
+export const apiClient = createApiClient();
+
+export { HttpApiError, NetworkError, isAbortError } from './errors';
+export type { ApiErrorBody, RateLimitInfo } from './errors';
+export type { TokenProvider, SessionTokens } from './session';

--- a/web/src/api/errors.test.ts
+++ b/web/src/api/errors.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractRateLimitInfo,
+  isAbortError,
+  isApiErrorBody,
+  normalizeErrorResponse,
+  parseRetryAfterHeader,
+  HttpApiError,
+  NetworkError,
+} from './errors';
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+describe('isApiErrorBody', () => {
+  it('accepts the documented shape', () => {
+    expect(isApiErrorBody({ code: 'x', message: 'm', requestId: 'r' })).toBe(true);
+    expect(isApiErrorBody({ code: 'x', message: 'm', requestId: 'r', details: { a: 1 } })).toBe(
+      true,
+    );
+  });
+
+  it('rejects anything missing a required field or the wrong type', () => {
+    expect(isApiErrorBody(null)).toBe(false);
+    expect(isApiErrorBody(undefined)).toBe(false);
+    expect(isApiErrorBody('oops')).toBe(false);
+    expect(isApiErrorBody({ code: 'x', message: 'm' })).toBe(false);
+    expect(isApiErrorBody({ code: 1, message: 'm', requestId: 'r' })).toBe(false);
+  });
+});
+
+describe('parseRetryAfterHeader', () => {
+  it('reads an integer Retry-After header', () => {
+    const response = new Response(null, { headers: { 'Retry-After': '7' } });
+    expect(parseRetryAfterHeader(response)).toBe(7);
+  });
+
+  it('returns undefined when absent or unparsable', () => {
+    expect(parseRetryAfterHeader(new Response(null))).toBeUndefined();
+    expect(parseRetryAfterHeader(new Response(null, { headers: { 'Retry-After': 'soon' } }))).toBe(
+      undefined,
+    );
+  });
+});
+
+describe('extractRateLimitInfo', () => {
+  it('combines the Retry-After header with scope/quota from details on a 429', () => {
+    const response = jsonResponse(
+      429,
+      {
+        code: 'rate_limited',
+        message: 'Too many requests',
+        requestId: 'req-1',
+        details: { retryAfterSeconds: 3, scope: 'auth', quota: 'rate_limit' },
+      },
+      { 'Retry-After': '3' },
+    );
+    const body = {
+      code: 'rate_limited',
+      message: 'Too many requests',
+      requestId: 'req-1',
+      details: { retryAfterSeconds: 3, scope: 'auth', quota: 'rate_limit' },
+    };
+    expect(extractRateLimitInfo(response, body)).toEqual({
+      retryAfterSeconds: 3,
+      scope: 'auth',
+      quota: 'rate_limit',
+    });
+  });
+
+  it('returns undefined for non-429 responses', () => {
+    const response = new Response(null, { status: 500, headers: { 'Retry-After': '3' } });
+    expect(extractRateLimitInfo(response, null)).toBeUndefined();
+  });
+});
+
+describe('normalizeErrorResponse', () => {
+  it('builds a HttpApiError from the canonical error envelope', async () => {
+    const response = jsonResponse(404, {
+      code: 'not_found',
+      message: 'Document not found',
+      requestId: 'req-2',
+    });
+    const error = await normalizeErrorResponse(response);
+    expect(error).toBeInstanceOf(HttpApiError);
+    expect(error.status).toBe(404);
+    expect(error.code).toBe('not_found');
+    expect(error.message).toBe('Document not found');
+    expect(error.requestId).toBe('req-2');
+    expect(error.rateLimit).toBeUndefined();
+  });
+
+  it('surfaces quota metadata on a 429 rather than swallowing it', async () => {
+    const response = jsonResponse(
+      429,
+      {
+        code: 'rate_limited',
+        message: 'Too many requests',
+        requestId: 'req-3',
+        details: { retryAfterSeconds: 5, scope: 'ip', quota: 'rate_limit' },
+      },
+      { 'Retry-After': '5' },
+    );
+    const error = await normalizeErrorResponse(response);
+    expect(error.status).toBe(429);
+    expect(error.rateLimit).toEqual({ retryAfterSeconds: 5, scope: 'ip', quota: 'rate_limit' });
+  });
+
+  it('falls back to a usable error for a non-JSON or empty body', async () => {
+    const empty = new Response(null, { status: 500, statusText: 'Internal Server Error' });
+    const errorFromEmpty = await normalizeErrorResponse(empty);
+    expect(errorFromEmpty.status).toBe(500);
+    expect(errorFromEmpty.code).toBe('unknown_error');
+
+    const html = new Response('<html>oops</html>', { status: 502, statusText: 'Bad Gateway' });
+    const errorFromHtml = await normalizeErrorResponse(html);
+    expect(errorFromHtml.status).toBe(502);
+    expect(errorFromHtml.code).toBe('unknown_error');
+  });
+});
+
+describe('isAbortError', () => {
+  it('recognizes the DOMException fetch/AbortController produce', () => {
+    expect(isAbortError(new DOMException('aborted', 'AbortError'))).toBe(true);
+    expect(isAbortError(new Error('aborted'))).toBe(false);
+    expect(isAbortError(new NetworkError('nope'))).toBe(false);
+  });
+});

--- a/web/src/api/errors.ts
+++ b/web/src/api/errors.ts
@@ -1,0 +1,138 @@
+// Normalized error types for every HTTP call the SPA makes. Everything the
+// server can return is typed against `generated/contract.ts` — nothing here
+// re-declares a shape the OpenAPI contract already owns.
+import type { components } from './generated/contract';
+
+/** Canonical error envelope every non-2xx JSON response carries. */
+export type ApiErrorBody = components['schemas']['ApiError'];
+
+/**
+ * Quota metadata surfaced from a 429. `retryAfterSeconds` is read from the
+ * `Retry-After` response header (the only header `rate_limit_guard.rs`
+ * actually sets); `scope`/`quota` come from `ApiError.details`, which the
+ * guard populates as `{ retryAfterSeconds, scope, quota }` but which the
+ * OpenAPI contract types only as `unknown`, so both are read defensively.
+ */
+export interface RateLimitInfo {
+  retryAfterSeconds: number;
+  scope?: string;
+  quota?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Runtime guard for the canonical error envelope — the wire body is `unknown` until checked. */
+export function isApiErrorBody(value: unknown): value is ApiErrorBody {
+  return (
+    isRecord(value) &&
+    typeof value.code === 'string' &&
+    typeof value.message === 'string' &&
+    typeof value.requestId === 'string'
+  );
+}
+
+function readRateLimitDetails(details: unknown): { scope?: string; quota?: string } {
+  if (!isRecord(details)) return {};
+  const scope = typeof details.scope === 'string' ? details.scope : undefined;
+  const quota = typeof details.quota === 'string' ? details.quota : undefined;
+  return { scope, quota };
+}
+
+/** Parses `Retry-After` as whole seconds; the guard always sends an integer, but we guard anyway. */
+export function parseRetryAfterHeader(response: Response): number | undefined {
+  const raw = response.headers.get('Retry-After');
+  if (raw === null) return undefined;
+  const seconds = Number.parseInt(raw, 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : undefined;
+}
+
+export function extractRateLimitInfo(
+  response: Response,
+  body: ApiErrorBody | null,
+): RateLimitInfo | undefined {
+  if (response.status !== 429) return undefined;
+  const headerSeconds = parseRetryAfterHeader(response);
+  const { scope, quota } = readRateLimitDetails(body?.details);
+  if (headerSeconds === undefined && scope === undefined && quota === undefined) {
+    return undefined;
+  }
+  return { retryAfterSeconds: headerSeconds ?? 0, scope, quota };
+}
+
+/**
+ * A non-2xx response the server answered with, normalized to
+ * `{code,message,requestId,details?}` plus HTTP status and (for 429) quota
+ * metadata. Thrown by every request path in `client.ts`, including the
+ * refresh call itself.
+ */
+export class HttpApiError extends Error {
+  readonly name = 'HttpApiError';
+  readonly status: number;
+  readonly code: string;
+  readonly requestId: string;
+  readonly details?: unknown;
+  readonly rateLimit?: RateLimitInfo;
+
+  constructor(params: {
+    status: number;
+    code: string;
+    message: string;
+    requestId: string;
+    details?: unknown;
+    rateLimit?: RateLimitInfo;
+  }) {
+    super(params.message);
+    this.status = params.status;
+    this.code = params.code;
+    this.requestId = params.requestId;
+    this.details = params.details;
+    this.rateLimit = params.rateLimit;
+  }
+}
+
+/** `fetch` itself rejected (offline, DNS, CORS, connection reset — no HTTP response to normalize). */
+export class NetworkError extends Error {
+  readonly name = 'NetworkError';
+  readonly cause?: unknown;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.cause = options?.cause;
+  }
+}
+
+/** True for the `DOMException` `fetch`/`AbortController` produce on cancellation. */
+export function isAbortError(value: unknown): value is DOMException {
+  return value instanceof DOMException && value.name === 'AbortError';
+}
+
+async function readJsonBodyOrNull(response: Response): Promise<unknown> {
+  try {
+    const text = await response.text();
+    return text.length > 0 ? JSON.parse(text) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Builds a `HttpApiError` from a non-ok `Response`. Reads the body defensively:
+ * a body that isn't the documented `ApiError` JSON shape (proxy error pages,
+ * empty 5xx bodies, etc.) still produces a usable error instead of throwing
+ * out of the error path itself.
+ */
+export async function normalizeErrorResponse(response: Response): Promise<HttpApiError> {
+  const parsed = await readJsonBodyOrNull(response);
+  const body = isApiErrorBody(parsed) ? parsed : null;
+  const rateLimit = extractRateLimitInfo(response, body);
+  return new HttpApiError({
+    status: response.status,
+    code: body?.code ?? 'unknown_error',
+    message: body?.message ?? response.statusText ?? `HTTP ${response.status}`,
+    requestId: body?.requestId ?? '',
+    details: body?.details,
+    rateLimit,
+  });
+}

--- a/web/src/api/lastEventId.test.ts
+++ b/web/src/api/lastEventId.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+  advanceCursor,
+  createCursor,
+  nextExpected,
+  parseLastEventIdToken,
+  requestCursorParams,
+  resolveLastEventId,
+  ZERO_CURSOR,
+} from './lastEventId';
+
+describe('parseLastEventIdToken', () => {
+  // Fixtures mirror crates/server/src/api/last_event_id.rs tests
+  // (`accepts_zero_through_i64_max`, `rejects_malformed_negative_overflow_conflict_future`)
+  // so this module is verifiably the same contract, not a lookalike.
+  it('accepts zero through i64::MAX', () => {
+    expect(parseLastEventIdToken('0')).toEqual({ ok: true, value: 0n });
+    expect(parseLastEventIdToken('42')).toEqual({ ok: true, value: 42n });
+    expect(parseLastEventIdToken('9223372036854775807')).toEqual({
+      ok: true,
+      value: 9223372036854775807n,
+    });
+  });
+
+  it('rejects malformed, negative, overflow', () => {
+    expect(parseLastEventIdToken('-1')).toEqual({ ok: false, error: 'negative' });
+    expect(parseLastEventIdToken('1.5')).toEqual({ ok: false, error: 'malformed' });
+    expect(parseLastEventIdToken('abc')).toEqual({ ok: false, error: 'malformed' });
+    expect(parseLastEventIdToken('')).toEqual({ ok: false, error: 'malformed' });
+    expect(parseLastEventIdToken('   ')).toEqual({ ok: false, error: 'malformed' });
+    expect(parseLastEventIdToken('9223372036854775808')).toEqual({
+      ok: false,
+      error: 'out_of_range',
+    });
+  });
+
+  it('tolerates leading/trailing whitespace and leading zeros, like Rust i64::parse', () => {
+    expect(parseLastEventIdToken('  7  ')).toEqual({ ok: true, value: 7n });
+    expect(parseLastEventIdToken('007')).toEqual({ ok: true, value: 7n });
+  });
+});
+
+describe('resolveLastEventId', () => {
+  it('both absent -> 0', () => {
+    expect(resolveLastEventId(undefined, undefined)).toEqual({ ok: true, value: 0n });
+  });
+
+  it('single source wins', () => {
+    expect(resolveLastEventId('9', undefined)).toEqual({ ok: true, value: 9n });
+    expect(resolveLastEventId(undefined, '9')).toEqual({ ok: true, value: 9n });
+  });
+
+  it('equal query+header is accepted', () => {
+    expect(resolveLastEventId('3', '3')).toEqual({ ok: true, value: 3n });
+  });
+
+  it('unequal query+header conflicts', () => {
+    expect(resolveLastEventId('3', '4')).toEqual({ ok: false, error: 'conflicting' });
+  });
+
+  it('rejects a cursor from the future against a high-water mark', () => {
+    expect(resolveLastEventId('9', undefined, 5n)).toEqual({ ok: false, error: 'out_of_range' });
+  });
+
+  it('propagates a malformed token from either source', () => {
+    expect(resolveLastEventId('abc', undefined)).toEqual({ ok: false, error: 'malformed' });
+    expect(resolveLastEventId(undefined, '-1')).toEqual({ ok: false, error: 'negative' });
+  });
+});
+
+describe('createCursor', () => {
+  it('defaults to the zero cursor', () => {
+    expect(createCursor()).toBe(ZERO_CURSOR);
+    expect(createCursor()).toBe('0');
+  });
+
+  it('normalizes a valid seed', () => {
+    expect(createCursor('007')).toBe('7');
+  });
+
+  it('throws on an invalid seed rather than silently starting at 0', () => {
+    expect(() => createCursor('not-a-number')).toThrow(/malformed/);
+    expect(() => createCursor('-1')).toThrow(/negative/);
+  });
+});
+
+describe('nextExpected', () => {
+  it('increments by one', () => {
+    expect(nextExpected('0')).toBe('1');
+    expect(nextExpected('41')).toBe('42');
+  });
+
+  it('does not lose precision above Number.MAX_SAFE_INTEGER', () => {
+    // 2**53 + 1, one past the point where `Number` can no longer represent
+    // consecutive integers exactly. A Number-based implementation would
+    // compute the wrong next value here.
+    const big = '9007199254740993';
+    expect(nextExpected(big)).toBe('9007199254740994');
+  });
+});
+
+describe('advanceCursor', () => {
+  it('reports a contiguous advance', () => {
+    expect(advanceCursor('4', '5')).toEqual({
+      ok: true,
+      cursor: '5',
+      contiguous: true,
+      expected: '5',
+    });
+  });
+
+  it('reports a non-contiguous but strictly increasing advance as a gap, not an error', () => {
+    // Legitimate for job events: event_log.sequence_no is one counter shared
+    // by the whole org (jobs.rs next_event_sequence), so another job's
+    // events consume sequence numbers in between. This must not be treated
+    // as a protocol failure.
+    expect(advanceCursor('2', '7')).toEqual({
+      ok: true,
+      cursor: '7',
+      contiguous: false,
+      expected: '3',
+    });
+  });
+
+  it('rejects a non-increasing id as not_monotonic (duplicate/out-of-order)', () => {
+    expect(advanceCursor('5', '5')).toEqual({ ok: false, error: 'not_monotonic' });
+    expect(advanceCursor('5', '3')).toEqual({ ok: false, error: 'not_monotonic' });
+  });
+
+  it('rejects a malformed id without throwing', () => {
+    expect(advanceCursor('5', 'abc')).toEqual({ ok: false, error: 'malformed' });
+    expect(advanceCursor('5', '-1')).toEqual({ ok: false, error: 'negative' });
+  });
+});
+
+describe('requestCursorParams', () => {
+  it('omits both for the zero cursor (fresh connect)', () => {
+    expect(requestCursorParams('0')).toBeUndefined();
+  });
+
+  it('sends equal query and header values for a resume', () => {
+    expect(requestCursorParams('42')).toEqual({ query: '42', header: '42' });
+  });
+});

--- a/web/src/api/lastEventId.ts
+++ b/web/src/api/lastEventId.ts
@@ -1,0 +1,186 @@
+// Client-side Last-Event-ID cursor: parsing, formatting and gap detection for
+// resumable SSE reconnect. Mirrors the parsing rules in
+// `crates/server/src/api/last_event_id.rs` (`parse_last_event_id_token`,
+// `resolve_last_event_id`) so a client-generated cursor can never be rejected
+// by the server for a reason the client itself couldn't have predicted.
+//
+// Sequence numbers are transported as a decimal string in the SSE `id:` line
+// (see `sse_event()` in `crates/server/src/routes/events.rs:354-360` and
+// `crates/server/src/services/qa/ask_stream.rs:797-803`, both doing
+// `.id(envelope.sequence.to_string())`), NOT as the JSON `sequence` field
+// inside `data:` (that field round-trips through `serde_json`/`JSON.parse` as
+// a JS `number`, which loses precision above 2**53). We therefore track and
+// compare cursors as arbitrary-precision decimal strings via `BigInt`, never
+// via `Number`, so a session that runs long enough to exceed 2**53 events
+// still resumes correctly.
+
+/** Server-side `i64` upper bound accepted by `parse_last_event_id_token` (last_event_id.rs:38-42). */
+const I64_MAX = 9223372036854775807n;
+
+export type LastEventIdErrorKind = 'malformed' | 'negative' | 'out_of_range';
+
+export type ParseLastEventIdResult =
+  { ok: true; value: bigint } | { ok: false; error: LastEventIdErrorKind };
+
+/**
+ * Parse one cursor token into `0..=i64::MAX`, mirroring
+ * `parse_last_event_id_token` (last_event_id.rs:26-43) byte for byte: trim,
+ * reject empty/non-digit/negative, reject values that overflow `i64`.
+ */
+export function parseLastEventIdToken(raw: string): ParseLastEventIdResult {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, error: 'malformed' };
+  }
+  if (trimmed.startsWith('-')) {
+    return { ok: false, error: 'negative' };
+  }
+  if (!/^[0-9]+$/.test(trimmed)) {
+    return { ok: false, error: 'malformed' };
+  }
+  const value = BigInt(trimmed);
+  if (value > I64_MAX) {
+    return { ok: false, error: 'out_of_range' };
+  }
+  return { ok: true, value };
+}
+
+export type ResolveLastEventIdError = LastEventIdErrorKind | 'conflicting';
+
+export type ResolveLastEventIdResult =
+  { ok: true; value: bigint } | { ok: false; error: ResolveLastEventIdError };
+
+/**
+ * Merge an optional `lastEventId` query value and `Last-Event-ID` header
+ * value the same way the server does in `resolve_last_event_id`
+ * (last_event_id.rs:53-78): both absent -> 0; one present -> that value;
+ * both present and equal -> that value; both present and unequal ->
+ * `conflicting`. `highWater`, when given, rejects a cursor from the future.
+ *
+ * Not used internally by `SseConnection` (which always sends matching
+ * query/header values), but kept here — and tested against the same fixtures
+ * as the server's own unit tests — so this module is a faithful, verifiable
+ * model of the resume contract rather than a generic SSE guess.
+ */
+export function resolveLastEventId(
+  query: string | undefined,
+  header: string | undefined,
+  highWater?: bigint,
+): ResolveLastEventIdResult {
+  const parsedQuery = query === undefined ? undefined : parseLastEventIdToken(query);
+  if (parsedQuery && !parsedQuery.ok) {
+    return parsedQuery;
+  }
+  const parsedHeader = header === undefined ? undefined : parseLastEventIdToken(header);
+  if (parsedHeader && !parsedHeader.ok) {
+    return parsedHeader;
+  }
+
+  let value: bigint;
+  if (parsedQuery === undefined && parsedHeader === undefined) {
+    value = 0n;
+  } else if (parsedHeader === undefined) {
+    value = (parsedQuery as { ok: true; value: bigint }).value;
+  } else if (parsedQuery === undefined) {
+    value = parsedHeader.value;
+  } else if (parsedQuery.value === parsedHeader.value) {
+    value = parsedQuery.value;
+  } else {
+    return { ok: false, error: 'conflicting' };
+  }
+
+  if (highWater !== undefined && value > highWater) {
+    return { ok: false, error: 'out_of_range' };
+  }
+  return { ok: true, value };
+}
+
+/** Canonical decimal-string cursor. `'0'` means "no events acknowledged yet". */
+export type LastEventIdCursor = string;
+
+export const ZERO_CURSOR: LastEventIdCursor = '0';
+
+/** Normalize a seed value (e.g. restored from storage) into a canonical cursor. Throws on an invalid seed. */
+export function createCursor(seed?: string): LastEventIdCursor {
+  if (seed === undefined) {
+    return ZERO_CURSOR;
+  }
+  const parsed = parseLastEventIdToken(seed);
+  if (!parsed.ok) {
+    throw new Error(`invalid Last-Event-ID seed "${seed}": ${parsed.error}`);
+  }
+  return parsed.value.toString();
+}
+
+/** The sequence a *contiguous* stream would deliver next after `cursor`. */
+export function nextExpected(cursor: LastEventIdCursor): LastEventIdCursor {
+  return (BigInt(cursor) + 1n).toString();
+}
+
+export type AdvanceCursorResult =
+  | { ok: true; cursor: LastEventIdCursor; contiguous: boolean; expected: LastEventIdCursor }
+  | { ok: false; error: LastEventIdErrorKind | 'not_monotonic' };
+
+/**
+ * Advance `current` by a newly received `id:` value.
+ *
+ * Only two things are ever guaranteed by the server, and they differ by
+ * endpoint — read the query, don't assume:
+ *
+ * - Strictly increasing (`received > current`) is guaranteed for BOTH
+ *   endpoints: job events select `WHERE sequence_no > $after` (jobs.rs:212)
+ *   and ask events do the same (ask_streams.rs list_events_after). A
+ *   `received <= current` id is never legitimate — it means a duplicate or
+ *   out-of-order delivery, so this returns `not_monotonic` rather than
+ *   silently accepting it.
+ * - Contiguity (`received === current + 1`) is NOT guaranteed for job
+ *   events: `event_log.sequence_no` is a single counter shared by the whole
+ *   org (`next_event_sequence`, jobs.rs:993-1001 — `MAX(sequence_no) FROM
+ *   event_log WHERE org_id = $1`, no `job_id` filter), so any other job's or
+ *   session's events legitimately consume sequence numbers in between the
+ *   ones a given job's SSE client sees. A generic client that assumes
+ *   per-stream contiguity would misfire constantly on job streams. Ask
+ *   stream sequences, by contrast, ARE per-session
+ *   (`ask_stream_sessions.next_sequence`, db/ask_streams.rs:82,401) so a
+ *   non-contiguous jump there really does mean a missing/purged event.
+ *
+ * This function reports `contiguous` either way and lets the caller decide
+ * what a gap means for their endpoint; it never hides the jump.
+ */
+export function advanceCursor(current: LastEventIdCursor, receivedId: string): AdvanceCursorResult {
+  const parsed = parseLastEventIdToken(receivedId);
+  if (!parsed.ok) {
+    return { ok: false, error: parsed.error };
+  }
+  if (parsed.value <= BigInt(current)) {
+    return { ok: false, error: 'not_monotonic' };
+  }
+  const expected = nextExpected(current);
+  const cursor = parsed.value.toString();
+  return { ok: true, cursor, contiguous: cursor === expected, expected };
+}
+
+export interface CursorRequestParams {
+  readonly query: string;
+  readonly header: string;
+}
+
+/**
+ * Build the `lastEventId` query value + `Last-Event-ID` header value for a
+ * (re)connect at `cursor`. Returns `undefined` for the zero cursor so a
+ * fresh connection omits both — required for `/ask/stream` without a
+ * `streamSessionId`, which rejects any non-zero cursor
+ * (`routes/ask.rs:177-182`, `LastEventIdError::OutOfRange`) — and matches
+ * plain `resolve_last_event_id(None, None, _) -> 0` for job events.
+ *
+ * Query and header are always sent equal on purpose: `resolve_last_event_id`
+ * only accepts an equal pair or a single source, never differing values
+ * (last_event_id.rs:66-71), and the live reconnect tests always send both
+ * (sse_stream_readiness.rs:561-566, :1110-1115).
+ */
+export function requestCursorParams(cursor: LastEventIdCursor): CursorRequestParams | undefined {
+  if (cursor === ZERO_CURSOR) {
+    return undefined;
+  }
+  return { query: cursor, header: cursor };
+}

--- a/web/src/api/session.test.ts
+++ b/web/src/api/session.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSessionManager,
+  NoSessionError,
+  SessionLostError,
+  type RefreshFn,
+  type SessionTokens,
+} from './session';
+
+function tokens(overrides: Partial<SessionTokens> = {}): SessionTokens {
+  return {
+    accessToken: 'access-1',
+    refreshToken: 'refresh-1',
+    tokenType: 'Bearer',
+    expiresIn: 3600,
+    orgId: 'org-1',
+    userId: 'user-1',
+    ...overrides,
+  };
+}
+
+function expiredTokens(overrides: Partial<SessionTokens> = {}): SessionTokens {
+  // Negative expiresIn puts expiresAt in the past regardless of skew.
+  return tokens({ expiresIn: -1, ...overrides });
+}
+
+/** A promise plus externally-callable resolve/reject, so tests can control exactly when a "network" call settles. */
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('createSessionManager', () => {
+  describe('no session', () => {
+    it('rejects getAccessToken with NoSessionError and never calls refreshFn', async () => {
+      const refreshFn = vi.fn<RefreshFn>();
+      const manager = createSessionManager(refreshFn);
+      await expect(manager.getAccessToken()).rejects.toBeInstanceOf(NoSessionError);
+      expect(refreshFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('valid cached token', () => {
+    it('returns the cached access token without calling refreshFn', async () => {
+      const refreshFn = vi.fn<RefreshFn>();
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(tokens());
+      await expect(manager.getAccessToken()).resolves.toBe('access-1');
+      expect(refreshFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rotation notifications', () => {
+    // ADR 0010 rotates the refresh token on every use and revokes the family
+    // when an already-rotated one is replayed, so anything persisting the token
+    // has to learn about the rotation the manager performs on its own — not
+    // just the ones the caller triggers.
+    it('notifies on the rotation performed inside a refresh, not only on setTokens', async () => {
+      const refreshFn = vi
+        .fn<RefreshFn>()
+        .mockResolvedValue(tokens({ accessToken: 'access-2', refreshToken: 'refresh-2' }));
+      const manager = createSessionManager(refreshFn);
+      const seen: string[] = [];
+      manager.onTokensRotated((rotated) => seen.push(rotated.refreshToken));
+
+      manager.setTokens(expiredTokens({ refreshToken: 'refresh-1' }));
+      expect(seen).toEqual(['refresh-1']);
+
+      await manager.getAccessToken();
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+      // The rotation the caller never asked for is the one that matters.
+      expect(seen).toEqual(['refresh-1', 'refresh-2']);
+    });
+
+    it('fires once per rotation even when concurrent callers share one refresh', async () => {
+      const refreshFn = vi.fn<RefreshFn>().mockResolvedValue(tokens({ refreshToken: 'refresh-2' }));
+      const manager = createSessionManager(refreshFn);
+      const seen: string[] = [];
+      manager.setTokens(expiredTokens({ refreshToken: 'refresh-1' }));
+      manager.onTokensRotated((rotated) => seen.push(rotated.refreshToken));
+
+      await Promise.all([
+        manager.getAccessToken(),
+        manager.getAccessToken(),
+        manager.getAccessToken(),
+      ]);
+      expect(seen).toEqual(['refresh-2']);
+    });
+
+    it('unsubscribes, and a throwing listener does not break the refresh', async () => {
+      const refreshFn = vi.fn<RefreshFn>().mockResolvedValue(tokens({ accessToken: 'access-2' }));
+      const manager = createSessionManager(refreshFn);
+      manager.onTokensRotated(() => {
+        throw new Error('persistence is unavailable');
+      });
+      const seen: string[] = [];
+      const unsubscribe = manager.onTokensRotated((rotated) => seen.push(rotated.accessToken));
+
+      manager.setTokens(expiredTokens());
+      unsubscribe();
+      await expect(manager.getAccessToken()).resolves.toBe('access-2');
+      expect(seen).toEqual(['access-1']);
+    });
+  });
+
+  describe('single-flight refresh', () => {
+    it('shares exactly one in-flight refresh across N concurrent getAccessToken calls on an expired token', async () => {
+      const deferred = createDeferred<SessionTokens>();
+      const refreshFn = vi.fn(() => deferred.promise);
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(expiredTokens());
+
+      const p1 = manager.getAccessToken();
+      const p2 = manager.getAccessToken();
+      const p3 = manager.getAccessToken();
+
+      // Give any (incorrect) per-call refresh a chance to fire before we resolve.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+
+      deferred.resolve(tokens({ accessToken: 'access-2', refreshToken: 'refresh-2' }));
+
+      await expect(Promise.all([p1, p2, p3])).resolves.toEqual([
+        'access-2',
+        'access-2',
+        'access-2',
+      ]);
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('shares exactly one in-flight refresh across N concurrent refreshNow calls', async () => {
+      const deferred = createDeferred<SessionTokens>();
+      const refreshFn = vi.fn(() => deferred.promise);
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(tokens()); // not expired — refreshNow forces it anyway
+
+      const calls = [manager.refreshNow(), manager.refreshNow(), manager.refreshNow()];
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+
+      deferred.resolve(tokens({ accessToken: 'access-3' }));
+      await expect(Promise.all(calls)).resolves.toEqual(['access-3', 'access-3', 'access-3']);
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('shares one in-flight refresh between a mix of getAccessToken (expired) and refreshNow callers', async () => {
+      const deferred = createDeferred<SessionTokens>();
+      const refreshFn = vi.fn(() => deferred.promise);
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(expiredTokens());
+
+      const calls = [manager.getAccessToken(), manager.refreshNow(), manager.getAccessToken()];
+      await Promise.resolve();
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+
+      deferred.resolve(tokens({ accessToken: 'access-4' }));
+      await expect(Promise.all(calls)).resolves.toEqual(['access-4', 'access-4', 'access-4']);
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('only refreshes once per real refresh call, not once per concurrent invocation (fails if single-flight is removed)', async () => {
+      // Regression guard: refreshFn returns a different token per call. If
+      // single-flight were broken, concurrent callers would disagree on the
+      // token, since each would have triggered its own refresh.
+      let counter = 0;
+      const refreshFn = vi.fn(async () => tokens({ accessToken: `access-${++counter}` }));
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(expiredTokens());
+
+      const results = await Promise.all([
+        manager.getAccessToken(),
+        manager.getAccessToken(),
+        manager.getAccessToken(),
+      ]);
+      expect(new Set(results).size).toBe(1);
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('failed refresh', () => {
+    it('rejects every concurrent waiter and fires onSessionLost exactly once', async () => {
+      const failure = new Error('refresh token rejected by server');
+      const refreshFn = vi.fn(async () => {
+        throw failure;
+      });
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(expiredTokens());
+
+      const lost = vi.fn();
+      manager.onSessionLost(lost);
+
+      const results = await Promise.allSettled([
+        manager.getAccessToken(),
+        manager.refreshNow(),
+        manager.refreshNow(),
+      ]);
+
+      for (const result of results) {
+        expect(result.status).toBe('rejected');
+      }
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+      expect(lost).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry the refresh in a loop after a terminal failure', async () => {
+      const refreshFn = vi.fn(async () => {
+        throw new Error('invalid refresh token');
+      });
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(expiredTokens());
+
+      await expect(manager.getAccessToken()).rejects.toThrow('invalid refresh token');
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+
+      // Further calls must reject immediately from cached terminal state —
+      // no second network attempt.
+      await expect(manager.getAccessToken()).rejects.toBeInstanceOf(SessionLostError);
+      await expect(manager.refreshNow()).rejects.toBeInstanceOf(SessionLostError);
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears in-memory tokens once terminally lost', async () => {
+      const refreshFn = vi.fn(async () => {
+        throw new Error('nope');
+      });
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(expiredTokens());
+      await expect(manager.getAccessToken()).rejects.toThrow();
+      expect(manager.hasSession()).toBe(false);
+      expect(manager.getRefreshTokenForLogout()).toBeNull();
+    });
+
+    it('lets a fresh setTokens recover from a terminally-lost state', async () => {
+      const refreshFn = vi.fn(async () => {
+        throw new Error('nope');
+      });
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(expiredTokens());
+      await expect(manager.getAccessToken()).rejects.toBeInstanceOf(Error);
+
+      manager.setTokens(tokens({ accessToken: 'fresh' }));
+      await expect(manager.getAccessToken()).resolves.toBe('fresh');
+    });
+  });
+
+  describe('onSessionLost subscription', () => {
+    it('stops delivering after unsubscribe', async () => {
+      const refreshFn = vi.fn(async () => {
+        throw new Error('nope');
+      });
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(expiredTokens());
+
+      const lost = vi.fn();
+      const unsubscribe = manager.onSessionLost(lost);
+      unsubscribe();
+
+      await expect(manager.getAccessToken()).rejects.toThrow();
+      expect(lost).not.toHaveBeenCalled();
+    });
+
+    it('supports multiple independent listeners, each called once', async () => {
+      const refreshFn = vi.fn(async () => {
+        throw new Error('nope');
+      });
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(expiredTokens());
+
+      const a = vi.fn();
+      const b = vi.fn();
+      manager.onSessionLost(a);
+      manager.onSessionLost(b);
+
+      await expect(
+        Promise.allSettled([manager.getAccessToken(), manager.getAccessToken()]),
+      ).resolves.toBeDefined();
+
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clear', () => {
+    it('drops tokens without notifying onSessionLost listeners', () => {
+      const refreshFn = vi.fn<RefreshFn>();
+      const manager = createSessionManager(refreshFn);
+      manager.setTokens(tokens());
+      const lost = vi.fn();
+      manager.onSessionLost(lost);
+
+      manager.clear();
+
+      expect(manager.hasSession()).toBe(false);
+      expect(lost).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('expiry skew', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('treats the token as due for renewal before the server-declared expiresIn elapses', async () => {
+    vi.useFakeTimers();
+    try {
+      const refreshFn = vi.fn(async () => tokens({ accessToken: 'renewed' }));
+      const manager = createSessionManager(refreshFn, { expirySkewMs: 10_000 });
+      manager.setTokens(tokens({ expiresIn: 15 })); // expires in 15s, skew 10s -> stale after 5s
+
+      vi.advanceTimersByTime(6_000);
+      await expect(manager.getAccessToken()).resolves.toBe('renewed');
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/web/src/api/session.ts
+++ b/web/src/api/session.ts
@@ -1,0 +1,198 @@
+// Session/token state for the SPA. Access token lives in memory only (no
+// storage, no cookie) and every consumer — the typed client in `client.ts`,
+// and the SSE agent's `sse.ts` — goes through the `TokenProvider` seam below
+// so there is exactly one refresh in flight at any time.
+import type { components } from './generated/contract';
+
+/** The pair `POST /auth/login` and `POST /auth/refresh` both return. */
+export type SessionTokens = components['schemas']['TokenResponse'];
+
+/**
+ * Seam shared with the SSE agent (`sse.ts` + `lastEventId.ts`). This shape is
+ * fixed — the other agent imports only the type and must not need to read
+ * this file's implementation. Do not change it without flagging it back.
+ */
+export interface TokenProvider {
+  /** Current access token, refreshing first if it is expired or missing. Concurrent callers share one in-flight refresh. */
+  getAccessToken(): Promise<string>;
+  /** Force one refresh after a 401 on a request that used a token believed valid. Also single-flight. */
+  refreshNow(): Promise<string>;
+  /** Subscribe to terminal session loss (refresh rejected). Returns an unsubscribe. */
+  onSessionLost(listener: () => void): () => void;
+}
+
+/** Thrown when a refresh attempt fails: the session is over until the next `setTokens`. */
+export class SessionLostError extends Error {
+  readonly name = 'SessionLostError';
+  readonly cause?: unknown;
+
+  constructor(
+    message = 'Session refresh failed; the session is no longer valid.',
+    cause?: unknown,
+  ) {
+    super(message);
+    this.cause = cause;
+  }
+}
+
+/** Thrown when a token is requested but nobody has ever logged in (no refresh token to use). */
+export class NoSessionError extends Error {
+  readonly name = 'NoSessionError';
+
+  constructor(message = 'No active session.') {
+    super(message);
+  }
+}
+
+/** Performs the actual network round-trip; injected so this module has no fetch/contract coupling. */
+export type RefreshFn = (refreshToken: string) => Promise<SessionTokens>;
+
+export interface SessionManager extends TokenProvider {
+  /** Installs a fresh token pair (e.g. after login). Clears any prior terminal session-lost state. */
+  setTokens(tokens: SessionTokens): void;
+  /** Drops in-memory tokens without notifying `onSessionLost` listeners (e.g. after an explicit logout call completes). */
+  clear(): void;
+  /** Whether any token (access or refresh) is currently held. */
+  hasSession(): boolean;
+  /** The refresh token to send in `POST /auth/logout`'s body, or null if there is no session. */
+  getRefreshTokenForLogout(): string | null;
+  /**
+   * Subscribe to every token rotation, including the ones the manager performs
+   * on its own during a refresh. Returns an unsubscribe.
+   *
+   * ADR 0010 rotates the refresh token on every use and revokes the whole family
+   * when an already-rotated token is replayed. Anything that persists the refresh
+   * token therefore cannot wait for a lifecycle event to write it back: a copy
+   * that misses one rotation is not merely stale, it is a token whose next use
+   * looks like a replay attack and signs the user out everywhere. Listeners fire
+   * synchronously as part of applying the new pair.
+   */
+  onTokensRotated(listener: (tokens: SessionTokens) => void): () => void;
+}
+
+export interface SessionManagerOptions {
+  /**
+   * Milliseconds subtracted from the server's `expiresIn` before we consider
+   * the access token due for renewal, so `getAccessToken` refreshes slightly
+   * ahead of actual server-side expiry instead of racing it. Default 10s.
+   */
+  expirySkewMs?: number;
+}
+
+const DEFAULT_EXPIRY_SKEW_MS = 10_000;
+
+export function createSessionManager(
+  refreshFn: RefreshFn,
+  options: SessionManagerOptions = {},
+): SessionManager {
+  const skewMs = options.expirySkewMs ?? DEFAULT_EXPIRY_SKEW_MS;
+
+  let accessToken: string | null = null;
+  let refreshToken: string | null = null;
+  let expiresAt = 0;
+  let terminallyLost = false;
+  let inFlight: Promise<string> | null = null;
+  const listeners = new Set<() => void>();
+  const rotationListeners = new Set<(tokens: SessionTokens) => void>();
+
+  function isExpired(): boolean {
+    return accessToken === null || Date.now() >= expiresAt;
+  }
+
+  function notifySessionLost(): void {
+    for (const listener of [...listeners]) listener();
+  }
+
+  function applyTokens(tokens: SessionTokens): string {
+    accessToken = tokens.accessToken;
+    refreshToken = tokens.refreshToken;
+    expiresAt = Date.now() + tokens.expiresIn * 1000 - skewMs;
+    // Synchronous, so a persisted copy can never lag a rotation. A listener that
+    // throws must not take the session down with it: the tokens are already
+    // applied and the caller is mid-refresh.
+    for (const listener of [...rotationListeners]) {
+      try {
+        listener(tokens);
+      } catch {
+        // ignored on purpose; persistence is best-effort, the session is not
+      }
+    }
+    return tokens.accessToken;
+  }
+
+  function forgetTokens(): void {
+    accessToken = null;
+    refreshToken = null;
+    expiresAt = 0;
+  }
+
+  // Single-flight: the first caller creates `inFlight`; every concurrent
+  // caller (whether it arrived via `getAccessToken` on an expired token or
+  // `refreshNow` reacting to a 401) observes it already set — synchronously,
+  // before any `await` — and shares the same promise. A failed attempt marks
+  // the session terminally lost so later calls reject immediately instead of
+  // retrying in a loop, until the next `setTokens`.
+  function triggerRefresh(): Promise<string> {
+    if (terminallyLost) {
+      return Promise.reject(new SessionLostError());
+    }
+    if (!refreshToken) {
+      return Promise.reject(new NoSessionError());
+    }
+    if (!inFlight) {
+      inFlight = refreshFn(refreshToken)
+        .then(applyTokens)
+        .catch((cause: unknown) => {
+          terminallyLost = true;
+          forgetTokens();
+          notifySessionLost();
+          throw cause;
+        })
+        .finally(() => {
+          inFlight = null;
+        });
+    }
+    return inFlight;
+  }
+
+  return {
+    async getAccessToken() {
+      if (terminallyLost) throw new SessionLostError();
+      if (accessToken === null && refreshToken === null) throw new NoSessionError();
+      if (!isExpired() && accessToken !== null) return accessToken;
+      return triggerRefresh();
+    },
+
+    async refreshNow() {
+      return triggerRefresh();
+    },
+
+    onSessionLost(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+
+    onTokensRotated(listener) {
+      rotationListeners.add(listener);
+      return () => rotationListeners.delete(listener);
+    },
+
+    setTokens(tokens) {
+      terminallyLost = false;
+      applyTokens(tokens);
+    },
+
+    clear() {
+      terminallyLost = false;
+      forgetTokens();
+    },
+
+    hasSession() {
+      return accessToken !== null || refreshToken !== null;
+    },
+
+    getRefreshTokenForLogout() {
+      return refreshToken;
+    },
+  };
+}

--- a/web/src/api/sse.test.ts
+++ b/web/src/api/sse.test.ts
@@ -1,0 +1,706 @@
+import { describe, expect, it } from 'vitest';
+import type { TokenProvider } from './session';
+import { classifySseCloseCode, SseConnection, SseFrameParser, type SseMessage } from './sse';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function envelopeFrame(id: string, event: string, data: unknown, requestId = 'req-1'): string {
+  const envelope = { version: 1, sequence: Number(id), event, requestId, data };
+  return `id: ${id}\nevent: ${event}\ndata: ${JSON.stringify(envelope)}\n\n`;
+}
+
+function controlFrame(reason: string, event = 'stream.closed', requestId = 'req-1'): string {
+  const payload = { version: 1, event, requestId, data: { reason }, control: true };
+  return `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+/** A simple queued SSE body: emits each string chunk on successive pulls, then closes. */
+function streamOf(
+  chunks: string[],
+  onCancel?: (reason: unknown) => void,
+): ReadableStream<Uint8Array> {
+  let index = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(new TextEncoder().encode(chunks[index]));
+      index += 1;
+    },
+    cancel(reason) {
+      onCancel?.(reason);
+    },
+  });
+}
+
+/** A body that never ends on its own and can be pushed into from the test. */
+function openStream(onCancel?: (reason: unknown) => void) {
+  let controllerRef!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllerRef = controller;
+    },
+    cancel(reason) {
+      onCancel?.(reason);
+    },
+  });
+  return {
+    stream,
+    push: (text: string) => controllerRef.enqueue(new TextEncoder().encode(text)),
+    close: () => controllerRef.close(),
+  };
+}
+
+/** A body that counts how many times the network layer was asked to produce a chunk (`pull`), one frame per pull, forever. */
+function countingFrameStream(makeFrame: (seq: number) => string) {
+  let produced = 0;
+  let pulls = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      pulls += 1;
+      produced += 1;
+      controller.enqueue(new TextEncoder().encode(makeFrame(produced)));
+    },
+  });
+  return { stream, pulls: () => pulls, produced: () => produced };
+}
+
+interface FetchCall {
+  url: string;
+  headers: Headers;
+  method?: string;
+}
+
+function fetchQueue(...responses: Array<Response | (() => Response)>) {
+  const calls: FetchCall[] = [];
+  let index = 0;
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      headers: new Headers(init?.headers),
+      method: init?.method,
+    });
+    const entry = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    return typeof entry === 'function' ? entry() : entry;
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function fakeTokenProvider(initialToken = 'token-1') {
+  const listeners = new Set<() => void>();
+  let token = initialToken;
+  let refreshCount = 0;
+  const provider: TokenProvider = {
+    async getAccessToken() {
+      return token;
+    },
+    async refreshNow() {
+      refreshCount += 1;
+      token = `${initialToken}-refreshed-${refreshCount}`;
+      return token;
+    },
+    onSessionLost(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+  return {
+    provider,
+    fireSessionLost: () => listeners.forEach((listener) => listener()),
+    refreshCount: () => refreshCount,
+    currentToken: () => token,
+  };
+}
+
+async function collect(connection: SseConnection, limit = 50): Promise<SseMessage[]> {
+  const out: SseMessage[] = [];
+  for await (const message of connection) {
+    out.push(message);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// SseFrameParser — pure framing, no network
+// ---------------------------------------------------------------------------
+
+describe('SseFrameParser', () => {
+  it('parses a basic event delivered in one push', () => {
+    const parser = new SseFrameParser();
+    const frames = parser.push('event: ask.token\nid: 1\ndata: {"text":"hi"}\n\n');
+    expect(frames).toEqual([
+      { event: 'ask.token', id: '1', data: '{"text":"hi"}', comment: false },
+    ]);
+  });
+
+  it('joins multi-line data fields with \\n, per the SSE spec', () => {
+    const parser = new SseFrameParser();
+    const frames = parser.push('data: line one\ndata: line two\n\n');
+    expect(frames).toHaveLength(1);
+    expect(frames[0].data).toBe('line one\nline two');
+  });
+
+  it('handles CRLF line endings', () => {
+    const parser = new SseFrameParser();
+    const frames = parser.push('event: job.progress\r\nid: 3\r\ndata: {"a":1}\r\n\r\n');
+    expect(frames).toEqual([{ event: 'job.progress', id: '3', data: '{"a":1}', comment: false }]);
+  });
+
+  it('handles a bare CR as a line ending', () => {
+    const parser = new SseFrameParser();
+    const frames = parser.push('event: e\rid: 1\rdata: d\r\r');
+    expect(frames).toEqual([{ event: 'e', id: '1', data: 'd', comment: false }]);
+  });
+
+  it('treats a comment-only block as a heartbeat, not a data frame', () => {
+    const parser = new SseFrameParser();
+    const frames = parser.push(':heartbeat\n\n');
+    expect(frames).toEqual([{ event: undefined, id: undefined, data: '', comment: true }]);
+  });
+
+  it('does not confuse a control frame (no id) with a durable one', () => {
+    const parser = new SseFrameParser();
+    const frames = parser.push('event: stream.closed\ndata: {"reason":"stream_error"}\n\n');
+    expect(frames).toEqual([
+      { event: 'stream.closed', id: undefined, data: '{"reason":"stream_error"}', comment: false },
+    ]);
+  });
+
+  it('parses multiple frames delivered in a single push', () => {
+    const parser = new SseFrameParser();
+    const frames = parser.push(
+      'id: 1\nevent: a\ndata: 1\n\n' + 'id: 2\nevent: b\ndata: 2\n\n' + ':ping\n\n',
+    );
+    expect(frames).toHaveLength(3);
+    expect(frames.map((f) => f.id)).toEqual(['1', '2', undefined]);
+    expect(frames[2].comment).toBe(true);
+  });
+
+  it('survives a chunk boundary splitting a frame mid-way (across two pushes)', () => {
+    const parser = new SseFrameParser();
+    const whole = 'id: 42\nevent: ask.token\ndata: {"text":"phần"}\n\n';
+    // Split in the middle of the data line, mid multi-byte-looking content.
+    const cut = whole.indexOf('"text"') + 3;
+    const first = parser.push(whole.slice(0, cut));
+    expect(first).toEqual([]); // nothing dispatched yet — frame incomplete
+    const second = parser.push(whole.slice(cut));
+    expect(second).toEqual([
+      { event: 'ask.token', id: '42', data: '{"text":"phần"}', comment: false },
+    ]);
+  });
+
+  it('survives a chunk boundary splitting a field name itself (e.g. "da" | "ta: x")', () => {
+    const parser = new SseFrameParser();
+    const first = parser.push('id: 1\nev');
+    expect(first).toEqual([]);
+    const second = parser.push('ent: a\nda');
+    expect(second).toEqual([]);
+    const third = parser.push('ta: hello\n\n');
+    expect(third).toEqual([{ event: 'a', id: '1', data: 'hello', comment: false }]);
+  });
+
+  it('survives a chunk boundary splitting the CRLF terminator itself', () => {
+    const parser = new SseFrameParser();
+    const first = parser.push('id: 1\r\nevent: a\r\ndata: x\r');
+    expect(first).toEqual([]); // trailing bare \r is ambiguous — held back as carry
+    const second = parser.push('\n\r\n');
+    expect(second).toEqual([{ event: 'a', id: '1', data: 'x', comment: false }]);
+  });
+
+  it('flushes a final frame that arrives without a trailing blank line', () => {
+    const parser = new SseFrameParser();
+    expect(parser.push('id: 9\nevent: a\ndata: last')).toEqual([]);
+    expect(parser.flush()).toEqual([{ event: 'a', id: '9', data: 'last', comment: false }]);
+  });
+
+  it('ignores stray blank lines between frames', () => {
+    const parser = new SseFrameParser();
+    const frames = parser.push('\n\nid: 1\nevent: a\ndata: x\n\n\n');
+    expect(frames).toEqual([{ event: 'a', id: '1', data: 'x', comment: false }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifySseCloseCode
+// ---------------------------------------------------------------------------
+
+describe('classifySseCloseCode', () => {
+  it('classifies every close reason emitted by the server', () => {
+    // See services/stream_auth.rs:37-49 and services/qa/ask_stream.rs for the
+    // exhaustive set of reasons the server actually sends.
+    expect(classifySseCloseCode('token_expired')).toBe('refresh');
+    expect(classifySseCloseCode('completed')).toBe('complete');
+    expect(classifySseCloseCode('snapshot_complete')).toBe('complete');
+    expect(classifySseCloseCode('stream_error')).toBe('retry');
+    expect(classifySseCloseCode('send_timeout')).toBe('retry');
+    expect(classifySseCloseCode('live_tail_timeout')).toBe('retry');
+    expect(classifySseCloseCode('session_revoked')).toBe('terminal');
+    expect(classifySseCloseCode('principal_denied')).toBe('terminal');
+    expect(classifySseCloseCode('auth_revoked')).toBe('terminal');
+    expect(classifySseCloseCode('citation_revoked')).toBe('terminal');
+    expect(classifySseCloseCode('cancelled')).toBe('terminal');
+    expect(classifySseCloseCode('session_expired')).toBe('terminal');
+  });
+
+  it('fails closed (terminal) for any reason it does not recognize', () => {
+    expect(classifySseCloseCode('some_future_reason_nobody_told_us_about')).toBe('terminal');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SseConnection — property tests
+// ---------------------------------------------------------------------------
+
+describe('SseConnection', () => {
+  it('delivers events in sequence order and resumes from the last acked id', async () => {
+    const first = streamOf([
+      envelopeFrame('1', 'ask.token', { text: 'A' }),
+      envelopeFrame('2', 'ask.token', { text: 'B' }),
+      controlFrame('stream_error'),
+    ]);
+    const second = streamOf([
+      envelopeFrame('3', 'ask.completed', { mode: 'x' }),
+      envelopeFrame('4', 'stream.closed', { reason: 'completed', streamSessionId: 's1' }),
+    ]);
+    const { fetchImpl, calls } = fetchQueue(
+      new Response(first, { status: 200 }),
+      new Response(second, { status: 200 }),
+    );
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream', method: 'POST' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+
+    const messages = await collect(connection, 6);
+    expect(messages.map((m) => m.kind)).toEqual([
+      'event',
+      'event',
+      'control',
+      'event',
+      'event',
+      'closed',
+    ]);
+    const ids = messages
+      .filter((m): m is Extract<SseMessage, { kind: 'event' }> => m.kind === 'event')
+      .map((m) => m.id);
+    expect(ids).toEqual(['1', '2', '3', '4']);
+    expect(ids.every((id, index) => index === 0 || Number(id) > Number(ids[index - 1]))).toBe(true);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].headers.has('last-event-id')).toBe(false); // fresh connect: no resume params
+    expect(calls[1].headers.get('last-event-id')).toBe('2'); // resumes after the last acked event
+    expect(calls[1].url).toContain('lastEventId=2');
+  });
+
+  it('mutation check: without the reconnect-on-retry path, this would stop at the control frame instead of resuming', async () => {
+    // Same fixture as above, asserting the specific behavior that a broken
+    // "retry classification always terminal" mutant would fail: after the
+    // stream_error control frame, iteration continues and a fresh event (id 3)
+    // is delivered rather than the stream ending there.
+    const first = streamOf([
+      envelopeFrame('1', 'ask.token', { text: 'A' }),
+      controlFrame('stream_error'),
+    ]);
+    const second = streamOf([envelopeFrame('2', 'ask.completed', {})]);
+    const { fetchImpl } = fetchQueue(
+      new Response(first, { status: 200 }),
+      new Response(second, { status: 200 }),
+    );
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const messages = await collect(connection, 4);
+    expect(messages.some((m) => m.kind === 'event' && m.id === '2')).toBe(true);
+  });
+
+  it('a 401 with code "unauthorized" at connect triggers exactly one refresh, then succeeds', async () => {
+    const unauthorized = new Response(
+      JSON.stringify({ code: 'unauthorized', message: 'x', requestId: 'r' }),
+      {
+        status: 401,
+      },
+    );
+    const ok = streamOf([envelopeFrame('1', 'ask.started', {})]);
+    const { fetchImpl, calls } = fetchQueue(unauthorized, new Response(ok, { status: 200 }));
+    const { provider, refreshCount, currentToken } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const messages = await collect(connection, 2);
+    expect(messages[0]).toMatchObject({ kind: 'event', id: '1' });
+    expect(refreshCount()).toBe(1);
+    expect(calls[1].headers.get('authorization')).toBe(`Bearer ${currentToken()}`);
+  });
+
+  it('a token_expired control frame mid-stream triggers exactly one refresh and one resume — not a storm', async () => {
+    const first = streamOf([
+      envelopeFrame('1', 'ask.token', { text: 'A' }),
+      controlFrame('token_expired'),
+    ]);
+    const second = streamOf([
+      envelopeFrame('2', 'ask.completed', {}),
+      envelopeFrame('3', 'stream.closed', { reason: 'completed', streamSessionId: 's1' }),
+    ]);
+    const { fetchImpl, calls } = fetchQueue(
+      new Response(first, { status: 200 }),
+      new Response(second, { status: 200 }),
+    );
+    const { provider, refreshCount } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const messages = await collect(connection, 6);
+    expect(refreshCount()).toBe(1);
+    expect(calls).toHaveLength(2);
+    expect(calls[1].headers.get('last-event-id')).toBe('1');
+    expect(messages.map((m) => m.kind)).toEqual(['event', 'control', 'event', 'event', 'closed']);
+  });
+
+  it('does not storm-refresh: a second consecutive auth failure with no progress ends the connection', async () => {
+    const firstControl = streamOf([controlFrame('token_expired')]);
+    const secondUnauthorized = new Response(
+      JSON.stringify({ code: 'token_expired', message: 'x', requestId: 'r' }),
+      { status: 401 },
+    );
+    const { fetchImpl, calls } = fetchQueue(
+      new Response(firstControl, { status: 200 }),
+      secondUnauthorized,
+    );
+    const { provider, refreshCount } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const messages = await collect(connection, 6);
+    expect(refreshCount()).toBe(1); // never a second refresh attempt
+    expect(calls).toHaveLength(2); // one retry, then stop — not a storm
+    expect(messages[messages.length - 1]).toEqual({
+      kind: 'closed',
+      reason: { type: 'server', code: 'token_expired' },
+    });
+  });
+
+  it('mutation check: without the storm guard, the above would keep refreshing/reconnecting forever', async () => {
+    // Sanity: prove the fixture really would loop without the guard by
+    // showing a *third* queued response is never touched.
+    const control = () => streamOf([controlFrame('token_expired')]);
+    const { fetchImpl, calls } = fetchQueue(
+      new Response(control(), { status: 200 }),
+      new Response(JSON.stringify({ code: 'token_expired', message: 'x', requestId: 'r' }), {
+        status: 401,
+      }),
+      new Response(control(), { status: 200 }), // would be hit by a storming client; must not be
+    );
+    const { provider, refreshCount } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    await collect(connection, 6);
+    expect(calls).toHaveLength(2);
+    expect(refreshCount()).toBe(1);
+  });
+
+  for (const reason of [
+    'session_revoked',
+    'principal_denied',
+    'citation_revoked',
+    'auth_revoked',
+    'cancelled',
+  ]) {
+    it(`delivers zero further content after a "${reason}" revoke, and does not reconnect`, async () => {
+      const body = streamOf([envelopeFrame('1', 'ask.token', { text: 'A' }), controlFrame(reason)]);
+      const { fetchImpl, calls } = fetchQueue(
+        new Response(body, { status: 200 }),
+        new Response(
+          streamOf([envelopeFrame('99', 'ask.token', { text: 'should never be seen' })]),
+          {
+            status: 200,
+          },
+        ),
+      );
+      const { provider } = fakeTokenProvider();
+      const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+        tokenProvider: provider,
+        fetchImpl,
+        backoff: () => 0,
+      });
+      const messages = await collect(connection, 6);
+      expect(messages.map((m) => m.kind)).toEqual(['event', 'control', 'closed']);
+      expect(messages[messages.length - 1]).toEqual({
+        kind: 'closed',
+        reason: { type: 'server', code: reason },
+      });
+      expect(calls).toHaveLength(1); // never reconnected
+    });
+  }
+
+  it('a durable stream.closed (with an id) ends the connection without reconnecting', async () => {
+    const body = streamOf([
+      envelopeFrame('1', 'ask.token', { text: 'A' }),
+      envelopeFrame('2', 'stream.closed', { reason: 'completed', streamSessionId: 's1' }),
+    ]);
+    const { fetchImpl, calls } = fetchQueue(new Response(body, { status: 200 }));
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const messages = await collect(connection, 5);
+    // The terminal frame carried an id, so it is an 'event' (cursor-advancing), not a synthetic 'control'.
+    expect(messages[1]).toMatchObject({ kind: 'event', id: '2' });
+    expect(messages[messages.length - 1]).toEqual({
+      kind: 'closed',
+      reason: { type: 'server', code: 'completed' },
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it('surfaces a non-contiguous but increasing sequence as a gap rather than silently accepting it', async () => {
+    const body = streamOf([
+      envelopeFrame('1', 'ask.token', { text: 'A' }),
+      envelopeFrame('2', 'ask.token', { text: 'B' }),
+      envelopeFrame('7', 'ask.token', { text: 'skipped ahead' }), // e.g. purge/loss between 2 and 7
+    ]);
+    const { fetchImpl } = fetchQueue(new Response(body, { status: 200 }));
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const messages = await collect(connection, 5);
+    const gapIndex = messages.findIndex((m) => m.kind === 'gap');
+    expect(gapIndex).toBeGreaterThan(-1);
+    expect(messages[gapIndex]).toEqual({ kind: 'gap', expected: '3', received: '7' });
+    // The event itself still gets delivered — a gap is surfaced, not dropped.
+    expect(messages[gapIndex + 1]).toMatchObject({ kind: 'event', id: '7' });
+  });
+
+  it('treats a non-increasing (duplicate/out-of-order) id as a protocol violation and stops — never delivers it twice', async () => {
+    const body = streamOf([
+      envelopeFrame('5', 'ask.token', { text: 'A' }),
+      envelopeFrame('5', 'ask.token', { text: 'A again — must not happen' }),
+    ]);
+    const { fetchImpl, calls } = fetchQueue(
+      new Response(body, { status: 200 }),
+      new Response(streamOf([envelopeFrame('6', 'ask.token', { text: 'never reached' })]), {
+        status: 200,
+      }),
+    );
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const messages = await collect(connection, 5);
+    // Cursor starts at '0', so id "5" arriving first is itself non-contiguous
+    // (a legitimate, benign gap — see advanceCursor's doc) and is surfaced
+    // before the duplicate-id protocol violation stops the connection.
+    expect(messages.map((m) => m.kind)).toEqual(['gap', 'event', 'protocol-violation', 'closed']);
+    expect(calls).toHaveLength(1); // does not reconnect and re-accept
+  });
+
+  it('an external session-lost signal aborts the fetch/reader immediately, delivering nothing further', async () => {
+    let cancelled = false;
+    const { stream, push } = openStream(() => {
+      cancelled = true;
+    });
+    const { fetchImpl } = fetchQueue(new Response(stream, { status: 200 }));
+    const { provider, fireSessionLost } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/jobs/j1/events' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+
+    const it_ = connection[Symbol.asyncIterator]();
+    push(envelopeFrame('1', 'job.progress', {}));
+    const firstResult = await it_.next();
+    expect(firstResult.value).toMatchObject({ kind: 'event', id: '1' });
+
+    fireSessionLost();
+    // The underlying source is cancelled synchronously by the abort — trying
+    // to push more into it now throws, which is an even stronger guarantee
+    // than "not delivered": nothing more can even be produced.
+    expect(() =>
+      push(envelopeFrame('2', 'job.progress', { text: 'must never be delivered' })),
+    ).toThrow();
+
+    const second = await it_.next();
+    expect(second.value).toEqual({ kind: 'closed', reason: { type: 'session-lost' } });
+    const third = await it_.next();
+    expect(third.done).toBe(true);
+    expect(cancelled).toBe(true);
+  });
+
+  it('abort() stops the fetch and releases the reader without yielding further messages', async () => {
+    let cancelled = false;
+    const { stream, push } = openStream(() => {
+      cancelled = true;
+    });
+    const { fetchImpl } = fetchQueue(new Response(stream, { status: 200 }));
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/jobs/j1/events' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+
+    const it_ = connection[Symbol.asyncIterator]();
+    push(envelopeFrame('1', 'job.progress', {}));
+    await it_.next();
+
+    connection.abort();
+    const result = await it_.next();
+    expect(result.done).toBe(true);
+    expect(cancelled).toBe(true);
+    expect(connection.aborted).toBe(true);
+  });
+
+  it('applies bounded backpressure: the network is not pulled far ahead of what the consumer has read', async () => {
+    const { stream, pulls } = countingFrameStream((seq) =>
+      envelopeFrame(String(seq), 'job.progress', { seq }),
+    );
+    const { fetchImpl } = fetchQueue(new Response(stream, { status: 200 }));
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/jobs/j1/events' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const it_ = connection[Symbol.asyncIterator]();
+
+    const first = await it_.next();
+    expect(first.value).toMatchObject({ kind: 'event', id: '1' });
+    const pullsAfterOne = pulls();
+    // A slow consumer: do not call next() again for a while. If reads ran
+    // ahead of consumption, `pulls()` would keep climbing on its own.
+    await sleep(50);
+    expect(pulls()).toBe(pullsAfterOne);
+    expect(pulls()).toBeLessThanOrEqual(2); // small constant pipeline depth (stream highWaterMark), not unbounded
+
+    for (let i = 0; i < 5; i += 1) {
+      await it_.next();
+    }
+    // Pulls track consumption 1:1 (plus the same small constant), never runaway.
+    expect(pulls()).toBeLessThanOrEqual(6 + 2);
+  });
+
+  it('retries a transient network failure with backoff, then succeeds', async () => {
+    let attempts = 0;
+    const fetchImpl = (async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw new TypeError('network down');
+      }
+      return new Response(
+        streamOf([
+          envelopeFrame('1', 'ask.token', { text: 'ok' }),
+          envelopeFrame('2', 'stream.closed', { reason: 'completed' }),
+        ]),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+      maxTransientAttempts: 5,
+    });
+    const messages = await collect(connection, 3);
+    expect(attempts).toBe(3); // exactly the transient failures + 1 success — no extra reconnect
+    expect(messages[0]).toMatchObject({ kind: 'event', id: '1' });
+  });
+
+  it('gives up after maxTransientAttempts and reports a network-error close', async () => {
+    const fetchImpl = (async () => {
+      throw new TypeError('network down');
+    }) as typeof fetch;
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+      maxTransientAttempts: 2,
+    });
+    const messages = await collect(connection, 5);
+    expect(messages).toEqual([{ kind: 'closed', reason: { type: 'network-error' } }]);
+  });
+
+  it('respects Retry-After on a 429 before retrying', async () => {
+    const rateLimited = new Response(
+      JSON.stringify({ code: 'rate_limited', message: 'x', requestId: 'r' }),
+      {
+        status: 429,
+        headers: { 'Retry-After': '0' },
+      },
+    );
+    const ok = streamOf([
+      envelopeFrame('1', 'ask.token', { text: 'ok' }),
+      envelopeFrame('2', 'stream.closed', { reason: 'completed' }),
+    ]);
+    const { fetchImpl, calls } = fetchQueue(rateLimited, new Response(ok, { status: 200 }));
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const messages = await collect(connection, 3);
+    expect(calls).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ kind: 'event', id: '1' });
+  });
+
+  it('treats a malformed JSON data field as a parse-error instead of throwing', async () => {
+    const body = streamOf(['id: 1\nevent: ask.token\ndata: {not json\n\n']);
+    const { fetchImpl } = fetchQueue(new Response(body, { status: 200 }));
+    const { provider } = fakeTokenProvider();
+    const connection = new SseConnection(() => ({ url: '/api/v1/ask/stream' }), {
+      tokenProvider: provider,
+      fetchImpl,
+      backoff: () => 0,
+    });
+    const messages = await collect(connection, 3);
+    expect(messages[0]).toMatchObject({ kind: 'parse-error' });
+  });
+
+  it('passes the bearer token and Accept header on every request', async () => {
+    const body = streamOf([envelopeFrame('1', 'ask.token', { text: 'ok' })]);
+    const { fetchImpl, calls } = fetchQueue(new Response(body, { status: 200 }));
+    const { provider, currentToken } = fakeTokenProvider('secret-token');
+    const connection = new SseConnection(
+      () => ({ url: '/api/v1/ask/stream', method: 'POST', body: '{}' }),
+      {
+        tokenProvider: provider,
+        fetchImpl,
+      },
+    );
+    await collect(connection, 1);
+    expect(calls[0].headers.get('authorization')).toBe(`Bearer ${currentToken()}`);
+    expect(calls[0].headers.get('accept')).toBe('text/event-stream');
+    expect(calls[0].method).toBe('POST');
+  });
+});

--- a/web/src/api/sse.ts
+++ b/web/src/api/sse.ts
@@ -1,0 +1,718 @@
+// Fetch-based SSE transport for Markhand's two resumable streams:
+// `GET /api/v1/jobs/{jobId}/events` (crates/server/src/routes/events.rs) and
+// `POST /api/v1/ask/stream` (crates/server/src/routes/ask.rs). Native
+// `EventSource` cannot send a bearer header, so this parses the
+// `text/event-stream` body of a `fetch()` response by hand.
+//
+// This module is deliberately endpoint-agnostic: it owns the wire protocol
+// (framing, cursor, refresh-on-401, reconnect, revocation, backpressure,
+// cancellation) and takes a `SseRequestFactory` from the caller for
+// everything endpoint-specific (URL, body, and — for `/ask/stream` — folding
+// a `streamSessionId` learned from the first `ask.started` event into later
+// reconnects). See the constructor doc for the exact seam.
+//
+// Server behaviour this file encodes, with citations:
+//
+// - Envelope shape `{version, sequence, event, requestId, data}`
+//   (camelCase on the wire): `crates/server/src/api/sse.rs:7-13`.
+// - The SSE `id:` line carries `envelope.sequence.to_string()`
+//   (routes/events.rs:354-360, services/qa/ask_stream.rs:797-803) — exact,
+//   unlike the JSON `sequence` field which is a lossy JS `number` after
+//   `JSON.parse`. See lastEventId.ts for why cursors are tracked from `id:`.
+// - A "control" close frame (`stream.closed` sent by `send_control_closed`,
+//   routes/events.rs:332-352 and services/qa/ask_stream.rs:759-778) has NO
+//   `id:` line at all — "must not advance Last-Event-ID" per the comment at
+//   routes/events.rs:344. A *durable* `stream.closed` (ask stream only, via
+//   `close_with_terminal`, db/ask_streams.rs:444-505) DOES carry a real `id`
+//   and belongs in the normal sequence. This file tells them apart purely by
+//   whether the frame carried an `id:` line, matching that invariant
+//   literally instead of guessing from the event name.
+// - Close reasons and what they mean, from `StreamAuthError::close_reason()`
+//   (services/stream_auth.rs:37-49) plus the ask-only/job-only reasons
+//   emitted directly (`cancelled`, `session_expired`, `snapshot_complete`,
+//   `live_tail_timeout`, `stream_error`, `send_timeout`, `completed`): see
+//   `classifySseCloseCode` below for the exact policy taken for each.
+// - `/ask/stream` resume-time authorization failure returns HTTP 401 with
+//   `ApiError.code` set to the same reason string (`RouteError::StreamClosed`,
+//   routes/ask.rs:456-461), while a plain expired/invalid/missing bearer
+//   token — at connect OR reconnect — always returns 401 with
+//   `code: "unauthorized"` (auth/middleware.rs:108-138), never
+//   `"token_expired"`. Both are treated as refreshable; the other
+//   `StreamClosed` codes (`session_revoked`, `principal_denied`,
+//   `citation_revoked`) are not.
+
+import type { components } from './generated/contract';
+import type { TokenProvider } from './session';
+import {
+  advanceCursor,
+  createCursor,
+  requestCursorParams,
+  type LastEventIdCursor,
+} from './lastEventId';
+
+export type { TokenProvider };
+
+/** The wire envelope for a durable event — re-exported so callers don't hand-roll it. */
+export type SseEnvelopeLike = components['schemas']['SseEnvelope'];
+
+/**
+ * The synthetic "give up" frame (`send_control_closed`). Structurally almost
+ * identical to `SseEnvelopeLike` — same field names, camelCase — plus
+ * `control: true`, and critically it never arrives with an SSE `id:` (see
+ * module doc), which is how `SseConnection` tells the two apart.
+ */
+export interface SseControlEnvelope {
+  readonly version: number;
+  readonly event: string;
+  readonly requestId: string;
+  readonly data: unknown;
+  readonly control: true;
+}
+
+/** One parsed unit handed to the consumer. Exactly one `kind` per SSE dispatch (plus a synthetic trailing `closed`). */
+export type SseMessage =
+  | { kind: 'event'; id: string; envelope: SseEnvelopeLike }
+  | { kind: 'control'; envelope: SseControlEnvelope }
+  | { kind: 'heartbeat' }
+  | { kind: 'gap'; expected: LastEventIdCursor; received: LastEventIdCursor }
+  | { kind: 'protocol-violation'; message: string; receivedId: string }
+  | { kind: 'parse-error'; raw: string; event?: string }
+  | { kind: 'closed'; reason: SseCloseReason };
+
+export type SseCloseReason =
+  { type: 'server'; code: string } | { type: 'network-error' } | { type: 'session-lost' };
+
+// ---------------------------------------------------------------------------
+// Low-level frame parser: bytes/text in, complete SSE dispatches out.
+// Handles multi-line `data:`, `event:`, `id:`, comment/heartbeat lines,
+// CRLF/LF/CR, and a chunk boundary splitting a frame (or a single line)
+// mid-way, by buffering an incomplete trailing line across `push()` calls.
+// ---------------------------------------------------------------------------
+
+/** One completed SSE dispatch. `comment` is true for a heartbeat/comment-only block (no `event:`/`data:`/`id:` seen). */
+export interface SseLineFrame {
+  readonly event?: string;
+  readonly data: string;
+  readonly id?: string;
+  readonly comment: boolean;
+}
+
+export class SseFrameParser {
+  private carry = '';
+  private eventType: string | undefined;
+  private dataLines: string[] = [];
+  private id: string | undefined;
+  private sawComment = false;
+  private sawField = false;
+
+  /** Feed a decoded text chunk (already UTF-8 decoded — see `decode({ stream: true })` below); returns any frames completed by it. */
+  push(text: string): SseLineFrame[] {
+    const combined = this.carry + text;
+    const lines = combined.split(/\r\n|\r|\n/);
+    // The trailing element is text after the last line break — an
+    // incomplete line if `text` didn't end on a break — and must carry over.
+    this.carry = lines.pop() ?? '';
+    const frames: SseLineFrame[] = [];
+    for (const line of lines) {
+      const frame = this.consumeLine(line);
+      if (frame) {
+        frames.push(frame);
+      }
+    }
+    return frames;
+  }
+
+  /** Call once when the underlying stream ends, to flush a final frame that arrived without a trailing blank line. */
+  flush(): SseLineFrame[] {
+    const frames: SseLineFrame[] = [];
+    if (this.carry !== '') {
+      const tail = this.carry;
+      this.carry = '';
+      const frame = this.consumeLine(tail);
+      if (frame) {
+        frames.push(frame);
+      }
+    }
+    const final = this.dispatch();
+    if (final) {
+      frames.push(final);
+    }
+    return frames;
+  }
+
+  private consumeLine(line: string): SseLineFrame | undefined {
+    if (line === '') {
+      return this.dispatch();
+    }
+    if (line.startsWith(':')) {
+      this.sawComment = true;
+      return undefined;
+    }
+    const colon = line.indexOf(':');
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? '' : line.slice(colon + 1);
+    if (value.startsWith(' ')) {
+      value = value.slice(1);
+    }
+    switch (field) {
+      case 'event':
+        this.eventType = value;
+        this.sawField = true;
+        break;
+      case 'data':
+        this.dataLines.push(value);
+        this.sawField = true;
+        break;
+      case 'id':
+        this.id = value;
+        this.sawField = true;
+        break;
+      default:
+        // Unknown/unused field (e.g. `retry:`) — ignore, don't error.
+        break;
+    }
+    return undefined;
+  }
+
+  private dispatch(): SseLineFrame | undefined {
+    const hadField = this.sawField;
+    const hadComment = this.sawComment;
+    if (!hadField && !hadComment) {
+      return undefined; // stray blank line — nothing accumulated since the last dispatch
+    }
+    const frame: SseLineFrame = {
+      event: this.eventType,
+      data: this.dataLines.join('\n'),
+      id: this.id,
+      comment: !hadField && hadComment,
+    };
+    this.eventType = undefined;
+    this.dataLines = [];
+    this.id = undefined;
+    this.sawComment = false;
+    this.sawField = false;
+    return frame;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Close-reason policy
+// ---------------------------------------------------------------------------
+
+export type SseCloseAction = 'refresh' | 'terminal' | 'retry' | 'complete';
+
+/** `token_expired` (services/stream_auth.rs:40): the token expired mid-stream — refresh once, then resume from Last-Event-ID. */
+const REFRESH_CODES: ReadonlySet<string> = new Set(['token_expired']);
+
+/** Durable end-of-stream reasons: `completed` is ask's normal finish (ask_stream.rs:452); `snapshot_complete` is job's (routes/events.rs:161-165, job already terminal, backlog drained). */
+const COMPLETE_CODES: ReadonlySet<string> = new Set(['completed', 'snapshot_complete']);
+
+/** Transient producer/server hiccups worth a backoff-and-reconnect, not a hard failure: `stream_error` (DB/timeout), `send_timeout` (reserve() timed out server-side), `live_tail_timeout` (idle-polled out while the job/session was still open). */
+const RETRY_CODES: ReadonlySet<string> = new Set([
+  'stream_error',
+  'send_timeout',
+  'live_tail_timeout',
+]);
+
+/**
+ * Classify a `stream.closed` reason (or a 401 `ApiError.code`) into what the
+ * client should do next. Everything not explicitly a refresh/complete/retry
+ * code — `session_revoked`, `principal_denied`, `auth_revoked`,
+ * `citation_revoked`, `cancelled`, `session_expired`, and any reason this
+ * client doesn't recognize — is `terminal`. Treating unknown reasons as
+ * terminal rather than retryable is a deliberate fail-closed choice: the
+ * "no reconnect storm" and "zero content after revoke" requirements both
+ * fail if a future/unrecognized server reason is guessed to be transient.
+ */
+export function classifySseCloseCode(code: string): SseCloseAction {
+  if (REFRESH_CODES.has(code)) return 'refresh';
+  if (COMPLETE_CODES.has(code)) return 'complete';
+  if (RETRY_CODES.has(code)) return 'retry';
+  return 'terminal';
+}
+
+function closeReasonOf(envelope: { event: string; data: unknown }): string | undefined {
+  if (envelope.event !== 'stream.closed') {
+    return undefined;
+  }
+  const data = envelope.data;
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    typeof (data as Record<string, unknown>).reason === 'string'
+  ) {
+    return (data as { reason: string }).reason;
+  }
+  return undefined;
+}
+
+function isEnvelopeShaped(
+  value: unknown,
+): value is { version: number; event: string; requestId: string; data: unknown } {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.event === 'string' && typeof record.requestId === 'string' && 'data' in record
+  );
+}
+
+async function safeReadJson(response: Response): Promise<Record<string, unknown> | undefined> {
+  try {
+    const value: unknown = await response.json();
+    return typeof value === 'object' && value !== null
+      ? (value as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** `Retry-After` on 429 (components.responses.RateLimited, openapi.yaml) is documented as a number of seconds. */
+function parseRetryAfterMs(headerValue: string | null): number | undefined {
+  if (!headerValue) {
+    return undefined;
+  }
+  const seconds = Number(headerValue);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1000 : undefined;
+}
+
+function defaultBackoff(attempt: number): number {
+  return Math.min(500 * 2 ** (attempt - 1), 10_000);
+}
+
+class AbortWaitError extends Error {}
+
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(new AbortWaitError('aborted'));
+  }
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new AbortWaitError('aborted'));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Connection
+// ---------------------------------------------------------------------------
+
+export interface SseRequestDescriptor {
+  readonly url: string;
+  readonly method?: string;
+  readonly headers?: Record<string, string>;
+  readonly body?: string;
+}
+
+/**
+ * Builds the request for a (re)connect at `cursor`. Called once per attempt,
+ * including every reconnect, so a caller resuming `/ask/stream` can close
+ * over the `streamSessionId` it learned from the first `ask.started`
+ * event's `envelope.data.streamSessionId` and add it as a query parameter
+ * from the second call onward — `SseConnection` itself has no notion of
+ * ask/job specifics, only of `lastEventId`/`Last-Event-ID`, which it adds
+ * automatically (see `requestCursorParams`).
+ */
+export type SseRequestFactory = (cursor: LastEventIdCursor) => SseRequestDescriptor;
+
+export interface SseConnectionOptions {
+  readonly tokenProvider: TokenProvider;
+  /** Defaults to global `fetch`; override in tests. */
+  readonly fetchImpl?: typeof fetch;
+  /** Resume from this cursor instead of a fresh connect at `0`. */
+  readonly initialLastEventId?: string;
+  /** External cancellation, merged with the connection's own `abort()`. */
+  readonly signal?: AbortSignal;
+  /** Backoff schedule for transient retries, keyed by 1-based attempt number. Overridable for deterministic tests. */
+  readonly backoff?: (attempt: number) => number;
+  /** Give up after this many consecutive transient failures. */
+  readonly maxTransientAttempts?: number;
+}
+
+type ConsumeOutcome =
+  | { action: 'aborted' }
+  | { action: 'reconnect' }
+  | { action: 'refresh' }
+  | { action: 'terminal'; code: string }
+  | { action: 'complete'; code: string };
+
+/**
+ * A resumable, bearer-authenticated SSE connection over `fetch`.
+ *
+ * Usage:
+ *
+ * ```ts
+ * const connection = new SseConnection(
+ *   (cursor) => ({ url: `/api/v1/jobs/${jobId}/events`, method: 'GET' }),
+ *   { tokenProvider },
+ * );
+ * for await (const message of connection) {
+ *   if (message.kind === 'event') { ... }
+ * }
+ * ```
+ *
+ * Properties this class is built to satisfy (see the class-level doc for
+ * server citations backing each policy):
+ *
+ * - No acknowledged event lost or repeated across reconnect: the cursor only
+ *   ever advances past an `id`-bearing frame once yielded, and every
+ *   (re)connect asks `SseRequestFactory` for a fresh descriptor which this
+ *   class stamps with that exact cursor as `lastEventId`/`Last-Event-ID`.
+ * - Sequence order + gap surfaced: `advanceCursor` (lastEventId.ts) rejects
+ *   any non-increasing id as a `protocol-violation` (terminal — never
+ *   silently accepted as if it were fine), and reports non-contiguous but
+ *   increasing ids as `gap` without deciding for the caller whether that's
+ *   alarming (see the long comment on `advanceCursor` — it isn't, for job
+ *   streams).
+ * - Exactly one refresh + resume per 401/`token_expired`, not a storm:
+ *   `refreshedWithoutProgress` allows exactly one `refreshNow()` between
+ *   moments of forward progress (any yielded event/heartbeat/control resets
+ *   it); a second consecutive auth failure with zero progress in between
+ *   goes straight to `closed`.
+ * - Zero content after session loss/revoke: a `terminal` classification
+ *   (session_revoked/principal_denied/citation_revoked/auth_revoked/
+ *   cancelled/session_expired/unknown) ends the generator immediately with
+ *   no further reconnect; separately, `tokenProvider.onSessionLost` aborts
+ *   the in-flight fetch/reader synchronously, without waiting for the
+ *   server to say so.
+ * - Bounded backpressure: this is an async generator — `reader.read()` is
+ *   only called again once the consumer calls `.next()` (i.e. resumes the
+ *   `for await` loop), so an unread stream never grows an internal queue.
+ * - Cancellation: `abort()` triggers `AbortController.abort()`, which both
+ *   aborts the in-flight `fetch()` (via `signal`) and cancels+releases the
+ *   stream reader (`consumeBody`'s `abort` listener calls `reader.cancel()`
+ *   before `reader.releaseLock()` in `finally`).
+ */
+export class SseConnection implements AsyncIterable<SseMessage> {
+  private readonly controller = new AbortController();
+  private readonly fetchImpl: typeof fetch;
+  private readonly backoff: (attempt: number) => number;
+  private readonly maxTransientAttempts: number;
+  private readonly unsubscribeSessionLost: () => void;
+  private cursor: LastEventIdCursor;
+  private refreshedWithoutProgress = false;
+  private transientAttempt = 0;
+  private sessionLostExternally = false;
+  private iterator: AsyncGenerator<SseMessage, void, void> | undefined;
+
+  constructor(
+    private readonly requestFactory: SseRequestFactory,
+    private readonly options: SseConnectionOptions,
+  ) {
+    this.cursor = createCursor(options.initialLastEventId);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.backoff = options.backoff ?? defaultBackoff;
+    this.maxTransientAttempts = options.maxTransientAttempts ?? 6;
+    if (options.signal) {
+      if (options.signal.aborted) {
+        this.controller.abort();
+      } else {
+        options.signal.addEventListener('abort', () => this.controller.abort(), { once: true });
+      }
+    }
+    this.unsubscribeSessionLost = options.tokenProvider.onSessionLost(() => {
+      this.sessionLostExternally = true;
+      this.controller.abort();
+    });
+  }
+
+  /** Stop the fetch and release the reader. Idempotent. No further messages are yielded except a final `session-lost` close if that's why we stopped. */
+  abort(): void {
+    this.controller.abort();
+  }
+
+  get aborted(): boolean {
+    return this.controller.signal.aborted;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<SseMessage> {
+    this.iterator ??= this.driveWithFinalClose();
+    return this.iterator;
+  }
+
+  private async *driveWithFinalClose(): AsyncGenerator<SseMessage, void, void> {
+    try {
+      yield* this.run();
+    } finally {
+      this.unsubscribeSessionLost();
+    }
+    if (this.sessionLostExternally) {
+      yield { kind: 'closed', reason: { type: 'session-lost' } };
+    }
+  }
+
+  private async *run(): AsyncGenerator<SseMessage, void, void> {
+    while (!this.controller.signal.aborted) {
+      const descriptor = this.requestFactory(this.cursor);
+
+      let token: string;
+      try {
+        token = await this.options.tokenProvider.getAccessToken();
+      } catch {
+        return;
+      }
+      if (this.controller.signal.aborted) {
+        return;
+      }
+
+      const headers = new Headers(descriptor.headers);
+      headers.set('Accept', 'text/event-stream');
+      headers.set('Authorization', `Bearer ${token}`);
+      let url = descriptor.url;
+      const resume = requestCursorParams(this.cursor);
+      if (resume) {
+        url += (url.includes('?') ? '&' : '?') + `lastEventId=${resume.query}`;
+        headers.set('Last-Event-ID', resume.header);
+      }
+
+      let response: Response;
+      try {
+        response = await this.fetchImpl(url, {
+          method: descriptor.method ?? 'GET',
+          headers,
+          body: descriptor.body,
+          signal: this.controller.signal,
+        });
+      } catch {
+        if (this.controller.signal.aborted) {
+          return;
+        }
+        this.transientAttempt += 1;
+        if (!(yield* this.stopOrRetry(this.transientAttempt))) return;
+        continue;
+      }
+
+      if (response.status === 401) {
+        const body = await safeReadJson(response);
+        const code = typeof body?.code === 'string' ? body.code : 'unauthorized';
+        const refreshable = code === 'unauthorized' || classifySseCloseCode(code) === 'refresh';
+        if (!refreshable) {
+          yield { kind: 'closed', reason: { type: 'server', code } };
+          return;
+        }
+        if (!(yield* this.refreshOrStop(code))) return;
+        continue;
+      }
+
+      if (!response.ok) {
+        if (response.status === 429 || response.status >= 500) {
+          const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
+          this.transientAttempt += 1;
+          if (!(yield* this.stopOrRetry(this.transientAttempt, retryAfterMs))) return;
+          continue;
+        }
+        const body = await safeReadJson(response);
+        const code = typeof body?.code === 'string' ? body.code : String(response.status);
+        yield { kind: 'closed', reason: { type: 'server', code } };
+        return;
+      }
+
+      if (!response.body) {
+        this.transientAttempt += 1;
+        if (!(yield* this.stopOrRetry(this.transientAttempt))) return;
+        continue;
+      }
+
+      const outcome = yield* this.consumeBody(response.body);
+      switch (outcome.action) {
+        case 'aborted':
+          return;
+        case 'reconnect':
+          this.transientAttempt += 1;
+          if (!(yield* this.stopOrRetry(this.transientAttempt))) return;
+          continue;
+        case 'refresh':
+          if (!(yield* this.refreshOrStop('token_expired'))) return;
+          continue;
+        case 'terminal':
+          yield { kind: 'closed', reason: { type: 'server', code: outcome.code } };
+          return;
+        case 'complete':
+          yield { kind: 'closed', reason: { type: 'server', code: outcome.code } };
+          return;
+      }
+    }
+  }
+
+  /** Single-flight refresh-then-resume, guarded against a storm: refuses a second refresh attempt without intervening forward progress. */
+  private async *refreshOrStop(code: string): AsyncGenerator<SseMessage, boolean, void> {
+    if (this.refreshedWithoutProgress) {
+      yield { kind: 'closed', reason: { type: 'server', code } };
+      return false;
+    }
+    this.refreshedWithoutProgress = true;
+    try {
+      await this.options.tokenProvider.refreshNow();
+    } catch {
+      return false;
+    }
+    return true;
+  }
+
+  private async retryOrStop(attempt: number, retryAfterMs?: number): Promise<boolean> {
+    if (attempt > this.maxTransientAttempts) {
+      return false;
+    }
+    try {
+      await delay(retryAfterMs ?? this.backoff(attempt), this.controller.signal);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async *stopOrRetry(
+    attempt: number,
+    retryAfterMs?: number,
+  ): AsyncGenerator<SseMessage, boolean, void> {
+    if (await this.retryOrStop(attempt, retryAfterMs)) {
+      return true;
+    }
+    if (!this.controller.signal.aborted) {
+      yield { kind: 'closed', reason: { type: 'network-error' } };
+    }
+    return false;
+  }
+
+  private async *consumeBody(
+    body: ReadableStream<Uint8Array>,
+  ): AsyncGenerator<SseMessage, ConsumeOutcome, void> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder(); // one persistent decoder: `{ stream: true }` below carries a
+    // split multi-byte UTF-8 sequence across chunk boundaries correctly —
+    // important for Vietnamese text, which is full of multi-byte codepoints.
+    const parser = new SseFrameParser();
+    const cancelOnAbort = () => {
+      reader.cancel().catch(() => {});
+    };
+    this.controller.signal.addEventListener('abort', cancelOnAbort, { once: true });
+    try {
+      while (true) {
+        let step: ReadableStreamReadResult<Uint8Array>;
+        try {
+          step = await reader.read();
+        } catch {
+          return this.controller.signal.aborted ? { action: 'aborted' } : { action: 'reconnect' };
+        }
+        if (this.controller.signal.aborted) {
+          return { action: 'aborted' };
+        }
+        if (step.done) {
+          const outcome = yield* this.processFrames(parser.flush());
+          return outcome ?? { action: 'reconnect' };
+        }
+        const text = decoder.decode(step.value, { stream: true });
+        const outcome = yield* this.processFrames(parser.push(text));
+        if (outcome) {
+          return outcome;
+        }
+      }
+    } finally {
+      this.controller.signal.removeEventListener('abort', cancelOnAbort);
+      reader.releaseLock();
+    }
+  }
+
+  private *processFrames(
+    frames: SseLineFrame[],
+  ): Generator<SseMessage, ConsumeOutcome | undefined, void> {
+    for (const frame of frames) {
+      this.transientAttempt = 0; // bytes arrived: the connection is alive and authenticated
+      for (const message of this.toMessages(frame)) {
+        if (
+          message.kind === 'event' ||
+          message.kind === 'heartbeat' ||
+          message.kind === 'control'
+        ) {
+          this.refreshedWithoutProgress = false;
+        }
+        yield message;
+        const outcome = this.closeOutcomeFor(message);
+        if (outcome) {
+          return outcome;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private toMessages(frame: SseLineFrame): SseMessage[] {
+    if (frame.comment) {
+      return [{ kind: 'heartbeat' }];
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(frame.data);
+    } catch {
+      return [{ kind: 'parse-error', raw: frame.data, event: frame.event }];
+    }
+    if (!isEnvelopeShaped(parsed)) {
+      return [{ kind: 'parse-error', raw: frame.data, event: frame.event }];
+    }
+
+    if (frame.id !== undefined) {
+      // Carries `id:` -> durable, sequence-bearing event (module doc).
+      const result = advanceCursor(this.cursor, frame.id);
+      if (!result.ok) {
+        return [
+          {
+            kind: 'protocol-violation',
+            message: `id "${frame.id}" invalid or not greater than last acked "${this.cursor}" (${result.error})`,
+            receivedId: frame.id,
+          },
+        ];
+      }
+      const messages: SseMessage[] = [];
+      if (!result.contiguous) {
+        messages.push({ kind: 'gap', expected: result.expected, received: frame.id });
+      }
+      this.cursor = result.cursor;
+      messages.push({ kind: 'event', id: frame.id, envelope: parsed as SseEnvelopeLike });
+      return messages;
+    }
+
+    // No `id:` -> synthetic control frame; must not advance the cursor.
+    return [
+      {
+        kind: 'control',
+        envelope: { ...(parsed as Record<string, unknown>), control: true } as SseControlEnvelope,
+      },
+    ];
+  }
+
+  private closeOutcomeFor(message: SseMessage): ConsumeOutcome | undefined {
+    if (message.kind === 'protocol-violation') {
+      // A duplicate/out-of-order id is never legitimate (lastEventId.ts) —
+      // fail closed rather than keep accepting a possibly-replayed stream.
+      return { action: 'terminal', code: 'protocol_violation' };
+    }
+    if (message.kind !== 'event' && message.kind !== 'control') {
+      return undefined;
+    }
+    const reason = closeReasonOf(message.envelope);
+    if (reason === undefined) {
+      return undefined;
+    }
+    switch (classifySseCloseCode(reason)) {
+      case 'refresh':
+        return { action: 'refresh' };
+      case 'complete':
+        return { action: 'complete', code: reason };
+      case 'retry':
+        return { action: 'reconnect' };
+      case 'terminal':
+        return { action: 'terminal', code: reason };
+    }
+  }
+}

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -1,37 +1,520 @@
-import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '../api/client';
+import { HttpApiError } from '../api/errors';
+import type { SessionTokens } from '../api/session';
+import { installMockFetch, mockControl, resetMockState, uninstallMockFetch } from '../mocks';
+import { createApiClient } from '../api/client';
+import { ScopeProvider, useScope } from '../state/ScopeProvider';
 import { AuthProvider, useAuth } from './AuthContext';
+import { loadPersistedRefreshToken } from './tokenStorage';
 
-afterEach(() => {
-  cleanup();
-});
+const DEMO_EMAIL = 'demo@markhand.test';
+const DEMO_PASSWORD = 'demo-password';
+
+/** Deferred promise helper for deterministic race tests (stale `me()` after logout, etc). */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const SAMPLE_ME = {
+  userId: 'user-1',
+  orgId: 'org-1',
+  email: DEMO_EMAIL,
+  displayName: 'Demo User',
+  permissions: ['qa.history'],
+  allowedCollectionIds: ['col-1'],
+  sessionId: 'session-1',
+};
+
+function sampleTokens(overrides: Partial<SessionTokens> = {}): SessionTokens {
+  return {
+    accessToken: 'access-1',
+    refreshToken: 'refresh-1',
+    tokenType: 'Bearer',
+    expiresIn: 3600,
+    orgId: 'org-1',
+    userId: 'user-1',
+    ...overrides,
+  };
+}
+
+/**
+ * A hand-built `ApiClient` double: only the members `AuthContext` actually
+ * calls are implemented, each a directly-controllable `vi.fn()`/deferred so
+ * races (stale response after logout, session-lost mid-flight) can be
+ * driven deterministically without timing tricks against real fetch/timers.
+ */
+function createFakeClient() {
+  let sessionLostListener: (() => void) | null = null;
+  let rotationListener: ((tokens: SessionTokens) => void) | null = null;
+  const setTokensCalls: SessionTokens[] = [];
+  let currentRefreshToken: string | null = null;
+  let clearedCount = 0;
+
+  const client = {
+    login: vi.fn(),
+    logout: vi.fn(async () => {}),
+    me: vi.fn(),
+    tokenProvider: {
+      getAccessToken: vi.fn(),
+      refreshNow: vi.fn(),
+      onSessionLost(listener: () => void) {
+        sessionLostListener = listener;
+        return () => {
+          if (sessionLostListener === listener) sessionLostListener = null;
+        };
+      },
+    },
+    sessionManager: {
+      setTokens: vi.fn((tokens: SessionTokens) => {
+        setTokensCalls.push(tokens);
+        currentRefreshToken = tokens.refreshToken;
+      }),
+      clear: vi.fn(() => {
+        clearedCount += 1;
+        currentRefreshToken = null;
+      }),
+      hasSession: vi.fn(() => currentRefreshToken !== null),
+      getRefreshTokenForLogout: vi.fn(() => currentRefreshToken),
+      getAccessToken: vi.fn(),
+      refreshNow: vi.fn(),
+      onSessionLost(listener: () => void) {
+        sessionLostListener = listener;
+        return () => {
+          if (sessionLostListener === listener) sessionLostListener = null;
+        };
+      },
+      onTokensRotated(listener: (tokens: SessionTokens) => void) {
+        rotationListener = listener;
+        return () => {
+          if (rotationListener === listener) rotationListener = null;
+        };
+      },
+    },
+  } as unknown as ApiClient;
+
+  return {
+    client,
+    setTokensCalls,
+    fireSessionLost: () => sessionLostListener?.(),
+    fireRotation: (tokens: SessionTokens) => {
+      currentRefreshToken = tokens.refreshToken;
+      rotationListener?.(tokens);
+    },
+    hasRotationListener: () => rotationListener !== null,
+    clearedCount: () => clearedCount,
+    currentRefreshToken: () => currentRefreshToken,
+  };
+}
 
 function Probe() {
   const { session } = useAuth();
   return <span data-testid="status">{session.status}</span>;
 }
 
-describe('AuthContext', () => {
-  it('defaults to an anonymous session', () => {
-    render(
-      <AuthProvider>
-        <Probe />
-      </AuthProvider>,
-    );
-    expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
-  });
+function ScopeProbe() {
+  const { scope } = useScope();
+  return <span data-testid="scope-org">{scope ? scope.orgId : 'null'}</span>;
+}
 
-  it('exposes an authenticated session when provided', () => {
-    render(
-      <AuthProvider session={{ status: 'authenticated', email: 'a@example.com', role: 'admin' }}>
-        <Probe />
-      </AuthProvider>,
-    );
-    expect(screen.getByTestId('status')).toHaveTextContent('authenticated');
-  });
+afterEach(() => {
+  cleanup();
+  window.sessionStorage.clear();
+  uninstallMockFetch();
+});
 
-  it('defaults to anonymous when useAuth is called outside a provider', () => {
+describe('AuthContext (default/outside provider)', () => {
+  it('defaults to an anonymous session when useAuth is called outside a provider', () => {
     render(<Probe />);
     expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
   });
 });
+
+describe('AuthContext bootstrap', () => {
+  it('goes straight to anonymous with no persisted refresh token, without calling me()', async () => {
+    const { client } = createFakeClient();
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Probe />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+    expect(client.me).not.toHaveBeenCalled();
+  });
+
+  it('restores an authenticated session from a persisted refresh token', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const { client, setTokensCalls } = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Probe />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+    // Seeded with the persisted refresh token behind an already-expired
+    // access token, so the real session manager's own refresh path (not a
+    // hand-rolled one here) is what would fetch a fresh access token.
+    expect(setTokensCalls[0]).toMatchObject({ refreshToken: 'stored-refresh', expiresIn: -1 });
+  });
+
+  it('clears the persisted token and stays anonymous when the stored refresh token is rejected', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stale-refresh');
+    const { client } = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new HttpApiError({
+        status: 401,
+        code: 'unauthorized',
+        message: 'refresh token is invalid',
+        requestId: 'r1',
+      }),
+    );
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Probe />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+    expect(loadPersistedRefreshToken()).toBeNull();
+  });
+});
+
+describe('AuthContext login/logout', () => {
+  it('login() populates the session from me() and persists the refresh token', async () => {
+    const { client } = createFakeClient();
+    (client.login as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTokens());
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+    function Harness() {
+      const { session, login } = useAuth();
+      return (
+        <>
+          <span data-testid="status">{session.status}</span>
+          <button onClick={() => void login(DEMO_EMAIL, DEMO_PASSWORD)}>go</button>
+        </>
+      );
+    }
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Harness />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+
+    await act(async () => {
+      screen.getByText('go').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+    expect(loadPersistedRefreshToken()).toBe('refresh-1');
+  });
+
+  it('login() surfaces a failed me() as an anonymous session and rethrows', async () => {
+    const { client } = createFakeClient();
+    (client.login as ReturnType<typeof vi.fn>).mockResolvedValue(sampleTokens());
+    (client.me as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('me failed'));
+
+    let caught: unknown;
+    function Harness() {
+      const { session, login } = useAuth();
+      return (
+        <>
+          <span data-testid="status">{session.status}</span>
+          <button
+            onClick={() => {
+              login(DEMO_EMAIL, DEMO_PASSWORD).catch((e) => {
+                caught = e;
+              });
+            }}
+          >
+            go
+          </button>
+        </>
+      );
+    }
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Harness />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+
+    await act(async () => {
+      screen.getByText('go').click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
+    expect(caught).toBeInstanceOf(Error);
+    expect(loadPersistedRefreshToken()).toBeNull();
+  });
+
+  it('logout() clears the session immediately and calls the API best-effort', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const { client } = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+    function Harness() {
+      const { session, logout } = useAuth();
+      return (
+        <>
+          <span data-testid="status">{session.status}</span>
+          <button onClick={() => void logout()}>bye</button>
+        </>
+      );
+    }
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Harness />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+
+    await act(async () => {
+      screen.getByText('bye').click();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
+    expect(client.logout).toHaveBeenCalledTimes(1);
+    expect(loadPersistedRefreshToken()).toBeNull();
+  });
+
+  it('a me() response that resolves after logout() must not repopulate the shell', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const { client } = createFakeClient();
+    const pendingMe = deferred<typeof SAMPLE_ME>();
+    (client.me as ReturnType<typeof vi.fn>).mockReturnValue(pendingMe.promise);
+
+    function Harness() {
+      const { session, logout } = useAuth();
+      return (
+        <>
+          <span data-testid="status">{session.status}</span>
+          <button onClick={() => void logout()}>bye</button>
+        </>
+      );
+    }
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Harness />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+    // Bootstrap's me() call is in flight (never resolved yet).
+    await waitFor(() => expect(client.me).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      screen.getByText('bye').click();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
+
+    // The stale bootstrap `me()` now resolves — after logout already ran.
+    await act(async () => {
+      pendingMe.resolve(SAMPLE_ME);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
+  });
+});
+
+describe('AuthContext session loss', () => {
+  it('onSessionLost mid-session clears the persisted token and becomes anonymous', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const { client, fireSessionLost } = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Probe />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+
+    act(() => {
+      fireSessionLost();
+    });
+
+    expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
+    expect(loadPersistedRefreshToken()).toBeNull();
+  });
+
+  // ADR 0010 rotates the refresh token on every use and revokes the family when
+  // an already-rotated one is replayed, so a stored copy that misses a rotation
+  // is worse than useless: its next use is indistinguishable from a replay
+  // attack. The dangerous rotation is the one nobody asked for — an access
+  // token expiring during ordinary use, rotated entirely inside session.ts.
+  it('persists the rotation that happens inside a refresh, not just at login', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const { client, fireRotation, hasRotationListener } = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Probe />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+    expect(hasRotationListener()).toBe(true);
+
+    act(() => {
+      fireRotation({
+        accessToken: 'access-rotated',
+        refreshToken: 'refresh-rotated',
+        tokenType: 'Bearer',
+        expiresIn: 900,
+        orgId: SAMPLE_ME.orgId,
+        userId: SAMPLE_ME.userId,
+      });
+    });
+
+    expect(loadPersistedRefreshToken()).toBe('refresh-rotated');
+    expect(screen.getByTestId('status')).toHaveTextContent('authenticated');
+  });
+});
+
+describe('AuthContext / scope integration', () => {
+  it('sets the scope on login and clears it on logout (per ScopeProvider.tsx handoff)', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const { client } = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+    function Harness() {
+      const { session, logout } = useAuth();
+      return (
+        <>
+          <span data-testid="status">{session.status}</span>
+          <button onClick={() => void logout()}>bye</button>
+        </>
+      );
+    }
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Harness />
+          <ScopeProbe />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+    expect(screen.getByTestId('scope-org')).toHaveTextContent('org-1');
+
+    await act(async () => {
+      screen.getByText('bye').click();
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('scope-org')).toHaveTextContent('null');
+  });
+});
+
+describe('AuthContext end-to-end against the real API client + mock server', () => {
+  beforeEach(() => {
+    installMockFetch();
+    resetMockState();
+    mockControl.reset();
+  });
+
+  it('logs in through the real mock server, persists the refresh token, and a fresh provider restores the session from it on "reload"', async () => {
+    const firstLoadClient = createApiClient({ baseUrl: '' });
+    render(
+      <ScopeProvider>
+        <AuthProvider client={firstLoadClient}>
+          <LoginHarness />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+    await act(async () => {
+      screen.getByText('go').click();
+    });
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+    expect(loadPersistedRefreshToken()).not.toBeNull();
+
+    cleanup();
+
+    // Simulate a reload: fresh AuthProvider around a brand-new `ApiClient`
+    // instance (a real reload creates a fresh module instance too — nothing
+    // is reused from `firstLoadClient`), with only the persisted refresh
+    // token surviving (the access token is memory-only and is gone, as it
+    // should be).
+    const reloadedClient = createApiClient({ baseUrl: '' });
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={reloadedClient}>
+          <Probe />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+  });
+
+  it('a rejected stored refresh token (401) lands on anonymous and clears storage', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'not-a-real-refresh-token');
+    const client = createApiClient({ baseUrl: '' });
+
+    render(
+      <ScopeProvider>
+        <AuthProvider client={client}>
+          <Probe />
+        </AuthProvider>
+      </ScopeProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+    expect(loadPersistedRefreshToken()).toBeNull();
+  });
+});
+
+function LoginHarness() {
+  const { session, login } = useAuth();
+  return (
+    <>
+      <span data-testid="status">{session.status}</span>
+      <button onClick={() => void login(DEMO_EMAIL, DEMO_PASSWORD)}>go</button>
+    </>
+  );
+}

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -1,32 +1,265 @@
-// Seam for P2.3 (Wave 1): real login/session/token/refresh logic is out of
-// scope for this workspace-foundations task. This only establishes the
-// shape — an in-memory session the shell and pages can read — so the auth
-// agent can replace `AuthProvider`'s implementation (wire it to
-// `api/client.ts`, keep the access token in memory, add org switch) without
-// having to introduce the context/hook pair from scratch.
-import { createContext, useContext, useMemo, type ReactNode } from 'react';
+// Real login/session implementation for P2-05 (plans/markhand-web/phase-2-web-spa.md
+// §P2.3). This replaces the Wave-0 seam but keeps `useAuth()` as the single
+// hook callers reach for; `session` is still the first thing on the returned
+// value so the one existing caller (`LoginPage.tsx`) does not have to change
+// how it reads status.
+//
+// Ground truth for this task: `MeResponse` has no single "role" field — only
+// `permissions: string[]` (see plans/markhand-web/phase-1c-multi-org-security.md
+// §P1C.2's permission constants/matrix). So `Session` surfaces permissions
+// directly instead of inventing a role label the server does not send.
+//
+// This file depends on `../state/ScopeProvider`'s `useScope()` (owned by the
+// concurrent org-switch agent, not edited here — only its already-committed
+// public seam is used). `ScopeProvider.tsx`'s own module doc names this
+// exact handoff: "the auth/shell agent calls `useScope().setScope(...)`
+// after login resolves, after an org switch completes, and with `null` on
+// logout/session-lost." This file owns the login/logout/session-lost calls;
+// the org-switch call site belongs to whoever builds org switching.
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { apiClient, type ApiClient } from '../api/client';
+import { isAbortError } from '../api/errors';
+import type { components } from '../api/generated/contract';
+import { useScope } from '../state/ScopeProvider';
+import {
+  clearPersistedRefreshToken,
+  loadPersistedRefreshToken,
+  savePersistedRefreshToken,
+} from './tokenStorage';
 
-export type Role = 'owner' | 'admin' | 'editor' | 'viewer';
+type MeResponse = components['schemas']['MeResponse'];
 
+/**
+ * `checking` covers both "bootstrapping on page load" and "a login/logout is
+ * in flight" — callers that only care about "may I render protected UI yet"
+ * treat it like anonymous (do not render), while `RouteGuard.tsx` shows a
+ * neutral loading state for it instead of bouncing to `/login` prematurely.
+ */
 export type Session =
-  { status: 'anonymous' } | { status: 'authenticated'; email: string; role: Role };
+  { status: 'checking' } | { status: 'anonymous' } | ({ status: 'authenticated' } & MeResponse);
 
 export interface AuthContextValue {
   session: Session;
+  /** `POST /auth/login` + populates the session from `GET /auth/me`. Rejects (and leaves the session anonymous) on any failure — callers show the error. */
+  login(email: string, password: string): Promise<void>;
+  /** Clears the session immediately (client-side), then best-effort calls `POST /auth/logout`. Never rejects. */
+  logout(): Promise<void>;
+  /** Re-fetches `GET /auth/me` and applies the result — e.g. after an org switch changes permissions/allowedCollectionIds without a full reload. */
+  refreshSession(): Promise<void>;
+  /**
+   * UI convenience only — never authorization. This only decides whether the
+   * shell *renders* something; the server is always the one that decides
+   * whether a request succeeds. A `true` here that turns out wrong just means
+   * a control is shown that the next API call answers with a 403.
+   */
+  hasPermission(permission: string): boolean;
 }
 
-const defaultValue: AuthContextValue = { session: { status: 'anonymous' } };
+const defaultValue: AuthContextValue = {
+  session: { status: 'anonymous' },
+  login: () => Promise.reject(new Error('useAuth() called outside an AuthProvider')),
+  logout: () => Promise.reject(new Error('useAuth() called outside an AuthProvider')),
+  refreshSession: () => Promise.reject(new Error('useAuth() called outside an AuthProvider')),
+  hasPermission: () => false,
+};
 
 const AuthContext = createContext<AuthContextValue>(defaultValue);
 
-export function AuthProvider({
-  children,
-  session = defaultValue.session,
-}: {
+export interface AuthProviderProps {
   children: ReactNode;
-  session?: Session;
-}) {
-  const value = useMemo<AuthContextValue>(() => ({ session }), [session]);
+  /** Injectable for tests; defaults to the app-wide singleton in `api/client.ts`. */
+  client?: ApiClient;
+}
+
+export function AuthProvider({ children, client = apiClient }: AuthProviderProps) {
+  // Lazy initializer (not an effect) so a visitor with no persisted refresh
+  // token renders `anonymous` on the very first paint — no synchronous
+  // setState-in-effect needed for that branch, and no flash of "checking"
+  // for the common case of a plain, never-logged-in visit.
+  const [session, setSession] = useState<Session>(() =>
+    loadPersistedRefreshToken() ? { status: 'checking' } : { status: 'anonymous' },
+  );
+  const scope = useScope();
+
+  // Guards against two known races:
+  //  - a stale `me()` response arriving after `logout()` (or after a newer
+  //    login/bootstrap superseded it) must not repopulate the shell;
+  //  - `onSessionLost` firing while a `me()` call is still in flight must win.
+  // Every attempt captures the epoch at its start and checks it again before
+  // calling `setSession`; anything else bumps the epoch first.
+  const epochRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const applyMe = useCallback(
+    (me: MeResponse) => {
+      setSession({ status: 'authenticated', ...me });
+      scope.setScope({
+        orgId: me.orgId,
+        permissions: me.permissions,
+        allowedCollectionIds: me.allowedCollectionIds,
+      });
+    },
+    [scope],
+  );
+
+  const becomeAnonymous = useCallback(() => {
+    clearPersistedRefreshToken();
+    setSession({ status: 'anonymous' });
+    scope.setScope(null);
+  }, [scope]);
+
+  // Persists the pair handed to `onTokensRotated`, which fires synchronously
+  // inside the rotation itself — the only point at which the stored copy is
+  // guaranteed not to lag the server's view of the family.
+  const persistRotatedTokens = useCallback((tokens: { refreshToken: string }) => {
+    savePersistedRefreshToken(tokens.refreshToken);
+  }, []);
+
+  // Re-persists whatever refresh token the session manager is holding right
+  // now. Still used at the login/bootstrap boundaries, where the caller wants
+  // the write to have happened before it proceeds rather than as a side effect
+  // of the rotation that just occurred.
+  const syncPersistedRefreshToken = useCallback(() => {
+    const current = client.sessionManager.getRefreshTokenForLogout();
+    if (current) savePersistedRefreshToken(current);
+  }, [client]);
+
+  // --- Bootstrap: restore "am I signed in?" once per provider lifetime. ---
+  // The "no stored token" case needs no work here at all — the lazy
+  // `useState` initializer above already rendered `anonymous` on first paint.
+  useEffect(() => {
+    const stored = loadPersistedRefreshToken();
+    if (!stored) return;
+    const epoch = (epochRef.current += 1);
+    const controller = new AbortController();
+    abortRef.current = controller;
+    (async () => {
+      try {
+        // Seed the session manager with the persisted refresh token behind
+        // an already-expired dummy access token (the same
+        // `expiresIn: -1` pattern `api/session.test.ts` uses to force a
+        // refresh), so the very first `getAccessToken()` call inside
+        // `client.me()` goes through the manager's own single-flight
+        // refresh path — this file never re-implements refresh itself.
+        client.sessionManager.setTokens({
+          accessToken: '',
+          refreshToken: stored,
+          tokenType: 'Bearer',
+          expiresIn: -1,
+          orgId: '',
+          userId: '',
+        });
+        const me = await client.me(controller.signal);
+        if (epochRef.current !== epoch) return;
+        applyMe(me);
+        syncPersistedRefreshToken();
+      } catch (cause) {
+        if (epochRef.current !== epoch || isAbortError(cause)) return;
+        becomeAnonymous();
+      }
+    })();
+    return () => controller.abort();
+    // Runs once per mount by design (bootstrap); `client`/`applyMe`/
+    // `becomeAnonymous`/`syncPersistedRefreshToken` are stable for the
+    // provider's lifetime (default client is a module singleton).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // --- Session loss mid-session (refresh rejected). ---
+  useEffect(
+    () =>
+      client.tokenProvider.onSessionLost(() => {
+        epochRef.current += 1;
+        abortRef.current?.abort();
+        becomeAnonymous();
+      }),
+    [client, becomeAnonymous],
+  );
+
+  // --- Keep the persisted refresh token from going stale. ---
+  // Refresh tokens rotate on every use and replaying an already-rotated one
+  // revokes the whole family (ADR 0010), so a persisted copy that misses a
+  // rotation does not merely fail to restore the session — its next use looks
+  // like a replay attack and signs the user out everywhere. An ordinary
+  // in-session refresh rotates the pair entirely inside `session.ts`, so the
+  // only correct place to write is the rotation itself: `onTokensRotated`
+  // fires synchronously as part of applying the new pair, closing the window
+  // rather than narrowing it.
+  useEffect(() => client.sessionManager.onTokensRotated(persistRotatedTokens), [client]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      abortRef.current?.abort();
+      const epoch = (epochRef.current += 1);
+      const tokens = await client.login({ email, password });
+      savePersistedRefreshToken(tokens.refreshToken);
+      const controller = new AbortController();
+      abortRef.current = controller;
+      try {
+        const me = await client.me(controller.signal);
+        if (epochRef.current !== epoch) return;
+        applyMe(me);
+        syncPersistedRefreshToken();
+      } catch (cause) {
+        if (epochRef.current !== epoch || isAbortError(cause)) return;
+        client.sessionManager.clear();
+        becomeAnonymous();
+        throw cause;
+      }
+    },
+    [client, applyMe, becomeAnonymous, syncPersistedRefreshToken],
+  );
+
+  const logout = useCallback(async () => {
+    epochRef.current += 1;
+    abortRef.current?.abort();
+    // Clear client-side first and unconditionally: logout must always take
+    // effect locally even if the network call below fails (matches
+    // `client.ts`'s own logout() contract).
+    becomeAnonymous();
+    try {
+      await client.logout();
+    } catch {
+      // Best-effort; the local session is already cleared above.
+    }
+  }, [client, becomeAnonymous]);
+
+  const refreshSession = useCallback(async () => {
+    abortRef.current?.abort();
+    const epoch = (epochRef.current += 1);
+    const controller = new AbortController();
+    abortRef.current = controller;
+    try {
+      const me = await client.me(controller.signal);
+      if (epochRef.current !== epoch) return;
+      applyMe(me);
+      syncPersistedRefreshToken();
+    } catch (cause) {
+      if (epochRef.current !== epoch || isAbortError(cause)) return;
+      becomeAnonymous();
+    }
+  }, [client, applyMe, becomeAnonymous, syncPersistedRefreshToken]);
+
+  const hasPermission = useCallback(
+    (permission: string) =>
+      session.status === 'authenticated' && session.permissions.includes(permission),
+    [session],
+  );
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ session, login, logout, refreshSession, hasPermission }),
+    [session, login, logout, refreshSession, hasPermission],
+  );
+
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 

--- a/web/src/auth/RouteGuard.test.tsx
+++ b/web/src/auth/RouteGuard.test.tsx
@@ -1,0 +1,226 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '../api/client';
+import type { SessionTokens } from '../api/session';
+import { RouterProvider } from '../state/RouterProvider';
+import { ScopeProvider } from '../state/ScopeProvider';
+import { AuthProvider } from './AuthContext';
+import { ProtectedRoute, PublicOnlyRoute, sanitizeNextPath } from './RouteGuard';
+
+const SAMPLE_ME = {
+  userId: 'user-1',
+  orgId: 'org-1',
+  email: 'demo@markhand.test',
+  displayName: 'Demo User',
+  permissions: ['qa.history'],
+  allowedCollectionIds: ['col-1'],
+  sessionId: 'session-1',
+};
+
+/** Same shape of fake client as AuthContext.test.tsx, trimmed to what these guard tests drive. */
+function createFakeClient(): ApiClient {
+  let currentRefreshToken: string | null = null;
+  return {
+    login: vi.fn(),
+    logout: vi.fn(async () => {}),
+    me: vi.fn(),
+    request: vi.fn(),
+    tokenProvider: {
+      getAccessToken: vi.fn(),
+      refreshNow: vi.fn(),
+      onSessionLost: () => () => {},
+    },
+    sessionManager: {
+      setTokens: vi.fn((tokens: SessionTokens) => {
+        currentRefreshToken = tokens.refreshToken;
+      }),
+      clear: vi.fn(() => {
+        currentRefreshToken = null;
+      }),
+      hasSession: vi.fn(() => currentRefreshToken !== null),
+      getRefreshTokenForLogout: vi.fn(() => currentRefreshToken),
+      getAccessToken: vi.fn(),
+      refreshNow: vi.fn(),
+      onSessionLost: () => () => {},
+      onTokensRotated: () => () => {},
+    },
+  } as unknown as ApiClient;
+}
+
+function renderWithProviders(children: ReactNode, client: ApiClient) {
+  return render(
+    <RouterProvider>
+      <ScopeProvider>
+        <AuthProvider client={client}>{children}</AuthProvider>
+      </ScopeProvider>
+    </RouterProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  window.sessionStorage.clear();
+  window.history.pushState(null, '', '/');
+});
+
+describe('sanitizeNextPath', () => {
+  it('falls back for null/empty input', () => {
+    expect(sanitizeNextPath(null)).toBe('/library');
+    expect(sanitizeNextPath(null, '/help')).toBe('/help');
+  });
+
+  it('accepts a same-origin root-relative path', () => {
+    expect(sanitizeNextPath('/qa/col-42')).toBe('/qa/col-42');
+  });
+
+  it('preserves a query string on the sanitized path', () => {
+    expect(sanitizeNextPath('/library?foo=bar')).toBe('/library?foo=bar');
+  });
+
+  it('rejects a foreign absolute URL (open-redirect guard)', () => {
+    expect(sanitizeNextPath('https://evil.example/steal')).toBe('/library');
+  });
+
+  it('rejects a protocol-relative URL', () => {
+    expect(sanitizeNextPath('//evil.example/steal')).toBe('/library');
+  });
+
+  it('falls back for an unparsable value', () => {
+    expect(sanitizeNextPath('javascript:alert(1)')).toBe('/library');
+  });
+});
+
+describe('ProtectedRoute', () => {
+  it('shows a neutral loading state while the session is checking', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const client = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {})); // never resolves
+
+    renderWithProviders(
+      <ProtectedRoute>
+        <p>secret</p>
+      </ProtectedRoute>,
+      client,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Đang kiểm tra phiên đăng nhập');
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+  });
+
+  it('renders children once authenticated', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const client = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+    renderWithProviders(
+      <ProtectedRoute>
+        <p>secret</p>
+      </ProtectedRoute>,
+      client,
+    );
+
+    await waitFor(() => expect(screen.getByText('secret')).toBeVisible());
+  });
+
+  it('redirects an anonymous visitor to /login with ?next= set to the current path', async () => {
+    window.history.pushState(null, '', '/library/col-9');
+    const client = createFakeClient();
+
+    renderWithProviders(
+      <ProtectedRoute>
+        <p>secret</p>
+      </ProtectedRoute>,
+      client,
+    );
+
+    await waitFor(() =>
+      expect(window.location.pathname + window.location.search).toBe(
+        '/login?next=%2Flibrary%2Fcol-9',
+      ),
+    );
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+  });
+
+  it('renders an in-shell notice (not a redirect) when authenticated but missing the required permission', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const client = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME); // has only 'qa.history'
+
+    renderWithProviders(
+      <ProtectedRoute permission="member.manage">
+        <p>secret</p>
+      </ProtectedRoute>,
+      client,
+    );
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/không có quyền/));
+    expect(screen.queryByText('secret')).not.toBeInTheDocument();
+    // Still on the same URL — this is a render decision, not a redirect.
+    expect(window.location.pathname).toBe('/');
+  });
+
+  it('renders children when authenticated and the required permission is present', async () => {
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const client = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME); // has 'qa.history'
+
+    renderWithProviders(
+      <ProtectedRoute permission="qa.history">
+        <p>secret</p>
+      </ProtectedRoute>,
+      client,
+    );
+
+    await waitFor(() => expect(screen.getByText('secret')).toBeVisible());
+  });
+});
+
+describe('PublicOnlyRoute', () => {
+  it('renders children (the login form) when anonymous', async () => {
+    const client = createFakeClient();
+
+    renderWithProviders(
+      <PublicOnlyRoute>
+        <p>login-form</p>
+      </PublicOnlyRoute>,
+      client,
+    );
+
+    await waitFor(() => expect(screen.getByText('login-form')).toBeVisible());
+  });
+
+  it('redirects an already-authenticated visitor away, honoring a sanitized ?next=', async () => {
+    window.history.pushState(null, '', '/login?next=%2Fqa%2Fcol-1');
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const client = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+    renderWithProviders(
+      <PublicOnlyRoute>
+        <p>login-form</p>
+      </PublicOnlyRoute>,
+      client,
+    );
+
+    await waitFor(() => expect(window.location.pathname).toBe('/qa/col-1'));
+    expect(screen.queryByText('login-form')).not.toBeInTheDocument();
+  });
+
+  it('ignores a foreign ?next= and falls back to the default destination', async () => {
+    window.history.pushState(null, '', '/login?next=https%3A%2F%2Fevil.example');
+    window.sessionStorage.setItem('markhand.refreshToken', 'stored-refresh');
+    const client = createFakeClient();
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+    renderWithProviders(
+      <PublicOnlyRoute>
+        <p>login-form</p>
+      </PublicOnlyRoute>,
+      client,
+    );
+
+    await act(async () => {});
+    await waitFor(() => expect(window.location.pathname).toBe('/library'));
+  });
+});

--- a/web/src/auth/RouteGuard.tsx
+++ b/web/src/auth/RouteGuard.tsx
@@ -1,0 +1,109 @@
+// Route/control guards for P2-05. These are UI convenience only — never
+// authorization. `ProtectedRoute`/`PublicOnlyRoute` decide whether to render
+// a page or bounce to `/login`; they cannot and do not stop an API call from
+// answering 403. The server is always the authority (see
+// plans/markhand-web/phase-2-web-spa.md §P2.3 and §P2.6: "Chỉ render theo
+// permission nhưng server vẫn là nguồn authorization").
+import { useEffect, type ReactNode } from 'react';
+import { useRouter } from '../state/RouterProvider';
+import { Notice } from '../components/ui';
+import { useAuth } from './AuthContext';
+
+function currentPathWithSearch(): string {
+  if (typeof window === 'undefined') return '/';
+  return window.location.pathname + window.location.search;
+}
+
+/**
+ * Validates a `next` redirect target: it must resolve to a same-origin,
+ * root-relative path. Anything else (a foreign absolute URL, a
+ * protocol-relative `//evil.example`, an unparsable value) falls back to
+ * `fallback` — this is the open-redirect guard for the `?next=` query param.
+ */
+export function sanitizeNextPath(next: string | null, fallback = '/library'): string {
+  if (!next) return fallback;
+  try {
+    const resolved = new URL(next, window.location.origin);
+    if (resolved.origin !== window.location.origin) return fallback;
+    const path = `${resolved.pathname}${resolved.search}`;
+    return path.startsWith('/') ? path : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function loginPathWithNext(): string {
+  return `/login?next=${encodeURIComponent(currentPathWithSearch())}`;
+}
+
+function AuthChecking() {
+  return (
+    <p className="auth-loading" role="status">
+      Đang kiểm tra phiên đăng nhập…
+    </p>
+  );
+}
+
+/**
+ * Wraps a route's page. Renders `children` only once the session is
+ * `authenticated`; while `checking` it shows a neutral loading state instead
+ * of guessing; once resolved `anonymous`, it redirects to `/login` with the
+ * current location preserved as `?next=` so login can return the visitor to
+ * where they were headed. Redirecting only ever runs from an effect keyed on
+ * `session.status`, and the redirect itself changes which route renders —
+ * this component unmounts once the pathname moves to `/login`, so the effect
+ * cannot re-fire and loop.
+ *
+ * `permission`, when given, is checked only for *rendering*: a signed-in
+ * visitor without it sees an in-shell notice instead of the page, never a
+ * silent redirect (they are still signed in; nothing here implies the server
+ * would actually deny them — the real answer comes from the API call itself).
+ */
+export function ProtectedRoute({
+  children,
+  permission,
+}: {
+  children: ReactNode;
+  permission?: string;
+}) {
+  const { session, hasPermission } = useAuth();
+  const { navigate } = useRouter();
+
+  useEffect(() => {
+    if (session.status === 'anonymous') {
+      navigate(loginPathWithNext());
+    }
+  }, [session.status, navigate]);
+
+  if (session.status === 'checking') return <AuthChecking />;
+  if (session.status === 'anonymous') return null;
+  if (permission && !hasPermission(permission)) {
+    return (
+      <Notice tone="warning">
+        Tài khoản của bạn không có quyền truy cập mục này. Đây chỉ là gợi ý hiển thị — máy chủ luôn
+        là nơi quyết định cuối cùng.
+      </Notice>
+    );
+  }
+  return <>{children}</>;
+}
+
+/**
+ * Wraps `/login` itself: an already-authenticated visitor is sent to their
+ * intended page (`?next=`, sanitized) instead of seeing the form again.
+ */
+export function PublicOnlyRoute({ children }: { children: ReactNode }) {
+  const { session } = useAuth();
+  const { navigate } = useRouter();
+
+  useEffect(() => {
+    if (session.status === 'authenticated') {
+      const params = new URLSearchParams(window.location.search);
+      navigate(sanitizeNextPath(params.get('next')));
+    }
+  }, [session.status, navigate]);
+
+  if (session.status === 'checking') return <AuthChecking />;
+  if (session.status === 'authenticated') return null;
+  return <>{children}</>;
+}

--- a/web/src/auth/tokenStorage.test.ts
+++ b/web/src/auth/tokenStorage.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  clearPersistedRefreshToken,
+  loadPersistedRefreshToken,
+  savePersistedRefreshToken,
+} from './tokenStorage';
+
+afterEach(() => {
+  window.sessionStorage.clear();
+});
+
+describe('tokenStorage', () => {
+  it('returns null when nothing has been persisted', () => {
+    expect(loadPersistedRefreshToken()).toBeNull();
+  });
+
+  it('round-trips a saved refresh token', () => {
+    savePersistedRefreshToken('refresh-abc');
+    expect(loadPersistedRefreshToken()).toBe('refresh-abc');
+  });
+
+  it('overwrites a previously persisted token', () => {
+    savePersistedRefreshToken('refresh-1');
+    savePersistedRefreshToken('refresh-2');
+    expect(loadPersistedRefreshToken()).toBe('refresh-2');
+  });
+
+  it('clears the persisted token', () => {
+    savePersistedRefreshToken('refresh-abc');
+    clearPersistedRefreshToken();
+    expect(loadPersistedRefreshToken()).toBeNull();
+  });
+
+  it('persists under sessionStorage, not localStorage (tab-lifetime, not indefinite)', () => {
+    savePersistedRefreshToken('refresh-abc');
+    expect(window.sessionStorage.getItem('markhand.refreshToken')).toBe('refresh-abc');
+    expect(window.localStorage.getItem('markhand.refreshToken')).toBeNull();
+  });
+});

--- a/web/src/auth/tokenStorage.ts
+++ b/web/src/auth/tokenStorage.ts
@@ -1,0 +1,73 @@
+// Where the rotating refresh token lives across a page reload.
+//
+// The access token stays memory-only (per plans/markhand-web/phase-2-web-spa.md
+// §P2.3) and is always lost on reload — that part is not a decision, it is
+// required. The refresh token is the actual decision: this deployment has no
+// server-set cookie to fall back on (ground truth for P2-05: the refresh
+// token travels in the JSON body, not a cookie — the ADR 0010 / P2.3 "if the
+// deployment uses cookie refresh" branch does not apply here), so without
+// persisting *something* browser-side, "am I still signed in?" can never
+// survive an ordinary reload: there would be nothing to hand back to
+// `POST /auth/refresh`.
+//
+// Decision: persist only the refresh token, in `sessionStorage`, under one
+// fixed key.
+//
+//   - `sessionStorage` over `localStorage`: it survives a same-tab reload/
+//     back-forward (the case this exists for) but is gone the moment the tab
+//     or browser closes — no indefinitely-lived ambient credential sitting in
+//     the browser profile after the user walks away.
+//   - `sessionStorage`/`localStorage` over "nothing persisted": the
+//     alternative is every reload silently logging the user out, which is a
+//     real, simpler, *more secure* option — it was rejected here only because
+//     the plan's P2-05 acceptance criteria (intended-route + expiry
+//     restoration) call for surviving a reload, not because it is wrong.
+//
+// Cost, stated plainly: any script that runs in this origin (i.e. a
+// successful XSS) can read this value and mint itself new access tokens by
+// calling refresh, for as long as the refresh token/family stays valid — a
+// HttpOnly cookie is the only thing that removes this exposure, and that is
+// not available in this deployment. `sessionStorage`'s tab-lifetime bound and
+// the CSP/sanitization work in P2.7/P2.13 are the mitigations; neither
+// eliminates the risk. [Unverified] whether XSS is otherwise reachable in
+// this app is outside this task's scope to assess.
+const STORAGE_KEY = 'markhand.refreshToken';
+
+function storage(): Storage | undefined {
+  try {
+    return typeof window === 'undefined' ? undefined : window.sessionStorage;
+  } catch {
+    // Some browser configurations (locked-down privacy settings, certain
+    // private-mode combinations) throw on *access* to sessionStorage, not
+    // just on read/write. Treat that the same as "no persistence available".
+    return undefined;
+  }
+}
+
+/** The persisted refresh token, or `null` if none is stored (or storage is unavailable). */
+export function loadPersistedRefreshToken(): string | null {
+  try {
+    return storage()?.getItem(STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persists `refreshToken` so a same-tab reload can restore the session. Best-effort. */
+export function savePersistedRefreshToken(refreshToken: string): void {
+  try {
+    storage()?.setItem(STORAGE_KEY, refreshToken);
+  } catch {
+    // Storage full/blocked: the session just will not survive a reload.
+    // In-memory login/logout/refresh behavior for the current tab is unaffected.
+  }
+}
+
+/** Removes the persisted refresh token (logout, session loss, failed bootstrap). */
+export function clearPersistedRefreshToken(): void {
+  try {
+    storage()?.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/web/src/hooks/useScopeSafeRequest.test.tsx
+++ b/web/src/hooks/useScopeSafeRequest.test.tsx
@@ -1,0 +1,173 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createScopeManager, type Scope, type ScopeManager } from '../state/scope';
+import { ScopeProvider } from '../state/ScopeProvider';
+import { useScopeSafeRequest } from './useScopeSafeRequest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function scope(orgId: string): Scope {
+  return { orgId, permissions: [], allowedCollectionIds: [] };
+}
+
+/** A promise plus externally-callable resolve, so a test can control exactly when a "network" call settles relative to an org switch. */
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function wrapperFor(manager: ScopeManager) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <ScopeProvider manager={manager}>{children}</ScopeProvider>;
+  };
+}
+
+async function flushMicrotasks(times = 3) {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('useScopeSafeRequest', () => {
+  it('renders the resolved value when no switch happens', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+
+    const { result } = renderHook(() => useScopeSafeRequest(async () => 'org-a-data', []), {
+      wrapper: wrapperFor(manager),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('success'));
+    expect(result.current.data).toBe('org-a-data');
+  });
+
+  it('discards a late HTTP response from the old org after a switch (fn ignores the abort signal entirely)', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const deferredA = createDeferred<string>();
+    const deferredB = createDeferred<string>();
+    let call = 0;
+
+    // `fn` deliberately never reads `signal` — proving the discard does not
+    // depend on the request actually honoring AbortController. It returns a
+    // distinct deferred per invocation, so we can resolve the abandoned
+    // org-A request independently of the current org-B one.
+    const { result } = renderHook(
+      () =>
+        useScopeSafeRequest(async () => {
+          const deferred = call === 0 ? deferredA : deferredB;
+          call += 1;
+          return deferred.promise;
+        }, []),
+      { wrapper: wrapperFor(manager) },
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('loading'));
+    expect(call).toBe(1);
+
+    // Switch org *before* the org-A request resolves. This starts a second,
+    // current request (org-B's), abandoning the first.
+    await act(async () => {
+      manager.setScope(scope('org-b'));
+      await flushMicrotasks();
+    });
+    expect(call).toBe(2);
+
+    // The org-A response finally arrives late. It must never be rendered —
+    // org-B's own request is still pending.
+    await act(async () => {
+      deferredA.resolve('org-a-data-arriving-late');
+      await flushMicrotasks();
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.status).toBe('loading');
+
+    // Sanity check: org-B's own (current) response does render once it settles.
+    await act(async () => {
+      deferredB.resolve('org-b-data');
+      await flushMicrotasks();
+    });
+    expect(result.current.data).toBe('org-b-data');
+    expect(result.current.status).toBe('success');
+  });
+
+  it('aborts the in-flight request signal the instant the org switches', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    let capturedSignal: AbortSignal | undefined;
+    const deferred = createDeferred<string>();
+
+    renderHook(
+      () =>
+        useScopeSafeRequest(async (signal) => {
+          capturedSignal = signal;
+          return deferred.promise;
+        }, []),
+      { wrapper: wrapperFor(manager) },
+    );
+
+    await waitFor(() => expect(capturedSignal).toBeDefined());
+    expect(capturedSignal?.aborted).toBe(false);
+
+    manager.setScope(scope('org-b'));
+
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it('never renders a stale payload across rapid A -> B -> A switching', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+
+    const deferredByVisit = [
+      createDeferred<string>(),
+      createDeferred<string>(),
+      createDeferred<string>(),
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ n }: { n: number }) => useScopeSafeRequest(async () => deferredByVisit[n].promise, [n]),
+      { wrapper: wrapperFor(manager), initialProps: { n: 0 } },
+    );
+    await waitFor(() => expect(result.current.status).toBe('loading'));
+
+    // Switch to org-b (n=1) before org-a-1 (visit 0) resolves.
+    await act(async () => {
+      manager.setScope(scope('org-b'));
+      rerender({ n: 1 });
+      await flushMicrotasks();
+    });
+
+    // Switch back to org-a (n=2, a *new* epoch, not the first org-a epoch) before org-b (visit 1) resolves.
+    await act(async () => {
+      manager.setScope(scope('org-a'));
+      rerender({ n: 2 });
+      await flushMicrotasks();
+    });
+
+    // Resolve everything out of order: the newest request last, stragglers first.
+    await act(async () => {
+      deferredByVisit[1].resolve('org-b-data');
+      deferredByVisit[0].resolve('org-a-1-data-stale');
+      await flushMicrotasks();
+    });
+
+    // Neither stale resolution may ever have been rendered — the current
+    // (third) request is still pending.
+    expect(result.current.data).not.toBe('org-b-data');
+    expect(result.current.data).not.toBe('org-a-1-data-stale');
+    expect(result.current.status).toBe('loading');
+
+    await act(async () => {
+      deferredByVisit[2].resolve('org-a-2-data-current');
+      await flushMicrotasks();
+    });
+    expect(result.current.data).toBe('org-a-2-data-current');
+    expect(result.current.status).toBe('success');
+  });
+});

--- a/web/src/hooks/useScopeSafeRequest.ts
+++ b/web/src/hooks/useScopeSafeRequest.ts
@@ -1,0 +1,144 @@
+// P2-06 (plans/markhand-web/phase-2-web-spa.md §P2.3 + Gate: "Không render
+// dữ liệu từ scope cũ"). Runs an async request tied to the *scope epoch*
+// active when it starts (see `state/scope.ts` for what an epoch is and why).
+//
+// Layered protections. Verified by mutation-testing each one in isolation
+// (strip it, watch `useScopeSafeRequest.test.tsx` go red, restore it — see
+// the P2-06 report for the transcript):
+//
+//   1. The `AbortController` passed to `fn` is registered with the
+//      `ScopeManager` and aborted the instant the epoch moves on (org
+//      switch/logout), so a well-behaved request stops real network work
+//      as early as possible. Does not by itself stop a response already in
+//      flight from resolving and calling `.then()`.
+//   2. `discarded` (set by this effect's own cleanup) and
+//      `manager.isCurrent(requestEpoch)` both gate the `setSettled()` calls
+//      in `.then()`/`.catch()`. Either one alone already prevents a stale
+//      resolution from ever reaching `settled` state — confirmed by
+//      mutation-testing them independently — so they are deliberately
+//      redundant with each other and with (3) below, not decorative.
+//   3. THE decisive guard, proven necessary by mutation testing (removing
+//      it, and only it, is the one change that turns
+//      `useScopeSafeRequest.test.tsx` red): the render-time comparison
+//      `settled.generation !== generation` below. Because it is a pure
+//      value comparison evaluated at render — not a callback racing against
+//      React's update scheduling — it holds regardless of exactly when (2)
+//      lets a write through: a write tagged with a superseded generation
+//      can never match the current one again, so it can be written to
+//      state and still never be the value the hook returns.
+//
+// Re-runs whenever an entry in `deps` changes, or whenever the scope epoch
+// changes — a switch always invalidates and restarts the request under the
+// new scope rather than leaving the old one to finish unread.
+//
+// Implementation note: this hook never calls `setState` synchronously
+// inside the effect body (only from the async `.then()`/`.catch()`
+// callbacks once a request actually settles). The "a new request just
+// started, so render as loading" transition instead uses React's
+// documented "adjust state while rendering" idiom (see
+// https://react.dev/reference/react/useState#storing-information-from-previous-renders):
+// `useRequestGeneration` compares the incoming epoch/deps against what was
+// rendered last and, if they differ, calls `setState` *during render*,
+// which React explicitly supports and re-renders once more before paint —
+// no extra effect, no synchronous-setState-in-effect lint violation.
+import { useEffect, useRef, useState, type DependencyList } from 'react';
+import { useScope } from '../state/ScopeProvider';
+
+export type ScopeSafeRequestStatus = 'loading' | 'success' | 'error';
+
+export interface ScopeSafeRequestState<T> {
+  readonly status: ScopeSafeRequestStatus;
+  readonly data: T | undefined;
+  readonly error: unknown;
+}
+
+interface Settled<T> {
+  readonly generation: number;
+  readonly status: 'success' | 'error';
+  readonly data: T | undefined;
+  readonly error: unknown;
+}
+
+function shallowEqualDeps(a: DependencyList, b: DependencyList): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (!Object.is(a[i], b[i])) return false;
+  }
+  return true;
+}
+
+interface Tracked {
+  readonly epoch: number;
+  readonly deps: DependencyList;
+  readonly generation: number;
+}
+
+/**
+ * A monotonically increasing "which request should be active" counter,
+ * bumped whenever `epoch` or any entry of `deps` changes relative to the
+ * previous render. Encodes both triggers (scope switch, caller-supplied
+ * deps change) into the single number the effect below actually depends on.
+ */
+function useRequestGeneration(epoch: number, deps: DependencyList): number {
+  const [tracked, setTracked] = useState<Tracked>(() => ({ epoch, deps, generation: 0 }));
+  if (tracked.epoch !== epoch || !shallowEqualDeps(tracked.deps, deps)) {
+    const next: Tracked = { epoch, deps, generation: tracked.generation + 1 };
+    setTracked(next);
+    return next.generation;
+  }
+  return tracked.generation;
+}
+
+export function useScopeSafeRequest<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  deps: DependencyList,
+): ScopeSafeRequestState<T> {
+  const { manager, epoch } = useScope();
+
+  // "Latest callback" ref, updated only from an effect (never mutated
+  // during render) — same convention as `useFocusTrap`'s `onCloseRef`.
+  const fnRef = useRef(fn);
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
+  const generation = useRequestGeneration(epoch, deps);
+  const [settled, setSettled] = useState<Settled<T> | null>(null);
+
+  useEffect(() => {
+    const requestEpoch = epoch;
+    const requestGeneration = generation;
+    const controller = new AbortController();
+    const unregister = manager.registerAbortable(requestEpoch, controller);
+    let discarded = false;
+
+    fnRef
+      .current(controller.signal)
+      .then((data) => {
+        if (discarded || !manager.isCurrent(requestEpoch)) return; // superseded: skip the write (belt; see module doc's guard (3) for the suspenders)
+        setSettled({ generation: requestGeneration, status: 'success', data, error: undefined });
+      })
+      .catch((error: unknown) => {
+        if (discarded || !manager.isCurrent(requestEpoch)) return; // superseded: skip the write (belt; see module doc's guard (3) for the suspenders)
+        setSettled({ generation: requestGeneration, status: 'error', data: undefined, error });
+      })
+      .finally(() => {
+        unregister();
+      });
+
+    return () => {
+      discarded = true;
+      controller.abort();
+      unregister();
+    };
+  }, [manager, epoch, generation]);
+
+  if (settled === null || settled.generation !== generation) {
+    // Either the very first request for this hook instance, or a newer
+    // generation has started (scope switch or `deps` change) and hasn't
+    // settled yet — render as loading either way, never the previous
+    // generation's leftover data.
+    return { status: 'loading', data: undefined, error: undefined };
+  }
+  return { status: settled.status, data: settled.data, error: settled.error };
+}

--- a/web/src/hooks/useScopeSafeSse.test.tsx
+++ b/web/src/hooks/useScopeSafeSse.test.tsx
@@ -1,0 +1,221 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createScopeManager, type Scope, type ScopeManager } from '../state/scope';
+import { ScopeProvider } from '../state/ScopeProvider';
+import { useScopeSafeSse, type ScopeSafeSseSource } from './useScopeSafeSse';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function scope(orgId: string): Scope {
+  return { orgId, permissions: [], allowedCollectionIds: [] };
+}
+
+function wrapperFor(manager: ScopeManager) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <ScopeProvider manager={manager}>{children}</ScopeProvider>;
+  };
+}
+
+/**
+ * A hand-rolled abortable async-iterable stream, standing in for
+ * `SseConnection` (deliberately not mocked — see the P2-06 brief: "SSE is
+ * deliberately not mocked [in mocks/**]; use your own fake for stream
+ * tests"). `push` delivers a message to whichever `next()` call is
+ * currently pending (or queues it).
+ *
+ * `abort()` is deliberately a plain spy that does NOT touch the iterator at
+ * all — it neither cancels a pending `next()` nor stops a later `push()`
+ * from being delivered. This is intentional, not a shortcut: it lets a test
+ * simulate a message that the transport had already decoded/queued before
+ * `abort()` was requested, arriving over the wire regardless of the abort
+ * call, so a test can prove the *hook's* epoch check — not the transport's
+ * cancellation — is what stops the message from reaching `onMessage`.
+ */
+function fakeSseSource<M>() {
+  let pendingResolve: ((result: IteratorResult<M>) => void) | undefined;
+  const queue: M[] = [];
+  const abort = vi.fn();
+
+  const source: ScopeSafeSseSource<M> = {
+    abort,
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<M>> {
+          if (queue.length > 0) {
+            return Promise.resolve({ value: queue.shift() as M, done: false });
+          }
+          return new Promise<IteratorResult<M>>((resolve) => {
+            pendingResolve = resolve;
+          });
+        },
+      };
+    },
+  };
+
+  return {
+    source,
+    abort,
+    push(message: M) {
+      if (pendingResolve) {
+        const resolve = pendingResolve;
+        pendingResolve = undefined;
+        resolve({ value: message, done: false });
+      } else {
+        queue.push(message);
+      }
+    },
+  };
+}
+
+async function flushMicrotasks(times = 3) {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('useScopeSafeSse', () => {
+  it('delivers messages while the scope is current', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const fake = fakeSseSource<string>();
+    const onMessage = vi.fn();
+
+    renderHook(() => useScopeSafeSse(() => fake.source, onMessage, []), {
+      wrapper: wrapperFor(manager),
+    });
+
+    await act(async () => {
+      fake.push('hello-org-a');
+      await flushMicrotasks();
+    });
+
+    expect(onMessage).toHaveBeenCalledWith('hello-org-a');
+  });
+
+  it('aborts the SSE stream from the old org the instant the scope switches', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const fake = fakeSseSource<string>();
+
+    renderHook(() => useScopeSafeSse(() => fake.source, vi.fn(), []), {
+      wrapper: wrapperFor(manager),
+    });
+    await flushMicrotasks();
+
+    expect(fake.abort).not.toHaveBeenCalled();
+
+    act(() => {
+      manager.setScope(scope('org-b'));
+    });
+
+    // Called at least once — both the central `registerAbortable` registry
+    // and the effect's own cleanup (its dependency array includes the
+    // epoch) call `abort()` on a switch; `SseConnection.abort()` documents
+    // itself as idempotent, so a double call is expected, not a bug.
+    expect(fake.abort).toHaveBeenCalled();
+  });
+
+  it('delivers nothing after a switch, even for a message already in flight when abort() fired', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const fake = fakeSseSource<string>();
+    const onMessage = vi.fn();
+    let calls = 0;
+
+    // Factory returns `undefined` (no new stream) on the second call, so the
+    // org-B run doesn't open a *second* reader on the same fake object —
+    // this test is isolated to whether org-A's single abandoned connection
+    // can still leak a message, not to stream-reopening behavior (covered
+    // by the "opens a fresh stream" test below).
+    renderHook(
+      () => useScopeSafeSse(() => (calls++ === 0 ? fake.source : undefined), onMessage, []),
+      { wrapper: wrapperFor(manager) },
+    );
+    await flushMicrotasks();
+    expect(calls).toBe(1);
+
+    act(() => {
+      manager.setScope(scope('org-b'));
+    });
+    await flushMicrotasks();
+    expect(calls).toBe(2); // the effect re-ran for the new epoch and asked the factory again
+    expect(fake.abort).toHaveBeenCalled();
+
+    // A message from org A's now-abandoned connection lands right after the
+    // switch — this fake's `abort()` deliberately does not cancel the
+    // pending `next()`, simulating a message the transport had already
+    // decoded before the abort request took effect. The hook's own epoch
+    // check (not the abort call, and not "no new stream was opened") is
+    // what must stop it from reaching `onMessage`.
+    await act(async () => {
+      fake.push('org-a-message-arriving-late');
+      await flushMicrotasks();
+    });
+
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('opens a fresh stream (and aborts the old one) on rapid A -> B -> A switching, delivering only current-scope messages', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const fakeA1 = fakeSseSource<string>();
+    const fakeB = fakeSseSource<string>();
+    const fakeA2 = fakeSseSource<string>();
+    const bySlot = [fakeA1, fakeB, fakeA2];
+    const onMessage = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ n }: { n: number }) => useScopeSafeSse(() => bySlot[n].source, onMessage, [n]),
+      { wrapper: wrapperFor(manager), initialProps: { n: 0 } },
+    );
+    await flushMicrotasks();
+
+    act(() => {
+      manager.setScope(scope('org-b'));
+      rerender({ n: 1 });
+    });
+    await flushMicrotasks();
+
+    act(() => {
+      manager.setScope(scope('org-a'));
+      rerender({ n: 2 });
+    });
+    await flushMicrotasks();
+
+    expect(fakeA1.abort).toHaveBeenCalled();
+    expect(fakeB.abort).toHaveBeenCalled();
+
+    // Stale sources still try to deliver — must be discarded.
+    await act(async () => {
+      fakeA1.push('stale-a1');
+      fakeB.push('stale-b');
+      await flushMicrotasks();
+    });
+    expect(onMessage).not.toHaveBeenCalled();
+
+    // Only the current (third) connection's messages reach the callback.
+    await act(async () => {
+      fakeA2.push('current-a2');
+      await flushMicrotasks();
+    });
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith('current-a2');
+  });
+
+  it('aborts the current stream on unmount', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const fake = fakeSseSource<string>();
+
+    const { unmount } = renderHook(() => useScopeSafeSse(() => fake.source, vi.fn(), []), {
+      wrapper: wrapperFor(manager),
+    });
+    await flushMicrotasks();
+
+    unmount();
+
+    expect(fake.abort).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/useScopeSafeSse.ts
+++ b/web/src/hooks/useScopeSafeSse.ts
@@ -1,0 +1,90 @@
+// P2-06 (plans/markhand-web/phase-2-web-spa.md §P2.3 + Gate: "Không render
+// dữ liệu từ scope cũ") applied to SSE. Drives any abortable async-iterable
+// stream (an `SseConnection` from `api/sse.ts`, or a fake in tests) tied to
+// the scope epoch active when it was opened.
+//
+// Same two protections as `useScopeSafeRequest`, applied per-message instead
+// of per-response:
+//
+//   1. The source is registered with the `ScopeManager` and `.abort()`ed the
+//      instant the epoch moves on, so a well-behaved connection stops
+//      real network work as early as possible.
+//   2. Even if a message was already queued/decoded by the time abort()
+//      fires — the async generator in `api/sse.ts` can yield one more item
+//      out of its internal buffer after cancellation is requested — the
+//      epoch is checked again immediately before calling `onMessage`. THIS
+//      is the discard point: a message whose epoch is no longer current is
+//      dropped and never delivered to the caller.
+//
+// Reopens the stream whenever an entry in `deps` changes or the scope epoch
+// changes; the previous source is always aborted first.
+import { useEffect, useRef, type DependencyList } from 'react';
+import { useScope } from '../state/ScopeProvider';
+
+/**
+ * Structural shape this hook needs from a stream source — deliberately not
+ * imported from `api/sse.ts` so this file has no compile-time coupling to
+ * that module's internals, only to the two members it actually calls.
+ * `SseConnection` satisfies this today.
+ */
+export interface ScopeSafeSseSource<M> {
+  abort(): void;
+  [Symbol.asyncIterator](): AsyncIterator<M>;
+}
+
+export function useScopeSafeSse<M>(
+  /** Return `undefined` to skip opening a stream this run (e.g. no collection selected yet). */
+  factory: () => ScopeSafeSseSource<M> | undefined,
+  onMessage: (message: M) => void,
+  deps: DependencyList,
+): void {
+  const { manager, epoch } = useScope();
+
+  // "Latest callback" refs, updated only from effects — same convention as
+  // `useFocusTrap`'s `onCloseRef`; never mutated during render.
+  const factoryRef = useRef(factory);
+  useEffect(() => {
+    factoryRef.current = factory;
+  }, [factory]);
+
+  const onMessageRef = useRef(onMessage);
+  useEffect(() => {
+    onMessageRef.current = onMessage;
+  }, [onMessage]);
+
+  useEffect(() => {
+    const source = factoryRef.current();
+    if (!source) return;
+
+    const requestEpoch = epoch;
+    const unregister = manager.registerAbortable(requestEpoch, source);
+    let discarded = false;
+
+    void (async () => {
+      try {
+        for await (const message of source) {
+          if (discarded || !manager.isCurrent(requestEpoch)) return; // stale scope: stop delivering, discard
+          onMessageRef.current(message);
+        }
+      } catch {
+        // Expected once aborted/cancelled. `api/sse.ts` surfaces its own
+        // retry/close policy through the message stream itself (a `closed`
+        // message), not through iterator rejection, so there is nothing
+        // else to act on here.
+      } finally {
+        unregister();
+      }
+    })();
+
+    return () => {
+      discarded = true;
+      source.abort();
+      unregister();
+    };
+    // `deps` is caller-supplied and deliberately re-spread here: this effect
+    // must reopen the stream on every entry in `deps` *and* whenever the
+    // scope epoch moves on, so an org switch always aborts the previous
+    // stream rather than continuing to read it under the new scope.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [manager, epoch, ...deps]);
+}

--- a/web/src/mocks/apiError.ts
+++ b/web/src/mocks/apiError.ts
@@ -1,0 +1,69 @@
+import type { components } from '../api/generated/contract';
+import { nextRequestId } from './ids';
+
+export type ApiErrorBody = components['schemas']['ApiError'];
+
+export interface QuotaDetails {
+  limit: number;
+  remaining: number;
+  resetAt: string;
+}
+
+/** Builds the canonical `{ code, message, requestId, details? }` error envelope. */
+export function apiError(code: string, message: string, details?: unknown): ApiErrorBody {
+  return { code, message, requestId: nextRequestId(), details };
+}
+
+export interface MockErrorResponse {
+  status: number;
+  body: ApiErrorBody;
+  headers?: Record<string, string>;
+}
+
+export function unauthorized(
+  message = 'Authentication required or token invalid/expired.',
+): MockErrorResponse {
+  return { status: 401, body: apiError('unauthorized', message) };
+}
+
+export function forbidden(
+  message = 'Caller lacks the permission required for this action.',
+): MockErrorResponse {
+  return { status: 403, body: apiError('forbidden', message) };
+}
+
+export function notFound(
+  message = 'The requested resource does not exist or is not visible to the caller.',
+): MockErrorResponse {
+  return { status: 404, body: apiError('not_found', message) };
+}
+
+export function conflict(
+  message = 'The request conflicts with the current state of the resource.',
+): MockErrorResponse {
+  return { status: 409, body: apiError('conflict', message) };
+}
+
+export function serviceUnavailable(
+  message = 'A required dependency is not currently reachable.',
+): MockErrorResponse {
+  return { status: 503, body: apiError('service_unavailable', message) };
+}
+
+/** 429 with the quota metadata the spec's "Ground truth" calls out, carried in `details`. */
+export function rateLimited(quota: Partial<QuotaDetails> = {}): MockErrorResponse {
+  const details: QuotaDetails = {
+    limit: quota.limit ?? 60,
+    remaining: quota.remaining ?? 0,
+    resetAt: quota.resetAt ?? new Date(Date.now() + 30_000).toISOString(),
+  };
+  const retryAfterSeconds = Math.max(
+    1,
+    Math.round((Date.parse(details.resetAt) - Date.now()) / 1000),
+  );
+  return {
+    status: 429,
+    body: apiError('rate_limited', 'Too many requests; quota exhausted.', details),
+    headers: { 'Retry-After': String(retryAfterSeconds) },
+  };
+}

--- a/web/src/mocks/control.ts
+++ b/web/src/mocks/control.ts
@@ -1,0 +1,76 @@
+/**
+ * Failure-on-demand controls for the mock. Tests (or a dev-mode UI toggle,
+ * once someone wires that up) call `mockControl.forceStatus(...)` before
+ * making a request to exercise the SPA's 401/403/404/409/429/503 paths without
+ * needing a real backend that can be coerced into those states.
+ */
+import type { MockErrorResponse } from './apiError';
+import {
+  conflict,
+  forbidden,
+  notFound,
+  rateLimited,
+  serviceUnavailable,
+  unauthorized,
+} from './apiError';
+import type { QuotaDetails } from './apiError';
+
+export type ForcedFailureKind = 401 | 403 | 404 | 409 | 429 | 503;
+
+interface ForcedFailure {
+  kind: ForcedFailureKind;
+  quota?: Partial<QuotaDetails>;
+  /** If set, only the next N matching requests fail; omitted/undefined means "until reset". */
+  remainingUses?: number;
+}
+
+// Keyed by operationId; "*" applies to every operation.
+const forced = new Map<string, ForcedFailure>();
+
+export const mockControl = {
+  /**
+   * Force the next call(s) to `operationId` (or every operation, via "*") to
+   * fail with `kind`. `times` limits how many calls fail before it clears
+   * itself; omit for "fails until `reset()`/`clear()`".
+   */
+  forceStatus(
+    operationId: string | '*',
+    kind: ForcedFailureKind,
+    opts: { times?: number; quota?: Partial<QuotaDetails> } = {},
+  ): void {
+    forced.set(operationId, { kind, quota: opts.quota, remainingUses: opts.times });
+  },
+
+  clear(operationId: string | '*'): void {
+    forced.delete(operationId);
+  },
+
+  reset(): void {
+    forced.clear();
+  },
+
+  /** Looks up (and consumes one use of) a forced failure for this operationId, if any. */
+  consume(operationId: string): MockErrorResponse | undefined {
+    const entry = forced.get(operationId) ?? forced.get('*');
+    if (!entry) return undefined;
+    const key = forced.has(operationId) ? operationId : '*';
+    if (entry.remainingUses !== undefined) {
+      entry.remainingUses -= 1;
+      if (entry.remainingUses <= 0) forced.delete(key);
+    }
+    switch (entry.kind) {
+      case 401:
+        return unauthorized();
+      case 403:
+        return forbidden();
+      case 404:
+        return notFound();
+      case 409:
+        return conflict();
+      case 429:
+        return rateLimited(entry.quota);
+      case 503:
+        return serviceUnavailable();
+    }
+  },
+};

--- a/web/src/mocks/fetchMock.test.ts
+++ b/web/src/mocks/fetchMock.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { installMockFetch, uninstallMockFetch, resetMockState } from './fetchMock';
+import { mockControl } from './control';
+import { getStore } from './fixtures';
+
+const API_PREFIX = '/api/v1';
+
+async function login(): Promise<{ accessToken: string }> {
+  const res = await fetch(`${API_PREFIX}/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'demo@markhand.test', password: 'demo-password' }),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as { accessToken: string };
+}
+
+function authed(accessToken: string, init: RequestInit = {}): RequestInit {
+  return { ...init, headers: { ...(init.headers ?? {}), Authorization: `Bearer ${accessToken}` } };
+}
+
+describe('fetchMock', () => {
+  beforeEach(() => {
+    installMockFetch();
+    resetMockState();
+  });
+
+  afterEach(() => {
+    uninstallMockFetch();
+  });
+
+  it('answers health/live without auth', async () => {
+    const res = await fetch(`${API_PREFIX}/health/live`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; requestId: string };
+    expect(body.status).toBe('ok');
+    expect(body.requestId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('serves the raw openapi document verbatim', async () => {
+    const res = await fetch(`${API_PREFIX}/openapi.yaml`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/yaml');
+    const text = await res.text();
+    expect(text).toContain('operationId: healthLive');
+  });
+
+  it('rejects an auth-required route with no Authorization header (401)', async () => {
+    const res = await fetch(`${API_PREFIX}/collections`);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code: string; requestId: string };
+    expect(body.code).toBe('unauthorized');
+  });
+
+  it('logs in, then uses the access token on an authenticated route', async () => {
+    const { accessToken } = await login();
+    const res = await fetch(`${API_PREFIX}/collections`, authed(accessToken));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[]; page: { hasMore: boolean } };
+    expect(body.items.length).toBeGreaterThan(0);
+    expect(body.page).toEqual({ hasMore: false, nextCursor: null });
+  });
+
+  it('rejects bad credentials with 401', async () => {
+    const res = await fetch(`${API_PREFIX}/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'demo@markhand.test', password: 'wrong' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('refreshes and rotates the refresh token (old one stops working)', async () => {
+    const loginRes = await fetch(`${API_PREFIX}/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'demo@markhand.test', password: 'demo-password' }),
+    });
+    const { refreshToken } = (await loginRes.json()) as { refreshToken: string };
+
+    const refreshRes = await fetch(`${API_PREFIX}/auth/refresh`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refreshToken }),
+    });
+    expect(refreshRes.status).toBe(200);
+
+    const replay = await fetch(`${API_PREFIX}/auth/refresh`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refreshToken }),
+    });
+    expect(replay.status).toBe(401);
+  });
+
+  it('logs out idempotently (204 even on replay)', async () => {
+    const { refreshToken } = (await (
+      await fetch(`${API_PREFIX}/auth/login`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'demo@markhand.test', password: 'demo-password' }),
+      })
+    ).json()) as { refreshToken: string };
+
+    const first = await fetch(`${API_PREFIX}/auth/logout`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refreshToken }),
+    });
+    expect(first.status).toBe(204);
+
+    const second = await fetch(`${API_PREFIX}/auth/logout`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refreshToken }),
+    });
+    expect(second.status).toBe(204);
+  });
+
+  it('returns 404 for an unknown collection', async () => {
+    const { accessToken } = await login();
+    const res = await fetch(
+      `${API_PREFIX}/collections/00000000-0000-0000-0000-000000000000`,
+      authed(accessToken),
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('not_found');
+  });
+
+  it('paginates listDocuments with a cursor that round-trips through PageInfo', async () => {
+    const { accessToken } = await login();
+    const collectionId = getStore().collections[0].id;
+    const firstPage = await fetch(
+      `${API_PREFIX}/collections/${collectionId}/documents?limit=1`,
+      authed(accessToken),
+    );
+    expect(firstPage.status).toBe(200);
+    const firstBody = (await firstPage.json()) as {
+      items: { id: string }[];
+      page: { hasMore: boolean; nextCursor: string | null };
+    };
+    expect(firstBody.items).toHaveLength(1);
+    expect(firstBody.page.hasMore).toBe(true);
+    expect(firstBody.page.nextCursor).toBeTruthy();
+
+    const secondPage = await fetch(
+      `${API_PREFIX}/collections/${collectionId}/documents?limit=1&cursor=${encodeURIComponent(firstBody.page.nextCursor!)}`,
+      authed(accessToken),
+    );
+    const secondBody = (await secondPage.json()) as {
+      items: { id: string }[];
+      page: { hasMore: boolean };
+    };
+    expect(secondBody.items).toHaveLength(1);
+    expect(secondBody.items[0].id).not.toBe(firstBody.items[0].id);
+  });
+
+  it('creates a collection end-to-end and can fetch it back', async () => {
+    const { accessToken } = await login();
+    const createRes = await fetch(
+      `${API_PREFIX}/collections`,
+      authed(accessToken, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'New Collection', slug: 'new-collection' }),
+      }),
+    );
+    expect(createRes.status).toBe(201);
+    const created = (await createRes.json()) as { id: string };
+
+    const getRes = await fetch(`${API_PREFIX}/collections/${created.id}`, authed(accessToken));
+    expect(getRes.status).toBe(200);
+    const fetched = (await getRes.json()) as { name: string };
+    expect(fetched.name).toBe('New Collection');
+  });
+
+  describe('failure injection', () => {
+    it('forces a 429 with quota metadata and a Retry-After header', async () => {
+      const { accessToken } = await login();
+      mockControl.forceStatus('listCollections', 429, {
+        times: 1,
+        quota: { limit: 10, remaining: 0 },
+      });
+      const res = await fetch(`${API_PREFIX}/collections`, authed(accessToken));
+      expect(res.status).toBe(429);
+      expect(res.headers.get('Retry-After')).toBeTruthy();
+      const body = (await res.json()) as {
+        code: string;
+        details: { limit: number; remaining: number; resetAt: string };
+      };
+      expect(body.code).toBe('rate_limited');
+      expect(body.details).toMatchObject({ limit: 10, remaining: 0 });
+
+      // Only the next `times` calls are forced; it self-clears after.
+      const followUp = await fetch(`${API_PREFIX}/collections`, authed(accessToken));
+      expect(followUp.status).toBe(200);
+    });
+
+    // Each status below is forced on an operation that actually *declares* that
+    // status in the spec — the drift-guard (`assertStatusDeclared`) rejects a
+    // forced status the operation's contract doesn't allow, so this table is
+    // itself a check that these five failure modes are genuinely reachable.
+    it('forces 401 on demand (authMe declares 401)', async () => {
+      const { accessToken } = await login();
+      mockControl.forceStatus('authMe', 401, { times: 1 });
+      const res = await fetch(`${API_PREFIX}/auth/me`, authed(accessToken));
+      expect(res.status).toBe(401);
+    });
+
+    it('forces 403 on demand (createCollection declares 403)', async () => {
+      const { accessToken } = await login();
+      mockControl.forceStatus('createCollection', 403, { times: 1 });
+      const res = await fetch(
+        `${API_PREFIX}/collections`,
+        authed(accessToken, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: 'x', slug: 'x' }),
+        }),
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('forces 404 on demand (getJob declares 404)', async () => {
+      const { accessToken } = await login();
+      mockControl.forceStatus('getJob', 404, { times: 1 });
+      const res = await fetch(
+        `${API_PREFIX}/jobs/${getStore().jobs.keys().next().value}`,
+        authed(accessToken),
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('produces a real (not forced) 409 for a document mid-conversion (createUpload)', async () => {
+      const { accessToken } = await login();
+      const collectionId = getStore().collections[0].id;
+      const inFlightDocument = (getStore().documents.get(collectionId) ?? []).find(
+        (d) => d.state !== 'indexed',
+      );
+      expect(inFlightDocument).toBeDefined();
+      const form = new FormData();
+      form.set('file', new File(['content'], 'revision.txt'));
+      form.set('collectionId', collectionId);
+      form.set('documentId', inFlightDocument!.id);
+      const res = await fetch(
+        `${API_PREFIX}/uploads`,
+        authed(accessToken, { method: 'POST', body: form }),
+      );
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe('conflict');
+    });
+
+    it('forces 503 on demand (healthReady declares 503, no auth required)', async () => {
+      mockControl.forceStatus('healthReady', 503, { times: 1 });
+      const res = await fetch(`${API_PREFIX}/health/ready`);
+      expect(res.status).toBe(503);
+      const followUp = await fetch(`${API_PREFIX}/health/ready`);
+      expect(followUp.status).toBe(200);
+    });
+  });
+
+  it('throws a clear error for the SSE streaming endpoints instead of returning wrong data', async () => {
+    const { accessToken } = await login();
+    await expect(
+      fetch(`${API_PREFIX}/ask/stream`, authed(accessToken, { method: 'POST' })),
+    ).rejects.toThrow(/deliberately not mocked/);
+  });
+});

--- a/web/src/mocks/fetchMock.ts
+++ b/web/src/mocks/fetchMock.ts
@@ -1,0 +1,221 @@
+/**
+ * Installs a fetch-level mock: overrides `globalThis.fetch` so any code using
+ * the standard `fetch()` API (the SPA's real `api/client.ts`, or a test) gets
+ * routed to the handlers in `handlers/*` instead of hitting a network. See the
+ * P2-02 report for why this shape was chosen over a standalone mock server.
+ */
+import './handlers'; // registers every operation as a side effect
+import { DELIBERATELY_UNMOCKED_OPERATIONS, getHandler, getRegisteredOperations } from './registry';
+import type { MockRequestContext } from './registry';
+import { getSpecIndex, type OperationDef } from './spec/openApiSpec';
+import {
+  assertJsonBodyMatchesSpec,
+  assertOperationsExistInSpec,
+  assertStatusDeclared,
+} from './spec/driftGuard';
+import { mockControl } from './control';
+import { authContextForHeader, resetMockStore } from './fixtures';
+import { resetRequestIdCounter } from './ids';
+import { unauthorized } from './apiError';
+
+/** Matches the app's own convention (see `src/api/health.ts`): API routes live under `/api/v1`. */
+const API_PREFIX = '/api/v1';
+
+interface CompiledRoute {
+  operationId: string;
+  method: string;
+  regex: RegExp;
+  paramNames: string[];
+}
+
+function pathToRegex(path: string): { regex: RegExp; paramNames: string[] } {
+  const paramNames: string[] = [];
+  const escaped = path
+    .split(/(\{[^}]+\})/)
+    .map((segment) => {
+      const paramMatch = /^\{([^}]+)\}$/.exec(segment);
+      if (paramMatch) {
+        paramNames.push(paramMatch[1]);
+        return '([^/]+)';
+      }
+      return segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    })
+    .join('');
+  return { regex: new RegExp(`^${escaped}$`), paramNames };
+}
+
+let compiledRoutes: CompiledRoute[] | undefined;
+
+function getRoutes(): CompiledRoute[] {
+  if (compiledRoutes) return compiledRoutes;
+  const registered = getRegisteredOperations();
+  assertOperationsExistInSpec(registered.map((r) => r.operationId));
+  const spec = getSpecIndex();
+  compiledRoutes = registered.map(({ operationId }) => {
+    const op = spec.operations[operationId];
+    const { regex, paramNames } = pathToRegex(op.path);
+    return { operationId, method: op.method, regex, paramNames };
+  });
+  return compiledRoutes;
+}
+
+/** Forces route recompilation on next request — used by tests that mutate the registry. */
+export function invalidateRouteCache(): void {
+  compiledRoutes = undefined;
+}
+
+function buildResponse(
+  status: number,
+  body: unknown,
+  headers?: Record<string, string>,
+  rawBody?: { text: string; contentType: string },
+): Response {
+  const responseHeaders = new Headers(headers);
+  if (rawBody) {
+    responseHeaders.set('content-type', rawBody.contentType);
+    return new Response(rawBody.text, { status, headers: responseHeaders });
+  }
+  if (body === undefined) {
+    return new Response(null, { status, headers: responseHeaders });
+  }
+  responseHeaders.set('content-type', 'application/json');
+  return new Response(JSON.stringify(body), { status, headers: responseHeaders });
+}
+
+function emit(
+  operationId: string,
+  status: number,
+  body: unknown,
+  headers?: Record<string, string>,
+  rawBody?: { text: string; contentType: string },
+): Response {
+  assertStatusDeclared(operationId, status);
+  if (!rawBody && body !== undefined) {
+    assertJsonBodyMatchesSpec(operationId, status, body);
+  }
+  return buildResponse(status, body, headers, rawBody);
+}
+
+function findDeclaredButUnmocked(method: string, pathname: string): OperationDef | undefined {
+  const spec = getSpecIndex();
+  for (const operationId of DELIBERATELY_UNMOCKED_OPERATIONS) {
+    const op = spec.operations[operationId as string];
+    if (!op || op.method !== method.toLowerCase()) continue;
+    const { regex } = pathToRegex(op.path);
+    if (regex.test(pathname)) return op;
+  }
+  return undefined;
+}
+
+/**
+ * A fallback base for resolving relative URLs (`fetch('/api/v1/...')`).
+ * Node's native `fetch`/`Request`/`URL` (what `vitest`'s "jsdom" environment
+ * actually uses under the hood — jsdom itself ships no fetch implementation)
+ * has no notion of "the page's origin" the way a real browser does, so a bare
+ * `fetch('/api/v1/health/live')` throws `ERR_INVALID_URL` unless resolved
+ * against *some* base first. The base's value is never observable by
+ * handlers (they only see `pathname`/`searchParams`).
+ */
+const RELATIVE_URL_BASE = 'http://mock.local/';
+
+async function mockFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  // If `input` is already a Request/absolute-URL, its URL was already valid
+  // when *it* was constructed, so only bare-string/URL-object input can be
+  // relative here.
+  const absoluteUrl =
+    input instanceof Request ? input.url : new URL(input.toString(), RELATIVE_URL_BASE).toString();
+  const request =
+    input instanceof Request && init === undefined ? input : new Request(absoluteUrl, init);
+  const url = new URL(request.url);
+  const pathname = url.pathname.startsWith(API_PREFIX)
+    ? url.pathname.slice(API_PREFIX.length) || '/'
+    : url.pathname;
+  const method = request.method.toUpperCase();
+
+  const routes = getRoutes();
+  const match = routes.find((r) => r.method === method.toLowerCase() && r.regex.test(pathname));
+
+  if (!match) {
+    const unmocked = findDeclaredButUnmocked(method, pathname);
+    if (unmocked) {
+      throw new Error(
+        `mocks/fetchMock: ${method} ${pathname} ("${unmocked.operationId}") is declared in the spec but ` +
+          `deliberately not mocked here — it's an SSE streaming endpoint. See the P2-02 report for the ` +
+          `rationale (web/src/mocks is fetch-level; streaming needs a real ReadableStream mock, out of scope).`,
+      );
+    }
+    throw new Error(`mocks/fetchMock: no mock handler matches ${method} ${pathname}`);
+  }
+
+  const op = getSpecIndex().operations[match.operationId];
+  const captured = match.regex.exec(pathname)?.slice(1) ?? [];
+  const params: Record<string, string> = {};
+  match.paramNames.forEach((name, i) => {
+    params[name] = decodeURIComponent(captured[i] ?? '');
+  });
+
+  if (op.requiresAuth && !authContextForHeader(request.headers.get('authorization'))) {
+    // Deliberately bypasses `emit`'s assertStatusDeclared: the spec applies
+    // root-level `bearerAuth` security to almost every operation, but only a
+    // handful of them (authMe, search, ask, askStream, jobEvents) actually list
+    // "401" in their per-operation `responses` — the rest just don't repeat it.
+    // A real server still answers 401 uniformly for a missing/invalid bearer
+    // token, so the mock does too; enforcing assertStatusDeclared here would
+    // make almost every protected endpoint impossible to exercise unauthenticated
+    // in a test, which is far more useful than pedantic spec literalism. This is
+    // the one intentional exception to "every status this mock returns must be
+    // spec-declared for that operation" — see the P2-02 report.
+    const failure = unauthorized();
+    return buildResponse(failure.status, failure.body, failure.headers);
+  }
+
+  const forced = mockControl.consume(match.operationId);
+  if (forced) {
+    return emit(match.operationId, forced.status, forced.body, forced.headers);
+  }
+
+  const handler = getHandler(match.operationId);
+  if (!handler) {
+    throw new Error(
+      `mocks/fetchMock: route matched "${match.operationId}" but no handler is registered for it`,
+    );
+  }
+
+  const ctx: MockRequestContext = {
+    method: op.method,
+    params,
+    query: url.searchParams,
+    headers: request.headers,
+    json: async <T>() => (await request.clone().json()) as T,
+    formData: () => request.clone().formData(),
+    request,
+  };
+
+  const result = await handler(ctx);
+  return emit(match.operationId, result.status, result.body, result.headers, result.rawBody);
+}
+
+let originalFetch: typeof globalThis.fetch | undefined;
+
+/** Installs the mock over `globalThis.fetch`. Idempotent — calling it twice is a no-op. */
+export function installMockFetch(): void {
+  if (originalFetch) return;
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = mockFetch as typeof globalThis.fetch;
+  invalidateRouteCache();
+}
+
+/** Restores the real `globalThis.fetch`. */
+export function uninstallMockFetch(): void {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+    originalFetch = undefined;
+  }
+}
+
+/** Resets seed data, request-id counter, and any forced failures. Call between tests. */
+export function resetMockState(): void {
+  resetMockStore();
+  resetRequestIdCounter();
+  mockControl.reset();
+}

--- a/web/src/mocks/fixtures.ts
+++ b/web/src/mocks/fixtures.ts
@@ -1,0 +1,274 @@
+/**
+ * In-memory seed data + mutable "store" the handlers read/write. Not derived
+ * from the spec (there's no ground-truth *data* to derive — only shape, which
+ * `schema/validate.ts` checks separately) but every record's required fields
+ * are exercised by `handlers/*.test.ts` against `spec.schemas`, so a fixture
+ * missing a field the spec requires fails a test rather than lingering.
+ */
+import type { components } from '../api/generated/contract';
+import { encodeCursor, decodeCursor, mockTimestamp, mockUuid } from './ids';
+
+type Collection = components['schemas']['Collection'];
+type Document = components['schemas']['Document'];
+type DocumentVersion = components['schemas']['DocumentVersion'];
+type Job = components['schemas']['Job'];
+type MeResponse = components['schemas']['MeResponse'];
+
+export interface MockUser {
+  userId: string;
+  orgId: string;
+  email: string;
+  password: string;
+  displayName: string;
+  permissions: string[];
+  allowedCollectionIds: string[];
+}
+
+export interface ConflictRecord {
+  id: string;
+  status: string;
+  severity: string;
+  conflictType: string;
+  claimAId: string;
+  claimBId: string;
+  collectionAId: string;
+  collectionBId: string;
+  firstDetectedAt: string;
+  resolvedAt: string | null;
+  resolutionNote: string | null;
+}
+
+export interface DownloadCapabilityRecord {
+  capability: string;
+  documentId: string;
+  versionId: string;
+  purpose: 'markdown' | 'original';
+  expiresAt: number;
+  redeemed: boolean;
+}
+
+export interface AccessTokenRecord {
+  userId: string;
+  sessionId: string;
+}
+
+interface Store {
+  users: MockUser[];
+  refreshTokens: Map<string, string>; // refreshToken -> userId
+  accessTokens: Map<string, AccessTokenRecord>; // accessToken -> {userId, sessionId}
+  collections: Collection[];
+  documents: Map<string, Document[]>; // collectionId -> documents
+  versions: Map<string, DocumentVersion[]>; // documentId -> versions, oldest first
+  jobs: Map<string, Job>;
+  conflicts: ConflictRecord[];
+  downloadCapabilities: Map<string, DownloadCapabilityRecord>;
+}
+
+const DEMO_USER: MockUser = {
+  userId: mockUuid(1),
+  orgId: mockUuid(2),
+  email: 'demo@markhand.test',
+  password: 'demo-password',
+  displayName: 'Demo User',
+  permissions: ['doc.quarantine.review', 'qa.history'],
+  allowedCollectionIds: [mockUuid(10), mockUuid(11)],
+};
+
+function seedCollections(): Collection[] {
+  return [
+    {
+      id: mockUuid(10),
+      name: 'Employee Handbook',
+      slug: 'employee-handbook',
+      description: 'Company policies and onboarding material.',
+      visibility: 'org',
+      createdAt: mockTimestamp(0),
+    },
+    {
+      id: mockUuid(11),
+      name: 'Product Specs',
+      slug: 'product-specs',
+      description: null,
+      visibility: 'private',
+      createdAt: mockTimestamp(60),
+    },
+  ];
+}
+
+function seedDocuments(): Map<string, Document[]> {
+  const map = new Map<string, Document[]>();
+  map.set(mockUuid(10), [
+    {
+      id: mockUuid(100),
+      collectionId: mockUuid(10),
+      title: 'Onboarding Guide.pdf',
+      state: 'indexed',
+      currentVersionId: mockUuid(1000),
+      createdAt: mockTimestamp(1),
+      updatedAt: mockTimestamp(5),
+    },
+    {
+      id: mockUuid(101),
+      collectionId: mockUuid(10),
+      title: 'Leave Policy.docx',
+      state: 'converting',
+      currentVersionId: null,
+      createdAt: mockTimestamp(2),
+      updatedAt: mockTimestamp(2),
+    },
+  ]);
+  map.set(mockUuid(11), [
+    {
+      id: mockUuid(110),
+      collectionId: mockUuid(11),
+      title: 'Roadmap.xlsx',
+      state: 'indexed',
+      currentVersionId: mockUuid(1100),
+      createdAt: mockTimestamp(3),
+      updatedAt: mockTimestamp(7),
+    },
+  ]);
+  return map;
+}
+
+function seedVersions(): Map<string, DocumentVersion[]> {
+  const map = new Map<string, DocumentVersion[]>();
+  map.set(mockUuid(100), [
+    {
+      id: mockUuid(1000),
+      documentId: mockUuid(100),
+      versionNumber: 1,
+      isCurrent: true,
+      sourceContentSha256: 'a'.repeat(64),
+      effectiveFrom: mockTimestamp(1),
+      effectiveTo: null,
+      changeSummary: 'Initial upload.',
+      createdAt: mockTimestamp(1),
+    },
+  ]);
+  map.set(mockUuid(110), [
+    {
+      id: mockUuid(1100),
+      documentId: mockUuid(110),
+      versionNumber: 1,
+      isCurrent: true,
+      sourceContentSha256: 'b'.repeat(64),
+      effectiveFrom: mockTimestamp(3),
+      effectiveTo: null,
+      changeSummary: null,
+      createdAt: mockTimestamp(3),
+    },
+  ]);
+  return map;
+}
+
+function seedJobs(): Map<string, Job> {
+  const map = new Map<string, Job>();
+  const job: Job = {
+    id: mockUuid(9000),
+    jobType: 'convert',
+    status: 'succeeded',
+    attempts: 1,
+    documentId: mockUuid(100),
+    versionId: mockUuid(1000),
+    createdAt: mockTimestamp(1),
+    updatedAt: mockTimestamp(2),
+    finishedAt: mockTimestamp(2),
+  };
+  map.set(job.id, job);
+  return map;
+}
+
+function seedConflicts(): ConflictRecord[] {
+  return [
+    {
+      id: mockUuid(8000),
+      status: 'open',
+      severity: 'high',
+      conflictType: 'contradiction',
+      claimAId: mockUuid(8001),
+      claimBId: mockUuid(8002),
+      collectionAId: mockUuid(10),
+      collectionBId: mockUuid(11),
+      firstDetectedAt: mockTimestamp(30),
+      resolvedAt: null,
+      resolutionNote: null,
+    },
+  ];
+}
+
+function freshStore(): Store {
+  return {
+    users: [{ ...DEMO_USER }],
+    refreshTokens: new Map(),
+    accessTokens: new Map(),
+    collections: seedCollections(),
+    documents: seedDocuments(),
+    versions: seedVersions(),
+    jobs: seedJobs(),
+    conflicts: seedConflicts(),
+    downloadCapabilities: new Map(),
+  };
+}
+
+let store = freshStore();
+
+/** Restores all mock state to the initial seed. Call between tests for isolation. */
+export function resetMockStore(): void {
+  store = freshStore();
+}
+
+export function getStore(): Store {
+  return store;
+}
+
+let runtimeIdSeed = 20_000; // seeded fixtures all use ids below this; keeps runtime-created ids collision-free
+
+/** A fresh id for entities created during a test/dev session (uploads, new collections, jobs...). */
+export function nextId(): string {
+  runtimeIdSeed += 1;
+  return mockUuid(runtimeIdSeed);
+}
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+  sessionId: string;
+}
+
+/** Mints and registers a fresh access/refresh token pair for `user`. */
+export function mintTokenPair(user: MockUser): TokenPair {
+  const accessToken = `mock-access.${nextId()}`;
+  const refreshToken = `mock-refresh.${nextId()}`;
+  const sessionId = `mock-session.${nextId()}`;
+  store.accessTokens.set(accessToken, { userId: user.userId, sessionId });
+  store.refreshTokens.set(refreshToken, user.userId);
+  return { accessToken, refreshToken, sessionId };
+}
+
+/** Looks up the caller (and their session) from an `Authorization: Bearer <token>` header value. */
+export function authContextForHeader(
+  authorizationHeader: string | null,
+): { user: MockUser; sessionId: string } | undefined {
+  const match = authorizationHeader ? /^Bearer\s+(.+)$/i.exec(authorizationHeader.trim()) : null;
+  if (!match) return undefined;
+  const record = store.accessTokens.get(match[1]);
+  if (!record) return undefined;
+  const user = store.users.find((u) => u.userId === record.userId);
+  if (!user) return undefined;
+  return { user, sessionId: record.sessionId };
+}
+
+export function toMeResponse(user: MockUser, sessionId: string): MeResponse {
+  return {
+    userId: user.userId,
+    orgId: user.orgId,
+    email: user.email,
+    displayName: user.displayName,
+    permissions: user.permissions,
+    allowedCollectionIds: user.allowedCollectionIds,
+    sessionId,
+  };
+}
+
+export { encodeCursor, decodeCursor };

--- a/web/src/mocks/handlers/auth.ts
+++ b/web/src/mocks/handlers/auth.ts
@@ -1,0 +1,66 @@
+import { registerOperation } from '../registry';
+import { apiError, unauthorized } from '../apiError';
+import { authContextForHeader, getStore, mintTokenPair, toMeResponse } from '../fixtures';
+import type { components } from '../../api/generated/contract';
+
+type LoginRequest = components['schemas']['LoginRequest'];
+type RefreshTokenRequest = components['schemas']['RefreshTokenRequest'];
+type TokenResponse = components['schemas']['TokenResponse'];
+
+function tokenResponse(
+  userId: string,
+  orgId: string,
+  pair: { accessToken: string; refreshToken: string },
+): TokenResponse {
+  return {
+    accessToken: pair.accessToken,
+    refreshToken: pair.refreshToken,
+    tokenType: 'Bearer',
+    expiresIn: 3600,
+    orgId,
+    userId,
+  };
+}
+
+registerOperation('authLogin', async (ctx) => {
+  const body = await ctx.json<LoginRequest>();
+  const user = getStore().users.find((u) => u.email === body.email && u.password === body.password);
+  if (!user) {
+    return { status: 401, body: apiError('unauthorized', 'Email or password is incorrect.') };
+  }
+  const pair = mintTokenPair(user);
+  return { status: 200, body: tokenResponse(user.userId, user.orgId, pair) };
+});
+
+registerOperation('authRefresh', async (ctx) => {
+  const body = await ctx.json<RefreshTokenRequest>();
+  const userId = getStore().refreshTokens.get(body.refreshToken);
+  if (!userId) {
+    return {
+      status: 401,
+      body: apiError('unauthorized', 'Refresh token is invalid, expired, or already used.'),
+    };
+  }
+  getStore().refreshTokens.delete(body.refreshToken); // rotation: old refresh token is single-use
+  const user = getStore().users.find((u) => u.userId === userId);
+  if (!user) {
+    return {
+      status: 401,
+      body: apiError('unauthorized', 'The account for this refresh token no longer exists.'),
+    };
+  }
+  const pair = mintTokenPair(user);
+  return { status: 200, body: tokenResponse(user.userId, user.orgId, pair) };
+});
+
+registerOperation('authLogout', async (ctx) => {
+  const body = await ctx.json<RefreshTokenRequest>();
+  getStore().refreshTokens.delete(body.refreshToken); // idempotent: absent token still returns 204
+  return { status: 204 };
+});
+
+registerOperation('authMe', (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized('No active session for this access token.');
+  return { status: 200, body: toMeResponse(auth.user, auth.sessionId) };
+});

--- a/web/src/mocks/handlers/health.ts
+++ b/web/src/mocks/handlers/health.ts
@@ -1,0 +1,19 @@
+import { registerOperation } from '../registry';
+import { nextRequestId } from '../ids';
+import { specText } from '../spec/specSource';
+
+function health() {
+  return { status: 200, body: { status: 'ok' as const, requestId: nextRequestId() } };
+}
+
+registerOperation('healthLive', () => health());
+registerOperation('healthReady', () => health());
+registerOperation('healthStart', () => health());
+
+// Served verbatim, from the exact same source file the rest of the mock is
+// derived from — this endpoint can't drift from the spec because it *is* the
+// spec's own text.
+registerOperation('openapiYaml', () => ({
+  status: 200,
+  rawBody: { text: specText, contentType: 'application/yaml' },
+}));

--- a/web/src/mocks/handlers/index.ts
+++ b/web/src/mocks/handlers/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Importing this module (for side effects) registers every mocked operation.
+ * Split by domain for readability; `registry.ts` is the aggregate registry
+ * they all write into.
+ */
+import './health';
+import './auth';
+import './library';
+import './qa';

--- a/web/src/mocks/handlers/library.ts
+++ b/web/src/mocks/handlers/library.ts
@@ -1,0 +1,523 @@
+import { registerOperation } from '../registry';
+import { notFound, conflict as conflictResponse, apiError } from '../apiError';
+import { nextRequestId, encodeCursor, decodeCursor, mockTimestamp } from '../ids';
+import { getStore, nextId } from '../fixtures';
+import type { components } from '../../api/generated/contract';
+
+type Collection = components['schemas']['Collection'];
+type CreateCollectionRequest = components['schemas']['CreateCollectionRequest'];
+type UpdateCollectionRequest = components['schemas']['UpdateCollectionRequest'];
+type Document = components['schemas']['Document'];
+type Job = components['schemas']['Job'];
+
+// ---------------------------------------------------------------------------
+// Collections
+// ---------------------------------------------------------------------------
+
+registerOperation('listCollections', () => ({
+  status: 200,
+  body: { items: getStore().collections, page: { hasMore: false, nextCursor: null } },
+}));
+
+registerOperation('createCollection', async (ctx) => {
+  const body = await ctx.json<CreateCollectionRequest>();
+  const collection: Collection = {
+    id: nextId(),
+    name: body.name,
+    slug: body.slug,
+    description: body.description ?? null,
+    visibility: body.visibility ?? 'org',
+    createdAt: mockTimestamp(0),
+  };
+  getStore().collections.push(collection);
+  return { status: 201, body: collection };
+});
+
+registerOperation('getCollection', (ctx) => {
+  const collection = getStore().collections.find((c) => c.id === ctx.params.collectionId);
+  if (!collection) return notFound(`Collection ${ctx.params.collectionId} does not exist.`);
+  return { status: 200, body: collection };
+});
+
+registerOperation('updateCollection', async (ctx) => {
+  const collection = getStore().collections.find((c) => c.id === ctx.params.collectionId);
+  if (!collection) return notFound(`Collection ${ctx.params.collectionId} does not exist.`);
+  const body = await ctx.json<UpdateCollectionRequest>();
+  collection.name = body.name;
+  if ('description' in body) collection.description = body.description ?? null;
+  return { status: 200, body: collection };
+});
+
+registerOperation('deleteCollection', (ctx) => {
+  const store = getStore();
+  const idx = store.collections.findIndex((c) => c.id === ctx.params.collectionId);
+  if (idx === -1) return notFound(`Collection ${ctx.params.collectionId} does not exist.`);
+  store.collections.splice(idx, 1);
+  return { status: 204 };
+});
+
+// ---------------------------------------------------------------------------
+// Documents
+// ---------------------------------------------------------------------------
+
+function findDocument(
+  documentId: string,
+): { document: Document; collectionId: string } | undefined {
+  for (const [collectionId, docs] of getStore().documents) {
+    const document = docs.find((d) => d.id === documentId);
+    if (document) return { document, collectionId };
+  }
+  return undefined;
+}
+
+registerOperation('listDocuments', (ctx) => {
+  const collectionId = ctx.params.collectionId;
+  if (!getStore().collections.some((c) => c.id === collectionId)) {
+    return notFound(`Collection ${collectionId} does not exist.`);
+  }
+  const all = getStore().documents.get(collectionId) ?? [];
+  const rawLimit = ctx.query.get('limit');
+  const limit = rawLimit ? Math.min(100, Math.max(1, Number(rawLimit))) : 50;
+  const offset = decodeCursor(ctx.query.get('cursor'));
+  const page = all.slice(offset, offset + limit);
+  const hasMore = offset + limit < all.length;
+  return {
+    status: 200,
+    body: {
+      items: page,
+      page: { hasMore, nextCursor: hasMore ? encodeCursor(offset + limit) : null },
+    },
+  };
+});
+
+registerOperation('approveIntake', async (ctx) => {
+  const { collectionId, documentId } = ctx.params;
+  const found = findDocument(documentId);
+  if (!found || found.collectionId !== collectionId) {
+    return notFound(`Document ${documentId} does not exist in collection ${collectionId}.`);
+  }
+  await ctx.json<{ reason?: string } | undefined>().catch(() => undefined);
+  const versionId = found.document.currentVersionId ?? nextId();
+  const jobId = nextId();
+  const job: Job = {
+    id: jobId,
+    jobType: 'convert',
+    status: 'pending',
+    attempts: 0,
+    documentId,
+    versionId,
+    createdAt: mockTimestamp(0),
+    updatedAt: mockTimestamp(0),
+    finishedAt: null,
+  };
+  getStore().jobs.set(jobId, job);
+  return {
+    status: 200,
+    body: { documentId, versionId, collectionId, jobId, created: true, requestId: nextRequestId() },
+  };
+});
+
+registerOperation('getDocument', (ctx) => {
+  const found = findDocument(ctx.params.documentId);
+  if (!found) return notFound(`Document ${ctx.params.documentId} does not exist.`);
+  return { status: 200, body: found.document };
+});
+
+registerOperation('deleteDocument', (ctx) => {
+  for (const docs of getStore().documents.values()) {
+    const idx = docs.findIndex((d) => d.id === ctx.params.documentId);
+    if (idx !== -1) {
+      docs.splice(idx, 1);
+      return { status: 204 };
+    }
+  }
+  return notFound(`Document ${ctx.params.documentId} does not exist.`);
+});
+
+registerOperation('previewDocument', (ctx) => {
+  const found = findDocument(ctx.params.documentId);
+  if (!found) return notFound(`Document ${ctx.params.documentId} does not exist.`);
+  const versions = getStore().versions.get(ctx.params.documentId) ?? [];
+  const requestedVersionId = ctx.query.get('versionId');
+  const version = requestedVersionId
+    ? versions.find((v) => v.id === requestedVersionId)
+    : versions.find((v) => v.isCurrent);
+  if (!version) return notFound(`No matching version for document ${ctx.params.documentId}.`);
+  return {
+    status: 200,
+    body: {
+      documentId: found.document.id,
+      versionId: version.id,
+      versionNumber: version.versionNumber,
+      sourceContentSha256: version.sourceContentSha256,
+      canonicalMarkdownSha256: `md-${version.sourceContentSha256}`,
+      isCurrent: version.isCurrent,
+      truncated: false,
+      markdown: `# ${found.document.title}\n\nMock preview content for version ${version.versionNumber}.`,
+      requestId: nextRequestId(),
+    },
+  };
+});
+
+registerOperation('listDocumentVersions', (ctx) => {
+  const versions = getStore().versions.get(ctx.params.documentId) ?? [];
+  return { status: 200, body: { items: versions, page: { hasMore: false, nextCursor: null } } };
+});
+
+registerOperation('getDocumentVersion', (ctx) => {
+  const versions = getStore().versions.get(ctx.params.documentId) ?? [];
+  const version = versions.find((v) => v.id === ctx.params.versionId);
+  if (!version) return notFound(`Version ${ctx.params.versionId} does not exist.`);
+  return { status: 200, body: version };
+});
+
+registerOperation('diffDocumentVersions', (ctx) => {
+  const versions = getStore().versions.get(ctx.params.documentId) ?? [];
+  const left = versions.find((v) => v.id === ctx.params.versionId);
+  const against = ctx.query.get('against');
+  const right = versions.find((v) => v.id === against);
+  if (!left || !right) return notFound('One or both versions in the diff do not exist.');
+  return {
+    status: 200,
+    body: {
+      documentId: ctx.params.documentId,
+      left,
+      right,
+      note: 'Identity diff only; not a text diff.',
+      requestId: nextRequestId(),
+    },
+  };
+});
+
+registerOperation('publishDocumentVersion', (ctx) => {
+  const versions = getStore().versions.get(ctx.params.documentId) ?? [];
+  const version = versions.find((v) => v.id === ctx.params.versionId);
+  if (version) {
+    versions.forEach((v) => (v.isCurrent = v.id === version.id));
+    const found = findDocument(ctx.params.documentId);
+    if (found) found.document.currentVersionId = version.id;
+  }
+  return { status: 204 };
+});
+
+registerOperation('issueDownloadCapability', async (ctx) => {
+  const versions = getStore().versions.get(ctx.params.documentId) ?? [];
+  const version = versions.find((v) => v.id === ctx.params.versionId);
+  if (!version) return notFound(`Version ${ctx.params.versionId} does not exist.`);
+  const body = await ctx.json<{ purpose: 'markdown' | 'original' }>();
+  const capability = nextId();
+  const expiresIn = 300;
+  getStore().downloadCapabilities.set(capability, {
+    capability,
+    documentId: ctx.params.documentId,
+    versionId: ctx.params.versionId,
+    purpose: body.purpose,
+    expiresAt: Date.now() + expiresIn * 1000,
+    redeemed: false,
+  });
+  return {
+    status: 200,
+    body: {
+      capability,
+      expiresIn,
+      purpose: body.purpose,
+      documentId: ctx.params.documentId,
+      versionId: ctx.params.versionId,
+      requestId: nextRequestId(),
+    },
+  };
+});
+
+registerOperation('redeemDownload', (ctx) => {
+  const record = getStore().downloadCapabilities.get(ctx.params.capability);
+  if (!record || record.redeemed || record.expiresAt < Date.now()) {
+    return notFound('Download capability is unknown, already redeemed, or expired.');
+  }
+  record.redeemed = true;
+  const found = findDocument(record.documentId);
+  const title = found?.document.title ?? 'document';
+  if (record.purpose === 'markdown') {
+    return {
+      status: 200,
+      rawBody: {
+        text: `# ${title}\n\nMock canonical markdown for download.`,
+        contentType: 'text/markdown; charset=utf-8',
+      },
+      headers: { 'Content-Disposition': 'attachment' },
+    };
+  }
+  return {
+    status: 200,
+    rawBody: { text: `mock original bytes for ${title}`, contentType: 'application/octet-stream' },
+    headers: { 'Content-Disposition': 'attachment' },
+  };
+});
+
+registerOperation('reindexDocument', (ctx) => {
+  // Spec declares only 200/429 for this operation (no 404) — enqueue regardless
+  // of whether the id is known, matching the declared contract exactly.
+  const jobId = nextId();
+  const found = findDocument(ctx.params.documentId);
+  const job: Job = {
+    id: jobId,
+    jobType: 'index',
+    status: 'pending',
+    attempts: 0,
+    documentId: ctx.params.documentId,
+    versionId: found?.document.currentVersionId ?? null,
+    createdAt: mockTimestamp(0),
+    updatedAt: mockTimestamp(0),
+    finishedAt: null,
+  };
+  getStore().jobs.set(jobId, job);
+  return {
+    status: 200,
+    body: {
+      jobId,
+      created: true,
+      documentId: ctx.params.documentId,
+      versionId: found?.document.currentVersionId ?? null,
+      requestId: nextRequestId(),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Citations
+// ---------------------------------------------------------------------------
+
+registerOperation('resolveCitation', async (ctx) => {
+  const body = await ctx.json<components['schemas']['ResolveCitationRequest']>();
+  const found = findDocument(body.logicalDocumentId);
+  if (!found) return notFound(`Document ${body.logicalDocumentId} does not exist.`);
+  return {
+    status: 200,
+    body: {
+      citation: {
+        citeId: nextId(),
+        logicalDocumentId: body.logicalDocumentId,
+        versionId: body.versionId,
+        versionNumber: 1,
+        sourceContentSha256: body.sourceContentSha256,
+        canonicalMarkdownSha256: body.canonicalMarkdownSha256,
+        quoteSha256: `quote-${body.chunkId}`,
+        chunkId: body.chunkId,
+        chunkIdentitySha256: `chunk-${body.chunkId}`,
+        page: null,
+        slide: null,
+        sheet: null,
+        sourceSpanStart: body.sourceSpanStart,
+        sourceSpanEnd: body.sourceSpanEnd,
+        quoteLocalStart: body.quoteLocalStart,
+        quoteLocalEnd: body.quoteLocalEnd,
+        quote: body.quote,
+        isCurrent: true,
+        anchor: `#${body.chunkId}`,
+      },
+      requestId: nextRequestId(),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Conflicts
+// ---------------------------------------------------------------------------
+
+registerOperation('listConflicts', () => ({
+  status: 200,
+  body: { items: getStore().conflicts, requestId: nextRequestId() },
+}));
+
+registerOperation('getConflict', (ctx) => {
+  const found = getStore().conflicts.find((c) => c.id === ctx.params.conflictId);
+  if (!found) return notFound(`Conflict ${ctx.params.conflictId} does not exist.`);
+  return { status: 200, body: { ...found, requestId: nextRequestId() } };
+});
+
+registerOperation('getConflictEvidence', (ctx) => {
+  const found = getStore().conflicts.find((c) => c.id === ctx.params.conflictId);
+  if (!found) return notFound(`Conflict ${ctx.params.conflictId} does not exist.`);
+  return {
+    status: 200,
+    body: {
+      conflictId: found.id,
+      status: found.status,
+      resolutionNote: found.resolutionNote,
+      resolvedAt: found.resolvedAt,
+      items: [
+        { legId: nextId(), collectionId: found.collectionAId, claimId: found.claimAId },
+        { legId: nextId(), collectionId: found.collectionBId, claimId: found.claimBId },
+      ],
+      requestId: nextRequestId(),
+    },
+  };
+});
+
+registerOperation('triageConflict', async (ctx) => {
+  const found = getStore().conflicts.find((c) => c.id === ctx.params.conflictId);
+  if (!found) return notFound(`Conflict ${ctx.params.conflictId} does not exist.`);
+  const body = await ctx.json<{ status: string; resolutionNote?: string }>();
+  found.status = body.status;
+  found.resolutionNote = body.resolutionNote ?? null;
+  found.resolvedAt = mockTimestamp(0);
+  return {
+    status: 200,
+    body: {
+      id: found.id,
+      status: found.status,
+      resolvedAt: found.resolvedAt,
+      requestId: nextRequestId(),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Jobs
+// ---------------------------------------------------------------------------
+
+registerOperation('getJob', (ctx) => {
+  const job = getStore().jobs.get(ctx.params.jobId);
+  if (!job) return notFound(`Job ${ctx.params.jobId} does not exist.`);
+  return { status: 200, body: job };
+});
+
+// ---------------------------------------------------------------------------
+// Uploads
+// ---------------------------------------------------------------------------
+
+registerOperation('createUpload', async (ctx) => {
+  const form = await ctx.formData();
+  const file = form.get('file');
+  const collectionId = form.get('collectionId');
+  const documentId = form.get('documentId');
+  // Not `instanceof File`: under vitest's jsdom test environment, the `File`
+  // global visible to test/handler code (jsdom's) and the `File` class the
+  // Node-native `fetch`/`FormData` machinery actually constructs (undici's)
+  // are two different classes, so `instanceof` fails even for a genuine file
+  // part. `file` is a `File | string` per the DOM lib types, so checking it's
+  // not a plain string distinguishes "file part" from "text field" just as
+  // reliably, without depending on which realm's File constructor built it.
+  if (typeof file === 'string' || file === null || typeof collectionId !== 'string') {
+    return { status: 400, body: apiError('bad_request', 'file and collectionId are required.') };
+  }
+  if (!getStore().collections.some((c) => c.id === collectionId)) {
+    return notFound(`Collection ${collectionId} does not exist.`);
+  }
+  const sha256 = `sha256-${file.name}-${file.size}`;
+  const isQuarantined = file.name.toLowerCase().startsWith('quarantine-');
+
+  if (typeof documentId === 'string') {
+    const found = findDocument(documentId);
+    if (!found) return notFound(`Document ${documentId} does not exist.`);
+    if (found.document.state !== 'indexed') {
+      return conflictResponse(
+        `Document ${documentId} is not fully indexed; cannot accept a new revision yet.`,
+      );
+    }
+    const versions = getStore().versions.get(documentId) ?? [];
+    const versionId = nextId();
+    const versionNumber = versions.length + 1;
+    versions.forEach((v) => (v.isCurrent = false));
+    versions.push({
+      id: versionId,
+      documentId,
+      versionNumber,
+      isCurrent: true,
+      sourceContentSha256: sha256,
+      effectiveFrom: mockTimestamp(0),
+      effectiveTo: null,
+      changeSummary: 'New revision uploaded.',
+      createdAt: mockTimestamp(0),
+    });
+    getStore().versions.set(documentId, versions);
+    found.document.currentVersionId = versionId;
+    found.document.state = 'converting';
+    const jobId = nextId();
+    getStore().jobs.set(jobId, {
+      id: jobId,
+      jobType: 'convert',
+      status: 'pending',
+      attempts: 0,
+      documentId,
+      versionId,
+      createdAt: mockTimestamp(0),
+      updatedAt: mockTimestamp(0),
+      finishedAt: null,
+    });
+    return {
+      status: 201,
+      body: {
+        disposition: 'accepted',
+        objectId: nextId(),
+        documentId,
+        versionId,
+        jobId,
+        collectionId,
+        sha256,
+        sizeBytes: file.size,
+        canonicalFormat: 'markdown',
+        requestId: nextRequestId(),
+      },
+    };
+  }
+
+  const newDocumentId = nextId();
+  const newVersionId = nextId();
+  const newDoc: Document = {
+    id: newDocumentId,
+    collectionId,
+    title: file.name,
+    state: isQuarantined ? 'uploaded' : 'converting',
+    currentVersionId: isQuarantined ? null : newVersionId,
+    createdAt: mockTimestamp(0),
+    updatedAt: mockTimestamp(0),
+  };
+  const docs = getStore().documents.get(collectionId) ?? [];
+  docs.push(newDoc);
+  getStore().documents.set(collectionId, docs);
+  getStore().versions.set(newDocumentId, [
+    {
+      id: newVersionId,
+      documentId: newDocumentId,
+      versionNumber: 1,
+      isCurrent: !isQuarantined,
+      sourceContentSha256: sha256,
+      effectiveFrom: mockTimestamp(0),
+      effectiveTo: null,
+      changeSummary: null,
+      createdAt: mockTimestamp(0),
+    },
+  ]);
+
+  let jobId: string | undefined;
+  if (!isQuarantined) {
+    jobId = nextId();
+    getStore().jobs.set(jobId, {
+      id: jobId,
+      jobType: 'convert',
+      status: 'pending',
+      attempts: 0,
+      documentId: newDocumentId,
+      versionId: newVersionId,
+      createdAt: mockTimestamp(0),
+      updatedAt: mockTimestamp(0),
+      finishedAt: null,
+    });
+  }
+
+  return {
+    status: 201,
+    body: {
+      disposition: isQuarantined ? 'quarantined' : 'accepted',
+      objectId: nextId(),
+      documentId: newDocumentId,
+      versionId: newVersionId,
+      jobId,
+      collectionId,
+      sha256,
+      sizeBytes: file.size,
+      canonicalFormat: 'markdown',
+      requestId: nextRequestId(),
+    },
+  };
+});

--- a/web/src/mocks/handlers/qa.ts
+++ b/web/src/mocks/handlers/qa.ts
@@ -1,0 +1,55 @@
+import { registerOperation } from '../registry';
+import { nextRequestId } from '../ids';
+import { getStore } from '../fixtures';
+import type { components } from '../../api/generated/contract';
+
+type SearchRequest = components['schemas']['SearchRequest'];
+type AskRequest = components['schemas']['AskRequest'];
+type CitationPin = components['schemas']['CitationPin'];
+
+function sampleCitation(seed: number): CitationPin {
+  return {
+    citeId: `cite-${seed}`,
+    sourceContentSha256: 'a'.repeat(64),
+    canonicalMarkdownSha256: 'b'.repeat(64),
+    quoteSha256: 'c'.repeat(64),
+    chunkIdentitySha256: 'd'.repeat(64),
+    quote: 'Employees accrue fifteen days of paid leave per year.',
+    sourceSpanStart: 120,
+    sourceSpanEnd: 178,
+    quoteLocalStart: 0,
+    quoteLocalEnd: 58,
+    isCurrent: true,
+    anchor: '#leave-policy',
+  };
+}
+
+registerOperation('search', async (ctx) => {
+  const body = await ctx.json<SearchRequest>();
+  const documents = [...getStore().documents.values()].flat();
+  const hits = documents.slice(0, body.limit ?? 10).map((doc, i) => ({
+    documentId: doc.id,
+    title: doc.title,
+    score: Number((1 - i * 0.1).toFixed(2)),
+    snippet: `Matched "${body.query}" in ${doc.title}.`,
+  }));
+  return {
+    status: 200,
+    body: { hits, citations: hits.map((_, i) => sampleCitation(i)), requestId: nextRequestId() },
+  };
+});
+
+registerOperation('ask', async (ctx) => {
+  const body = await ctx.json<AskRequest>();
+  return {
+    status: 200,
+    body: {
+      answer: `Mock grounded answer for: "${body.question}"`,
+      mode: body.mode ?? 'current',
+      citations: [sampleCitation(0)],
+      warnings: [],
+      embeddingMode: 'mock',
+      requestId: nextRequestId(),
+    },
+  };
+});

--- a/web/src/mocks/ids.test.ts
+++ b/web/src/mocks/ids.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  mockUuid,
+  mockTimestamp,
+  encodeCursor,
+  decodeCursor,
+  nextRequestId,
+  resetRequestIdCounter,
+} from './ids';
+
+describe('mockUuid', () => {
+  it('is deterministic and syntactically a uuid', () => {
+    expect(mockUuid(1)).toBe(mockUuid(1));
+    expect(mockUuid(1)).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it('differs for different seeds', () => {
+    expect(mockUuid(1)).not.toBe(mockUuid(2));
+  });
+
+  it('rejects negative or non-integer seeds', () => {
+    expect(() => mockUuid(-1)).toThrow();
+    expect(() => mockUuid(1.5)).toThrow();
+  });
+});
+
+describe('mockTimestamp', () => {
+  it('is deterministic and parses as a valid date-time', () => {
+    const ts = mockTimestamp(5);
+    expect(ts).toBe(mockTimestamp(5));
+    expect(Number.isNaN(Date.parse(ts))).toBe(false);
+  });
+
+  it('increases with the step', () => {
+    expect(Date.parse(mockTimestamp(10))).toBeGreaterThan(Date.parse(mockTimestamp(5)));
+  });
+});
+
+describe('pagination cursors', () => {
+  it('round-trips through encode/decode', () => {
+    for (const offset of [0, 1, 50, 12345]) {
+      expect(decodeCursor(encodeCursor(offset))).toBe(offset);
+    }
+  });
+
+  it('treats an absent cursor as offset 0', () => {
+    expect(decodeCursor(undefined)).toBe(0);
+    expect(decodeCursor(null)).toBe(0);
+  });
+
+  it('rejects a cursor it did not mint', () => {
+    expect(() => decodeCursor('not-a-real-cursor')).toThrow();
+  });
+
+  it('is opaque (not a plain-text offset)', () => {
+    expect(encodeCursor(7)).not.toContain('7');
+  });
+});
+
+describe('nextRequestId', () => {
+  beforeEach(() => resetRequestIdCounter());
+
+  it('produces a fresh uuid each call and resets cleanly', () => {
+    const a = nextRequestId();
+    const b = nextRequestId();
+    expect(a).not.toBe(b);
+    resetRequestIdCounter();
+    expect(nextRequestId()).toBe(a);
+  });
+});

--- a/web/src/mocks/ids.ts
+++ b/web/src/mocks/ids.ts
@@ -1,0 +1,64 @@
+/**
+ * Deterministic id/timestamp/cursor generation for mock fixtures.
+ *
+ * Deterministic on purpose: tests that assert against mock responses should
+ * get the same uuid/timestamp/cursor every run, not something that changes
+ * with wall-clock time or a random seed. All three helpers are pure functions
+ * of an integer counter/offset the caller supplies (usually a small fixture
+ * index), so the same call always returns the same value.
+ */
+
+const UUID_NAMESPACE = '00000000-0000-4000-8000-'; // fixed prefix; only the last 12 hex digits vary
+
+/** A stable, syntactically-valid (RFC 4122 v4-shaped) uuid derived from a small integer. */
+export function mockUuid(seed: number): string {
+  if (!Number.isInteger(seed) || seed < 0) {
+    throw new Error(`mockUuid: seed must be a non-negative integer, got ${seed}`);
+  }
+  return `${UUID_NAMESPACE}${seed.toString(16).padStart(12, '0')}`;
+}
+
+const BASE_TIMESTAMP_MS = Date.UTC(2026, 0, 1, 0, 0, 0); // 2026-01-01T00:00:00.000Z
+
+/** A stable ISO-8601 timestamp, `stepMinutes` minutes after a fixed epoch. */
+export function mockTimestamp(stepMinutes: number): string {
+  return new Date(BASE_TIMESTAMP_MS + stepMinutes * 60_000).toISOString();
+}
+
+/**
+ * Opaque pagination cursor helpers. The cursor is a base64url encoding of the
+ * next-offset integer — opaque to callers (per the spec's "opaque pagination
+ * cursor" wording), but it genuinely round-trips through `PageInfo.nextCursor`
+ * the way the real API's cursor is expected to.
+ */
+export function encodeCursor(offset: number): string {
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error(`encodeCursor: offset must be a non-negative integer, got ${offset}`);
+  }
+  return btoa(`offset:${offset}`).replace(/=+$/, '');
+}
+
+export function decodeCursor(cursor: string | null | undefined): number {
+  if (!cursor) return 0;
+  let decoded: string;
+  try {
+    decoded = atob(cursor);
+  } catch {
+    throw new Error(`decodeCursor: "${cursor}" is not valid base64`);
+  }
+  const match = /^offset:(\d+)$/.exec(decoded);
+  if (!match)
+    throw new Error(`decodeCursor: "${cursor}" did not decode to a recognizable offset cursor`);
+  return Number(match[1]);
+}
+
+let requestIdCounter = 0;
+/** A fresh per-response requestId. Reset between tests via `resetRequestIdCounter`. */
+export function nextRequestId(): string {
+  requestIdCounter += 1;
+  return mockUuid(0xfeed_0000 + requestIdCounter);
+}
+
+export function resetRequestIdCounter(): void {
+  requestIdCounter = 0;
+}

--- a/web/src/mocks/index.ts
+++ b/web/src/mocks/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Public surface of the OpenAPI-driven mock. See the P2-02 report for the
+ * design rationale. Typical vitest usage:
+ *
+ * ```ts
+ * import { installMockFetch, uninstallMockFetch, resetMockState, mockControl } from '../mocks';
+ *
+ * beforeEach(() => { installMockFetch(); resetMockState(); });
+ * afterEach(() => uninstallMockFetch());
+ *
+ * it('shows a 429 banner', async () => {
+ *   mockControl.forceStatus('listCollections', 429, { times: 1 });
+ *   // ...render the component, assert on the banner...
+ * });
+ * ```
+ *
+ * Dev-mode wiring (calling `installMockFetch()` from `main.tsx` behind an env
+ * flag) is intentionally not done here — `main.tsx` belongs to app bootstrap,
+ * outside `web/src/mocks/**`, which is this task's ownership boundary.
+ */
+export {
+  installMockFetch,
+  uninstallMockFetch,
+  resetMockState,
+  invalidateRouteCache,
+} from './fetchMock';
+export { mockControl } from './control';
+export type { ForcedFailureKind } from './control';
+export { getSpecIndex, getOperation } from './spec/openApiSpec';
+export {
+  registerOperation,
+  getRegisteredOperations,
+  DELIBERATELY_UNMOCKED_OPERATIONS,
+} from './registry';
+export type { MockRequestContext, MockHandlerResult, MockHandler } from './registry';
+export { resetMockStore, getStore } from './fixtures';

--- a/web/src/mocks/registry.ts
+++ b/web/src/mocks/registry.ts
@@ -1,0 +1,59 @@
+import type { HttpMethod } from './spec/openApiSpec';
+
+export interface MockRequestContext {
+  method: HttpMethod;
+  /** Path params extracted from the matched `{param}` segments of the operation's path template. */
+  params: Record<string, string>;
+  query: URLSearchParams;
+  headers: Headers;
+  /** Parses the request body as JSON. Throws if the body isn't valid JSON. */
+  json: <T = unknown>() => Promise<T>;
+  /** Available for the one multipart operation (`createUpload`). */
+  formData: () => Promise<FormData>;
+  request: Request;
+}
+
+export interface MockHandlerResult {
+  status: number;
+  /** JSON-serializable response body. Omit for 204/empty responses. */
+  body?: unknown;
+  /** Use for non-JSON bodies (redeemDownload's markdown/binary, openapiYaml's raw text). */
+  rawBody?: { text: string; contentType: string };
+  headers?: Record<string, string>;
+}
+
+export type MockHandler = (
+  ctx: MockRequestContext,
+) => Promise<MockHandlerResult> | MockHandlerResult;
+
+export interface RegisteredOperation {
+  operationId: string;
+  handle: MockHandler;
+}
+
+/**
+ * Central registry of every operation the mock implements, keyed by
+ * operationId. Route templates, methods, and declared status codes are never
+ * duplicated here — they're looked up from the parsed spec
+ * (`spec/openApiSpec.ts`) by `fetchMock.ts` and by `specDrift.test.ts`, using
+ * this map's keys as the only "which operations do we mock" source of truth.
+ */
+const registry = new Map<string, MockHandler>();
+
+export function registerOperation(operationId: string, handle: MockHandler): void {
+  if (registry.has(operationId)) {
+    throw new Error(`mocks/registry: operationId "${operationId}" is already registered`);
+  }
+  registry.set(operationId, handle);
+}
+
+export function getRegisteredOperations(): RegisteredOperation[] {
+  return [...registry.entries()].map(([operationId, handle]) => ({ operationId, handle }));
+}
+
+export function getHandler(operationId: string): MockHandler | undefined {
+  return registry.get(operationId);
+}
+
+/** Operations the spec declares that this mock deliberately does not implement (see README/report: SSE streaming). */
+export const DELIBERATELY_UNMOCKED_OPERATIONS = ['jobEvents', 'askStream'] as const;

--- a/web/src/mocks/schema/validate.test.ts
+++ b/web/src/mocks/schema/validate.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { validateAgainstSchema, assertMatchesSchema } from './validate';
+import { buildSpecIndex } from '../spec/openApiSpec';
+
+describe('validateAgainstSchema', () => {
+  it('passes a value that satisfies a simple object schema', () => {
+    const schema = {
+      type: 'object',
+      required: ['status', 'requestId'],
+      properties: {
+        status: { type: 'string', enum: ['ok'] },
+        requestId: { type: 'string', format: 'uuid' },
+      },
+    };
+    const errors = validateAgainstSchema(schema, {
+      status: 'ok',
+      requestId: '11111111-1111-1111-1111-111111111111',
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('flags a missing required property', () => {
+    const schema = { type: 'object', required: ['a', 'b'], properties: {} };
+    const errors = validateAgainstSchema(schema, { a: 1 });
+    expect(errors).toEqual(['$.b: missing required property']);
+  });
+
+  it('flags a bad enum value', () => {
+    const schema = { type: 'string', enum: ['ok'] };
+    const errors = validateAgainstSchema(schema, 'not-ok');
+    expect(errors[0]).toMatch(/is not one of enum/);
+  });
+
+  it('flags a malformed uuid', () => {
+    const schema = { type: 'string', format: 'uuid' };
+    expect(validateAgainstSchema(schema, 'not-a-uuid')[0]).toMatch(/not a valid uuid/);
+    expect(validateAgainstSchema(schema, '11111111-1111-1111-1111-111111111111')).toEqual([]);
+  });
+
+  it('flags a malformed date-time', () => {
+    const schema = { type: 'string', format: 'date-time' };
+    expect(validateAgainstSchema(schema, 'not-a-date')[0]).toMatch(/not a valid date-time/);
+    expect(validateAgainstSchema(schema, '2024-01-01T00:00:00Z')).toEqual([]);
+  });
+
+  it('supports nullable via a type array (OpenAPI 3.1 style)', () => {
+    const schema = { type: ['string', 'null'] };
+    expect(validateAgainstSchema(schema, null)).toEqual([]);
+    expect(validateAgainstSchema(schema, 'hi')).toEqual([]);
+    expect(validateAgainstSchema(schema, 3)[0]).toMatch(/expected type/);
+  });
+
+  it('validates array items', () => {
+    const schema = { type: 'array', items: { type: 'string' } };
+    expect(validateAgainstSchema(schema, ['a', 'b'])).toEqual([]);
+    expect(validateAgainstSchema(schema, ['a', 1])[0]).toMatch(/\$\[1\]/);
+  });
+
+  it('assertMatchesSchema throws with the accumulated errors', () => {
+    expect(() => assertMatchesSchema({ type: 'object', required: ['x'] }, {}, 'thing')).toThrow(
+      /schema validation failed/,
+    );
+  });
+});
+
+describe('validateAgainstSchema against real spec schemas', () => {
+  const spec = buildSpecIndex();
+
+  it('validates a realistic Collection fixture', () => {
+    const errors = validateAgainstSchema(spec.schemas.Collection, {
+      id: '11111111-1111-1111-1111-111111111111',
+      name: 'Handbook',
+      slug: 'handbook',
+      description: null,
+      visibility: 'org',
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('catches a Collection fixture missing a required field', () => {
+    const errors = validateAgainstSchema(spec.schemas.Collection, {
+      id: '11111111-1111-1111-1111-111111111111',
+      slug: 'handbook',
+      visibility: 'org',
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
+    expect(errors).toEqual(['$.name: missing required property']);
+  });
+
+  it('validates the ApiError envelope shape', () => {
+    const errors = validateAgainstSchema(spec.schemas.ApiError, {
+      code: 'not_found',
+      message: 'Collection not found',
+      requestId: '11111111-1111-1111-1111-111111111111',
+    });
+    expect(errors).toEqual([]);
+  });
+});

--- a/web/src/mocks/schema/validate.ts
+++ b/web/src/mocks/schema/validate.ts
@@ -1,0 +1,110 @@
+/**
+ * A minimal JSON-Schema-subset validator, sized exactly for what
+ * `crates/server/openapi/openapi.yaml` actually uses: `type` (scalar or an
+ * array of types, the OpenAPI 3.1 way of expressing nullable), `enum`,
+ * `required` + `properties` on objects, `items` on arrays, and `format`
+ * (`uuid`, `date-time`; others are accepted without a value-shape check).
+ * No `allOf`/`oneOf`/`anyOf`/`pattern`/`$ref` support — the document doesn't
+ * use them (verified by inspection; `openApiSpec.ts` resolves `$ref`s before
+ * schemas ever reach this validator).
+ *
+ * This exists so mock fixtures are checked against the spec's shape, not just
+ * hand-typed and hoped to match — a required field silently dropped from a
+ * fixture is exactly the kind of drift this project can't afford.
+ */
+
+export type JsonSchema = Record<string, unknown>;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function typeOfValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  if (typeof value === 'number') return Number.isInteger(value) ? 'integer' : 'number';
+  return typeof value;
+}
+
+function matchesType(value: unknown, expected: string): boolean {
+  const actual = typeOfValue(value);
+  if (expected === 'number') return actual === 'number' || actual === 'integer';
+  if (expected === 'integer') return actual === 'integer';
+  return actual === expected;
+}
+
+function checkFormat(format: string, value: unknown, path: string, errors: string[]): void {
+  if (typeof value !== 'string') return; // format only meaningfully applies to strings here
+  if (format === 'uuid' && !UUID_RE.test(value)) {
+    errors.push(`${path}: "${value}" is not a valid uuid`);
+  }
+  if (format === 'date-time' && Number.isNaN(Date.parse(value))) {
+    errors.push(`${path}: "${value}" is not a valid date-time`);
+  }
+}
+
+export function validateAgainstSchema(
+  schema: JsonSchema | undefined,
+  value: unknown,
+  path = '$',
+): string[] {
+  if (!schema || Object.keys(schema).length === 0) return []; // untyped / additionalProperties-only schema
+  const errors: string[] = [];
+
+  const typeField = schema.type;
+  if (typeField !== undefined) {
+    const expectedTypes = Array.isArray(typeField) ? (typeField as string[]) : [String(typeField)];
+    if (!expectedTypes.some((t) => matchesType(value, t))) {
+      errors.push(
+        `${path}: expected type ${expectedTypes.join(' | ')}, got ${typeOfValue(value)} (${JSON.stringify(value)})`,
+      );
+      return errors; // type mismatch makes deeper checks meaningless
+    }
+  }
+
+  if (Array.isArray(schema.enum) && value !== null && value !== undefined) {
+    if (!schema.enum.includes(value as never)) {
+      errors.push(
+        `${path}: ${JSON.stringify(value)} is not one of enum [${schema.enum.join(', ')}]`,
+      );
+    }
+  }
+
+  if (typeof schema.format === 'string') {
+    checkFormat(schema.format, value, path, errors);
+  }
+
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    const required = Array.isArray(schema.required) ? (schema.required as string[]) : [];
+    for (const key of required) {
+      if (!(key in obj) || obj[key] === undefined) {
+        errors.push(`${path}.${key}: missing required property`);
+      }
+    }
+    const properties = (schema.properties as Record<string, JsonSchema> | undefined) ?? {};
+    for (const [key, propSchema] of Object.entries(properties)) {
+      if (key in obj && obj[key] !== undefined) {
+        errors.push(...validateAgainstSchema(propSchema, obj[key], `${path}.${key}`));
+      }
+    }
+  }
+
+  if (Array.isArray(value) && schema.items) {
+    value.forEach((item, i) => {
+      errors.push(...validateAgainstSchema(schema.items as JsonSchema, item, `${path}[${i}]`));
+    });
+  }
+
+  return errors;
+}
+
+/** Throws with all accumulated errors if the value does not satisfy the schema. */
+export function assertMatchesSchema(
+  schema: JsonSchema | undefined,
+  value: unknown,
+  label: string,
+): void {
+  const errors = validateAgainstSchema(schema, value, label);
+  if (errors.length > 0) {
+    throw new Error(`schema validation failed:\n  ${errors.join('\n  ')}`);
+  }
+}

--- a/web/src/mocks/spec/driftGuard.ts
+++ b/web/src/mocks/spec/driftGuard.ts
@@ -1,0 +1,53 @@
+import { getSpecIndex } from './openApiSpec';
+import { validateAgainstSchema } from '../schema/validate';
+
+/**
+ * The spec-drift guard the P2-02 task asks for: every operationId this mock
+ * claims to implement must actually exist in `openapi.yaml`, and every status
+ * code / JSON body it emits for that operation must be one the spec declares.
+ * If the spec drops an operation, a status code, or tightens a schema, these
+ * throw instead of the mock quietly answering for an API that no longer
+ * exists — see `specDrift.test.ts` for a live demonstration.
+ */
+
+export function assertOperationsExistInSpec(operationIds: readonly string[]): void {
+  const spec = getSpecIndex();
+  for (const operationId of operationIds) {
+    if (!spec.operations[operationId]) {
+      throw new Error(
+        `mocks drift-guard: operationId "${operationId}" is registered as a mock handler but ` +
+          `does not exist in crates/server/openapi/openapi.yaml. The spec removed/renamed this ` +
+          `operation — remove or rename the corresponding handler in web/src/mocks/handlers/.`,
+      );
+    }
+  }
+}
+
+export function assertStatusDeclared(operationId: string, status: number): void {
+  const op = getSpecIndex().operations[operationId];
+  if (!op) {
+    throw new Error(`mocks drift-guard: operationId "${operationId}" does not exist in the spec.`);
+  }
+  if (!(String(status) in op.responses)) {
+    throw new Error(
+      `mocks drift-guard: operation "${operationId}" (${op.method.toUpperCase()} ${op.path}) returned ` +
+        `status ${status}, but the spec only declares [${Object.keys(op.responses).join(', ')}] for it.`,
+    );
+  }
+}
+
+export function assertJsonBodyMatchesSpec(
+  operationId: string,
+  status: number,
+  body: unknown,
+): void {
+  const op = getSpecIndex().operations[operationId];
+  const schema = op?.responses[String(status)]?.content['application/json'];
+  if (!schema) return; // no JSON schema declared for this status (e.g. 204, or a non-JSON media type)
+  const errors = validateAgainstSchema(schema, body);
+  if (errors.length > 0) {
+    throw new Error(
+      `mocks drift-guard: response body for ${operationId} (${status}) does not match its spec schema:\n  ${errors.join('\n  ')}`,
+    );
+  }
+}

--- a/web/src/mocks/spec/openApiSpec.test.ts
+++ b/web/src/mocks/spec/openApiSpec.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { buildSpecIndex, getOperation } from './openApiSpec';
+
+const spec = buildSpecIndex();
+
+describe('buildSpecIndex against the real openapi.yaml', () => {
+  it('indexes all 24 component schemas', () => {
+    expect(Object.keys(spec.schemas)).toHaveLength(24);
+    expect(spec.schemas.TokenResponse).toBeDefined();
+    expect(spec.schemas.ApiError).toBeDefined();
+  });
+
+  it('indexes every operationId with its method and path', () => {
+    expect(spec.operations.authLogin).toMatchObject({ method: 'post', path: '/auth/login' });
+    expect(spec.operations.listCollections).toMatchObject({ method: 'get', path: '/collections' });
+    expect(spec.operations.createCollection).toMatchObject({
+      method: 'post',
+      path: '/collections',
+    });
+    expect(spec.operations.getCollection).toMatchObject({
+      method: 'get',
+      path: '/collections/{collectionId}',
+    });
+    expect(spec.operationIds).toContain('reindexDocument');
+    expect(spec.operationIds).toContain('askStream');
+    expect(spec.operationIds).toContain('jobEvents');
+  });
+
+  it('resolves $ref-based error responses down to the ApiError schema', () => {
+    const op = spec.operations.authLogin;
+    expect(Object.keys(op.responses).sort()).toEqual(['200', '401', '429']);
+    const err = op.responses['401'].content['application/json'];
+    expect(err.required).toEqual(['code', 'message', 'requestId']);
+    const rateLimited = op.responses['429'].content['application/json'];
+    expect(rateLimited.required).toEqual(['code', 'message', 'requestId']);
+  });
+
+  it('resolves the 200 response schema down to TokenResponse required fields', () => {
+    const op = spec.operations.authLogin;
+    const ok = op.responses['200'].content['application/json'];
+    expect(ok.required).toEqual(
+      expect.arrayContaining([
+        'accessToken',
+        'refreshToken',
+        'tokenType',
+        'expiresIn',
+        'orgId',
+        'userId',
+      ]),
+    );
+  });
+
+  it('marks requestBody as required for auth/login, refresh and logout', () => {
+    expect(spec.operations.authLogin.requestBody?.required).toBe(true);
+    expect(spec.operations.authRefresh.requestBody?.required).toBe(true);
+    expect(spec.operations.authLogout.requestBody?.required).toBe(true);
+  });
+
+  it('leaves requestBody undefined for the two body-less POSTs (publish, reindex)', () => {
+    expect(spec.operations.publishDocumentVersion.requestBody).toBeUndefined();
+    expect(spec.operations.reindexDocument.requestBody).toBeUndefined();
+  });
+
+  it('captures path parameters, including ones declared on the shared pathItem', () => {
+    const op = spec.operations.getCollection;
+    expect(op.parameters).toEqual([
+      {
+        name: 'collectionId',
+        in: 'path',
+        required: true,
+        schema: { type: 'string', format: 'uuid' },
+      },
+    ]);
+  });
+
+  it('captures listDocuments query parameters (limit, cursor) plus the shared collectionId path param', () => {
+    const op = spec.operations.listDocuments;
+    const names = op.parameters.map((p) => `${p.in}:${p.name}`);
+    expect(names).toEqual(['path:collectionId', 'query:limit', 'query:cursor']);
+  });
+
+  it('captures the multipart/form-data request body for createUpload', () => {
+    const op = spec.operations.createUpload;
+    expect(op.requestBody?.required).toBe(true);
+    expect(Object.keys(op.requestBody?.content ?? {})).toEqual(['multipart/form-data']);
+    const schema = op.requestBody?.content['multipart/form-data'];
+    expect(schema?.required).toEqual(['file', 'collectionId']);
+  });
+
+  it('exposes 204-only responses with no JSON content (publishDocumentVersion)', () => {
+    const op = spec.operations.publishDocumentVersion;
+    expect(Object.keys(op.responses)).toEqual(['204', '429']);
+    expect(op.responses['204'].content).toEqual({});
+  });
+
+  it('marks health/auth/openapi.yaml operations as not requiring auth (explicit `security: []`)', () => {
+    expect(spec.operations.healthLive.requiresAuth).toBe(false);
+    expect(spec.operations.healthReady.requiresAuth).toBe(false);
+    expect(spec.operations.authLogin.requiresAuth).toBe(false);
+    expect(spec.operations.authRefresh.requiresAuth).toBe(false);
+    expect(spec.operations.authLogout.requiresAuth).toBe(false);
+    expect(spec.operations.openapiYaml.requiresAuth).toBe(false);
+  });
+
+  it('defaults every other operation to requiring auth (inherited root bearerAuth)', () => {
+    expect(spec.operations.authMe.requiresAuth).toBe(true);
+    expect(spec.operations.listCollections.requiresAuth).toBe(true);
+    expect(spec.operations.search.requiresAuth).toBe(true);
+    expect(spec.operations.getJob.requiresAuth).toBe(true);
+  });
+
+  it('throws a descriptive error for an operationId the spec does not declare', () => {
+    expect(() => getOperation('thisOperationDoesNotExist')).toThrow(/is not declared/);
+  });
+});

--- a/web/src/mocks/spec/openApiSpec.ts
+++ b/web/src/mocks/spec/openApiSpec.ts
@@ -1,0 +1,196 @@
+/**
+ * Loads `crates/server/openapi/openapi.yaml` (via Vite's `?raw` import — see
+ * `yaml.ts` for why we parse it ourselves instead of adding a YAML dependency),
+ * resolves internal `$ref`s, and builds a lookup index keyed by `operationId`.
+ *
+ * This is the runtime source of truth the mock handlers and the spec-drift test
+ * are checked against. It reads the *document*, not the generated
+ * `src/api/generated/contract.ts` — so it stays authoritative even in the
+ * (should-never-happen-but-might) window where contract.ts has drifted from
+ * the spec, and it doesn't require `pnpm api:generate` to have been re-run.
+ */
+import { parseYaml, type YamlValue } from './yaml';
+import { specText } from './specSource';
+
+type YamlObject = Record<string, YamlValue>;
+
+function asObject(value: YamlValue | undefined): YamlObject {
+  if (value === null || value === undefined || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value as YamlObject;
+}
+
+function asArray(value: YamlValue | undefined): YamlValue[] {
+  return Array.isArray(value) ? value : [];
+}
+
+const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
+export type HttpMethod = (typeof HTTP_METHODS)[number];
+
+export interface ParameterDef {
+  name: string;
+  in: 'path' | 'query' | 'header' | 'cookie';
+  required: boolean;
+  schema: YamlObject;
+}
+
+export interface MediaTypeMap {
+  [mediaType: string]: YamlObject;
+}
+
+export interface ResponseDef {
+  status: string;
+  description?: string;
+  content: MediaTypeMap;
+}
+
+export interface RequestBodyDef {
+  required: boolean;
+  content: MediaTypeMap;
+}
+
+export interface OperationDef {
+  operationId: string;
+  method: HttpMethod;
+  path: string;
+  parameters: ParameterDef[];
+  requestBody?: RequestBodyDef;
+  responses: Record<string, ResponseDef>;
+  /** Whether this operation requires `Authorization: Bearer <token>` per the spec's security rules. */
+  requiresAuth: boolean;
+}
+
+export interface SpecIndex {
+  raw: YamlObject;
+  schemas: Record<string, YamlObject>;
+  operations: Record<string, OperationDef>;
+  operationIds: string[];
+}
+
+function resolveRef(root: YamlObject, node: YamlValue, guard = 0): YamlValue {
+  if (guard > 20) throw new Error('spec: $ref cycle guard tripped');
+  if (
+    node !== null &&
+    typeof node === 'object' &&
+    !Array.isArray(node) &&
+    typeof node.$ref === 'string'
+  ) {
+    const ref = node.$ref;
+    if (!ref.startsWith('#/')) throw new Error(`spec: only local $refs are supported, got ${ref}`);
+    const segments = ref.slice(2).split('/');
+    let cursor: YamlValue = root;
+    for (const seg of segments) {
+      cursor = asObject(cursor)[seg] ?? null;
+    }
+    return resolveRef(root, cursor, guard + 1);
+  }
+  return node;
+}
+
+function resolveObject(root: YamlObject, node: YamlValue): YamlObject {
+  return asObject(resolveRef(root, node));
+}
+
+function parseParameter(root: YamlObject, node: YamlValue): ParameterDef {
+  const resolved = resolveObject(root, node);
+  return {
+    name: String(resolved.name ?? ''),
+    in: (resolved.in as ParameterDef['in']) ?? 'query',
+    required: Boolean(resolved.required ?? false),
+    schema: asObject(resolved.schema),
+  };
+}
+
+function parseContent(root: YamlObject, contentNode: YamlValue): MediaTypeMap {
+  const content = asObject(contentNode);
+  const out: MediaTypeMap = {};
+  for (const [mediaType, schemaNode] of Object.entries(content)) {
+    out[mediaType] = resolveObject(root, asObject(schemaNode).schema);
+  }
+  return out;
+}
+
+function parseResponses(root: YamlObject, responsesNode: YamlValue): Record<string, ResponseDef> {
+  const responses = asObject(responsesNode);
+  const out: Record<string, ResponseDef> = {};
+  for (const [status, respNode] of Object.entries(responses)) {
+    const resolved = resolveObject(root, respNode);
+    out[status] = {
+      status,
+      description: typeof resolved.description === 'string' ? resolved.description : undefined,
+      content: parseContent(root, resolved.content),
+    };
+  }
+  return out;
+}
+
+export function buildSpecIndex(source: string = specText): SpecIndex {
+  const raw = asObject(parseYaml(source));
+  const components = asObject(raw.components);
+  const schemas: Record<string, YamlObject> = {};
+  for (const [name, node] of Object.entries(asObject(components.schemas))) {
+    schemas[name] = asObject(node);
+  }
+
+  const rootRequiresAuth = asArray(raw.security).length > 0;
+
+  const operations: Record<string, OperationDef> = {};
+  const paths = asObject(raw.paths);
+  for (const [path, pathItemNode] of Object.entries(paths)) {
+    const pathItem = asObject(pathItemNode);
+    const sharedParams = asArray(pathItem.parameters).map((p) => parseParameter(raw, p));
+    for (const method of HTTP_METHODS) {
+      const opNode = pathItem[method];
+      if (opNode === undefined || opNode === null) continue;
+      const op = asObject(opNode);
+      const operationId = String(op.operationId ?? '');
+      if (!operationId) continue;
+      const ownParams = asArray(op.parameters).map((p) => parseParameter(raw, p));
+      let requestBody: RequestBodyDef | undefined;
+      if (op.requestBody !== undefined && op.requestBody !== null) {
+        const rb = resolveObject(raw, op.requestBody);
+        requestBody = {
+          required: Boolean(rb.required ?? false),
+          content: parseContent(raw, rb.content),
+        };
+      }
+      const requiresAuth = 'security' in op ? asArray(op.security).length > 0 : rootRequiresAuth;
+
+      operations[operationId] = {
+        operationId,
+        method,
+        path,
+        parameters: [...sharedParams, ...ownParams],
+        requestBody,
+        responses: parseResponses(raw, op.responses),
+        requiresAuth,
+      };
+    }
+  }
+
+  return { raw, schemas, operations, operationIds: Object.keys(operations) };
+}
+
+let cached: SpecIndex | undefined;
+/** The parsed+indexed spec, memoized (parsing ~1500 lines once per process is plenty cheap, but no need to repeat it). */
+export function getSpecIndex(): SpecIndex {
+  if (!cached) cached = buildSpecIndex();
+  return cached;
+}
+
+export function getOperation(operationId: string): OperationDef {
+  const op = getSpecIndex().operations[operationId];
+  if (!op) {
+    throw new Error(
+      `mocks/spec: operationId "${operationId}" is not declared in crates/server/openapi/openapi.yaml. ` +
+        `Either the mock is stale (rename/remove the handler) or the spec regressed.`,
+    );
+  }
+  return op;
+}
+
+/** Resolves `$ref` for any node against the loaded document; exported for schema validation use. */
+export function resolveAgainstSpec(node: YamlValue): YamlValue {
+  return resolveRef(getSpecIndex().raw, node);
+}

--- a/web/src/mocks/spec/specSource.ts
+++ b/web/src/mocks/spec/specSource.ts
@@ -1,0 +1,10 @@
+/**
+ * Single point of contact with the on-disk OpenAPI document. Every other
+ * module that needs the spec's raw text or parsed/indexed form imports it
+ * from here (or from `openApiSpec.ts`, which itself imports this) rather than
+ * re-stating the relative path to `crates/server/openapi/openapi.yaml` — one
+ * place to fix if the file ever moves.
+ */
+import specText from '../../../../crates/server/openapi/openapi.yaml?raw';
+
+export { specText };

--- a/web/src/mocks/spec/yaml.test.ts
+++ b/web/src/mocks/spec/yaml.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { parseYaml } from './yaml';
+import { specText } from './specSource';
+
+describe('parseYaml (targeted constructs)', () => {
+  it('parses simple block mappings and scalars', () => {
+    const doc = parseYaml(
+      `title: Hello\nversion: 0.1.0\ncount: 3\nok: true\nnope: false\nblank: null\n`,
+    );
+    expect(doc).toEqual({
+      title: 'Hello',
+      version: '0.1.0',
+      count: 3,
+      ok: true,
+      nope: false,
+      blank: null,
+    });
+  });
+
+  it('parses nested block mappings', () => {
+    const doc = parseYaml(`a:\n  b: 1\n  c:\n    d: 2\n`);
+    expect(doc).toEqual({ a: { b: 1, c: { d: 2 } } });
+  });
+
+  it('parses block sequences of plain scalars', () => {
+    const doc = parseYaml(`required:\n  - id\n  - name\n  - slug\n`);
+    expect(doc).toEqual({ required: ['id', 'name', 'slug'] });
+  });
+
+  it('parses "- key: value" continued-mapping sequence items (the parameters[] shape)', () => {
+    const doc = parseYaml(
+      [
+        'parameters:',
+        '  - $ref: "#/components/parameters/collectionId"',
+        '  - name: limit',
+        '    in: query',
+        '    schema:',
+        '      type: integer',
+        '      default: 50',
+        '  - name: cursor',
+        '    in: query',
+      ].join('\n'),
+    );
+    expect(doc).toEqual({
+      parameters: [
+        { $ref: '#/components/parameters/collectionId' },
+        { name: 'limit', in: 'query', schema: { type: 'integer', default: 50 } },
+        { name: 'cursor', in: 'query' },
+      ],
+    });
+  });
+
+  it('parses flow sequences and flow mappings, including quoted "null" as a string', () => {
+    const doc = parseYaml(`a: [file, collectionId]\nb: { type: [integer, "null"] }\nc: []\n`);
+    expect(doc).toEqual({
+      a: ['file', 'collectionId'],
+      b: { type: ['integer', 'null'] },
+      c: [],
+    });
+    // The quoted "null" must stay the string "null", not become YAML null — it's a
+    // JSON Schema type-name entry (`type: [integer, "null"]`), not an absent value.
+    expect((doc as { b: { type: unknown[] } }).b.type[1]).toBe('null');
+    expect((doc as { b: { type: unknown[] } }).b.type[1]).not.toBeNull();
+  });
+
+  it('parses quoted mapping keys (numeric-looking response status codes)', () => {
+    const doc = parseYaml(
+      `responses:\n  "200":\n    description: ok\n  "429":\n    description: rate limited\n`,
+    );
+    expect(doc).toEqual({
+      responses: {
+        '200': { description: 'ok' },
+        '429': { description: 'rate limited' },
+      },
+    });
+  });
+
+  it('parses folded (>) block scalars without choking on colons/slashes inside them', () => {
+    const doc = parseYaml(
+      [
+        'description: >',
+        '  Line one has a colon: yes.',
+        '  Line two has a slash /like/this.',
+        'next: value',
+      ].join('\n'),
+    );
+    expect(doc).toEqual({
+      description: 'Line one has a colon: yes. Line two has a slash /like/this.',
+      next: 'value',
+    });
+  });
+
+  it('parses path keys containing literal braces without treating them as flow collections', () => {
+    const doc = parseYaml(
+      `paths:\n  /collections/{collectionId}:\n    get:\n      operationId: getCollection\n`,
+    );
+    expect(doc).toEqual({
+      paths: {
+        '/collections/{collectionId}': {
+          get: { operationId: 'getCollection' },
+        },
+      },
+    });
+  });
+
+  it('parses single-item flow objects on one line, as used for inline response bodies', () => {
+    const doc = parseYaml(`documentId: { type: string, format: uuid }\n`);
+    expect(doc).toEqual({ documentId: { type: 'string', format: 'uuid' } });
+  });
+});
+
+describe('parseYaml against the real openapi.yaml', () => {
+  const doc = parseYaml(specText) as Record<string, unknown>;
+
+  it('parses without throwing and yields the expected top-level shape', () => {
+    expect(doc.openapi).toBe('3.1.0');
+    expect(typeof doc.paths).toBe('object');
+    expect(typeof doc.components).toBe('object');
+  });
+
+  it('finds all 24 component schemas', () => {
+    const schemas = (doc.components as Record<string, unknown>).schemas as Record<string, unknown>;
+    expect(Object.keys(schemas)).toHaveLength(24);
+  });
+
+  it('parses a representative path item with multiple methods and shared parameters', () => {
+    const paths = doc.paths as Record<string, unknown>;
+    const collectionItem = paths['/collections/{collectionId}'] as Record<string, unknown>;
+    expect(Object.keys(collectionItem).sort()).toEqual(['delete', 'get', 'parameters', 'patch']);
+    const params = collectionItem.parameters as unknown[];
+    expect(params).toEqual([{ $ref: '#/components/parameters/collectionId' }]);
+  });
+
+  it('parses the listDocuments operation query parameters (the "- name: value" continuation shape)', () => {
+    const paths = doc.paths as Record<string, unknown>;
+    const op = (paths['/collections/{collectionId}/documents'] as Record<string, unknown>)
+      .get as Record<string, unknown>;
+    expect(op.operationId).toBe('listDocuments');
+    const params = op.parameters as Record<string, unknown>[];
+    expect(params).toHaveLength(3);
+    expect(params[1]).toMatchObject({ name: 'limit', in: 'query' });
+    expect(params[2]).toMatchObject({ name: 'cursor', in: 'query' });
+  });
+
+  it('parses requestBody + multiple non-2xx responses with $ref and inline schemas', () => {
+    const paths = doc.paths as Record<string, unknown>;
+    const op = (paths['/uploads'] as Record<string, unknown>).post as Record<string, unknown>;
+    expect(op.operationId).toBe('createUpload');
+    const responses = op.responses as Record<string, unknown>;
+    expect(Object.keys(responses).sort()).toEqual([
+      '201',
+      '400',
+      '403',
+      '404',
+      '409',
+      '413',
+      '429',
+    ]);
+  });
+
+  it('parses operations that take no requestBody at all (publish, reindex)', () => {
+    const paths = doc.paths as Record<string, unknown>;
+    const publish = (
+      paths['/documents/{documentId}/versions/{versionId}/publish'] as Record<string, unknown>
+    ).post as Record<string, unknown>;
+    expect(publish.requestBody).toBeUndefined();
+    const reindex = (paths['/documents/{documentId}/reindex'] as Record<string, unknown>)
+      .post as Record<string, unknown>;
+    expect(reindex.requestBody).toBeUndefined();
+  });
+});

--- a/web/src/mocks/spec/yaml.ts
+++ b/web/src/mocks/spec/yaml.ts
@@ -1,0 +1,367 @@
+/**
+ * Minimal YAML-subset parser.
+ *
+ * This is NOT a general-purpose YAML implementation. It understands exactly the
+ * subset of YAML 1.1 that `crates/server/openapi/openapi.yaml` actually uses:
+ * block mappings, block sequences (including the `- key: value` continued-mapping
+ * form), flow sequences (`[a, b]`), flow mappings (`{a: b, c: d}`), single-line
+ * plain/quoted scalars, and folded (`>`)/literal (`|`) block scalars.
+ *
+ * It deliberately does NOT support: anchors/aliases, multi-document streams,
+ * tags, multiline plain scalars, or complex (non-scalar) mapping keys. None of
+ * those appear in the OpenAPI document this parser is built for. Confirmed by
+ * `grep` against the source file before writing this (see git history / PR
+ * description for the audit) — if the document grows one of those constructs,
+ * this parser will throw or misparse rather than silently produce wrong data,
+ * and the accompanying tests (`yaml.test.ts`, `openApiSpec.test.ts`) exercise it
+ * against the real file so drift shows up immediately.
+ */
+
+export type YamlValue =
+  string | number | boolean | null | YamlValue[] | { [key: string]: YamlValue };
+
+interface Line {
+  indent: number;
+  text: string; // full original line, including leading whitespace
+}
+
+function toLines(source: string): Line[] {
+  const rawLines = source.split(/\r\n|\n|\r/);
+  const lines: Line[] = [];
+  for (const raw of rawLines) {
+    if (raw.trim() === '') continue; // blank lines never carry structure here
+    if (/^\s*#/.test(raw)) continue; // whole-line comment (not used today, cheap safety net)
+    if (raw.trim() === '---' || raw.trim() === '...') continue; // ignore doc markers if present
+    const indent = raw.length - raw.trimStart().length;
+    lines.push({ indent, text: raw });
+  }
+  return lines;
+}
+
+function parseScalarText(rawText: string): YamlValue {
+  const text = rawText.trim();
+  if (text === '') return null;
+  if (text[0] === '{' || text[0] === '[') {
+    const { value } = parseFlow(text, 0);
+    return value;
+  }
+  if (text[0] === '"') return parseDoubleQuoted(text, 0).value;
+  if (text[0] === "'") return parseSingleQuoted(text, 0).value;
+  if (text === 'true') return true;
+  if (text === 'false') return false;
+  if (text === 'null' || text === '~') return null;
+  if (/^-?\d+$/.test(text)) return Number(text);
+  if (/^-?\d+\.\d+$/.test(text)) return Number(text);
+  return text;
+}
+
+function parseDoubleQuoted(text: string, start: number): { value: string; end: number } {
+  // text[start] === '"'
+  let i = start + 1;
+  let out = '';
+  while (i < text.length && text[i] !== '"') {
+    if (text[i] === '\\' && i + 1 < text.length) {
+      const next = text[i + 1];
+      const map: Record<string, string> = { n: '\n', t: '\t', '"': '"', '\\': '\\' };
+      out += map[next] ?? next;
+      i += 2;
+    } else {
+      out += text[i];
+      i += 1;
+    }
+  }
+  return { value: out, end: i + 1 };
+}
+
+function parseSingleQuoted(text: string, start: number): { value: string; end: number } {
+  // text[start] === "'"; '' is an escaped single quote in YAML single-quoted scalars.
+  let i = start + 1;
+  let out = '';
+  while (i < text.length) {
+    if (text[i] === "'") {
+      if (text[i + 1] === "'") {
+        out += "'";
+        i += 2;
+        continue;
+      }
+      break;
+    }
+    out += text[i];
+    i += 1;
+  }
+  return { value: out, end: i + 1 };
+}
+
+function skipSpaces(text: string, pos: number): number {
+  let i = pos;
+  while (i < text.length && text[i] === ' ') i += 1;
+  return i;
+}
+
+function parseFlowScalarToken(text: string, pos: number): { value: YamlValue; end: number } {
+  const start = skipSpaces(text, pos);
+  if (text[start] === '{' || text[start] === '[') return parseFlow(text, start);
+  if (text[start] === '"') return parseDoubleQuoted(text, start);
+  if (text[start] === "'") return parseSingleQuoted(text, start);
+  let i = start;
+  while (i < text.length && text[i] !== ',' && text[i] !== '}' && text[i] !== ']') i += 1;
+  const token = text.slice(start, i).trim();
+  return { value: parseScalarText(token), end: i };
+}
+
+function parseFlow(text: string, pos: number): { value: YamlValue; end: number } {
+  const start = skipSpaces(text, pos);
+  if (text[start] === '[') {
+    let i = skipSpaces(text, start + 1);
+    const arr: YamlValue[] = [];
+    if (text[i] === ']') return { value: arr, end: i + 1 };
+    for (;;) {
+      const { value, end } = parseFlowScalarToken(text, i);
+      arr.push(value);
+      i = skipSpaces(text, end);
+      if (text[i] === ',') {
+        i = skipSpaces(text, i + 1);
+        continue;
+      }
+      if (text[i] === ']') return { value: arr, end: i + 1 };
+      throw new Error(
+        `yaml: malformed flow sequence at ${JSON.stringify(text.slice(pos, pos + 40))}`,
+      );
+    }
+  }
+  if (text[start] === '{') {
+    let i = skipSpaces(text, start + 1);
+    const obj: Record<string, YamlValue> = {};
+    if (text[i] === '}') return { value: obj, end: i + 1 };
+    for (;;) {
+      i = skipSpaces(text, i);
+      let key: string;
+      if (text[i] === '"') {
+        const r = parseDoubleQuoted(text, i);
+        key = r.value;
+        i = r.end;
+      } else if (text[i] === "'") {
+        const r = parseSingleQuoted(text, i);
+        key = r.value;
+        i = r.end;
+      } else {
+        const colon = text.indexOf(':', i);
+        key = text.slice(i, colon).trim();
+        i = colon;
+      }
+      i = skipSpaces(text, i);
+      if (text[i] !== ':')
+        throw new Error(
+          `yaml: expected ':' in flow mapping near ${JSON.stringify(text.slice(pos, pos + 40))}`,
+        );
+      i = skipSpaces(text, i + 1);
+      const { value, end } = parseFlowScalarToken(text, i);
+      obj[key] = value;
+      i = skipSpaces(text, end);
+      if (text[i] === ',') {
+        i = skipSpaces(text, i + 1);
+        continue;
+      }
+      if (text[i] === '}') return { value: obj, end: i + 1 };
+      throw new Error(
+        `yaml: malformed flow mapping at ${JSON.stringify(text.slice(pos, pos + 40))}`,
+      );
+    }
+  }
+  throw new Error(`yaml: expected '{' or '[' at ${JSON.stringify(text.slice(pos, pos + 40))}`);
+}
+
+/** Splits an unquoted-key line's content (after indent) into {key, remainderStartCol}. */
+function splitPlainKey(content: string): { key: string; afterKeyOffset: number } {
+  // No key in this document contains a colon, so the first top-level ': ' (or a
+  // trailing ':' with nothing after it) is always the mapping delimiter.
+  const trimmedEnd = content.replace(/\s+$/, '');
+  if (trimmedEnd.endsWith(':') && !trimmedEnd.slice(0, -1).includes(': ')) {
+    return { key: trimmedEnd.slice(0, -1), afterKeyOffset: trimmedEnd.length };
+  }
+  const idx = content.indexOf(': ');
+  if (idx === -1) {
+    throw new Error(`yaml: could not find mapping delimiter in ${JSON.stringify(content)}`);
+  }
+  return { key: content.slice(0, idx), afterKeyOffset: idx + 2 };
+}
+
+/** Parses the key portion of a mapping-entry line (content after indent). */
+function parseKey(content: string): { key: string; afterKeyOffset: number } {
+  if (content[0] === '"') {
+    const r = parseDoubleQuoted(content, 0);
+    let i = skipSpaces(content, r.end);
+    if (content[i] !== ':')
+      throw new Error(`yaml: expected ':' after quoted key in ${JSON.stringify(content)}`);
+    i += 1;
+    if (content[i] === ' ') i += 1;
+    return { key: r.value, afterKeyOffset: i };
+  }
+  if (content[0] === "'") {
+    const r = parseSingleQuoted(content, 0);
+    let i = skipSpaces(content, r.end);
+    if (content[i] !== ':')
+      throw new Error(`yaml: expected ':' after quoted key in ${JSON.stringify(content)}`);
+    i += 1;
+    if (content[i] === ' ') i += 1;
+    return { key: r.value, afterKeyOffset: i };
+  }
+  return splitPlainKey(content);
+}
+
+function isSeqItemLine(line: Line): boolean {
+  const rest = line.text.slice(line.indent);
+  return rest === '-' || rest.startsWith('- ');
+}
+
+/** Consumes a folded (`>`) or literal (`|`) block scalar starting after `lines[idx]`. */
+function consumeBlockScalar(
+  lines: Line[],
+  idx: number,
+  parentIndent: number,
+  folded: boolean,
+): { value: string; idx: number } {
+  const chunks: string[] = [];
+  let i = idx;
+  let blockIndent: number | null = null;
+  while (i < lines.length && lines[i].indent > parentIndent) {
+    if (blockIndent === null) blockIndent = lines[i].indent;
+    chunks.push(lines[i].text.slice(blockIndent));
+    i += 1;
+  }
+  const value = folded ? chunks.join(' ').replace(/\s+/g, ' ').trim() : chunks.join('\n');
+  return { value, idx: i };
+}
+
+function parseMappingEntry(
+  obj: Record<string, YamlValue>,
+  lines: Line[],
+  idx: number,
+  indent: number,
+): number {
+  const line = lines[idx];
+  const content = line.text.slice(indent);
+  const { key, afterKeyOffset } = parseKey(content);
+  const remainder = content.slice(afterKeyOffset).trim();
+  if (remainder === '') {
+    const next = lines[idx + 1];
+    if (next && next.indent > indent) {
+      const nextContent = next.text.slice(next.indent);
+      if (nextContent[0] === '[' || nextContent[0] === '{') {
+        // A flow collection wrapped onto its own (more-indented) continuation
+        // line, e.g. `required:\n  [a, b, c]`. This is a single-line flow value,
+        // not the start of a nested block — consume exactly that one line.
+        obj[key] = parseScalarText(nextContent);
+        return idx + 2;
+      }
+      const { value, idx: nextIdx } = parseBlockValue(lines, idx + 1, next.indent);
+      obj[key] = value;
+      return nextIdx;
+    }
+    obj[key] = null;
+    return idx + 1;
+  }
+  if (remainder === '>' || remainder === '|' || remainder === '>-' || remainder === '|-') {
+    const { value, idx: nextIdx } = consumeBlockScalar(
+      lines,
+      idx + 1,
+      indent,
+      remainder[0] === '>',
+    );
+    obj[key] = value;
+    return nextIdx;
+  }
+  obj[key] = parseScalarText(remainder);
+  return idx + 1;
+}
+
+function parseSequence(
+  lines: Line[],
+  idx: number,
+  indent: number,
+): { value: YamlValue[]; idx: number } {
+  const items: YamlValue[] = [];
+  let i = idx;
+  while (i < lines.length && lines[i].indent === indent && isSeqItemLine(lines[i])) {
+    const line = lines[i];
+    const rest = line.text.slice(indent);
+    if (rest === '-') {
+      const next = lines[i + 1];
+      if (next && next.indent > indent) {
+        const { value, idx: nextIdx } = parseBlockValue(lines, i + 1, next.indent);
+        items.push(value);
+        i = nextIdx;
+      } else {
+        items.push(null);
+        i += 1;
+      }
+      continue;
+    }
+    const itemContent = rest.slice(2); // after "- "
+    const itemCol = indent + 2;
+    // Quoted-key mapping entries (`- "foo": bar`) don't occur in this document,
+    // so a quoted first character always means a plain scalar item.
+    const looksLikeMapping =
+      itemContent[0] !== '"' &&
+      itemContent[0] !== "'" &&
+      (() => {
+        const trimmedEnd = itemContent.replace(/\s+$/, '');
+        return (
+          (trimmedEnd.endsWith(':') && !trimmedEnd.slice(0, -1).includes(': ')) ||
+          itemContent.includes(': ')
+        );
+      })();
+    if (looksLikeMapping) {
+      const obj: Record<string, YamlValue> = {};
+      const virtualLine: Line = { indent: itemCol, text: ' '.repeat(itemCol) + itemContent };
+      const linesForEntry = [virtualLine, ...lines.slice(i + 1)];
+      const localIdx = parseMappingEntry(obj, linesForEntry, 0, itemCol);
+      // localIdx is relative to linesForEntry; convert continuation scanning to the
+      // real array by continuing the standard mapping loop against `lines`.
+      let realIdx = i + 1 + (localIdx - 1);
+      while (
+        realIdx < lines.length &&
+        lines[realIdx].indent === itemCol &&
+        !isSeqItemLine(lines[realIdx])
+      ) {
+        realIdx = parseMappingEntry(obj, lines, realIdx, itemCol);
+      }
+      items.push(obj);
+      i = realIdx;
+    } else {
+      items.push(parseScalarText(itemContent));
+      i += 1;
+    }
+  }
+  return { value: items, idx: i };
+}
+
+function parseMapping(
+  lines: Line[],
+  idx: number,
+  indent: number,
+): { value: Record<string, YamlValue>; idx: number } {
+  const obj: Record<string, YamlValue> = {};
+  let i = idx;
+  while (i < lines.length && lines[i].indent === indent && !isSeqItemLine(lines[i])) {
+    i = parseMappingEntry(obj, lines, i, indent);
+  }
+  return { value: obj, idx: i };
+}
+
+function parseBlockValue(
+  lines: Line[],
+  idx: number,
+  indent: number,
+): { value: YamlValue; idx: number } {
+  if (idx >= lines.length) return { value: null, idx };
+  if (isSeqItemLine(lines[idx])) return parseSequence(lines, idx, indent);
+  return parseMapping(lines, idx, indent);
+}
+
+export function parseYaml(source: string): YamlValue {
+  const lines = toLines(source);
+  if (lines.length === 0) return null;
+  const { value } = parseBlockValue(lines, 0, lines[0].indent);
+  return value;
+}

--- a/web/src/mocks/specDrift.test.ts
+++ b/web/src/mocks/specDrift.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertOperationsExistInSpec,
+  assertStatusDeclared,
+  assertJsonBodyMatchesSpec,
+} from './spec/driftGuard';
+import { getRegisteredOperations, registerOperation } from './registry';
+import { installMockFetch, uninstallMockFetch } from './fetchMock';
+
+/**
+ * Demonstrates the spec-drift guard the P2-02 task asks for: "at minimum, a
+ * check that every mocked operation exists in the spec with the status code
+ * you return, so an endpoint that disappears from the spec breaks the mock
+ * instead of lingering."
+ */
+describe('spec-drift guard', () => {
+  it('passes for every operation this mock actually implements today', () => {
+    const operationIds = getRegisteredOperations().map((r) => r.operationId);
+    expect(operationIds.length).toBeGreaterThan(0);
+    expect(() => assertOperationsExistInSpec(operationIds)).not.toThrow();
+  });
+
+  it('FAILS when pointed at an operationId the spec does not declare', () => {
+    expect(() =>
+      assertOperationsExistInSpec(['listCollections', 'thisOperationWasRemovedFromTheSpec']),
+    ).toThrow(
+      /operationId "thisOperationWasRemovedFromTheSpec".*does not exist in crates\/server\/openapi\/openapi\.yaml/s,
+    );
+  });
+
+  it('FAILS when a handler returns a status code its operation does not declare', () => {
+    // listCollections only declares 200 and 429 (see openapi.yaml) — 500 isn't one of them.
+    expect(() => assertStatusDeclared('listCollections', 500)).toThrow(
+      /operation "listCollections".*returned status 500.*only declares \[200, 429\]/s,
+    );
+  });
+
+  it('FAILS when a response body is missing a field the spec requires', () => {
+    expect(() =>
+      assertJsonBodyMatchesSpec('healthLive', 200, { status: 'ok' /* missing requestId */ }),
+    ).toThrow(/does not match its spec schema/);
+    expect(() =>
+      assertJsonBodyMatchesSpec('healthLive', 200, {
+        status: 'ok',
+        requestId: '11111111-1111-1111-1111-111111111111',
+      }),
+    ).not.toThrow();
+  });
+
+  it('FAILS end-to-end through the real mock pipeline for an operation the registry has but the spec dropped', async () => {
+    // Simulate exactly the scenario the task describes: a handler that still
+    // exists in web/src/mocks/handlers/** for an operation the spec no longer
+    // has (renamed/removed upstream). Register it directly against the live
+    // registry (this test file's own isolated module instance) so the mock's
+    // real route-compilation path — the one every other test in this package
+    // goes through via `installMockFetch()` — is what actually throws, not a
+    // hand-picked assertion.
+    registerOperation('anOperationThatIsNotInOpenapiYaml', () => ({
+      status: 200,
+      body: { ok: true },
+    }));
+
+    installMockFetch();
+    try {
+      await expect(fetch('/api/v1/anything')).rejects.toThrow(
+        /operationId "anOperationThatIsNotInOpenapiYaml".*is registered as a mock handler but.*does not exist/s,
+      );
+    } finally {
+      uninstallMockFetch();
+    }
+  });
+});

--- a/web/src/pages/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage.test.tsx
@@ -1,0 +1,166 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ApiClient } from '../api/client';
+import { HttpApiError, NetworkError } from '../api/errors';
+import { AuthProvider, useAuth } from '../auth/AuthContext';
+import { ScopeProvider } from '../state/ScopeProvider';
+import { LoginPage } from './LoginPage';
+
+const SAMPLE_ME = {
+  userId: 'user-1',
+  orgId: 'org-1',
+  email: 'demo@markhand.test',
+  displayName: 'Demo User',
+  permissions: ['qa.history'],
+  allowedCollectionIds: ['col-1'],
+  sessionId: 'session-1',
+};
+
+function createFakeClient(): ApiClient {
+  return {
+    login: vi.fn(),
+    logout: vi.fn(async () => {}),
+    me: vi.fn(),
+    request: vi.fn(),
+    tokenProvider: { getAccessToken: vi.fn(), refreshNow: vi.fn(), onSessionLost: () => () => {} },
+    sessionManager: {
+      setTokens: vi.fn(),
+      clear: vi.fn(),
+      hasSession: vi.fn(() => false),
+      getRefreshTokenForLogout: vi.fn(() => null),
+      getAccessToken: vi.fn(),
+      refreshNow: vi.fn(),
+      onSessionLost: () => () => {},
+      onTokensRotated: () => () => {},
+    },
+  } as unknown as ApiClient;
+}
+
+function StatusProbe() {
+  const { session } = useAuth();
+  return <span data-testid="status">{session.status}</span>;
+}
+
+function renderLoginPage(client: ApiClient) {
+  return render(
+    <ScopeProvider>
+      <AuthProvider client={client}>
+        <StatusProbe />
+        <LoginPage />
+      </AuthProvider>
+    </ScopeProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  window.sessionStorage.clear();
+});
+
+describe('LoginPage', () => {
+  it('renders email/password fields and a submit button', async () => {
+    const client = createFakeClient();
+    renderLoginPage(client);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+
+    expect(screen.getByLabelText('Email')).toBeVisible();
+    expect(screen.getByLabelText('Mật khẩu')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Đăng nhập' })).toBeVisible();
+  });
+
+  it('submits the entered credentials to login()', async () => {
+    const client = createFakeClient();
+    (client.login as ReturnType<typeof vi.fn>).mockResolvedValue({
+      accessToken: 'a',
+      refreshToken: 'r',
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      orgId: 'org-1',
+      userId: 'user-1',
+    });
+    (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+    renderLoginPage(client);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'demo@markhand.test' } });
+    fireEvent.change(screen.getByLabelText('Mật khẩu'), { target: { value: 'demo-password' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Đăng nhập' }));
+
+    await waitFor(() =>
+      expect(client.login).toHaveBeenCalledWith({
+        email: 'demo@markhand.test',
+        password: 'demo-password',
+      }),
+    );
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+  });
+
+  it('shows a Vietnamese message for wrong credentials (401) and re-enables the form', async () => {
+    const client = createFakeClient();
+    (client.login as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new HttpApiError({
+        status: 401,
+        code: 'unauthorized',
+        message: 'Email or password is incorrect.',
+        requestId: 'r1',
+      }),
+    );
+    renderLoginPage(client);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'demo@markhand.test' } });
+    fireEvent.change(screen.getByLabelText('Mật khẩu'), { target: { value: 'wrong' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Đăng nhập' }));
+
+    await waitFor(() => expect(screen.getByText('Email hoặc mật khẩu không đúng.')).toBeVisible());
+    expect(screen.getByRole('button', { name: 'Đăng nhập' })).not.toBeDisabled();
+  });
+
+  it('shows a generic message for a network failure', async () => {
+    const client = createFakeClient();
+    (client.login as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new NetworkError('Network request failed'),
+    );
+    renderLoginPage(client);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'demo@markhand.test' } });
+    fireEvent.change(screen.getByLabelText('Mật khẩu'), { target: { value: 'demo-password' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Đăng nhập' }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Không thể kết nối máy chủ. Kiểm tra kết nối mạng và thử lại.'),
+      ).toBeVisible(),
+    );
+  });
+
+  it('disables the form while a login is pending', async () => {
+    const client = createFakeClient();
+    let resolveLogin!: (value: unknown) => void;
+    (client.login as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((resolve) => {
+        resolveLogin = resolve;
+      }),
+    );
+    renderLoginPage(client);
+    await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'demo@markhand.test' } });
+    fireEvent.change(screen.getByLabelText('Mật khẩu'), { target: { value: 'demo-password' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Đăng nhập' }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Đăng nhập' })).toBeDisabled());
+    expect(screen.getByLabelText('Email')).toBeDisabled();
+    expect(screen.getByLabelText('Mật khẩu')).toBeDisabled();
+
+    resolveLogin({
+      accessToken: 'a',
+      refreshToken: 'r',
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      orgId: 'org-1',
+      userId: 'user-1',
+    });
+  });
+});

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,21 +1,87 @@
+import { useId, useState, type FormEvent } from 'react';
+import { HttpApiError, NetworkError } from '../api/errors';
 import { useAuth } from '../auth/AuthContext';
-import { Button } from '../components/ui';
+import { Button, Notice } from '../components/ui';
+
+function messageFor(cause: unknown): string {
+  if (cause instanceof HttpApiError && cause.status === 401) {
+    return 'Email hoặc mật khẩu không đúng.';
+  }
+  if (cause instanceof HttpApiError && cause.status === 429) {
+    return 'Quá nhiều lần thử. Vui lòng thử lại sau ít phút.';
+  }
+  if (cause instanceof NetworkError) {
+    return 'Không thể kết nối máy chủ. Kiểm tra kết nối mạng và thử lại.';
+  }
+  return 'Không thể đăng nhập lúc này. Vui lòng thử lại.';
+}
 
 export function LoginPage() {
-  const { session } = useAuth();
+  const { login } = useAuth();
+  const emailId = useId();
+  const passwordId = useId();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPending(true);
+    setError(null);
+    try {
+      await login(email, password);
+      // Success leaves this page mounted only for an instant: `session`
+      // becomes 'authenticated' and `PublicOnlyRoute` (in App.tsx) is the one
+      // place that decides where an authenticated visitor belongs and
+      // navigates there — this component does not duplicate that decision.
+    } catch (cause) {
+      setError(messageFor(cause));
+      setPending(false);
+    }
+  }
 
   return (
     <section className="page" aria-labelledby="login-heading">
       <p className="eyebrow">Đăng nhập</p>
       <h1 id="login-heading">Đăng nhập vào Markhand</h1>
-      <p className="lede">
-        {session.status === 'authenticated'
-          ? `Đã đăng nhập với vai trò ${session.role}.`
-          : 'Nhập thông tin đăng nhập để truy cập bộ sưu tập và trợ lý tài liệu.'}
-      </p>
-      <Button variant="primary" disabled>
-        Đăng nhập (đang chờ client xác thực)
-      </Button>
+      <p className="lede">Nhập thông tin đăng nhập để truy cập bộ sưu tập và trợ lý tài liệu.</p>
+
+      {error && <Notice tone="error">{error}</Notice>}
+
+      <form className="auth-form" onSubmit={(event) => void handleSubmit(event)} noValidate>
+        <div className="field">
+          <label htmlFor={emailId}>Email</label>
+          <input
+            id={emailId}
+            name="email"
+            type="email"
+            autoComplete="username"
+            required
+            disabled={pending}
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </div>
+
+        <div className="field">
+          <label htmlFor={passwordId}>Mật khẩu</label>
+          <input
+            id={passwordId}
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            disabled={pending}
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </div>
+
+        <Button type="submit" variant="primary" loading={pending} disabled={pending}>
+          Đăng nhập
+        </Button>
+      </form>
     </section>
   );
 }

--- a/web/src/state/ScopeProvider.test.tsx
+++ b/web/src/state/ScopeProvider.test.tsx
@@ -1,0 +1,74 @@
+import { act, cleanup, render, renderHook, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createScopeManager } from './scope';
+import { ScopeProvider, useScope } from './ScopeProvider';
+
+afterEach(() => {
+  cleanup();
+});
+
+function Probe() {
+  const { epoch, scope, setScope } = useScope();
+  return (
+    <div>
+      <span data-testid="epoch">{epoch}</span>
+      <span data-testid="org">{scope?.orgId ?? 'anonymous'}</span>
+      <button
+        type="button"
+        onClick={() => setScope({ orgId: 'org-b', permissions: [], allowedCollectionIds: [] })}
+      >
+        switch to B
+      </button>
+    </div>
+  );
+}
+
+describe('ScopeProvider', () => {
+  it('throws when useScope is used outside a provider', () => {
+    const { result } = renderHook(() => {
+      try {
+        return useScope();
+      } catch (error) {
+        return error;
+      }
+    });
+    expect(result.current).toBeInstanceOf(Error);
+  });
+
+  it('starts anonymous at epoch 0', () => {
+    render(
+      <ScopeProvider>
+        <Probe />
+      </ScopeProvider>,
+    );
+    expect(screen.getByTestId('epoch')).toHaveTextContent('0');
+    expect(screen.getByTestId('org')).toHaveTextContent('anonymous');
+  });
+
+  it('re-renders subscribers with the new epoch/scope after setScope', () => {
+    render(
+      <ScopeProvider>
+        <Probe />
+      </ScopeProvider>,
+    );
+    act(() => {
+      screen.getByRole('button', { name: 'switch to B' }).click();
+    });
+    expect(screen.getByTestId('epoch')).toHaveTextContent('1');
+    expect(screen.getByTestId('org')).toHaveTextContent('org-b');
+  });
+
+  it('accepts an injected manager so tests can drive/observe it directly', () => {
+    const manager = createScopeManager();
+    render(
+      <ScopeProvider manager={manager}>
+        <Probe />
+      </ScopeProvider>,
+    );
+    act(() => {
+      manager.setScope({ orgId: 'org-a', permissions: [], allowedCollectionIds: [] });
+    });
+    expect(screen.getByTestId('org')).toHaveTextContent('org-a');
+    expect(manager.getSnapshot().epoch).toBe(1);
+  });
+});

--- a/web/src/state/ScopeProvider.tsx
+++ b/web/src/state/ScopeProvider.tsx
@@ -1,0 +1,71 @@
+// React wiring for the scope seam in `scope.ts` (see that file's module doc
+// for the race this exists to close, per P2-06 / plans/markhand-web/phase-2-web-spa.md
+// §P2.3). This component owns no org/session logic itself — it just exposes
+// a `ScopeManager` singleton through context via `useSyncExternalStore`, the
+// same pattern `RouterProvider.tsx` uses for router state.
+//
+// Handoff seam: the auth/shell agent calls `useScope().setScope(...)` (or
+// holds a reference to the same `ScopeManager`) after login resolves, after
+// an org switch completes, and with `null` on logout/session-lost. This
+// file does not call `setScope` itself.
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react';
+import { createScopeManager, type Scope, type ScopeManager, type ScopeSnapshot } from './scope';
+
+export interface ScopeContextValue extends ScopeSnapshot {
+  /** Escape hatch for callers that need the full seam (registerAbortable, isCurrent) beyond scope/epoch. */
+  readonly manager: ScopeManager;
+  setScope: ScopeManager['setScope'];
+  isCurrent: ScopeManager['isCurrent'];
+  registerAbortable: ScopeManager['registerAbortable'];
+}
+
+const ScopeContext = createContext<ScopeContextValue | null>(null);
+
+export interface ScopeProviderProps {
+  children: ReactNode;
+  /** Escape hatch for tests that need to drive/observe the manager directly. Defaults to a fresh manager per mount. */
+  manager?: ScopeManager;
+}
+
+export function ScopeProvider({ children, manager: injected }: ScopeProviderProps) {
+  // `useState`'s lazy initializer (not a ref) for the stable per-mount
+  // singleton: it is computed exactly once and its result is a value React
+  // considers safe to read during render, unlike a ref's `.current`.
+  const [manager] = useState<ScopeManager>(() => injected ?? createScopeManager());
+
+  const snapshot = useSyncExternalStore(
+    manager.subscribe,
+    manager.getSnapshot,
+    manager.getSnapshot,
+  );
+
+  const value = useMemo<ScopeContextValue>(
+    () => ({
+      ...snapshot,
+      manager,
+      setScope: manager.setScope,
+      isCurrent: manager.isCurrent,
+      registerAbortable: manager.registerAbortable,
+    }),
+    [snapshot, manager],
+  );
+
+  return <ScopeContext.Provider value={value}>{children}</ScopeContext.Provider>;
+}
+
+export function useScope(): ScopeContextValue {
+  const context = useContext(ScopeContext);
+  if (!context) {
+    throw new Error('useScope must be used within a ScopeProvider');
+  }
+  return context;
+}
+
+export type { Scope, ScopeManager, ScopeSnapshot };

--- a/web/src/state/scope.test.ts
+++ b/web/src/state/scope.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createScopeManager, type Scope } from './scope';
+
+function scope(orgId: string, overrides: Partial<Scope> = {}): Scope {
+  return { orgId, permissions: [], allowedCollectionIds: [], ...overrides };
+}
+
+describe('createScopeManager', () => {
+  describe('initial state', () => {
+    it('starts anonymous at epoch 0', () => {
+      const manager = createScopeManager();
+      expect(manager.getSnapshot()).toEqual({ epoch: 0, scope: null });
+      expect(manager.isCurrent(0)).toBe(true);
+    });
+  });
+
+  describe('epoch bumping', () => {
+    it('bumps the epoch on login (null -> a scope)', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      const snapshot = manager.getSnapshot();
+      expect(snapshot.epoch).toBe(1);
+      expect(snapshot.scope?.orgId).toBe('org-a');
+    });
+
+    it('bumps the epoch on an org switch (org A -> org B)', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      manager.setScope(scope('org-b'));
+      expect(manager.getSnapshot()).toMatchObject({ epoch: 2, scope: { orgId: 'org-b' } });
+    });
+
+    it('bumps the epoch on logout (a scope -> null)', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      manager.setScope(null);
+      expect(manager.getSnapshot()).toEqual({ epoch: 2, scope: null });
+    });
+
+    it('bumps the epoch when switching back to a previously-active org (A -> B -> A)', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      const epochA1 = manager.getSnapshot().epoch;
+      manager.setScope(scope('org-b'));
+      manager.setScope(scope('org-a'));
+      const epochA2 = manager.getSnapshot().epoch;
+      expect(epochA2).not.toBe(epochA1);
+      expect(epochA2).toBe(3);
+    });
+
+    it('does NOT bump the epoch when re-setting the same org (e.g. a /auth/me refresh)', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a', { permissions: ['read'] }));
+      const epochBefore = manager.getSnapshot().epoch;
+      manager.setScope(scope('org-a', { permissions: ['read', 'write'] }));
+      const snapshot = manager.getSnapshot();
+      expect(snapshot.epoch).toBe(epochBefore);
+      // But the scope payload itself is still refreshed.
+      expect(snapshot.scope?.permissions).toEqual(['read', 'write']);
+    });
+
+    it('never reuses an epoch value', () => {
+      const manager = createScopeManager();
+      const seen = new Set<number>([manager.getSnapshot().epoch]);
+      for (const org of ['org-a', 'org-b', 'org-a', 'org-c', 'org-a']) {
+        manager.setScope(scope(org));
+        const epoch = manager.getSnapshot().epoch;
+        expect(seen.has(epoch)).toBe(false);
+        seen.add(epoch);
+      }
+    });
+  });
+
+  describe('subscribe', () => {
+    it('notifies listeners on every setScope call, including same-org refreshes', () => {
+      const manager = createScopeManager();
+      const listener = vi.fn();
+      manager.subscribe(listener);
+
+      manager.setScope(scope('org-a'));
+      manager.setScope(scope('org-a', { permissions: ['x'] }));
+      manager.setScope(scope('org-b'));
+
+      expect(listener).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops notifying after unsubscribe', () => {
+      const manager = createScopeManager();
+      const listener = vi.fn();
+      const unsubscribe = manager.subscribe(listener);
+      unsubscribe();
+
+      manager.setScope(scope('org-a'));
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('registerAbortable', () => {
+    it('does not abort an abortable registered for the current epoch', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      const { epoch } = manager.getSnapshot();
+      const abortable = { abort: vi.fn() };
+
+      manager.registerAbortable(epoch, abortable);
+      expect(abortable.abort).not.toHaveBeenCalled();
+    });
+
+    it('aborts every abortable registered under the previous epoch the instant the scope switches', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      const { epoch: epochA } = manager.getSnapshot();
+
+      const request1 = { abort: vi.fn() };
+      const request2 = { abort: vi.fn() };
+      manager.registerAbortable(epochA, request1);
+      manager.registerAbortable(epochA, request2);
+
+      manager.setScope(scope('org-b'));
+
+      expect(request1.abort).toHaveBeenCalledTimes(1);
+      expect(request2.abort).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts immediately (synchronously) if the epoch is already stale when registering', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      const staleEpoch = manager.getSnapshot().epoch;
+      manager.setScope(scope('org-b'));
+
+      const lateRegistration = { abort: vi.fn() };
+      manager.registerAbortable(staleEpoch, lateRegistration);
+
+      expect(lateRegistration.abort).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not abort an abortable belonging to a *different, still-current* epoch when a same-org refresh happens', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      const { epoch } = manager.getSnapshot();
+      const abortable = { abort: vi.fn() };
+      manager.registerAbortable(epoch, abortable);
+
+      manager.setScope(scope('org-a', { permissions: ['x'] })); // same org: no epoch bump
+
+      expect(abortable.abort).not.toHaveBeenCalled();
+    });
+
+    it('honors unregister: an abortable that finished on its own is not aborted again on a later switch', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      const { epoch } = manager.getSnapshot();
+      const abortable = { abort: vi.fn() };
+      const unregister = manager.registerAbortable(epoch, abortable);
+
+      unregister();
+      manager.setScope(scope('org-b'));
+
+      expect(abortable.abort).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isCurrent', () => {
+    it('is true only for the epoch that is currently active', () => {
+      const manager = createScopeManager();
+      manager.setScope(scope('org-a'));
+      const epochA = manager.getSnapshot().epoch;
+      manager.setScope(scope('org-b'));
+      const epochB = manager.getSnapshot().epoch;
+
+      expect(manager.isCurrent(epochA)).toBe(false);
+      expect(manager.isCurrent(epochB)).toBe(true);
+    });
+  });
+});

--- a/web/src/state/scope.ts
+++ b/web/src/state/scope.ts
@@ -1,0 +1,162 @@
+// The "current scope" seam for P2-06 (plans/markhand-web/phase-2-web-spa.md
+// §P2.3 + Gate: "Không render dữ liệu từ scope cũ").
+//
+// Scope switching (org switch, login, logout) is a race, not a feature: a
+// slow request/SSE stream started under org A can resolve/deliver *after*
+// the UI has moved on to org B. The fix modeled here is a monotonic
+// "epoch" — a generation counter for "which scope is currently trusted" —
+// plus a central registry of things to abort the instant the epoch moves
+// on. Nothing in this file knows about HTTP or SSE specifics; those seams
+// live in `hooks/useScopeSafeRequest.ts` and `hooks/useScopeSafeSse.ts`,
+// which both (a) register their `AbortController`/connection here so a
+// switch aborts them centrally, and (b) re-check `isCurrent(epoch)` right
+// before acting on a resolved value — because an abort is not guaranteed to
+// stop a response that is already in flight (see those files for why both
+// checks are needed).
+//
+// Seam handed to whoever drives org switching (the auth agent, per the
+// P2-06 brief — this file does not do login/logout/org-picker UI): call
+// `setScope(...)` exactly once per transition — after login, after an org
+// switch completes, and with `null` on logout. Everything else reacts to
+// that single call.
+
+export interface Scope {
+  readonly orgId: string;
+  readonly permissions: readonly string[];
+  readonly allowedCollectionIds: readonly string[];
+}
+
+export interface ScopeSnapshot {
+  /**
+   * Identifies the current scope generation. Bumped by every `setScope`
+   * call that changes org — including anonymous <-> authenticated
+   * transitions (login, logout) — and by re-logging into the same org
+   * after a logout (there is no null epoch in between two different
+   * *sessions*, only between two different *scopes*). Never reused, so an
+   * epoch value captured once always means exactly one specific scope
+   * generation forever.
+   */
+  readonly epoch: number;
+  readonly scope: Scope | null;
+}
+
+/** Anything that can be told "stop, you're stale" — an `AbortController`, an `SseConnection`, or any other cancellable unit of in-flight work. */
+export interface Abortable {
+  abort(): void;
+}
+
+export interface ScopeManager {
+  getSnapshot(): ScopeSnapshot;
+  /** React `useSyncExternalStore`-compatible subscription. Returns an unsubscribe. */
+  subscribe(listener: () => void): () => void;
+  /**
+   * Installs a new scope. Bumps the epoch — and aborts every `Abortable`
+   * still registered under the previous epoch — whenever `scope`'s `orgId`
+   * differs from the current one, or the null/non-null state changes
+   * (login, logout, org switch). Setting a scope with the *same* `orgId`
+   * (e.g. a `/auth/me` re-fetch that refreshes `permissions`/
+   * `allowedCollectionIds` for the org already active) updates the
+   * snapshot but does NOT bump the epoch — in-flight work for that org is
+   * not stale and is left alone.
+   */
+  setScope(scope: Scope | null): void;
+  /**
+   * True if `epoch` is still the current one. This is the exact check a
+   * caller makes right before rendering/applying a resolved response or
+   * delivered SSE message — the discard point. A stale epoch here means
+   * "this belongs to a scope the user has already switched away from";
+   * the value must never be rendered.
+   */
+  isCurrent(epoch: number): boolean;
+  /**
+   * Registers `abortable` to be aborted the instant the epoch moves past
+   * `epoch`. If `epoch` is already stale by the time this is called,
+   * `abortable` is aborted synchronously and nothing is registered.
+   * Returns an unregister function — callers must call it once the
+   * abortable finishes on its own (success, error, or its own abort) so
+   * the registry does not grow unbounded over a long session.
+   */
+  registerAbortable(epoch: number, abortable: Abortable): () => void;
+}
+
+function sameScope(a: Scope | null, b: Scope | null): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  return a.orgId === b.orgId;
+}
+
+export function createScopeManager(): ScopeManager {
+  let epoch = 0;
+  let scope: Scope | null = null;
+  // Cached snapshot object: `getSnapshot()` must return a referentially
+  // stable value between actual state changes (React's
+  // `useSyncExternalStore` — which `ScopeProvider.tsx` uses — calls
+  // `getSnapshot()` on every render to detect whether a re-render is
+  // needed; a fresh object literal on every call would look like a change
+  // every time and loop forever). Only replaced from inside `setScope`,
+  // exactly when `epoch`/`scope` actually change.
+  let snapshot: ScopeSnapshot = { epoch, scope };
+  const listeners = new Set<() => void>();
+  // One registry per still-open epoch. An epoch's entry is deleted as soon
+  // as it is superseded (its abortables are aborted and the set dropped),
+  // so this only ever holds the current epoch's abortables plus whatever
+  // hasn't called its unregister function yet from the immediately
+  // preceding switch.
+  const abortables = new Map<number, Set<Abortable>>();
+
+  function notify(): void {
+    for (const listener of [...listeners]) listener();
+  }
+
+  return {
+    getSnapshot() {
+      return snapshot;
+    },
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+
+    setScope(next) {
+      if (sameScope(scope, next)) {
+        scope = next;
+        snapshot = { epoch, scope };
+        notify();
+        return;
+      }
+      const previousEpoch = epoch;
+      scope = next;
+      epoch += 1;
+      snapshot = { epoch, scope };
+      const toAbort = abortables.get(previousEpoch);
+      abortables.delete(previousEpoch);
+      if (toAbort) {
+        for (const abortable of toAbort) {
+          abortable.abort();
+        }
+      }
+      notify();
+    },
+
+    isCurrent(candidate) {
+      return candidate === epoch;
+    },
+
+    registerAbortable(forEpoch, abortable) {
+      if (forEpoch !== epoch) {
+        abortable.abort();
+        return () => {};
+      }
+      let set = abortables.get(forEpoch);
+      if (!set) {
+        set = new Set();
+        abortables.set(forEpoch, set);
+      }
+      set.add(abortable);
+      return () => {
+        set.delete(abortable);
+      };
+    },
+  };
+}

--- a/web/src/state/scopeCache.test.ts
+++ b/web/src/state/scopeCache.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { createScopeManager, type Scope } from './scope';
+import { createScopeCache } from './scopeCache';
+
+function scope(orgId: string): Scope {
+  return { orgId, permissions: [], allowedCollectionIds: [] };
+}
+
+describe('createScopeCache', () => {
+  it('serves what was set for the current epoch', () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const { epoch } = manager.getSnapshot();
+    const cache = createScopeCache<string>(manager);
+
+    cache.set(epoch, 'collections', 'org-a-collections');
+
+    expect(cache.get('collections')).toBe('org-a-collections');
+    expect(cache.has('collections')).toBe(true);
+  });
+
+  it('does not serve org A entries while org B is current', () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const epochA = manager.getSnapshot().epoch;
+    const cache = createScopeCache<string>(manager);
+    cache.set(epochA, 'collections', 'org-a-collections');
+
+    manager.setScope(scope('org-b'));
+
+    expect(cache.get('collections')).toBeUndefined();
+    expect(cache.has('collections')).toBe(false);
+  });
+
+  it('discards a write for an epoch that is no longer current (late response landing after a switch)', () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const epochA = manager.getSnapshot().epoch;
+    const cache = createScopeCache<string>(manager);
+
+    // Switch happens *before* the org-A fetch resolves and tries to write.
+    manager.setScope(scope('org-b'));
+    cache.set(epochA, 'collections', 'org-a-collections-arriving-late');
+
+    expect(cache.get('collections')).toBeUndefined();
+  });
+
+  it('switching back to org A does not resurrect org A pre-switch data', () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const epochA1 = manager.getSnapshot().epoch;
+    const cache = createScopeCache<string>(manager);
+    cache.set(epochA1, 'collections', 'org-a-collections-first-visit');
+
+    manager.setScope(scope('org-b'));
+    manager.setScope(scope('org-a')); // back to A, but a new generation
+
+    expect(cache.get('collections')).toBeUndefined();
+
+    const epochA2 = manager.getSnapshot().epoch;
+    expect(epochA2).not.toBe(epochA1);
+    cache.set(epochA2, 'collections', 'org-a-collections-second-visit');
+    expect(cache.get('collections')).toBe('org-a-collections-second-visit');
+  });
+
+  it('accepts a write for a same-org refresh that does not bump the epoch', () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const cache = createScopeCache<string>(manager);
+    const { epoch } = manager.getSnapshot();
+
+    cache.set(epoch, 'collections', 'v1');
+    manager.setScope(scope('org-a')); // same org: no epoch bump
+    cache.set(manager.getSnapshot().epoch, 'collections', 'v2');
+
+    expect(cache.get('collections')).toBe('v2');
+  });
+
+  it('clear() drops everything regardless of scope', () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const cache = createScopeCache<string>(manager);
+    cache.set(manager.getSnapshot().epoch, 'k', 'v');
+    cache.clear();
+    expect(cache.get('k')).toBeUndefined();
+  });
+
+  it('delete() removes a single key without touching others', () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const cache = createScopeCache<string>(manager);
+    const { epoch } = manager.getSnapshot();
+    cache.set(epoch, 'a', '1');
+    cache.set(epoch, 'b', '2');
+    cache.delete('a');
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe('2');
+  });
+});

--- a/web/src/state/scopeCache.ts
+++ b/web/src/state/scopeCache.ts
@@ -1,0 +1,77 @@
+// A cache keyed by "current scope" for P2-06 (Gate: "Không render dữ liệu
+// từ scope cũ"). Two protections, both required — see the module doc in
+// `scope.ts` for why one alone is not enough:
+//
+// 1. Reactive clear: subscribed to the `ScopeManager`, so the instant the
+//    epoch moves on (any org switch, login, or logout) the entire backing
+//    map is dropped. Org A's entries are gone before org B's UI can read
+//    them, and switching back to org A later starts from an empty map
+//    rather than resurrecting pre-switch data.
+// 2. Write-time epoch check: `set()` takes the epoch the value was fetched
+//    for and silently discards the write if that epoch is no longer
+//    current. This is the case (1) alone cannot cover: a request started
+//    under org A that only *resolves* after the switch to org B — its
+//    `.then()` calling `cache.set(oldEpoch, ...)` — must not repopulate the
+//    (already-cleared) cache with org A data while org B is active.
+import type { ScopeManager } from './scope';
+
+export interface ScopeCache<T> {
+  get(key: string): T | undefined;
+  has(key: string): boolean;
+  /**
+   * Write-through, but only if `epoch` is still current. Pass the epoch
+   * that was current when the underlying fetch was *started* (or, more
+   * precisely, whatever epoch the data is known to belong to) — not the
+   * epoch read at call time — so a write raced by a switch is discarded
+   * rather than silently laundered into "current".
+   */
+  set(epoch: number, key: string, value: T): void;
+  delete(key: string): void;
+  /** Drops every entry regardless of scope. Mainly for tests; the cache already self-clears on every switch. */
+  clear(): void;
+}
+
+export function createScopeCache<T>(manager: ScopeManager): ScopeCache<T> {
+  let entries = new Map<string, T>();
+  let syncedEpoch = manager.getSnapshot().epoch;
+
+  function syncEpoch(): void {
+    const current = manager.getSnapshot().epoch;
+    if (current !== syncedEpoch) {
+      entries = new Map();
+      syncedEpoch = current;
+    }
+  }
+
+  // Belt-and-suspenders: clears eagerly on notify (not just lazily on next
+  // get/set), so nothing served between a switch and the next cache call
+  // observes a stale generation's map.
+  manager.subscribe(syncEpoch);
+
+  return {
+    get(key) {
+      syncEpoch();
+      return entries.get(key);
+    },
+
+    has(key) {
+      syncEpoch();
+      return entries.has(key);
+    },
+
+    set(epoch, key, value) {
+      syncEpoch();
+      if (!manager.isCurrent(epoch)) return; // discard: write belongs to a superseded scope
+      entries.set(key, value);
+    },
+
+    delete(key) {
+      syncEpoch();
+      entries.delete(key);
+    },
+
+    clear() {
+      entries = new Map();
+    },
+  };
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -284,6 +284,57 @@ code {
   max-width: none;
 }
 
+/* Auth shell: session/org visibility (App.tsx) and the login form (LoginPage.tsx). */
+.session-status {
+  align-items: center;
+  display: flex;
+  gap: 0.6rem;
+  margin-left: 0.5rem;
+}
+
+.session-identity {
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.session-org {
+  color: var(--color-text-secondary);
+}
+
+.auth-loading {
+  color: var(--color-text-secondary);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 24rem;
+}
+
+.auth-form .field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.auth-form label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.auth-form input {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  padding: 0.55rem 0.7rem;
+}
+
+.auth-form input:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 1px;
+}
+
 @media (max-width: 600px) {
   .topbar {
     min-height: 4rem;


### PR DESCRIPTION
## Outcome

Follow-on to #310, which merged with only the web foundations (P2-01, P2-13) and the OpenAPI schema work. This lands the five remaining wave 0/1 issues: P2-02 mock server, P2-03 typed client, P2-04 SSE transport, P2-05 login shell, P2-06 scope-safe org switching. 54 files, +9137/-56, all under `web/src`.

#310 was merged while later commits were still being pushed to the same branch, so the branch was restarted from the new `master` and only the unmerged work re-applied. Nothing here duplicates what already landed.

## Scope

Frontend only — no `crates/`, no CI, no evidence tooling. The one server-adjacent change is `web/src/api/session.ts` gaining an `onTokensRotated` listener, which is client code.

## Evidence

- [x] Tests: `make check-web` exit 0 on this exact tree — 26 test files, 302 tests, lint 0 errors, format clean, build OK.
- [x] Manual/benchmark/migration evidence: N/A, no runtime or schema change.
- Mutation-checked rather than asserted, each reverted after: removing the SSE reconnect storm guard makes its test hang past 120 s with a real storm; removing `reader.cancel()` on abort hangs the abort test on a reader never released; removing the client's single-flight refresh turns 8 of 36 red; disabling the rotation subscription fails exactly the "persists the rotation that happens inside a refresh" test; stripping all three scope guards turns exactly the two race tests red.
- Two of the scope-race tests were found to pass with **every** guard removed — assertions after the resolve were never flushed without `act()`, and a shared deferred masked the race. They were rewritten before the guards were trusted.

## Boundary and security review

- [x] Dependency boundary check passed — no new dependency; the four markdown packages landed in #310.
- [x] Tenant/ACL impact reviewed: P2-06 exists precisely for the phase Gate condition "không render dữ liệu từ scope cũ". Aborting an in-flight request is not sufficient on its own, so each layer also discards on arrival — generation comparison at render, a per-message check before the SSE consumer, and a cache that refuses writes from a superseded epoch.
- [x] Sensitive logging/secret/egress impact reviewed: the refresh token is persisted in `sessionStorage`. That is a real XSS exposure, bounded to the tab rather than left in the browser profile; there is no server-set cookie in this deployment, so the alternative is signing the user out on every reload. The rationale, including that "persist nothing" is the more secure option that was rejected, is in `auth/tokenStorage.ts`'s header rather than only in this description.
- [x] Security review trigger checked: ADR 0010 revokes the whole token family when an already-rotated refresh token is replayed, so a persisted copy that misses a rotation does not merely fail — its next use looks like an attack. Persistence is therefore written from `onTokensRotated`, fired synchronously inside the rotation.

## Follow-up

- [ ] The scope-safe hooks are opt-in: a future Library or Q&A page can bypass them with a raw `useEffect`. Worth a lint rule when P2.4/P2.5 start.
- [ ] `as unknown as ApiClient` in the test doubles hid an interface change — adding a required method to `SessionManager` type-checked clean and failed only at runtime, in 22 tests. Dropping the cast would catch that at compile time.
- [ ] The mock server carries a 367-line hand-written YAML subset parser, a consequence of forbidding new dependencies during the agent run. A `yaml` devDependency is the better end state.
- [ ] P2-11 and P2-12 still have no backing API — none of the 32 endpoints cover member/invite/role/usage, and R04 states "Out: admin membership API". They belong to Phase 1C.
- [ ] `master` still has no branch protection: `protected: false`, `required_status_checks.enforcement_level: "off"`. I could not read repository rulesets (the endpoint returns 403 for this repo), so if protection was configured that way it is not visible to me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1aW1B4YfpWERwjsVVficE

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1aW1B4YfpWERwjsVVficE)_