### PR TITLE
Web accessibility pass and SPA static serving (P2-14, P2-16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,6 +2186,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-postgres-rustls",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2944,6 +2945,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -3856,6 +3863,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -7497,10 +7514,19 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.13.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -7703,6 +7729,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -53,6 +53,18 @@ thiserror.workspace = true
 tokio = { version = "1.53.0", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-postgres = { version = "0.7.18", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-postgres-rustls = "0.14.0"
+# ServiceBuilder for layering Cache-Control/security headers onto the static
+# asset service (src/spa.rs, P2-16). Was previously dev-only (test harness
+# used `tower::ServiceExt::oneshot`); promoted to a normal dependency since
+# production code now needs `tower::ServiceBuilder` too. Already present in
+# the dependency graph regardless (tower-http itself depends on it).
+tower = { version = "0.5.3", features = ["util"] }
+# P2-16: serves web/dist (hashed assets + SPA fallback). Already resolved as a
+# transitive dep of reqwest at 0.6.11 (see Cargo.lock) so this pins the same
+# version rather than introducing a new major dependency; only the `fs`
+# (ServeDir) and `set-header` (per-route Cache-Control/CSP layering) features
+# are new compile surface.
+tower-http = { version = "0.6.11", default-features = false, features = ["fs", "set-header"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
 uuid = { version = "1.24.0", features = ["serde", "v4", "v8"] }
@@ -65,4 +77,3 @@ test-hooks = []
 
 [dev-dependencies]
 http-body-util = "0.1.4"
-tower = { version = "0.5.3", features = ["util"] }

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -6,6 +6,12 @@ server, applies checksum-verified PostgreSQL migrations, and exposes:
 - `GET /api/v1/health/live` — process liveness;
 - `GET /api/v1/health/ready` — PostgreSQL, Qdrant and MinIO readiness.
 
+It can optionally also serve the built web SPA (`web/dist`) — hashed/immutable
+assets, history-fallback for UI routes, strict security headers — without ever
+letting an unmatched `/api/v1/*` path fall through to the SPA shell. See
+`src/spa.rs` and [`deploy/README.md`](../../deploy/README.md#web-spa-static-serving-p2-16).
+Serving is entirely optional: absent `web/dist`, the server just runs the API.
+
 For a local run, start the real dependency stack and export endpoints from
 `deploy/dev/.env.example`:
 

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -482,7 +482,7 @@ pub fn router(state: AppState) -> Router {
     let state = Arc::new(state);
     // Layer order (outer → inner): request-id → write-gate → cors → rate-limit → handler.
     // `mutation_write_gate` is the central O03 contract (see middleware/write_gate.rs).
-    Router::new()
+    let mut app = Router::new()
         .merge(routes::health::router())
         .merge(routes::auth::router())
         .merge(routes::uploads::router(max_upload_bytes))
@@ -492,8 +492,33 @@ pub fn router(state: AppState) -> Router {
         .merge(routes::search::router())
         .merge(routes::ask::router())
         .merge(routes::events::router())
-        .route("/api/v1/openapi.yaml", axum::routing::get(openapi_yaml))
-        .layer(from_fn_with_state(state.clone(), baseline_ip_rate_limit))
+        .route("/api/v1/openapi.yaml", axum::routing::get(openapi_yaml));
+
+    // P2-16: serve web/dist (hashed assets + SPA history fallback) when a
+    // built bundle is present; otherwise the API runs standalone (tests,
+    // dev, CI, and any deployment layer that ships the SPA separately).
+    //
+    // Mounted inside the middleware stack below, but that stack is a no-op
+    // for these routes and deliberately so — checked, not assumed:
+    // `baseline_ip_rate_limit` returns early for any path outside
+    // `/api/v1/` (middleware/mod.rs:236), and `is_write_gate_exempt` is true
+    // for the same set (middleware/write_gate.rs:50). So an SPA page load
+    // pulling a dozen hashed assets cannot burn the caller's API rate-limit
+    // budget, and static GETs never take the O03 advisory lock. Request-id
+    // injection does still apply, which is what we want for tracing.
+    match crate::spa::resolve_web_dist_dir() {
+        Some(dist_dir) => match crate::spa::spa_router::<Arc<AppState>>(&dist_dir) {
+            Some(spa) => app = app.merge(spa),
+            None => tracing::warn!(
+                target: "spa",
+                dir = %dist_dir.display(),
+                "web dist directory configured but unusable; serving API only"
+            ),
+        },
+        None => tracing::debug!(target: "spa", "no web dist directory found; serving API only"),
+    }
+
+    app.layer(from_fn_with_state(state.clone(), baseline_ip_rate_limit))
         .layer(from_fn_with_state(state.clone(), cors_middleware))
         .layer(from_fn_with_state(state.clone(), mutation_write_gate))
         .layer(from_fn_with_state(state.clone(), inject_request_id))

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -11,6 +11,7 @@ pub mod jobs;
 pub mod middleware;
 pub mod routes;
 pub mod services;
+pub mod spa;
 pub mod state;
 pub mod storage;
 pub mod telemetry;

--- a/crates/server/src/spa.rs
+++ b/crates/server/src/spa.rs
@@ -1,0 +1,479 @@
+//! Static SPA serving for the built `web/dist` bundle (P2-16).
+//!
+//! Serving is **optional**: [`resolve_web_dist_dir`] / [`spa_router`] return
+//! `None` when the directory (or its `index.html`) is missing, and the
+//! caller (`http::router`) simply skips mounting any static routes in that
+//! case. Tests, `cargo test`, CI and local `cargo run` without a prior
+//! `pnpm --dir web build` all keep working as API-only — measured by
+//! `tests/spa_static_serving.rs::server_starts_and_serves_api_without_web_dist`.
+//!
+//! # History-fallback boundary (the load-bearing guarantee of this module)
+//!
+//! [`spa_fallback`] is installed as the router's *global* fallback, so it
+//! runs for every request that didn't match an explicit route — that
+//! includes typo'd/removed `/api/v1/*` paths, not just real UI deep links.
+//! It therefore starts by checking the request path and refuses to answer
+//! for anything under `/api/` or `/metrics`: those fall through to a plain
+//! 404, exactly like an unmatched route would without this module mounted
+//! at all. Only paths outside that reserved space get the SPA shell.
+//!
+//! This is asserted by `tests/spa_static_serving.rs`, and the report for
+//! P2-16 records a mutation run that makes the fallback greedy (drops the
+//! `/api/` guard) to confirm the API-404 test goes red without it.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{header, HeaderName, HeaderValue, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::Router;
+use tower::ServiceBuilder;
+use tower_http::services::ServeDir;
+use tower_http::set_header::SetResponseHeaderLayer;
+
+/// Overrides the SPA directory; unset/empty falls back to `web/dist`
+/// relative to the process CWD (repo root for `cargo run`, compose/Docker
+/// WORKDIR in deployment — see `deploy/Dockerfile.server`).
+pub const WEB_DIST_ENV: &str = "MARKHAND_WEB_DIST_DIR";
+
+/// Strict CSP for the SPA shell and its static assets.
+///
+/// Narrowest policy that still loads the app as shipped today:
+/// - `script-src 'self'` — the Vite build emits only `<script type="module"
+///   src="/assets/...">`, no inline scripts, so no `unsafe-inline` is needed.
+/// - `style-src`/`font-src` allow `fonts.googleapis.com`/`fonts.gstatic.com`
+///   because `web/src/styles.css` currently loads Caprasimo/Figtree via a
+///   CSS `@import` from Google Fonts (checked 2026-07-27). This is the one
+///   deliberate cross-origin allowance in an otherwise `'self'`-only policy.
+///   **Product decision handed back, not made silently**: the alternative is
+///   self-hosting those two font families under `web/dist` and dropping this
+///   allowance entirely — narrower, but requires a `web/src` change outside
+///   this crate's ownership. Until that happens, this is the CSP.
+/// - no `data:`/`unsafe-inline` anywhere; `object-src`/`base-uri`/
+///   `frame-ancestors` are all `'none'`.
+const CONTENT_SECURITY_POLICY: &str = concat!(
+    "default-src 'self'; ",
+    "script-src 'self'; ",
+    "style-src 'self' https://fonts.googleapis.com; ",
+    "font-src 'self' https://fonts.gstatic.com; ",
+    "img-src 'self'; ",
+    "connect-src 'self'; ",
+    "object-src 'none'; ",
+    "base-uri 'none'; ",
+    "frame-ancestors 'none'; ",
+    "form-action 'self'",
+);
+
+/// `X-Frame-Options` is kept alongside CSP `frame-ancestors` for older UAs
+/// that respect the former but not the latter.
+const X_FRAME_OPTIONS: &str = "DENY";
+const X_CONTENT_TYPE_OPTIONS: &str = "nosniff";
+/// Same-origin destinations get the full URL; cross-origin ones get only the
+/// origin — avoids leaking document paths/query strings off-site.
+const REFERRER_POLICY: &str = "strict-origin-when-cross-origin";
+
+/// HTML must be revalidated every load (SPA shell references hashed asset
+/// URLs baked in at build time; caching the shell itself would pin clients
+/// to a stale asset manifest after a deploy).
+const HTML_CACHE_CONTROL: &str = "no-cache, must-revalidate";
+/// Hashed asset filenames (`index-<hash>.js`) make the content at a given
+/// URL permanently immutable — safe to cache for a year, per plan P2.9/P2.7.
+const ASSET_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+
+/// Resolves the directory to serve, or `None` if serving should stay off.
+///
+/// `MARKHAND_WEB_DIST_DIR` wins when set and non-empty (used by deploy —
+/// see `deploy/Dockerfile.server`/`deploy/compose.poc.yml`); otherwise falls
+/// back to `web/dist` relative to CWD *only if it exists*. The latter never
+/// fires for `cargo test` (Cargo runs test binaries with CWD = the crate
+/// directory, `crates/server`, which has no `web/dist`), so test/CI runs
+/// stay API-only by construction rather than by env-var discipline.
+pub fn resolve_web_dist_dir() -> Option<PathBuf> {
+    if let Ok(configured) = std::env::var(WEB_DIST_ENV) {
+        let trimmed = configured.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
+    let default = PathBuf::from("web/dist");
+    if default.is_dir() {
+        Some(default)
+    } else {
+        None
+    }
+}
+
+/// Built SPA index document, read once at startup.
+struct SpaIndex {
+    html: Vec<u8>,
+}
+
+/// Builds the SPA sub-router (`/assets/*` + history-fallback), or `None`
+/// when `dist_dir/index.html` is absent/unreadable — the caller must then
+/// skip mounting this at all so the API keeps serving standalone.
+pub fn spa_router<S>(dist_dir: &Path) -> Option<Router<S>>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    let index_path = dist_dir.join("index.html");
+    let html = match std::fs::read(&index_path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::warn!(
+                target: "spa",
+                path = %index_path.display(),
+                error = %error,
+                "web dist directory configured but index.html is unreadable; serving API only"
+            );
+            return None;
+        }
+    };
+    let index = Arc::new(SpaIndex { html });
+
+    let assets_dir = dist_dir.join("assets");
+    let assets_service = ServiceBuilder::new()
+        .layer(SetResponseHeaderLayer::overriding(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static(ASSET_CACHE_CONTROL),
+        ))
+        .layer(security_header_layer(
+            header::X_CONTENT_TYPE_OPTIONS,
+            X_CONTENT_TYPE_OPTIONS,
+        ))
+        .layer(security_header_layer(
+            header::X_FRAME_OPTIONS,
+            X_FRAME_OPTIONS,
+        ))
+        .layer(security_header_layer(
+            header::REFERRER_POLICY,
+            REFERRER_POLICY,
+        ))
+        .layer(security_header_layer(
+            header::CONTENT_SECURITY_POLICY,
+            CONTENT_SECURITY_POLICY,
+        ))
+        .service(ServeDir::new(assets_dir));
+
+    let fallback_index = index.clone();
+
+    Some(
+        Router::new()
+            .nest_service("/assets", assets_service)
+            .fallback(move |method: Method, uri: Uri| {
+                let index = fallback_index.clone();
+                async move { spa_fallback(&index, &method, &uri) }
+            }),
+    )
+}
+
+fn security_header_layer(
+    name: HeaderName,
+    value: &'static str,
+) -> SetResponseHeaderLayer<HeaderValue> {
+    SetResponseHeaderLayer::overriding(name, HeaderValue::from_static(value))
+}
+
+/// Global router fallback. Reached for any request that matched no explicit
+/// route (auth/collections/.../openapi.yaml, `/metrics`, `/assets/*`), which
+/// includes non-existent `/api/v1/*` paths. Guarding on the path prefix
+/// first is what keeps the API's 404 surface intact — see module docs.
+fn spa_fallback(index: &SpaIndex, method: &Method, uri: &Uri) -> Response {
+    let path = uri.path();
+    if path.starts_with("/api/") || path == "/metrics" {
+        // Never serve the SPA shell for API/ops surfaces — preserve the
+        // plain "no route matched" 404 those paths would get without this
+        // module mounted at all.
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    if method != Method::GET && method != Method::HEAD {
+        return StatusCode::METHOD_NOT_ALLOWED.into_response();
+    }
+    let body = if method == Method::HEAD {
+        Body::empty()
+    } else {
+        Body::from(index.html.clone())
+    };
+    let mut response = Response::new(body);
+    let headers = response.headers_mut();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(HTML_CACHE_CONTROL),
+    );
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static(X_CONTENT_TYPE_OPTIONS),
+    );
+    headers.insert(
+        header::X_FRAME_OPTIONS,
+        HeaderValue::from_static(X_FRAME_OPTIONS),
+    );
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static(REFERRER_POLICY),
+    );
+    headers.insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(CONTENT_SECURITY_POLICY),
+    );
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Expected header values, spelled out here independently of the
+    // production constants above. Asserting a response header against the
+    // very `const` that produced it is a tautology: change the constant and
+    // both sides move together, so a swapped cache policy or a weakened CSP
+    // stays green. Mutation-checked: flipping HTML_CACHE_CONTROL to the
+    // immutable value left every test passing before these literals existed.
+    // These are what actually gate P2.9's "HTML revalidates, hashed assets
+    // immutable" and P2.7's header set — if you change a production constant
+    // on purpose, this block must change too, deliberately.
+    const EXPECT_HTML_CACHE: &str = "no-cache, must-revalidate";
+    const EXPECT_ASSET_CACHE: &str = "public, max-age=31536000, immutable";
+    const EXPECT_NOSNIFF: &str = "nosniff";
+    const EXPECT_FRAME: &str = "DENY";
+    const EXPECT_REFERRER: &str = "strict-origin-when-cross-origin";
+    const EXPECT_CSP: &str = "default-src 'self'; script-src 'self'; \
+style-src 'self' https://fonts.googleapis.com; \
+font-src 'self' https://fonts.gstatic.com; img-src 'self'; \
+connect-src 'self'; object-src 'none'; base-uri 'none'; \
+frame-ancestors 'none'; form-action 'self'";
+
+    use axum::body::to_bytes;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn write_dist(dir: &Path) {
+        std::fs::create_dir_all(dir.join("assets")).unwrap();
+        std::fs::write(
+            dir.join("index.html"),
+            b"<!doctype html><html><body>spa shell</body></html>",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("assets").join("index-deadbeef.js"),
+            b"console.log(1)",
+        )
+        .unwrap();
+    }
+
+    // `resolve_web_dist_dir` reads a process-global env var; serialize the
+    // two tests that touch it so they can't interleave (cargo test runs
+    // `#[test]` fns concurrently within one process by default).
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[test]
+    fn resolve_returns_none_without_env_or_default_dir() {
+        let _guard = env_lock();
+        // Isolate from whatever the process CWD happens to be (this test
+        // binary's CWD is the crate dir, which has no web/dist — but assert
+        // it explicitly rather than relying on that as an accident).
+        std::env::remove_var(WEB_DIST_ENV);
+        let cwd_default = PathBuf::from("web/dist");
+        assert!(
+            !cwd_default.is_dir(),
+            "test assumes no web/dist under the crate directory"
+        );
+        assert!(resolve_web_dist_dir().is_none());
+    }
+
+    #[test]
+    fn resolve_honors_env_override_even_when_missing() {
+        let _guard = env_lock();
+        std::env::set_var(WEB_DIST_ENV, "/nonexistent/does/not/exist");
+        // The env var always wins when set/non-empty; spa_router (not
+        // resolve_web_dist_dir) is what decides "usable" by checking
+        // index.html, so a bad override degrades there, not here.
+        assert_eq!(
+            resolve_web_dist_dir(),
+            Some(PathBuf::from("/nonexistent/does/not/exist"))
+        );
+        std::env::remove_var(WEB_DIST_ENV);
+    }
+
+    #[test]
+    fn spa_router_is_none_when_index_html_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        // Directory exists but is empty — no index.html.
+        assert!(spa_router::<()>(dir.path()).is_none());
+    }
+
+    #[tokio::test]
+    async fn fallback_serves_index_html_for_ui_deep_link() {
+        let dir = tempfile::tempdir().unwrap();
+        write_dist(dir.path());
+        let app = spa_router::<()>(dir.path()).expect("router");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/library/some-collection-id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            EXPECT_HTML_CACHE
+        );
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/html; charset=utf-8"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
+            EXPECT_NOSNIFF
+        );
+        assert_eq!(
+            response.headers().get(header::X_FRAME_OPTIONS).unwrap(),
+            EXPECT_FRAME
+        );
+        assert_eq!(
+            response.headers().get(header::REFERRER_POLICY).unwrap(),
+            EXPECT_REFERRER
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_SECURITY_POLICY)
+                .unwrap(),
+            EXPECT_CSP
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("spa shell"));
+    }
+
+    #[tokio::test]
+    async fn fallback_never_swallows_unmatched_api_path() {
+        let dir = tempfile::tempdir().unwrap();
+        write_dist(dir.path());
+        let app = spa_router::<()>(dir.path()).expect("router");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/does-not-exist")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(
+            body.is_empty(),
+            "unmatched /api/v1 path must not receive the SPA shell body"
+        );
+    }
+
+    #[tokio::test]
+    async fn fallback_never_swallows_metrics() {
+        let dir = tempfile::tempdir().unwrap();
+        write_dist(dir.path());
+        let app = spa_router::<()>(dir.path()).expect("router");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn asset_is_served_immutable_with_security_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        write_dist(dir.path());
+        let app = spa_router::<()>(dir.path()).expect("router");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/assets/index-deadbeef.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            EXPECT_ASSET_CACHE
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
+            EXPECT_NOSNIFF
+        );
+        assert_eq!(
+            response.headers().get(header::X_FRAME_OPTIONS).unwrap(),
+            EXPECT_FRAME
+        );
+        assert_eq!(
+            response.headers().get(header::REFERRER_POLICY).unwrap(),
+            EXPECT_REFERRER
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_SECURITY_POLICY)
+                .unwrap(),
+            EXPECT_CSP
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_asset_is_a_plain_404_not_the_spa_shell() {
+        let dir = tempfile::tempdir().unwrap();
+        write_dist(dir.path());
+        let app = spa_router::<()>(dir.path()).expect("router");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/assets/does-not-exist.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(!String::from_utf8_lossy(&body).contains("spa shell"));
+    }
+
+    #[tokio::test]
+    async fn non_get_head_ui_path_is_method_not_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_dist(dir.path());
+        let app = spa_router::<()>(dir.path()).expect("router");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/library/x")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}

--- a/crates/server/tests/spa_static_serving.rs
+++ b/crates/server/tests/spa_static_serving.rs
@@ -1,0 +1,238 @@
+//! Packaged-server evidence for P2-16 (build + serve the SPA).
+//!
+//! Exercises the *real* `http::router(AppState)` — the full middleware stack
+//! (request-id, write-gate, CORS, rate-limit) wraps the SPA routes exactly
+//! like every `/api/v1` route, not a bare `spa::spa_router` in isolation
+//! (that unit-level guarantee is covered by `src/spa.rs`'s own tests).
+//!
+//! Hermetic by construction, no live Postgres/MinIO required:
+//! - `/api/v1/health/*` is write-gate-exempt (see
+//!   `middleware::write_gate::is_write_gate_exempt`), so an *unmatched*
+//!   sub-path under it (`/api/v1/health/does-not-exist`) reaches the router's
+//!   fallback without ever touching the DB pool, giving a deterministic 404
+//!   without a live database.
+//! - Every other assertion here (deep-link fallback, asset cache headers) is
+//!   entirely outside `/api/v1`, which `is_write_gate_exempt` and
+//!   `baseline_ip_rate_limit` both already treat as ops-adjacent/exempt.
+//!
+//! Mutation-test transcript for these guarantees lives in the P2-16 report,
+//! not in this file — each assertion below was confirmed to go red by
+//! independently breaking the corresponding guard in `src/spa.rs` (dropping
+//! the `/api/` prefix check, swapping the two Cache-Control constants,
+//! deleting one security-header `insert`/layer at a time) and rerunning.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use fileconv_server::spa::WEB_DIST_ENV;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+/// `MARKHAND_WEB_DIST_DIR` is a process-global env var; serialize every test
+/// in this binary that touches it so parallel `#[tokio::test]` execution
+/// can't interleave a set/remove from one test into another's window.
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Never-reachable-but-syntactically-valid DB URL — matches the pattern
+/// already used by `http.rs`'s own `liveness_has_a_contract_compliant_body`
+/// unit test. `deadpool_postgres::Pool` connects lazily, so building the
+/// pool/state/router never dials out; only a handler that actually needs a
+/// connection would. Every path this test hits is write-gate-exempt.
+fn hermetic_pool() -> deadpool_postgres::Pool {
+    fileconv_server::db::pool::create_pool(
+        "postgres://markhand_app:markhand_app@127.0.0.1:5432/markhand_test",
+    )
+    .expect("pool construction is lazy and infallible for a well-formed URL")
+}
+
+fn write_fixture_dist(dir: &std::path::Path) -> String {
+    std::fs::create_dir_all(dir.join("assets")).expect("mkdir assets");
+    std::fs::write(
+        dir.join("index.html"),
+        b"<!doctype html><html><body><div id=\"root\">markhand-spa-shell</div></body></html>",
+    )
+    .expect("write index.html");
+    let asset_name = "index-fixturehash123.js";
+    std::fs::write(
+        dir.join("assets").join(asset_name),
+        b"console.log('markhand');",
+    )
+    .expect("write asset");
+    asset_name.to_string()
+}
+
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8_lossy(&bytes).to_string()
+}
+
+#[tokio::test]
+async fn server_boots_and_serves_api_without_web_dist_present() {
+    // The lock is scoped to env-var manipulation plus the (synchronous)
+    // router build, which is the only window where `WEB_DIST_ENV` is read —
+    // `resolve_web_dist_dir` runs inside `build_router`, never later. Holding
+    // it across the awaits below would serialize nothing useful and trips
+    // clippy's `await_holding_lock`, which CI runs as `-D warnings`.
+    let app = {
+        let _guard = env_lock();
+        std::env::remove_var(WEB_DIST_ENV);
+        // Default lookup ("web/dist" relative to CWD) must not resolve here —
+        // `cargo test`'s CWD for this binary is `crates/server`, which has none.
+        assert!(
+            fileconv_server::spa::resolve_web_dist_dir().is_none(),
+            "test assumes no web/dist is reachable from the crate directory"
+        );
+        common::build_router(
+            hermetic_pool(),
+            "postgres://markhand_app:markhand_app@127.0.0.1:5432/markhand_test",
+            None,
+        )
+    };
+
+    // The API keeps working standalone: this is the "serving is optional"
+    // guarantee (packaged server / dev / CI without a prior `pnpm build`).
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/health/live")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // And a UI path gets axum's bare 404 (no SPA shell mounted at all),
+    // rather than any kind of html response.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/library/anything")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn packaged_server_deep_link_api_404_and_asset_cache_policy() {
+    let dist = tempfile::tempdir().expect("tempdir");
+    let asset_name = write_fixture_dist(dist.path());
+
+    // Scoped for the same reason as the test above: set-then-build is the
+    // whole critical section, and the guard must not cross an await.
+    let app = {
+        let _guard = env_lock();
+        std::env::set_var(WEB_DIST_ENV, dist.path());
+        common::build_router(
+            hermetic_pool(),
+            "postgres://markhand_app:markhand_app@127.0.0.1:5432/markhand_test",
+            None,
+        )
+    };
+
+    // --- Deep-link refresh: an unregistered UI route serves the SPA shell.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/library/9f2c1e10-aaaa-4bbb-8ccc-123456789abc")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "deep link must serve the SPA shell"
+    );
+    let headers = response.headers().clone();
+    assert_eq!(
+        headers.get(axum::http::header::CONTENT_TYPE).unwrap(),
+        "text/html; charset=utf-8"
+    );
+    assert_eq!(
+        headers.get(axum::http::header::CACHE_CONTROL).unwrap(),
+        "no-cache, must-revalidate",
+        "HTML shell must be revalidated every load, never cached"
+    );
+    assert_eq!(
+        headers
+            .get(axum::http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap(),
+        "nosniff"
+    );
+    assert_eq!(
+        headers.get(axum::http::header::X_FRAME_OPTIONS).unwrap(),
+        "DENY"
+    );
+    assert!(headers.contains_key(axum::http::header::CONTENT_SECURITY_POLICY));
+    assert!(headers.contains_key(axum::http::header::REFERRER_POLICY));
+    let body = body_string(response).await;
+    assert!(body.contains("markhand-spa-shell"));
+
+    // --- API 404 behaviour: an unmatched `/api/v1` path is never swallowed
+    // by the SPA fallback. Uses a write-gate-exempt sub-path
+    // (`/api/v1/health/...`) so this stays hermetic (no live Postgres) while
+    // still going through the *full* router (request-id → write-gate → CORS
+    // → rate-limit → fallback), not a bare `spa_router`.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/health/does-not-exist")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "unmatched /api/v1 path must 404, never fall through to the SPA shell"
+    );
+    let body = body_string(response).await;
+    assert!(
+        !body.contains("markhand-spa-shell"),
+        "unmatched API path leaked the SPA shell body: {body}"
+    );
+
+    // --- Asset cache policy: hashed assets are long-cached and immutable.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/assets/{asset_name}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(axum::http::header::CACHE_CONTROL)
+            .unwrap(),
+        "public, max-age=31536000, immutable"
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get(axum::http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap(),
+        "nosniff"
+    );
+    assert!(response
+        .headers()
+        .contains_key(axum::http::header::CONTENT_SECURITY_POLICY));
+
+    std::env::remove_var(WEB_DIST_ENV);
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -168,5 +168,30 @@ auto-strips `mem_limit`/`cpus`/`pids_limit` for boot only; the canonical
 
 Kubernetes/HA, production TLS termination, Profile B GPU capacity claims.
 
+## Web SPA static serving (P2-16)
+
+`fileconv-server` can serve the built web SPA (`web/dist`) directly — hashed,
+long-cached assets under `/assets/*`, history-fallback for UI routes, and
+strict security headers on both. See `crates/server/src/spa.rs` for the
+implementation and its own module docs for the exact CSP/cache-control
+contract.
+
+- Build the SPA first: `pnpm --dir web build` → `web/dist`.
+- Point the server at it with `MARKHAND_WEB_DIST_DIR=/path/to/web/dist`
+  (absolute path recommended for containers). Unset, the server falls back to
+  `./web/dist` relative to its CWD, and if neither resolves it simply serves
+  the API alone — **serving the SPA is optional, never required to boot**.
+- `deploy/Dockerfile.server` and `compose.poc.yml` do **not** currently build
+  or copy `web/dist` into the API image/container — that would add a
+  Node/pnpm build stage to a pipeline whose base images and evidence are
+  digest-pinned (`poc/images.lock.json`) for the F02 gate, which is a
+  separate decision this change deliberately did not make unasked. Until
+  that ADR lands, ship the SPA either behind a separate static host/CDN
+  pointed at the same API origin, or bind-mount a locally built `web/dist`
+  into the API container and set `MARKHAND_WEB_DIST_DIR` accordingly.
+- HSTS is intentionally **not** set by the application — it is a
+  reverse-proxy/TLS-terminator concern in production (the app has no
+  certificate and cannot know if the edge actually terminates HTTPS).
+
 <!-- ci: nudge after digest pins -->
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.3)
+      axe-core:
+        specifier: ^4.12.1
+        version: 4.12.1
       eslint:
         specifier: ^10.7.0
         version: 10.7.0
@@ -1214,6 +1217,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -3300,6 +3307,8 @@ snapshots:
   aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
+
+  axe-core@4.12.1: {}
 
   bail@2.0.2: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -29,6 +29,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.4",
+    "axe-core": "^4.12.1",
     "eslint": "^10.7.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -99,6 +99,29 @@ describe('App', () => {
     expect(screen.getByRole('heading', { name: 'Trợ giúp Markhand' })).toBeVisible();
   });
 
+  // P2-14 (plans/markhand-web/phase-2-web-spa.md §P2.7): "focus sau route
+  // change". Without this, a keyboard/screen-reader user who activates a
+  // rail link keeps focus on the link itself while the page underneath it
+  // changes — the new page's heading is never announced and Tab continues
+  // from the rail instead of from the content. Moving focus to the `<main>`
+  // landmark (already `tabIndex={-1}` at App.tsx's `#main-content`, put
+  // there for the skip link) is the standard SPA fix; this only asserts it
+  // actually happens, not just that the markup exists for it to.
+  it('moves focus to the main landmark after a route change (not just on first paint)', () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+
+    render(<App />);
+    const main = screen.getByRole('main');
+    // The initial mount must not be reporting a false positive here — a
+    // browser tab load starts focus on <body>, not on the landmark.
+    expect(document.activeElement).not.toBe(main);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Trợ giúp' }));
+
+    expect(window.location.pathname).toBe('/help');
+    expect(document.activeElement).toBe(main);
+  });
+
   it('redirects a deep-linked protected route to /login when anonymous, preserving it as ?next=', async () => {
     window.history.pushState(null, '', '/library/col-42');
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 503 })));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -88,12 +88,37 @@ export function App() {
 function AppShell() {
   const [connection, setConnection] = useState<ConnectionState>({ kind: 'checking' });
   const controllerRef = useRef<AbortController | null>(null);
-  const { match } = useRouter();
+  const { match, pathname } = useRouter();
   // The rail is the app's chrome for every *inside-the-app* route. `/login`
   // (both design sources render it as a distinct, chrome-free full-bleed
   // screen — see the report) is the one route that opts out, matching
   // `PublicOnlyRoute`'s own framing: a visitor there isn't "in the app" yet.
   const showRail = match.name !== 'login';
+
+  // P2-14 (plans/markhand-web/phase-2-web-spa.md §P2.7): "focus sau route
+  // change". Without this, activating a rail link (or any in-app
+  // navigation) leaves focus sitting on the control that triggered it while
+  // the page underneath changes — a keyboard/screen-reader user never has
+  // the new page's heading announced, and Tab would continue from the rail
+  // rather than from the content. `#main-content` is already `tabIndex={-1}`
+  // (added for the skip link below), so it's a valid, non-tab-stealing
+  // programmatic focus target.
+  //
+  // Keyed on `pathname`, not `match.name`: a param-only change (e.g.
+  // switching collection while staying on the `library` route) is still a
+  // real navigation the user asked for and still deserves this. The first
+  // render is deliberately skipped — initial page load should leave focus
+  // wherever the browser puts it (verified in App.test.tsx: activeElement
+  // is not `#main-content` before any navigation has happened).
+  const mainRef = useRef<HTMLElement | null>(null);
+  const isFirstRouteRef = useRef(true);
+  useEffect(() => {
+    if (isFirstRouteRef.current) {
+      isFirstRouteRef.current = false;
+      return;
+    }
+    mainRef.current?.focus();
+  }, [pathname]);
 
   const loadConnection = useCallback(async () => {
     controllerRef.current?.abort();
@@ -149,7 +174,7 @@ function AppShell() {
           </span>
         </div>
 
-        <main id="main-content" className="welcome" tabIndex={-1}>
+        <main id="main-content" className="welcome" tabIndex={-1} ref={mainRef}>
           {match.name === 'home' ? (
             <>
               <p className="eyebrow">Không gian tri thức</p>

--- a/web/src/a11y.test.tsx
+++ b/web/src/a11y.test.tsx
@@ -1,0 +1,180 @@
+// P2-14 (plans/markhand-web/phase-2-web-spa.md §P2.7): "axe không có
+// critical violations". This is the one place axe-core actually runs
+// against this app's real rendered states — the login page, the library
+// page with documents and a selected document, and an open modal — rather
+// than against isolated markup fixtures. `axe-core` is a devDependency only
+// (see package.json); there is no Playwright in this repo and this task
+// does not add one, so this suite is Vitest + Testing Library like every
+// other test here.
+//
+// Contrast is explicitly out of scope for this file: jsdom has no layout
+// engine and does not resolve real painted colours (no CSSOM box model, no
+// browser compositing), so axe's `color-contrast` rule cannot report
+// anything meaningful under jsdom — it is disabled at every call below,
+// with this same reasoning, rather than silenced globally. Contrast in this
+// project is verified by hand and recorded as `contrast:` comments in
+// styles.css (see that file's top-of-file comment for the convention).
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import axe, { type RunOptions } from 'axe-core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApiClient, type ApiClient } from './api/client';
+import type { components } from './api/generated/contract';
+import { installMockFetch, resetMockState, uninstallMockFetch } from './mocks';
+import { getStore, nextId } from './mocks/fixtures';
+import { mockTimestamp } from './mocks/ids';
+import { LibraryPage } from './pages/LibraryPage';
+import { LoginPage } from './pages/LoginPage';
+import { RouterProvider } from './state/RouterProvider';
+import { ScopeProvider } from './state/ScopeProvider';
+
+type Collection = components['schemas']['Collection'];
+type LibraryDocument = components['schemas']['Document'];
+type DocumentVersion = components['schemas']['DocumentVersion'];
+
+const DEMO_EMAIL = 'demo@markhand.test';
+const DEMO_PASSWORD = 'demo-password';
+
+// `color-contrast` disabled everywhere in this file: see the module doc
+// above — jsdom cannot compute real painted colour, so this rule can only
+// ever produce false positives/negatives here, never a real signal.
+const AXE_OPTIONS: RunOptions = {
+  rules: { 'color-contrast': { enabled: false } },
+};
+
+function seedCollection(overrides: Partial<Collection> = {}): Collection {
+  const collection: Collection = {
+    id: nextId(),
+    name: 'Bộ sưu tập kiểm thử',
+    slug: 'test-collection',
+    description: null,
+    visibility: 'org',
+    createdAt: mockTimestamp(0),
+    ...overrides,
+  };
+  getStore().collections.push(collection);
+  return collection;
+}
+
+/** A document that already has a current version, so the preview panel actually renders content. */
+function seedDocumentWithVersion(
+  collectionId: string,
+  overrides: Partial<LibraryDocument> = {},
+): LibraryDocument {
+  const versionId = nextId();
+  const doc: LibraryDocument = {
+    id: nextId(),
+    collectionId,
+    title: 'Tài liệu.pdf',
+    state: 'indexed',
+    currentVersionId: versionId,
+    createdAt: mockTimestamp(0),
+    updatedAt: mockTimestamp(0),
+    ...overrides,
+  };
+  const docs = getStore().documents.get(collectionId) ?? [];
+  docs.push(doc);
+  getStore().documents.set(collectionId, docs);
+  const version: DocumentVersion = {
+    id: versionId,
+    documentId: doc.id,
+    versionNumber: 1,
+    isCurrent: true,
+    sourceContentSha256: 'a'.repeat(64),
+    effectiveFrom: mockTimestamp(0),
+    effectiveTo: null,
+    changeSummary: null,
+    createdAt: mockTimestamp(0),
+  };
+  getStore().versions.set(doc.id, [version]);
+  return doc;
+}
+
+async function loggedInClient(): Promise<ApiClient> {
+  const client = createApiClient({ baseUrl: '' });
+  await client.login({ email: DEMO_EMAIL, password: DEMO_PASSWORD });
+  return client;
+}
+
+/**
+ * Fails with every `critical`/`serious` violation's rule id and target
+ * selectors, so a real failure here is diagnosable from the test output
+ * alone rather than requiring a re-run with extra logging.
+ */
+async function expectNoSeriousViolations(container: Element): Promise<void> {
+  const results = await axe.run(container, AXE_OPTIONS);
+  const bad = results.violations.filter(
+    (violation) => violation.impact === 'critical' || violation.impact === 'serious',
+  );
+  if (bad.length > 0) {
+    const detail = bad
+      .map(
+        (violation) =>
+          `${violation.id} (${violation.impact}): ${violation.nodes
+            .map((node) => node.target.join(' '))
+            .join(', ')}`,
+      )
+      .join('\n');
+    throw new Error(`axe found ${bad.length} critical/serious violation(s):\n${detail}`);
+  }
+}
+
+describe('accessibility (axe-core, no critical/serious violations)', () => {
+  beforeEach(() => {
+    installMockFetch();
+    resetMockState();
+  });
+
+  afterEach(() => {
+    cleanup();
+    uninstallMockFetch();
+  });
+
+  it('the login page', async () => {
+    const { container } = render(<LoginPage />);
+    await expectNoSeriousViolations(container);
+  });
+
+  it('the library page with documents and a selected document', async () => {
+    const collection = seedCollection();
+    seedDocumentWithVersion(collection.id, { title: 'Báo cáo tài chính.pdf' });
+    seedDocumentWithVersion(collection.id, { title: 'Hợp đồng.docx', state: 'converting' });
+    const client = await loggedInClient();
+
+    const { container } = render(
+      <RouterProvider>
+        <ScopeProvider>
+          <LibraryPage collectionId={collection.id} client={client} />
+        </ScopeProvider>
+      </RouterProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Báo cáo tài chính\.pdf/ }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { level: 2, name: 'Báo cáo tài chính.pdf' }),
+      ).toBeVisible(),
+    );
+
+    await expectNoSeriousViolations(container);
+  });
+
+  it('an open modal (delete confirmation)', async () => {
+    const collection = seedCollection();
+    seedDocumentWithVersion(collection.id, { title: 'Sẽ bị xóa.pdf' });
+    const client = await loggedInClient();
+
+    const { container } = render(
+      <RouterProvider>
+        <ScopeProvider>
+          <LibraryPage collectionId={collection.id} client={client} />
+        </ScopeProvider>
+      </RouterProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Sẽ bị xóa\.pdf/ }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Xóa' }));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeVisible());
+
+    await expectNoSeriousViolations(container);
+  });
+});

--- a/web/src/components/ui.test.tsx
+++ b/web/src/components/ui.test.tsx
@@ -78,6 +78,34 @@ describe('SelectControl', () => {
     fireEvent.click(screen.getByRole('option', { name: /Chủ sở hữu/ }));
     expect(trigger).toHaveTextContent('Chủ sở hữu');
   });
+
+  // P2-14 (plans/markhand-web/phase-2-web-spa.md §P2.7): "keyboard-operable
+  // … search" — this is the status filter's underlying widget
+  // (DocumentFilters.tsx). Nothing in this suite previously drove it by
+  // keyboard at all (the only test above is mouse-only), so the component's
+  // own hand-rolled ArrowDown/Enter/Escape handling (`handleKeyDown` in
+  // ui.tsx) had no regression coverage.
+  it('opens with ArrowDown, moves with arrow keys, selects with Enter, and Escape closes without changing the value', () => {
+    render(<ControlledSelect />);
+    const trigger = screen.getByRole('combobox', { name: 'Vai trò' });
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(trigger, { key: 'ArrowUp' });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(trigger).toHaveTextContent('Chủ sở hữu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.keyDown(trigger, { key: 'Escape' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    // Escape only closes the popup; it must not also change the value.
+    expect(trigger).toHaveTextContent('Chủ sở hữu');
+  });
 });
 
 describe('Modal', () => {
@@ -89,8 +117,49 @@ describe('Modal', () => {
       </Modal>,
     );
     expect(screen.getByRole('dialog', { name: 'Xoá tài liệu' })).toBeVisible();
+    // The title above already claimed this ("focuses the first focusable
+    // element…") but nothing below it ever checked `activeElement` — P2-14
+    // (plans/markhand-web/phase-2-web-spa.md §P2.7, "focus sau … modal
+    // open/close") needs that actually proven, not just asserted in prose.
+    //
+    // The actually-first focusable element in DOM order is the header's own
+    // close (Đóng) icon-button — it renders before `children` inside
+    // `.dialog-header` (see ui.tsx's Modal markup) — not whatever the caller
+    // passed as body content. Documented here as the real, observed
+    // behaviour rather than assumed: useFocusTrap's querySelector runs in
+    // document order and has no special case for "past the header".
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Đóng' }));
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('restores focus to the triggering element once the modal unmounts', () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Mở hộp thoại
+          </button>
+          {open && (
+            <Modal title="Xoá tài liệu" onClose={() => setOpen(false)}>
+              <button type="button">Xác nhận</button>
+            </Modal>
+          )}
+        </>
+      );
+    }
+    render(<Harness />);
+    const trigger = screen.getByRole('button', { name: 'Mở hộp thoại' });
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    fireEvent.click(trigger);
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Đóng' }));
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(trigger);
   });
 
   it('closes when the backdrop is clicked but not when the panel is clicked', () => {

--- a/web/src/components/upload/UploadItemRow.tsx
+++ b/web/src/components/upload/UploadItemRow.tsx
@@ -223,6 +223,23 @@ export function UploadItemRow({
 
         {phase.kind === 'tracking' && (
           <span className="upload-item-status" role="status">
+            {/* Job progress has no percentage the server reports (`Job.status`
+                is an enum, not a number — see jobLifecycle.ts's module doc),
+                so this is a `progressbar` in the same indeterminate shape
+                already used above for a non-computable upload length, never
+                a fabricated aria-valuenow. Rendered only while the job is
+                still running: once conversionPhase is terminal
+                (converted/failed) there is nothing left to show progress
+                on. */}
+            {!jobTerminal && (
+              <span
+                className="upload-progress-track upload-progress-track--indeterminate"
+                role="progressbar"
+                aria-label={`Đang xử lý ${file.name}`}
+              >
+                <span className="upload-progress-value upload-progress-value--indeterminate" />
+              </span>
+            )}
             {conversionPhase
               ? conversionLabel(conversionPhase)
               : 'Đã tải lên — đang xác nhận tác vụ xử lý…'}

--- a/web/src/components/upload/UploadPanel.test.tsx
+++ b/web/src/components/upload/UploadPanel.test.tsx
@@ -193,6 +193,24 @@ describe('UploadPanel', () => {
     expect(screen.getByLabelText('Chọn tệp để tải lên')).toBeInTheDocument();
   });
 
+  // P2-14 (plans/markhand-web/phase-2-web-spa.md §P2.7): "keyboard-operable
+  // upload". The real file input is visually hidden (`.upload-dropzone-input`
+  // in styles.css: opacity 0 + 1x1px, not `display:none`/`visibility:hidden`
+  // — see that rule's own comment for why), which only actually keeps it
+  // keyboard-reachable if it stays out of `display:none`/`tabindex="-1"`.
+  // This asserts the reachability, not just the visual-hiding technique in
+  // the stylesheet: a real Tab would land here and Enter/Space is native
+  // `<input type="file">` behaviour the browser supplies for free once
+  // focus lands, which jsdom does not simulate opening a file dialog for.
+  it('keeps the file input keyboard-reachable despite being visually hidden', () => {
+    renderPanel(createScopeManager());
+    const input = screen.getByLabelText('Chọn tệp để tải lên');
+    expect(input).not.toHaveAttribute('tabindex', '-1');
+    expect(input).not.toBeDisabled();
+    input.focus();
+    expect(document.activeElement).toBe(input);
+  });
+
   it('sends the file and collectionId as multipart form data on selection', async () => {
     renderPanel(createScopeManager());
     const xhr = selectFile('report.pdf');
@@ -343,6 +361,62 @@ describe('UploadPanel', () => {
     await waitFor(() =>
       expect(screen.getByText(/hệ thống đang hoàn thiện lập chỉ mục/)).toBeVisible(),
     );
+  });
+
+  // P2-14 (plans/markhand-web/phase-2-web-spa.md §P2.7): a `progressbar` for
+  // the job, not just the upload — the job has no percentage the server
+  // reports (`Job` has only a `status` enum, no numeric progress field; see
+  // `jobLifecycle.ts`'s module doc), so this is deliberately the same
+  // indeterminate shape already used for a non-computable upload length,
+  // never a fabricated percentage.
+  it('shows an indeterminate progressbar while a job is tracked, and none once it reaches a terminal state', async () => {
+    const manager = createScopeManager();
+    manager.setScope(scope('org-a'));
+    const sources: ReturnType<typeof fakeSseSource<SseMessage>>[] = [];
+    vi.mocked(createJobEventsSource).mockImplementation(() => {
+      const fake = fakeSseSource<SseMessage>();
+      sources.push(fake);
+      return fake.source;
+    });
+
+    renderPanel(manager);
+    const xhr = selectFile();
+    await flush();
+
+    getStore().jobs.set(JOB_ID, {
+      id: JOB_ID,
+      jobType: 'convert',
+      status: 'running',
+      attempts: 1,
+      documentId: DOC_ID,
+      versionId: VERSION_ID,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      finishedAt: null,
+    });
+    xhr.respond(201, { disposition: 'accepted', documentId: DOC_ID, jobId: JOB_ID });
+    await flush();
+
+    await waitFor(() => expect(screen.getByRole('progressbar')).toBeVisible());
+    expect(screen.getByRole('progressbar')).not.toHaveAttribute('aria-valuenow');
+
+    getStore().jobs.set(JOB_ID, {
+      id: JOB_ID,
+      jobType: 'convert',
+      status: 'succeeded',
+      attempts: 1,
+      documentId: DOC_ID,
+      versionId: VERSION_ID,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+    });
+    act(() => sources[0].push(fakeJobEnvelope()));
+
+    await waitFor(() =>
+      expect(screen.getByText(/hệ thống đang hoàn thiện lập chỉ mục/)).toBeVisible(),
+    );
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('a job.failed transition is shown as a conversion failure, distinct from an upload failure', async () => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1380,7 +1380,15 @@ textarea.input {
 }
 
 .upload-item-meta {
-  color: color-mix(in srgb, var(--color-text) 55%, transparent);
+  /* contrast: this shipped at 55% (copy-pasted from the same spec value
+     .text-muted already measured and rejected far above) — 3.45:1 on
+     --color-surface (this row's background), under WCAG AA's 4.5:1 for
+     12px text. Switched to the same 68% formula as every other muted-text
+     rule in this file (5.01:1 on --color-surface). Found by grepping this
+     file for `color-mix(in srgb, var(--color-text)` and diffing every
+     percentage against the documented-safe 68%, not by assuming this rule
+     matched its neighbors. */
+  color: color-mix(in srgb, var(--color-text) 68%, transparent);
   font-size: 12px;
 }
 


### PR DESCRIPTION
## Outcome

Two of the three remaining Phase 2 items. The SPA is accessible enough to pass an automated audit on its real rendered states, and `fileconv-server` can serve the built bundle without ever letting a UI fallback answer for an API path.

## Scope

- `b761bab` **P2-14** — accessibility and interaction.
- `91d7bf2` **P2-16** — production build and SPA static serving.

P2-15 (Playwright E2E) is the only Phase 2 item left that is not blocked on something else; it was deliberately held until now because it asserts on markup P2-14 was changing and wants the packaged server P2-16 builds.

### P2-14

Four of the six §P2.7 requirements were already satisfied by earlier waves and were left alone rather than re-solved: skip link, landmarks, the upload progressbar, reduced-motion. What was actually missing:

- **Focus after route change.** Nothing moved focus on navigation, so activating a rail link left focus on the control while the page changed underneath — the new page was never announced and Tab continued from the rail.
- **Modal focus was correct but unproven** — the existing test was named "focuses the first focusable element" and never asserted `activeElement`. Writing that assertion corrected an assumption: the first focusable element is the Modal's own close button, which renders before `children`.
- **A progressbar for the job phase.** `Job.status` is an enum with no percentage, so this is indeterminate rather than a fabricated `aria-valuenow`.
- **`axe-core`** now runs against login, the library with a selected document, and an open modal. `color-contrast` is disabled at each call site because jsdom has no layout or paint — that rule can only produce noise there, and contrast remains a hand-measured concern.

One real contrast defect found by grepping every `color-mix` on `--color-text` and diffing against the documented-safe 68%: `.upload-item-meta` shipped at 55% (3.45:1 on the row's surface, under AA for 12px text). Now 68% (5.01:1).

**Not done:** keyboard operability of "ask". `QaPage` is a placeholder with no interactive controls — there is nothing to make operable until P2-10 builds it.

### P2-16

Serving is optional and that is load-bearing: with no `web/dist` the server boots and serves the API exactly as before, which `cargo test`, CI and `cargo run` all rely on.

The history fallback is the router's global fallback, so it is reached by every unmatched path including a typo'd `/api/v1/*`. It refuses to answer for anything under `/api/` or `/metrics` before doing anything else.

**A review fix worth reading:** the header and cache-control tests were tautologies — each asserted a response header against the very `const` that produced it, so both sides moved together. Swapping `HTML_CACHE_CONTROL` to the immutable value left the whole suite green, and a CSP weakened with `unsafe-inline` would have too. Expected values are now literals in the test module and both mutations turn them red. §P2.9's "HTML revalidates, hashed assets immutable" is gated now rather than merely stated.

Also corrected: a comment claimed the middleware stack applies "uniformly to the whole app, static assets included". It does not, and that is desirable — `baseline_ip_rate_limit` returns early outside `/api/v1/` and `is_write_gate_exempt` is true for the same set, so an SPA page load pulling a dozen assets cannot burn the caller's API rate-limit budget.

## Evidence

- [x] Tests: `pnpm --dir web format:check lint test build` — 37 files, 413 tests passed; lint 0 errors (5 pre-existing warnings, none added). `cargo fmt --all -- --check` clean; `cargo clippy --no-deps -p fileconv-knowledge -p fileconv-server --all-targets -- -D warnings` clean; `cargo test -p fileconv-server` — 28 test binaries green, including the new `spa_static_serving` pair.
- [x] Manual/benchmark/migration evidence: N/A — no benchmark or migration change. Every guarantee is mutation-checked (behaviour broken, test confirmed red, restored):
  - Greedy fallback (drop the `/api/` guard) → the API-404 and metrics tests go red.
  - `HTML_CACHE_CONTROL` swapped to the immutable value → red (this is the mutation that was **green** before the tautology fix).
  - CSP weakened with `unsafe-inline` → red on both the shell and the asset test.
  - Route-change focus call removed → red.
  - `htmlFor` dropped from the login email label → axe reports a critical `label` violation, so the new suite can actually fail rather than being green by construction.

**Not verified, stated rather than implied:** `scripts/check-rust-lint-baseline.py` exits 101 in the dev environment because it builds the whole workspace and the Tauri desktop crate needs GTK dev libraries (`gdk-3.0.pc`) that are not installed. The failure is in `gdk-sys`, predates this change, and cannot be caused by it — this touches `crates/server` only — but that gate was not run locally. CI runs it.

## Boundary and security review

- [x] Dependency boundary check passed. `tower-http` (`fs`, `set-header`) pinned to 0.6.11, the version already resolved transitively via reqwest; `tower` promoted from dev- to normal dependency since production code now needs `ServiceBuilder`. `axe-core` is a devDependency only and cannot reach the bundle.
- [x] Tenant/ACL impact reviewed, or N/A — N/A. No change to auth, scope resolution or any tenant-scoped query. Static serving is unauthenticated by design and exposes only the built client bundle.
- [x] Sensitive logging/secret/egress impact reviewed. The one egress consideration is the CSP, below.
- [x] Security review trigger checked. This adds a public unauthenticated surface, so the header set is the control: strict CSP, `X-Frame-Options: DENY`, `nosniff`, `strict-origin-when-cross-origin`, applied to both the shell and static assets, and now actually gated by tests.

**Decision I am handing back rather than making quietly:** the CSP allows `fonts.googleapis.com` and `fonts.gstatic.com`, because `web/src/styles.css` loads Caprasimo/Figtree via a CSS `@import`. That is the single cross-origin allowance in an otherwise `'self'`-only policy. The narrower alternative is self-hosting those two families under `web/dist` and dropping the allowance — a `web/src` change that was out of scope here. Say the word and I will do it.

HSTS is intentionally **not** set by the application: it is a TLS-terminator concern and the app cannot know whether the edge terminates HTTPS.

## Follow-up

- [ ] Docs, ADR, OpenAPI, roadmap or runbook updated where required — **done where it applies**: `deploy/README.md` and `crates/server/README.md` document the serving contract, the `MARKHAND_WEB_DIST_DIR` override, and the fact that `deploy/Dockerfile.server` / `compose.poc.yml` do **not** yet build `web/dist` into the API image. Adding a Node/pnpm stage to a digest-pinned image pipeline (`poc/images.lock.json`, F02 gate) is a separate decision this change deliberately did not make unasked. No OpenAPI change — the route inventory and two-way parity check are untouched, since the SPA routes sit outside `/api/v1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1aW1B4YfpWERwjsVVficE)_