### PR TITLE
docs: update Phase 2 milestone status to reflect shipped work

### DIFF
--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -4,7 +4,21 @@ Parent plan: [`../../../phase-2-web-spa.md`](../../../phase-2-web-spa.md)
 
 <!-- roadmap-default-status: backlog -->
 
-Issue ở **Backlog**. UI/mock có thể chạy sau OpenAPI 1B; final gate phụ thuộc Phase 1C.
+**Trạng thái tổng quan (cập nhật 2026-07-27).** MVP xây trên mock server đã xong và
+đã merge vào `master`: 11/16 issue **Done** (P2-01…09, P2-13, P2-14, P2-16 phần build
++ serve). Ba issue **Blocked** vì thiếu API backend, không phải vì UI: P2-10 (Q&A) chờ
+R02/R03/R05; P2-11 (member/role) và P2-12 (usage/quota) chờ Phase 1C. Một issue
+**Ready** chưa bắt đầu: P2-15 (E2E). Xem `**Status:**` từng issue bên dưới.
+
+> Ranh giới quan trọng: "Done" ở đây nghĩa là **hành vi client đã build và test trên
+> mock/deterministic**, đã qua CI (`web`, `rust`, `rust-integration`) trên `master`.
+> **Exit gate của cả Phase 2 vẫn CHƯA đạt** — nó đòi E2E trên backend deploy thật + gate
+> denial/security của Phase 1C (xem mục "Exit gate" cuối trang). Mock E2E không thay
+> integration.
+
+Truy vết merge: **#311** (P2-01…06 — foundations, client, SSE, mock, login, org switch),
+**#312** (P2-07…09 — library, upload, actions), **#313** (P2-14, P2-16 — a11y, serve SPA).
+P2-13 đi cùng wave 0 (#311); phần CSP/header của nó thực tế landed ở P2-16 (#313).
 
 ## Dependency
 
@@ -22,12 +36,16 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-01 — React/Vite workspace và UI foundations
 
+- **Status:** Done — #311. Web workspace, no Tauri import, CI job `web` xanh.
+
 - **Plan/files:** Tạo `web/` scripts/layout; copy browser-safe tokens/icons/primitives.
 - **Depends:** Không. **Acceptance/tests:** Build/test độc lập; no Tauri import;
   typecheck/lint/unit/dependency-boundary; desktop vẫn xanh.
 - **Security:** Dependency/license scan. **Out:** shared package/redesign desktop.
 
 ## P2-02 — OpenAPI contracts và mock server
+
+- **Status:** Done — #311. Generated types + `pnpm api:check` drift gate; mock server sinh từ OpenAPI.
 
 - **Plan/files:** Pin generator; generated types; drift check; auth/org/library/job/
   Q&A/admin/error/SSE fixtures và mock scenarios.
@@ -39,6 +57,8 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-03 — Typed HTTP client/session refresh
 
+- **Status:** Done — #311. Refresh single-flight; ADR 0010 rotation; concurrent-401/revoke tests.
+
 - **Plan/files:** Fetch wrapper, access token memory, refresh single-flight, one retry,
   normalized errors/request ID/quota, abort.
 - **Depends:** P2-02. **Acceptance/tests:** Concurrent 401 một refresh; revoked refresh
@@ -47,6 +67,8 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-04 — Fetch-based SSE transport
 
+- **Status:** Done — #311. Fetch-based (không EventSource), Last-Event-ID, reconnect/backoff, abort-on-scope.
+
 - **Plan/files:** Streaming parser với bearer, Last-Event-ID, dedupe/gap, refresh/
   reconnect/backoff/snapshot, abort on scope change.
 - **Depends:** P2-02/03. **Acceptance/tests:** Không native EventSource/token URL;
@@ -54,6 +76,8 @@ P2-15 + Phase 1C gate → P2-16
 - **Security:** Bounded buffer/backoff, no content logs. **Out:** WebSocket.
 
 ## P2-05 — Login/session/application shell
+
+- **Status:** Done — #311. Bearer refresh trong memory (không cookie/CSRF); router + guard matrix.
 
 - **Plan/files:** Router, auth bootstrap/login/protected shell/guards/logout/help stub.
 - **Depends:** P2-01/03 + P1B-F05 browser refresh contract. **Acceptance/tests:**
@@ -65,6 +89,8 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-06 — Org switch và scope-safe state
 
+- **Status:** Done — #311. Scope epoch; `useScopeSafeRequest`/`useScopeSafeSse` bỏ response scope cũ.
+
 - **Plan/files:** Org-scoped cache keys; atomic switch; abort REST/SSE; clear stores;
   scope generation ignores late response.
 - **Depends:** P2-03…05 + backend 1C org APIs. **Acceptance/tests:** No old-org render;
@@ -72,6 +98,8 @@ P2-15 + Phase 1C gate → P2-16
 - **Security:** No unapproved persisted tenant cache. **Out:** simultaneous org view.
 
 ## P2-07 — Library/list/sanitized preview
+
+- **Status:** Done — #312. Collection nav, filter + cursor pagination thật, preview qua SafeMarkdown. Không có endpoint cross-collection nên "tất cả bộ sưu tập" chỉ điều hướng.
 
 - **Plan/files:** Adapt browser-safe LibraryView; collection navigation, filter/page,
   status, preview states + SafeMarkdown; unresolved conflict badge/count, side-by-side
@@ -82,6 +110,8 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-08 — Upload progress và job lifecycle
 
+- **Status:** Done — #312. XHR progress thật, job SSE-nudge → `GET /jobs/{id}`. Không quan sát được stage index (API chỉ trả convert job id) — báo "converted, indexing tiếp server-side".
+
 - **Plan/files:** Multipart/progress/cancel; job SSE; reconnect snapshot; accessible
   status for uploaded→indexed/failed.
 - **Depends:** P2-04/07. **Acceptance/tests:** Client/server progress distinct; recover
@@ -90,12 +120,16 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-09 — Download/delete/reindex/retry
 
+- **Status:** Done — #312. Capability issue+redeem, delete tombstone có confirm. Không có endpoint retry-convert nên "thử lại" = reindex (ghi rõ trong UI).
+
 - **Plan/files:** Authorized actions, permission/confirm/conflict/idempotency handling.
 - **Depends:** P2-07/08 + backend 1C guards. **Acceptance/tests:** Delete closes preview;
   server deny wins; confirm/concurrency/stale/signed-route tests.
 - **Security:** No client-built object URLs; CSRF/idempotency. **Out:** purge policy.
 
 ## P2-10 — Streaming search/Q&A/citations
+
+- **Status:** Blocked — chờ backend R02/R03/R05 (semantics `citation_revoked` khi xóa xen giữa 2 batch, reconnect/Last-Event-ID/purge, entailment fail-closed). UI chưa khóa để tránh làm trên hành vi server chưa chốt. `QaPage` hiện là placeholder.
 
 - **Plan/files:** Search/ask panel, current/as-of/compare/history selector, index
   readiness, stream reducer, fallback + version-change notes, citation deep-link with
@@ -109,6 +143,8 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-11 — Member/role admin
 
+- **Status:** Blocked — không có endpoint member/invite/role trong 32 route hiện tại (thuộc Phase 1C, R04 ghi "Out: admin membership API").
+
 - **Plan/files:** Member table/invite/suspend/role selector; owner restrictions from API.
 - **Depends:** P2-02/03/05 + backend 1C-02…04. **Acceptance/tests:** Owner/admin matrix,
   last-owner conflict, invite/suspend/role/403/409/stale-update tests.
@@ -116,12 +152,16 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-12 — Usage/quota/reservations
 
+- **Status:** Blocked — chỉ có quota metadata qua header; không có endpoint tổng hợp usage (chờ Phase 1C).
+
 - **Plan/files:** Usage cards, limits, active reservations/jobs, actionable 429.
 - **Depends:** P2-03/05 + backend 1C-09…11. **Acceptance/tests:** API numbers match;
   unit/timezone/403/429/stale tests.
 - **Security:** No client-derived authority/cross-org usage. **Out:** billing.
 
 ## P2-13 — Browser/SafeMarkdown hardening
+
+- **Status:** Done — SafeMarkdown + sanitize allowlist + content bound ở #311; CSP/frame/nosniff/referrer landed cùng P2-16 (#313). HSTS để cho reverse proxy (không set ở app).
 
 - **Plan/files:** CSP-compatible app, protocol allowlist, raw HTML/SVG/data URL denial,
   content bounds, header checks.
@@ -131,12 +171,16 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-14 — Accessibility/interaction quality
 
+- **Status:** Done — #313. axe không critical/serious (login/library/modal), focus-sau-route-change, progressbar job. Keyboard cho "ask" chưa làm được vì P2-10 chưa tồn tại.
+
 - **Plan/files:** Skip/landmark/focus/keyboard/progress labels/contrast/reduced motion.
 - **Depends:** P2-05/07…12. **Acceptance/tests:** No axe critical; keyboard primary
   flows; focus/reduced-motion/screen reader tests.
 - **Security:** Error không đọc internal/token. **Out:** formal certification/i18n.
 
 ## P2-15 — Contract/integration/E2E suite
+
+- **Status:** Ready — chưa bắt đầu. Unit/component đã có (405 test). Playwright full-flow chờ làm; phần E2E trên deploy thật cần endpoint Phase 1C.
 
 - **Plan/files:** Unit API/SSE/cache; component auth/library/Q&A/admin; Playwright full
   flows, org switch, deny/quota; CI artifacts redacted.
@@ -146,6 +190,8 @@ P2-15 + Phase 1C gate → P2-16
 - **Security:** Ephemeral users/credentials. **Out:** thay backend denial suite.
 
 ## P2-16 — Production build/static serving/final gate
+
+- **Status:** In progress — build + static serving + packaged-server test đã landed (#313: history fallback không nuốt /api/*, cache immutable vs no-cache, security headers, tất cả mutation-checked). **Final gate CHƯA đạt**: E2E deploy thật + SLO + scan + gate Phase 1C-12/13 còn lại; Dockerfile.server chưa copy web/dist (quyết định ADR riêng, xem deploy/README.md).
 
 - **Plan/files:** Hashed Vite assets; server/image dist; UI-only history fallback;
   API 404; HTML revalidate, immutable assets, headers.

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "9999d3f0928c2103";
+    const ROADMAP_SOURCE_HASH = "c595b9dfef5eac22";
     const phases = [
       {
         "id": "phase-f",
@@ -1327,82 +1327,82 @@
           [
             "P2-01",
             "React/Vite workspace và UI foundations",
-            "backlog"
+            "done"
           ],
           [
             "P2-02",
             "OpenAPI contracts và mock server",
-            "backlog"
+            "done"
           ],
           [
             "P2-03",
             "Typed HTTP client/session refresh",
-            "backlog"
+            "done"
           ],
           [
             "P2-04",
             "Fetch-based SSE transport",
-            "backlog"
+            "done"
           ],
           [
             "P2-05",
             "Login/session/application shell",
-            "backlog"
+            "done"
           ],
           [
             "P2-06",
             "Org switch và scope-safe state",
-            "backlog"
+            "done"
           ],
           [
             "P2-07",
             "Library/list/sanitized preview",
-            "backlog"
+            "done"
           ],
           [
             "P2-08",
             "Upload progress và job lifecycle",
-            "backlog"
+            "done"
           ],
           [
             "P2-09",
             "Download/delete/reindex/retry",
-            "backlog"
+            "done"
           ],
           [
             "P2-10",
             "Streaming search/Q&A/citations",
-            "backlog"
+            "blocked"
           ],
           [
             "P2-11",
             "Member/role admin",
-            "backlog"
+            "blocked"
           ],
           [
             "P2-12",
             "Usage/quota/reservations",
-            "backlog"
+            "blocked"
           ],
           [
             "P2-13",
             "Browser/SafeMarkdown hardening",
-            "backlog"
+            "done"
           ],
           [
             "P2-14",
             "Accessibility/interaction quality",
-            "backlog"
+            "done"
           ],
           [
             "P2-15",
             "Contract/integration/E2E suite",
-            "backlog"
+            "ready"
           ],
           [
             "P2-16",
             "Production build/static serving/final gate",
-            "backlog"
+            "in_progress"
           ]
         ]
       },

--- a/plans/reports/plan-260726-2320-markhand-web-phase2-execution.md
+++ b/plans/reports/plan-260726-2320-markhand-web-phase2-execution.md
@@ -7,6 +7,15 @@ Base commit: `7b0a85e` (branch `claude/pull-master-large-pr-eg39zh`, PR #310)
 Tài liệu này là **thứ tự làm**, dựa trên trạng thái code đo được hôm nay, và nêu hai
 thứ chặn thật mà bản plan gốc không thể biết trước.
 
+> **Cập nhật kết quả (2026-07-27).** Kế hoạch này đã thực thi xong phần không bị chặn.
+> Đã merge vào `master`: **#311** (Wave 0+1: P2-01…06), **#312** (Wave 2: P2-07…09),
+> **#313** (Wave 5 phần làm được: P2-14 a11y, P2-16 build+serve SPA). B1 (schema
+> OpenAPI) đã lấp và có parity check mức schema. Còn lại: **P2-15** (E2E — Ready, chưa
+> bắt đầu), và Wave 3–4 vẫn **Blocked** đúng như mục 2/4 dưới đây dự báo — P2-10 chờ
+> R02/R03/R05, P2-11/P2-12 chờ Phase 1C (quyết định B2 chưa chốt). **Exit gate Phase 2
+> chưa đạt** (cần E2E deploy thật + gate Phase 1C). Trạng thái chi tiết từng issue:
+> [`../markhand-web/backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md).
+
 ## 1. Điều kiện vào — đã đạt
 
 | Hạng mục | Trạng thái đo được |


### PR DESCRIPTION
## Outcome

The Phase 2 (Web SPA) milestone tracker now reflects what actually shipped. The issue catalog previously read as all-backlog even though the MVP-on-mock is merged to master across #311, #312 and #313.

## Scope

Docs only — no code change.

- `plans/markhand-web/backlog/phase-2/issues/README.md` — a per-issue `**Status:**` line for all 16 issues, plus an overview and merge trace.
- `plans/markhand-web/roadmap.html` — regenerated from the catalog by `scripts/build-roadmap.py`.
- `plans/reports/plan-260726-2320-markhand-web-phase2-execution.md` — an outcome note so it no longer reads as purely forward-looking.

Phase 2 now shows **11 Done · 1 In progress · 1 Ready · 3 Blocked**.

Marked honestly rather than optimistically:

- **11 Done** (P2-01…09, P2-13, P2-14) — client behaviour built and tested on the mock/deterministic harness, green in CI on master.
- **P2-16 In progress, not Done** — build + static serving + the packaged-server test landed (#313), but the phase's final gate (real-deploy E2E, SLO, Phase 1C denial) is not met.
- **P2-10 / P2-11 / P2-12 Blocked on backend, not on UI** — Q&A needs R02/R03/R05; member and usage admin need Phase 1C APIs that do not exist yet.
- **P2-15 Ready**, not started.
- The whole-phase exit gate is explicitly recorded as **not met**: mock E2E does not substitute for integration on a real deployment plus the Phase 1C gate.

## Evidence

- [x] Tests: `python3 scripts/build-roadmap.py --check` passes — 113 issues, roadmap consistent with the catalogs (Phase 2: ready 1, blocked 3, in_progress incl. P2-16, done incl. P2-01…09/13/14).
- [x] Manual/benchmark/migration evidence: N/A — documentation only, no code, no schema, no benchmark.

## Boundary and security review

- [x] Dependency boundary check passed — N/A, no dependency change.
- [x] Tenant/ACL impact reviewed, or N/A — N/A, docs only.
- [x] Sensitive logging/secret/egress impact reviewed, or N/A — N/A; the catalog references PR numbers and issue ids only, no secrets or internal hostnames.
- [x] Security review trigger checked — none; no runtime surface touched.

## Follow-up

- [ ] Docs, ADR, OpenAPI, roadmap or runbook updated where required — this PR **is** that update. The roadmap dashboard is regenerated, not hand-edited, so it stays derivable from the catalog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1aW1B4YfpWERwjsVVficE)_