### PR TITLE
docs: audit Phase 1C status against the codebase (0/13 → 11 in-progress, 2 backlog)

### DIFF
--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -4,7 +4,26 @@ Parent plan: [`../../../phase-1c-multi-org-security.md`](../../../phase-1c-multi
 
 <!-- roadmap-default-status: backlog -->
 
-Mọi issue ở trạng thái **Backlog**, activate sau Phase 1B gate.
+**Audit 2026-07-27 (đọc code, không đoán).** Con số cũ "0/13" gây hiểu nhầm: phần lớn
+**nền tảng thực thi 1C đã được xây sẵn trong Phase 1B** (RLS FORCE, ACL predicate ở
+retrieval, Qdrant mandatory filter, quota atomic, rate-limit, audit append-only) — nhưng
+**chưa issue nào đạt full acceptance**, nên không tick Done cái nào. Kết quả audit:
+
+- **11 In progress** — có building block thật + có test, nhưng thiếu phần định nghĩa 1C.
+- **2 Backlog** — chỉ có schema/prose, logic chính chưa viết: **1C-02** (invite/last-owner)
+  và **1C-13** (security/load gate).
+- **0 Done.**
+
+> **Hai ranh giới quan trọng, áp cho MỌI issue dưới đây:**
+> 1. **Test enforcement gần như toàn bộ là `#[ignore]` DB-gated** — chỉ chạy trong job CI
+>    `rust-integration` khi có `MARKHAND_TEST_DATABASE_URL`/MinIO/Qdrant, KHÔNG chạy trong
+>    `cargo test` mặc định. Fast-unit chỉ phủ logic thuần (scope resolve, filter, HMAC).
+> 2. **`context.rs:11-12` tự ghi "full ACL resolution belongs to Phase 1C"** — substrate
+>    hiện tại xây cho single-org POC (1B), chưa phải multi-org đầy đủ.
+>
+> **Exit gate Phase 1C (1C-12 + 1C-13) CHƯA đạt** — cả hai deliverable "suite gắn kết" và
+> "gate có report" đều chưa tồn tại như deliverable. Và Phase 1C chỉ activate sau khi
+> **Phase 1B gate đóng** (R04/R06 còn pending), nên toàn phase vẫn là công việc phía trước.
 
 ## Dependency
 
@@ -17,6 +36,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-01 — Organization lifecycle và validated context
 
+- **Status:** In progress — nửa *validated-context* đã có + test DB-gated: resolver `auth/permissions.rs:39`, membership re-verify (JWT chỉ là hint) `auth/middleware.rs:144`, fail-closed `auth/context.rs:30`, RLS `migrations/0002`. **Thiếu nửa lifecycle**: không có endpoint org create/list/detail/switch, không xử lý org-header (org lấy từ JWT claim), chưa có two-org resolver test.
+
 - **Plan/files:** Org create/list/detail/switch, service/repo/middleware; issue new
   context/session after verified membership.
 - **Depends:** Phase 1B auth/schema. **Acceptance/tests:** Chỉ thấy org của mình;
@@ -24,6 +45,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 - **Security/migration:** Không global org state; audit switch. **Out:** billing/OIDC.
 
 ## 1C-02 — Membership, invites và last-owner invariant
+
+- **Status:** Backlog — chỉ có **schema** (`org_invites` hashed single-use `migrations/0003:93`, `org_memberships` `0001:26`). KHÔNG có service/route invite (create/accept/revoke/expiry), KHÔNG có last-owner invariant (grep rỗng), không có membership state/version, `member.manage` seed nhưng chưa dùng. Session-family revoke có (`auth/session.rs:862`) nhưng thuộc auth 1B.
 
 - **Plan/files:** Hashed single-use invite; membership state; transactional last-owner;
   membership version; session revoke. MVP chưa có mail dùng invite URL/token hiển thị
@@ -36,6 +59,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-03 — Canonical RBAC seed
 
+- **Status:** In progress — bảng `permissions/roles/role_permissions` + seed 4 role owner/admin/editor/viewer + matrix (`migrations/0011:38`, `is_system=true`), idempotent (`tests/schema_migrations.rs` DB-gated). **Thiếu**: seed POC-only gắn 1 org hardcode (không seed cho org mới), không trigger immutable system-role, không OpenAPI fixture, không test kiểm giá trị matrix.
+
 - **Plan/files:** Permission constants + DB seed owner/admin/editor/viewer; immutable
   system roles; OpenAPI fixture.
 - **Depends:** Phase 1B role schema. **Acceptance/tests:** Matrix đúng/idempotent,
@@ -43,6 +68,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 - **Security/migration:** Stable keys, expand/backfill. **Out:** custom role builder.
 
 ## 1C-04 — Route/service guards và service identities
+
+- **Status:** In progress — deny-by-default `require_permission` (`auth/permissions.rs:118`) áp ở **cả route lẫn service** (nhiều endpoint), DB role least-priv migrator/app (`migrations/0027/0028`), test unit + DB-gated (`citation_authz_matrix.rs:537`). **Thiếu**: guard ở tầng worker/reconcile (worker chạy với **permission rỗng** `bin/worker.rs:153`, chỉ có tenant scope), không có missing-guard inventory (ROUTE_INVENTORY chỉ là parity method/path), chưa phủ allow/deny cho doc.delete/publish/member.manage/audit.view/jobs.system.
 
 - **Plan/files:** Deny-by-default `authorize`; apply route+service+worker/reconcile;
   least-privilege identities.
@@ -52,6 +79,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-05 — Collection ACL resolver/cache
 
+- **Status:** In progress — resolver cơ bản (org/private/owner/`collection_user_access`) + fail-closed `services/retrieval/mod.rs:181` + test. **Thiếu đúng phần 1C**: grant theo `groups`/`role` chưa resolve (bảng có, không ai đọc), KHÔNG có ACL-version/snapshot, KHÔNG có cache, KHÔNG có invalidation API. `context.rs:11` tự ghi full ACL thuộc 1C.
+
 - **Plan/files:** Private/org/groups grants; ACL/version snapshot; cache key org/user/
   membership/ACL version; invalidation APIs.
 - **Depends:** 1C-02/03. **Acceptance/tests:** Semantics đúng, empty/error fail closed;
@@ -60,12 +89,16 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-06 — PostgreSQL ACL enforcement
 
+- **Status:** In progress — tenant+ACL predicate trên FTS/hydration/conflict-evidence (`db/search.rs:312/486`), list/count tenant-scoped, test DB-gated + fast. **Thiếu**: autocomplete (không tồn tại), nhánh FTS candidate chưa mang ACL subquery (dựa re-check ở hydration), count chưa có ACL predicate, không unit test missing-predicate riêng.
+
 - **Plan/files:** Tenant+ACL predicates cho list/count/autocomplete/FTS/hydration.
 - **Depends:** 1C-05. **Acceptance/tests:** Không path thiếu context; no existence/count
   leak; SQL join/subquery/missing-predicate tests.
 - **Security/migration:** PG authority, prepared queries. **Out:** vector/object path.
 
 ## 1C-07 — Qdrant/storage/jobs fail-closed enforcement
+
+- **Status:** In progress — Qdrant mandatory org+collection filter (`storage/qdrant.rs:897`), PG payload validation, download capability authorize+replay (`services/download.rs`), authorize preview/download/export/job/SSE, abort in-flight → `citation_revoked` (`services/qa/ask_stream.rs`); test tốt (fast + DB/MinIO/Qdrant-gated). **Thiếu**: vài fast-unit deny (forged/timeout Qdrant client); signed-URL không áp dụng — thay bằng capability token (theo thiết kế).
 
 - **Plan/files:** Mandatory org+non-empty collection filter; PG payload validation;
   authorize preview/download/export/job/SSE; abort in-flight on ACL change.
@@ -74,6 +107,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 - **Security/migration:** No signed URL logs. **Out:** public sharing/CDN.
 
 ## 1C-08 — RLS và pool defense
+
+- **Status:** In progress — FORCE RLS ~26 bảng (`migrations/0010`), app role không owner/không BYPASSRLS (`0027/0028`), GUC transaction-local `set_config('app.org_id',…,true)` (`db/pool.rs:94`), assert FORCE-RLS ở startup (`database.rs:309`), test pool-leak/cross-org/force-rls/deploy-role (DB-gated). **Thiếu**: pool reset/DISCARD/verify runtime lúc checkout, DB role riêng cho worker (worker dùng chung `markhand_app`).
 
 - **Plan/files:** Nếu ADR chọn: FORCE RLS, non-owner app role, transaction-local context,
   worker role, pool reset/verification.
@@ -84,6 +119,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-09 — Atomic quota lifecycle
 
+- **Status:** In progress — reserve/finalize/refund + reserve_upload hai-tài-nguyên atomic (`services/quota.rs`), idempotency theo key, expiry, sweeper **đã wire** vào background (`http.rs:367`), checked arithmetic, advisory lock; 11 test DB-gated + unit. **Thiếu**: token-quota lifecycle (`Tokens` định nghĩa nhưng `ask` không reserve), concurrent-jobs enforce ở prod (test-only), quota reconcile, test mới đạt 16 concurrent (acceptance đòi ≥100).
+
 - **Plan/files:** Reserve/finalize/refund, idempotency/expiry/sweeper/reconcile cho
   storage/token/jobs.
 - **Depends:** Phase 1B jobs + 1C-01. **Acceptance/tests:** 100 concurrent reservations
@@ -91,6 +128,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 - **Security/migration:** Checked arithmetic, org/resource unique key. **Out:** billing.
 
 ## 1C-10 — Rate limit và per-org fairness
+
+- **Status:** In progress — limiter per-IP/user/route (`middleware/rate_limit.rs`) + Retry-After header + metrics privacy-safe + worker type-fairness (`workers/index.rs:137`). **Thiếu đúng phần định nghĩa 1C-10**: **per-ORG fairness** (không có bucket per-org — key org chỉ là prefix per-user; không có scheduler/semaphore GPU per-org; worker chạy **1 org/tiến trình** `bin/worker.rs:151`), không có test noisy-neighbor/SLO, không có GPU scheduler.
 
 - **Plan/files:** User/IP/auth limits, per-org worker/GPU scheduler/semaphore, headers,
   privacy-safe metrics.
@@ -100,6 +139,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-11 — Audit/admin APIs
 
+- **Status:** In progress — `audit_log` append-only (trigger immutability `migrations/0026`) + writer co-commit trong txn mutation (`services/audit.rs:447`) + redaction forbidden-keys + test tốt (DB-gated + unit). **Nhưng nửa admin = 0**: KHÔNG có endpoint audit/member/role/usage nào (openapi grep rỗng), hàm đọc `db/audit.rs:11 list_recent` **chưa được gọi** và không phân trang/filter, không có code quản membership, không có audit action cho member/role/config, không có retention.
+
 - **Plan/files:** Member/role/ACL/config/quota/data/cloud events; read-only pagination/
   filter/retention; owner-only controls.
 - **Depends:** 1C-02…10. **Acceptance/tests:** Mọi mutation có actor/org/action/target/
@@ -107,6 +148,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
 - **Security/migration:** No document/prompt/token/PII/URL. **Out:** SIEM archive.
 
 ## 1C-12 — Multi-org denial suite
+
+- **Status:** In progress — có ~10 cross-org check **rải rác** (list/count, vector, jobs, SSE, worker, RLS/pool-leak, in-flight ACL revoke) đều `#[ignore]` DB-gated. **Deliverable "suite gắn kết" CHƯA có**: không có fixture 2-org/≥3-user/duplicate-name/groups/stale-token; các mặt **FTS, Q&A, preview/download, export, cache** CHƯA có test cross-org; chưa chạy trên deployed environment (acceptance đòi CI **và** deployed).
 
 - **Plan/files:** Fixture 2 org, ≥3 users, duplicate names, private/org/groups, stale
   token; phủ list/count/FTS/vector/Q&A/citation/preview/download/export/jobs/SSE/
@@ -117,6 +160,8 @@ ADR RLS ───────→ 1C-08 ─────────────�
   **Out:** external pentest.
 
 ## 1C-13 — Security/revoke/load gate
+
+- **Status:** Backlog — gate có tên **KHÔNG tồn tại**: không có 1C gate trong `bench/markhand_web/gates.yaml` (toàn `G0-*`, disposition `block-phase-1b`), không có 1C gate report trong `plans/reports/` (chỉ có report 1B), không có 1C CI job (chỉ `phase1b-o04-release-gate`). **Noisy-neighbor** và **supply-chain/container scan** chưa có gì (chỉ prose + 1 rủi ro mở `R-P0-10-SCALE-01` chưa đo).
 
 - **Plan/files:** Token/revoke/cache/Qdrant partial/reconcile/quota/noisy-neighbor/
   supply-chain suite + gate report.

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "c595b9dfef5eac22";
+    const ROADMAP_SOURCE_HASH = "8023502e0fe552df";
     const phases = [
       {
         "id": "phase-f",
@@ -1252,7 +1252,7 @@
           [
             "1C-01",
             "Organization lifecycle và validated context",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-02",
@@ -1262,52 +1262,52 @@
           [
             "1C-03",
             "Canonical RBAC seed",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-04",
             "Route/service guards và service identities",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-05",
             "Collection ACL resolver/cache",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-06",
             "PostgreSQL ACL enforcement",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-07",
             "Qdrant/storage/jobs fail-closed enforcement",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-08",
             "RLS và pool defense",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-09",
             "Atomic quota lifecycle",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-10",
             "Rate limit và per-org fairness",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-11",
             "Audit/admin APIs",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-12",
             "Multi-org denial suite",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-13",


### PR DESCRIPTION
## Outcome

The roadmap showed Phase 1C as **0/13**, which reads as "nothing done". That is misleading: a read-only audit of the code shows much of the 1C enforcement substrate was already built inside the Phase 1B POC. The catalog now carries a per-issue `**Status:**` grounded in `file:line` evidence, and the roadmap is regenerated from it.

**Result: 0 Done · 11 In progress · 2 Backlog.**

## Scope

Docs only — `plans/markhand-web/backlog/phase-1c/issues/README.md` (per-issue status + overview) and the regenerated `plans/markhand-web/roadmap.html`.

## How the audit was done

Four parallel read-only sweeps over `crates/server/src/`, `migrations/`, `tests/`, `openapi/openapi.yaml`, `bench/markhand_web/gates.yaml`, and `.github/workflows/ci.yml` — one per issue cluster. Each returned `file:line` evidence, the test-gating of every cited test, and an explicit NOT-FOUND list per unmet acceptance clause. I made the status calls myself for consistency; agents only gathered evidence.

## Two guardrails, stated once for all 13 issues

1. **Nearly every enforcement test is `#[ignore]` DB-gated** — it runs only in the `rust-integration` CI job with `MARKHAND_TEST_DATABASE_URL`/MinIO/Qdrant set, never in a default `cargo test`. Fast-unit coverage is limited to pure logic (scope resolution, filter clauses, HMAC).
2. **`auth/context.rs:11-12` itself defers full ACL to Phase 1C** — the substrate is single-org POC, not full multi-org.

## The honest split

**Nothing is Done** — every issue has unmet acceptance clauses.

**In progress** (real, tested building block exists; the 1C-defining part is missing):

| Issue | Built | Missing (the 1C part) |
|---|---|---|
| 1C-01 | validated context: resolver, membership re-verify, fail-closed, RLS | org create/list/detail/switch endpoints; org-header handling; two-org resolver test |
| 1C-03 | `permissions/roles/role_permissions` + 4-role seed + matrix, idempotent | seed is POC-org-bound; no immutable-role trigger; no OpenAPI fixture; no matrix test |
| 1C-04 | deny-by-default `require_permission` at route **and** service; least-priv DB roles | no guard at worker/reconcile layer (worker runs with empty permission set); no missing-guard inventory; allow/deny matrix incomplete |
| 1C-05 | basic resolver (org/private/owner/user-grant) + fail-closed | groups/role grants unresolved; no ACL-version/snapshot; no cache; no invalidation API |
| 1C-06 | tenant+ACL predicates on FTS/hydration/conflict-evidence; list/count tenant-scoped | autocomplete absent; FTS leg lacks inline ACL subquery; count lacks ACL predicate |
| 1C-07 | Qdrant mandatory org+collection filter; capability authorize+replay; preview/download/job/SSE authz; abort-in-flight (`citation_revoked`) | a few fast-unit deny tests; signed-URL N/A by design (capability tokens instead) |
| 1C-08 | FORCE RLS ~26 tables; non-owner app role; txn-local GUC; startup source assertion | runtime pool reset/DISCARD/verify; dedicated worker DB role |
| 1C-09 | reserve/finalize/refund + two-resource upload; idempotency; expiry; wired sweeper; checked arithmetic | token-quota lifecycle (never reserved in `ask`); concurrent-jobs enforcement in prod; quota reconcile; ≥100-concurrent test (currently 16) |
| 1C-10 | per-IP/user/route limiter; Retry-After; privacy-safe metrics; worker type-fairness | **per-ORG fairness** (the actual deliverable): no per-org bucket, no per-org scheduler/semaphore, worker is one-org-per-process; no noisy-neighbor SLO test |
| 1C-11 | `audit_log` append-only + co-commit writer + redaction, tested | admin/member API = **zero endpoints**; audit read fn uncalled/no pagination; no member-management code; no member/role/config audit actions; no retention |
| 1C-12 | ~10 scattered `#[ignore]` cross-org checks (list/count, vector, jobs, SSE, worker, RLS/pool, in-flight revoke) | the cohesive named suite + 2-org fixture; FTS / Q&A / preview-download / export / cache have no cross-org test; no deployed-env run |

**Backlog** (schema/prose only, defining logic unwritten):

- **1C-02** — `org_invites`/`org_memberships` table shapes exist, but no invite service/route, no last-owner invariant, no membership state/version.
- **1C-13** — the named security/load gate does not exist: no 1C gate in `gates.yaml`, no 1C gate report under `plans/reports/`, no 1C CI job (only `phase1b-o04-release-gate`); noisy-neighbor and supply-chain/container scan have zero implementation.

The phase exit gate (1C-12 + 1C-13) is explicitly recorded as **not met**.

## Evidence

- [x] Tests: `python3 scripts/build-roadmap.py --check` passes — 113 issues, roadmap consistent with the catalogs (Phase 1C: 11 in_progress, 2 backlog).
- [x] Manual/benchmark/migration evidence: N/A — documentation only; no code, schema, or benchmark change.

## Boundary and security review

- [x] Dependency boundary check passed — N/A, no dependency change.
- [x] Tenant/ACL impact reviewed, or N/A — N/A to runtime; this is a status audit of tenant/ACL code, changing no behaviour.
- [x] Sensitive logging/secret/egress impact reviewed, or N/A — N/A; the catalog cites file paths and line numbers, no secrets.
- [x] Security review trigger checked — none; no runtime surface touched. (The audit itself surfaces where multi-org enforcement is and is not yet tested outside DB-gated CI — useful context for whoever closes Phase 1C.)

## Follow-up

- [ ] Docs, ADR, OpenAPI, roadmap or runbook updated where required — this PR **is** that update; the roadmap is regenerated, not hand-edited, so it stays derivable from the catalog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1aW1B4YfpWERwjsVVficE)_