### PR TITLE
Membership admin, end to end: server API + web UI (P2-11, P2-12; 1C-02/1C-11 slice)

### DIFF
--- a/crates/server/migrations/0029_expand_org_membership_state.sql
+++ b/crates/server/migrations/0029_expand_org_membership_state.sql
@@ -1,0 +1,29 @@
+-- Phase: 1C
+-- Owner: security-owner
+-- Change: expand
+-- Lock/data risk: single ADD COLUMN ... NOT NULL DEFAULT on org_memberships; POC
+--   seed has only a handful of rows (single-org POC, migrations/0011), so the
+--   ACCESS EXCLUSIVE lock taken for the DEFAULT backfill is momentary. No shipped
+--   application code reads or writes this column yet.
+-- Rollback compatibility: no released application version depends on `state`;
+--   dropping the column later is compatible with any released client.
+--
+-- P2-11 needs "suspend member" to be distinct from "remove member": a suspended
+-- membership keeps its row (role, created_at, audit trail, owner-history) but
+-- must be treated as absent for authorization. `active` is the default so every
+-- existing/POC-seeded row stays authorized after this migration applies.
+-- The org-context resolver (auth/permissions.rs resolve_org_context /
+-- resolve_org_context_on_txn) is updated in the same change to require
+-- state = 'active', so a suspended member resolves exactly like a missing
+-- membership (MembershipMissing), fail-closed.
+--
+-- Deferred on purpose: a `version` column for 1C-05 ACL cache invalidation is
+-- NOT added here (see plans/reports/plan-260728-0231-markhand-web-membership-admin-slice.md
+-- section 6/8b) — there is no cache yet to invalidate.
+
+ALTER TABLE org_memberships
+    ADD COLUMN state text NOT NULL DEFAULT 'active'
+        CHECK (state IN ('active', 'suspended'));
+
+COMMENT ON COLUMN org_memberships.state IS
+    'active|suspended. Suspended members resolve as MembershipMissing (P2-11 suspend, distinct from DELETE); row/history is preserved.';

--- a/crates/server/migrations/manifest.json
+++ b/crates/server/migrations/manifest.json
@@ -28,6 +28,7 @@
     "0025_backfill_event_log_ids_ask_stream_ops.sql": "b8375bfae33f81ae799fcc2802b567c722816369bf793955221caad7ce5cb6c0",
     "0026_expand_audit_append_only.sql": "79ffe4cded8b9c1fee03691b7011d971a3ddb17aaa18d396f9c72100d5013eb8",
     "0027_expand_migrator_app_grants.sql": "c46298a4a2e7c8a0a3fd4c5e3bcfe402d51dd007e5cf1423877f05a14d95fced",
-    "0028_expand_audit_ownership_migrator.sql": "087cd986645f779267011d359574afa8e8e255a60fcc63d01224ad7514efa2ee"
+    "0028_expand_audit_ownership_migrator.sql": "087cd986645f779267011d359574afa8e8e255a60fcc63d01224ad7514efa2ee",
+    "0029_expand_org_membership_state.sql": "41de0ab024806d760d1e080ec1cbbb54855695ee541566e216cf55f563dc1ec0"
   }
 }

--- a/crates/server/openapi/openapi.yaml
+++ b/crates/server/openapi/openapi.yaml
@@ -955,6 +955,182 @@ paths:
                 type: string
         "429":
           $ref: "#/components/responses/RateLimited"
+  /members:
+    get:
+      operationId: listMembers
+      summary: List org members (requires member.manage)
+      responses:
+        "200":
+          description: Memberships in the caller's current org (both active and suspended).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MembershipPage"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /members/invites:
+    get:
+      operationId: listMemberInvites
+      summary: List invites, open and terminal (requires member.manage)
+      responses:
+        "200":
+          description: Invites for the caller's current org. Never includes tokenHash.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvitePage"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+    post:
+      operationId: createMemberInvite
+      summary: Create a single-use invite (requires member.manage; owner role requires an active owner caller)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateInviteRequest"
+      responses:
+        "201":
+          description: >
+            Invite created. The plaintext token is returned exactly once here
+            and is never retrievable again (only its hash is stored).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateInviteResponse"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /members/invites/accept:
+    post:
+      operationId: acceptMemberInvite
+      summary: Accept an invite by token (authenticated bearer only — no existing org membership required)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AcceptInviteRequest"
+      responses:
+        "201":
+          description: Membership created in the invite's org.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Membership"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "401":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "409":
+          description: Invite already accepted/revoked, expired, or caller is already a member.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /members/invites/{inviteId}/revoke:
+    parameters:
+      - $ref: "#/components/parameters/inviteId"
+    post:
+      operationId: revokeMemberInvite
+      summary: Revoke an invite that has not yet been accepted/revoked (requires member.manage)
+      responses:
+        "200":
+          description: Invite revoked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Invite"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "409":
+          description: Invite already accepted or revoked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /members/{userId}:
+    parameters:
+      - $ref: "#/components/parameters/userId"
+    patch:
+      operationId: patchMember
+      summary: Change role and/or suspend/reactivate a member (requires member.manage; last-owner invariant enforced)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchMemberRequest"
+      responses:
+        "200":
+          description: Membership updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Membership"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "409":
+          description: Operation would leave the org with zero active owners.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+    delete:
+      operationId: deleteMember
+      summary: Remove a member from the org (requires member.manage; last-owner invariant enforced)
+      responses:
+        "204":
+          description: Member removed; refresh-token sessions invalidated.
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "409":
+          description: Operation would leave the org with zero active owners.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /usage:
+    get:
+      operationId: getUsage
+      summary: Aggregated per-resource usage/limit/reserved (requires member.manage)
+      responses:
+        "200":
+          description: Usage snapshot for every quota ResourceKind.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
 components:
   securitySchemes:
     bearerAuth:
@@ -985,6 +1161,20 @@ components:
         format: uuid
     jobId:
       name: jobId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    inviteId:
+      name: inviteId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    userId:
+      name: userId
       in: path
       required: true
       schema:
@@ -1511,3 +1701,129 @@ components:
         finishedAt:
           type: [string, "null"]
           format: date-time
+    Membership:
+      type: object
+      required: [userId, role, state, createdAt]
+      properties:
+        userId:
+          type: string
+          format: uuid
+        role:
+          type: string
+          enum: [owner, admin, editor, viewer]
+        state:
+          type: string
+          enum: [active, suspended]
+        createdAt:
+          type: string
+          format: date-time
+    MembershipPage:
+      type: object
+      required: [items, page]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Membership"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+    Invite:
+      type: object
+      required: [id, email, role, status, expiresAt, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+        role:
+          type: string
+          enum: [owner, admin, editor, viewer]
+        status:
+          type: string
+          description: Derived, not stored — never both terminal and pending.
+          enum: [pending, accepted, revoked, expired]
+        expiresAt:
+          type: string
+          format: date-time
+        acceptedAt:
+          type: [string, "null"]
+          format: date-time
+        revokedAt:
+          type: [string, "null"]
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+    InvitePage:
+      type: object
+      required: [items, page]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Invite"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+    CreateInviteRequest:
+      type: object
+      required: [email, role]
+      properties:
+        email:
+          type: string
+        role:
+          type: string
+          enum: [owner, admin, editor, viewer]
+        ttlSecs:
+          type: integer
+          description: Invite lifetime in seconds (default 7 days; clamped [60, 2592000]).
+    CreateInviteResponse:
+      type: object
+      required: [invite, token]
+      properties:
+        invite:
+          $ref: "#/components/schemas/Invite"
+        token:
+          type: string
+          description: >
+            Plaintext single-use invite token, returned exactly once. Only its
+            hash is ever persisted — this value cannot be retrieved again.
+    AcceptInviteRequest:
+      type: object
+      required: [token]
+      properties:
+        token:
+          type: string
+    PatchMemberRequest:
+      type: object
+      description: At least one of role/state must be present.
+      properties:
+        role:
+          type: string
+          enum: [owner, admin, editor, viewer]
+        state:
+          type: string
+          enum: [active, suspended]
+    UsageEntry:
+      type: object
+      required: [resource, limit, committed, reserved, remaining]
+      properties:
+        resource:
+          type: string
+          enum: [storage_bytes, documents, concurrent_jobs, tokens]
+        limit:
+          type: integer
+        committed:
+          type: integer
+        reserved:
+          type: integer
+        remaining:
+          type: integer
+    UsageResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/UsageEntry"

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -92,6 +92,31 @@ pub const ROUTE_INVENTORY: &[(&str, &str, &[&str])] = &[
         &["200", "400", "401", "403", "404", "429"],
     ),
     ("get", "/openapi.yaml", &["200", "429"]),
+    // P2-11 / P2-12 membership + invite + usage admin surface (Wave 2).
+    ("get", "/members", &["200", "403", "429"]),
+    ("get", "/members/invites", &["200", "403", "429"]),
+    ("post", "/members/invites", &["201", "400", "403", "429"]),
+    (
+        "post",
+        "/members/invites/{inviteId}/revoke",
+        &["200", "403", "404", "409", "429"],
+    ),
+    (
+        "post",
+        "/members/invites/accept",
+        &["201", "400", "401", "404", "409", "429"],
+    ),
+    (
+        "patch",
+        "/members/{userId}",
+        &["200", "400", "403", "404", "409", "429"],
+    ),
+    (
+        "delete",
+        "/members/{userId}",
+        &["204", "403", "404", "409", "429"],
+    ),
+    ("get", "/usage", &["200", "403", "429"]),
 ];
 
 const HEALTH_PATHS: &[&str] = &["/health/live", "/health/ready", "/health/start"];
@@ -123,6 +148,9 @@ pub const BODY_TAKING_OPERATIONS: &[(&str, &str)] = &[
     ("post", "/search"),
     ("post", "/ask"),
     ("post", "/ask/stream"),
+    ("post", "/members/invites"),
+    ("post", "/members/invites/accept"),
+    ("patch", "/members/{userId}"),
 ];
 
 pub fn embedded_openapi_yaml() -> &'static str {

--- a/crates/server/src/auth/permissions.rs
+++ b/crates/server/src/auth/permissions.rs
@@ -53,9 +53,13 @@ pub async fn resolve_org_context(
         return Err(ResolveError::UserDisabled);
     }
 
+    // P2-11: a suspended membership resolves exactly like a missing one
+    // (fail-closed) — suspend is deliberately not full removal, so the row/role
+    // history survives, but `state <> 'active'` must deny here same as no row.
     let membership = client
         .query_opt(
-            "SELECT role FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+            "SELECT role FROM org_memberships
+             WHERE org_id = $1 AND user_id = $2 AND state = 'active'",
             &[&org_id, &user_id],
         )
         .await
@@ -152,9 +156,11 @@ pub async fn resolve_org_context_on_txn(
     if disabled_at.is_some() {
         return Err(ResolveError::UserDisabled);
     }
+    // P2-11: same suspended-as-missing rule as `resolve_org_context` above.
     let membership = txn
         .query_opt(
-            "SELECT role FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+            "SELECT role FROM org_memberships
+             WHERE org_id = $1 AND user_id = $2 AND state = 'active'",
             &[&org_id, &user_id],
         )
         .await

--- a/crates/server/src/auth/session.rs
+++ b/crates/server/src/auth/session.rs
@@ -372,9 +372,14 @@ async fn find_user_org(client: &mut Object, user_id: Uuid) -> Result<Option<Uuid
             .await
             .map_err(|_| SessionError::Database)?;
         set_org_guc_txn(&txn, org_id).await?;
+        // `state = 'active'` mirrors `resolve_org_context`: a suspended
+        // membership is treated as absent, so a suspended member cannot log in
+        // and mint a fresh token for the org. In multi-org this correctly skips
+        // a suspended org and finds an active one instead.
         let membership = txn
             .query_opt(
-                "SELECT 1 FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+                "SELECT 1 FROM org_memberships
+                 WHERE org_id = $1 AND user_id = $2 AND state = 'active'",
                 &[&org_id, &user_id],
             )
             .await
@@ -637,9 +642,16 @@ pub async fn refresh_session(
         txn.commit().await.map_err(|_| SessionError::Database)?;
         return Err(SessionError::UserDisabled);
     }
+    // `state = 'active'` gives refresh the same suspend backstop that
+    // `resolve_org_context` gives every request: a member suspended after their
+    // token was issued cannot refresh it, and — because the miss path below
+    // revokes the family in THIS transaction — suspend hard-kills the session
+    // without depending on the out-of-band `revoke_all_user_families` call the
+    // suspend route makes (which could be lost to a crash between the two).
     let membership = txn
         .query_opt(
-            "SELECT 1 FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+            "SELECT 1 FROM org_memberships
+             WHERE org_id = $1 AND user_id = $2 AND state = 'active'",
             &[&org_id, &user_id],
         )
         .await

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -118,6 +118,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0028_expand_audit_ownership_migrator.sql",
         include_str!("../migrations/0028_expand_audit_ownership_migrator.sql"),
     ),
+    (
+        "0029_expand_org_membership_state.sql",
+        include_str!("../migrations/0029_expand_org_membership_state.sql"),
+    ),
 ];
 
 /// Embedded migration sources in apply order (name, SQL). Used by integration tests.

--- a/crates/server/src/db/members.rs
+++ b/crates/server/src/db/members.rs
@@ -1,0 +1,377 @@
+//! Tenant-scoped membership + invite repository (ADR 0007, P2-11 / 1C-02).
+//!
+//! All functions require an [`OrgContext`] and must run inside
+//! `pool::with_org_txn` / `with_org_txn_typed` so RLS `app.org_id` is set
+//! before any row is touched: `org_memberships` (migrations 0001/0002) and
+//! `org_invites` (migrations 0003/0010) are both `FORCE ROW LEVEL SECURITY`.
+//!
+//! This module is pure data access — the last-owner invariant, invite hash
+//! verification, and token lifecycle rules live in `services::members`.
+
+use chrono::{DateTime, Utc};
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::{MembershipRole, MembershipState, OrgInvite, OrgMembership, SecretHash};
+
+/// One owner-role membership row read under `FOR UPDATE` for the last-owner
+/// invariant (see [`lock_owner_rows`] and `services::members::check_last_owner_invariant`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OwnerRow {
+    pub user_id: Uuid,
+    pub state: MembershipState,
+}
+
+/// Lists every membership row for the tenant (both states — admins must be
+/// able to see suspended members in order to reactivate them).
+pub async fn list(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<Vec<OrgMembership>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT org_id, user_id, role, state, created_at
+             FROM org_memberships
+             WHERE org_id = $1
+             ORDER BY created_at, user_id",
+            &[&ctx.org_id()],
+        )
+        .await?;
+    rows.iter().map(map_membership).collect()
+}
+
+/// Fetches one membership row regardless of state.
+pub async fn get(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    user_id: Uuid,
+) -> Result<OrgMembership, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT org_id, user_id, role, state, created_at
+             FROM org_memberships
+             WHERE org_id = $1 AND user_id = $2",
+            &[&ctx.org_id(), &user_id],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_membership(&row)
+}
+
+/// Inserts a new active membership; `None` when `(org_id, user_id)` already
+/// exists (caller maps this to a typed "already a member" error).
+pub async fn try_insert(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    user_id: Uuid,
+    role: MembershipRole,
+) -> Result<Option<OrgMembership>, DbError> {
+    let role_str = role.as_str();
+    let row = txn
+        .query_opt(
+            "INSERT INTO org_memberships (org_id, user_id, role)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (org_id, user_id) DO NOTHING
+             RETURNING org_id, user_id, role, state, created_at",
+            &[&ctx.org_id(), &user_id, &role_str],
+        )
+        .await?;
+    row.as_ref().map(map_membership).transpose()
+}
+
+/// Updates only the role of an existing membership.
+pub async fn update_role(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    user_id: Uuid,
+    role: MembershipRole,
+) -> Result<OrgMembership, DbError> {
+    let role_str = role.as_str();
+    let row = txn
+        .query_opt(
+            "UPDATE org_memberships
+             SET role = $3
+             WHERE org_id = $1 AND user_id = $2
+             RETURNING org_id, user_id, role, state, created_at",
+            &[&ctx.org_id(), &user_id, &role_str],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_membership(&row)
+}
+
+/// Sets membership state (suspend/reactivate). The row and its role/history
+/// are preserved either way — this is deliberately not a delete.
+pub async fn set_state(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    user_id: Uuid,
+    state: MembershipState,
+) -> Result<OrgMembership, DbError> {
+    let state_str = state.as_str();
+    let row = txn
+        .query_opt(
+            "UPDATE org_memberships
+             SET state = $3
+             WHERE org_id = $1 AND user_id = $2
+             RETURNING org_id, user_id, role, state, created_at",
+            &[&ctx.org_id(), &user_id, &state_str],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_membership(&row)
+}
+
+/// Hard-deletes a membership row.
+///
+/// `refresh_tokens(org_id, user_id)` carries `FOREIGN KEY ... REFERENCES
+/// org_memberships(org_id, user_id)` with no `ON DELETE` action
+/// (migrations/0003_expand_auth_sessions_rbac.sql), i.e. `NO ACTION`/RESTRICT:
+/// any refresh_tokens row for this user in this org — even an already-revoked
+/// one — blocks this DELETE. This function does not clear those rows itself
+/// (so a caller that only wants a plain delete, e.g. a test fixture, gets an
+/// honest FK error instead of a surprise cascading session wipe);
+/// `services::members::remove_member` calls [`purge_refresh_tokens`] first in
+/// the same transaction.
+pub async fn delete(txn: &Transaction<'_>, ctx: &OrgContext, user_id: Uuid) -> Result<(), DbError> {
+    let deleted = txn
+        .execute(
+            "DELETE FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+            &[&ctx.org_id(), &user_id],
+        )
+        .await?;
+    if deleted == 0 {
+        return Err(DbError::NotFound);
+    }
+    Ok(())
+}
+
+/// Hard-deletes every refresh-token row for `user_id` in the tenant so
+/// [`delete`] can satisfy the FK above. This is full session teardown, not a
+/// soft revoke — for paths that keep the membership row (role downgrade,
+/// suspend) use `auth::session::revoke_all_user_families` instead, which only
+/// sets `revoked_at`.
+pub async fn purge_refresh_tokens(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    user_id: Uuid,
+) -> Result<u64, DbError> {
+    let deleted = txn
+        .execute(
+            "DELETE FROM refresh_tokens WHERE org_id = $1 AND user_id = $2",
+            &[&ctx.org_id(), &user_id],
+        )
+        .await?;
+    Ok(deleted)
+}
+
+/// Row-locks every owner-role membership in the tenant (`SELECT ... FOR
+/// UPDATE`) so concurrent remove/downgrade/suspend operations serialize on
+/// the same rows before counting remaining active owners. Must run inside
+/// the same transaction as the mutation it guards — see
+/// `services::members::check_last_owner_invariant` for the (DB-free) counting
+/// logic and `plans/reports/plan-260728-0231-...` section 4 for the invariant.
+pub async fn lock_owner_rows(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+) -> Result<Vec<OwnerRow>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT user_id, state
+             FROM org_memberships
+             WHERE org_id = $1 AND role = 'owner'
+             FOR UPDATE",
+            &[&ctx.org_id()],
+        )
+        .await?;
+    rows.iter()
+        .map(|row| {
+            let state: String = row.get("state");
+            Ok(OwnerRow {
+                user_id: row.get("user_id"),
+                state: MembershipState::parse(&state).map_err(DbError::Config)?,
+            })
+        })
+        .collect()
+}
+
+fn map_membership(row: &Row) -> Result<OrgMembership, DbError> {
+    let role: String = row.get("role");
+    let state: String = row.get("state");
+    Ok(OrgMembership {
+        org_id: row.get("org_id"),
+        user_id: row.get("user_id"),
+        role: MembershipRole::parse(&role).map_err(DbError::Config)?,
+        state: MembershipState::parse(&state).map_err(DbError::Config)?,
+        created_at: row.get("created_at"),
+    })
+}
+
+// ---------------------------------------------------------------------
+// Invites
+// ---------------------------------------------------------------------
+
+/// Input for inserting a new single-use invite. Only the hash is stored —
+/// the plaintext token is minted/returned exactly once by
+/// `services::members::create_invite` and never persisted.
+pub struct NewInvite<'a> {
+    pub id: Uuid,
+    pub email: &'a str,
+    pub role: MembershipRole,
+    pub token_hash: &'a str,
+    pub invited_by_user_id: Uuid,
+    pub expires_at: DateTime<Utc>,
+}
+
+pub async fn insert_invite(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    input: NewInvite<'_>,
+) -> Result<OrgInvite, DbError> {
+    let role_str = input.role.as_str();
+    let row = txn
+        .query_one(
+            "INSERT INTO org_invites (
+                id, org_id, email, role, token_hash, invited_by_user_id, expires_at
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+             RETURNING id, org_id, email, role, token_hash, invited_by_user_id,
+                       expires_at, accepted_at, revoked_at, created_at",
+            &[
+                &input.id,
+                &ctx.org_id(),
+                &input.email,
+                &role_str,
+                &input.token_hash,
+                &input.invited_by_user_id,
+                &input.expires_at,
+            ],
+        )
+        .await?;
+    map_invite(&row)
+}
+
+/// Lists every invite for the tenant (open and terminal) so the admin UI can
+/// show history; routes must never echo `token_hash` back to a client.
+pub async fn list_invites(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+) -> Result<Vec<OrgInvite>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT id, org_id, email, role, token_hash, invited_by_user_id,
+                    expires_at, accepted_at, revoked_at, created_at
+             FROM org_invites
+             WHERE org_id = $1
+             ORDER BY created_at DESC",
+            &[&ctx.org_id()],
+        )
+        .await?;
+    rows.iter().map(map_invite).collect()
+}
+
+pub async fn get_invite(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    invite_id: Uuid,
+) -> Result<OrgInvite, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, email, role, token_hash, invited_by_user_id,
+                    expires_at, accepted_at, revoked_at, created_at
+             FROM org_invites
+             WHERE org_id = $1 AND id = $2",
+            &[&ctx.org_id(), &invite_id],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_invite(&row)
+}
+
+/// Looks up an invite by token hash, scoped to `ctx.org_id()` (set as the
+/// `app.org_id` GUC by the caller's `with_org_txn`/`with_org_txn_typed`).
+///
+/// The plaintext invite token embeds its org id (`mhinv1.<org_id>.<secret>`,
+/// mirroring `auth::session`'s refresh-token shape) precisely so accept-invite
+/// — which runs before any membership/permission exists for the caller — can
+/// set the correct GUC before querying an RLS-protected table without ever
+/// concatenating an unvalidated org id into SQL.
+pub async fn find_invite_by_token_hash(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    token_hash: &str,
+) -> Result<Option<OrgInvite>, DbError> {
+    let row = txn
+        .query_opt(
+            "SELECT id, org_id, email, role, token_hash, invited_by_user_id,
+                    expires_at, accepted_at, revoked_at, created_at
+             FROM org_invites
+             WHERE org_id = $1 AND token_hash = $2",
+            &[&ctx.org_id(), &token_hash],
+        )
+        .await?;
+    row.as_ref().map(map_invite).transpose()
+}
+
+/// Marks an invite accepted. Only updates rows that are not already terminal
+/// (`ck_org_invites__terminal_xor`), so a replayed accept on a terminal invite
+/// returns `NotFound` here (caller should check terminal state first via
+/// `get_invite`/`find_invite_by_token_hash` to return a precise typed error).
+pub async fn mark_invite_accepted(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    invite_id: Uuid,
+    accepted_at: DateTime<Utc>,
+) -> Result<OrgInvite, DbError> {
+    let row = txn
+        .query_opt(
+            "UPDATE org_invites
+             SET accepted_at = $3
+             WHERE org_id = $1 AND id = $2
+               AND accepted_at IS NULL AND revoked_at IS NULL
+             RETURNING id, org_id, email, role, token_hash, invited_by_user_id,
+                       expires_at, accepted_at, revoked_at, created_at",
+            &[&ctx.org_id(), &invite_id, &accepted_at],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_invite(&row)
+}
+
+/// Marks an invite revoked; same not-already-terminal guard as
+/// [`mark_invite_accepted`].
+pub async fn mark_invite_revoked(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    invite_id: Uuid,
+    revoked_at: DateTime<Utc>,
+) -> Result<OrgInvite, DbError> {
+    let row = txn
+        .query_opt(
+            "UPDATE org_invites
+             SET revoked_at = $3
+             WHERE org_id = $1 AND id = $2
+               AND accepted_at IS NULL AND revoked_at IS NULL
+             RETURNING id, org_id, email, role, token_hash, invited_by_user_id,
+                       expires_at, accepted_at, revoked_at, created_at",
+            &[&ctx.org_id(), &invite_id, &revoked_at],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_invite(&row)
+}
+
+fn map_invite(row: &Row) -> Result<OrgInvite, DbError> {
+    let role: String = row.get("role");
+    let token_hash: String = row.get("token_hash");
+    Ok(OrgInvite {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        email: row.get("email"),
+        role: MembershipRole::parse(&role).map_err(DbError::Config)?,
+        token_hash: SecretHash::new(token_hash),
+        invited_by_user_id: row.get("invited_by_user_id"),
+        expires_at: row.get("expires_at"),
+        accepted_at: row.get("accepted_at"),
+        revoked_at: row.get("revoked_at"),
+        created_at: row.get("created_at"),
+    })
+}

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -11,6 +11,7 @@ pub mod embedding_batches;
 pub mod error;
 pub mod index_metadata;
 pub(crate) mod jobs;
+pub mod members;
 pub mod models;
 pub mod orgs;
 pub mod pool;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -63,11 +63,59 @@ pub enum MembershipRole {
     Viewer,
 }
 
+impl MembershipRole {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Owner => "owner",
+            Self::Admin => "admin",
+            Self::Editor => "editor",
+            Self::Viewer => "viewer",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "owner" => Ok(Self::Owner),
+            "admin" => Ok(Self::Admin),
+            "editor" => Ok(Self::Editor),
+            "viewer" => Ok(Self::Viewer),
+            other => Err(format!("unknown membership role: {other}")),
+        }
+    }
+}
+
+/// P2-11: suspended is distinct from removed (row/history kept, access denied).
+/// The org-context resolver treats `Suspended` exactly like a missing membership.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MembershipState {
+    Active,
+    Suspended,
+}
+
+impl MembershipState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Suspended => "suspended",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "active" => Ok(Self::Active),
+            "suspended" => Ok(Self::Suspended),
+            other => Err(format!("unknown membership state: {other}")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OrgMembership {
     pub org_id: Uuid,
     pub user_id: Uuid,
     pub role: MembershipRole,
+    pub state: MembershipState,
     pub created_at: DateTime<Utc>,
 }
 
@@ -880,7 +928,7 @@ pub fn expected_table_columns() -> &'static [(&'static str, &'static [&'static s
         ),
         (
             "org_memberships",
-            &["org_id", "user_id", "role", "created_at"],
+            &["org_id", "user_id", "role", "created_at", "state"],
         ),
         ("permissions", &["id", "code", "description", "created_at"]),
         (

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -489,6 +489,7 @@ pub fn router(state: AppState) -> Router {
         .merge(routes::collections::router())
         .merge(routes::documents::router())
         .merge(routes::jobs::router())
+        .merge(routes::members::router())
         .merge(routes::search::router())
         .merge(routes::ask::router())
         .merge(routes::events::router())

--- a/crates/server/src/routes/members.rs
+++ b/crates/server/src/routes/members.rs
@@ -1,0 +1,816 @@
+//! Membership + invite + usage admin routes (P2-11 / P2-12, Wave 2 surface).
+//!
+//! Builds the HTTP surface on top of the frozen Wave 1 domain layer
+//! (`services::members`, `db::members`) — see
+//! `plans/reports/plan-260728-0231-markhand-web-membership-admin-slice.md`
+//! section 4 (E1-E8) and section 5 (per-mutation obligations). This module
+//! must not change domain invariants; it only guards, maps errors to status
+//! codes, and wires audit/session-revoke calls the domain layer documents as
+//! Wave 2's responsibility.
+//!
+//! ## Known Wave 1 gap this route layer works around (read before editing)
+//!
+//! `services::members::{change_role, remove_member, suspend_member,
+//! reactivate_member}` all call `db::members::get(txn, ctx, target_user_id)`
+//! with a bare `?`, and `MemberError`'s blanket `From<DbError>` collapses
+//! *every* `DbError` variant — including `DbError::NotFound` — to
+//! `MemberError::Database`. That means a target user with no membership row
+//! (the exact shape of a cross-org DELETE/PATCH, since RLS simply hides the
+//! foreign row) would surface as a 500 instead of a 404 if this route called
+//! those functions directly. `revoke_invite` in the same file *does*
+//! special-case `DbError::NotFound` before this point — the other four
+//! functions do not. This is a domain-layer bug (frozen file, out of Wave 2's
+//! ownership — reported, not patched here). [`fetch_current_membership`]
+//! below pre-checks existence through `db::members::get` directly (read-only,
+//! same tenant-scoped transaction pattern) so PATCH/DELETE return a clean 404
+//! before ever reaching the buggy path. This does not close a race against a
+//! membership row deleted between the pre-check and the mutation transaction
+//! (that residual case would still surface as 500) — see the Wave 2 report.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, patch, post};
+use axum::{Extension, Json, Router};
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Pool;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api::{ApiError, Page, PageInfo};
+use crate::auth::context::OrgContext;
+use crate::auth::middleware::{verify_bearer_claims, AuthenticatedOrg};
+use crate::auth::permissions::require_permission;
+use crate::auth::session::revoke_all_user_families;
+use crate::db::error::DbError;
+use crate::db::members as member_rows;
+use crate::db::models::{MembershipRole, MembershipState, OrgInvite, OrgMembership};
+use crate::db::pool::with_org_txn;
+use crate::http::AppState;
+use crate::middleware::RequestId;
+use crate::services::audit::{self, AuditAction};
+use crate::services::members::{self, MemberError, ResourceUsage};
+
+/// Permission code guarding every endpoint in this module except accept-invite
+/// (auth-only by design — see the module-level accept-invite note in
+/// `services::members` and the Wave 2 plan report section on the auth
+/// wrinkle). Seeded in `migrations/0011` but unused before this slice.
+const PERMISSION_MEMBER_MANAGE: &str = "member.manage";
+
+const MAX_EMAIL_LEN: usize = 320;
+const MAX_TOKEN_LEN: usize = 512;
+const MIN_INVITE_TTL_SECS: i64 = 60;
+const MAX_INVITE_TTL_SECS: i64 = 30 * 24 * 3600;
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/v1/members", get(list_members))
+        .route(
+            "/api/v1/members/invites",
+            get(list_invites).post(create_invite),
+        )
+        .route("/api/v1/members/invites/accept", post(accept_invite))
+        .route(
+            "/api/v1/members/invites/{invite_id}/revoke",
+            post(revoke_invite),
+        )
+        .route(
+            "/api/v1/members/{user_id}",
+            patch(patch_member).delete(delete_member),
+        )
+        .route("/api/v1/usage", get(usage_overview))
+}
+
+// ---------------------------------------------------------------------
+// Wire DTOs (route-local — see ownership note: api/types.rs is not in this
+// wave's edit list, so response shapes live here rather than being exported
+// for reuse elsewhere).
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MembershipDto {
+    user_id: Uuid,
+    role: String,
+    state: String,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InviteDto {
+    id: Uuid,
+    email: String,
+    role: String,
+    /// One of `pending`, `accepted`, `revoked`, `expired` — derived, not stored.
+    status: String,
+    expires_at: DateTime<Utc>,
+    accepted_at: Option<DateTime<Utc>>,
+    revoked_at: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateInviteResponse {
+    invite: InviteDto,
+    /// Plaintext invite token, surfaced exactly once. Never logged, never
+    /// written to audit metadata (see `services::members::CreatedInvite` doc
+    /// and plan section 2 caveat C3).
+    token: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageEntryDto {
+    resource: String,
+    limit: i64,
+    committed: i64,
+    reserved: i64,
+    remaining: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageResponse {
+    items: Vec<UsageEntryDto>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateInviteRequest {
+    email: String,
+    role: String,
+    #[serde(default)]
+    ttl_secs: Option<i64>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcceptInviteRequest {
+    token: String,
+}
+
+/// Hand-written (never derived) so a stray `{:?}` on this request never
+/// prints the plaintext invite token.
+impl std::fmt::Debug for AcceptInviteRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AcceptInviteRequest")
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PatchMemberRequest {
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+}
+
+fn membership_dto(row: OrgMembership) -> MembershipDto {
+    MembershipDto {
+        user_id: row.user_id,
+        role: row.role.as_str().to_string(),
+        state: row.state.as_str().to_string(),
+        created_at: row.created_at,
+    }
+}
+
+fn invite_status(invite: &OrgInvite, now: DateTime<Utc>) -> &'static str {
+    if invite.revoked_at.is_some() {
+        "revoked"
+    } else if invite.accepted_at.is_some() {
+        "accepted"
+    } else if invite.expires_at <= now {
+        "expired"
+    } else {
+        "pending"
+    }
+}
+
+fn invite_dto(invite: &OrgInvite) -> InviteDto {
+    let now = Utc::now();
+    InviteDto {
+        id: invite.id,
+        email: invite.email.clone(),
+        role: invite.role.as_str().to_string(),
+        status: invite_status(invite, now).to_string(),
+        expires_at: invite.expires_at,
+        accepted_at: invite.accepted_at,
+        revoked_at: invite.revoked_at,
+        created_at: invite.created_at,
+    }
+}
+
+fn usage_dto(usage: ResourceUsage) -> UsageEntryDto {
+    UsageEntryDto {
+        resource: usage.kind.as_str().to_string(),
+        limit: usage.limit,
+        committed: usage.committed,
+        reserved: usage.reserved,
+        remaining: usage.remaining,
+    }
+}
+
+/// Ranks roles for downgrade detection (`change_role` obligation: revoke
+/// refresh-token families after a role *downgrade*, not an upgrade). Higher
+/// is more privileged.
+fn role_rank(role: MembershipRole) -> u8 {
+    match role {
+        MembershipRole::Owner => 3,
+        MembershipRole::Admin => 2,
+        MembershipRole::Editor => 1,
+        MembershipRole::Viewer => 0,
+    }
+}
+
+/// Read-only existence pre-check — see the module doc's Wave 1 gap note.
+/// Returns `Ok(None)` for both "no such user" and "exists in another org"
+/// (RLS makes the two indistinguishable, which is the point).
+async fn fetch_current_membership(
+    pool: &Pool,
+    ctx: &OrgContext,
+    user_id: Uuid,
+) -> Result<Option<OrgMembership>, DbError> {
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                match member_rows::get(txn, &ctx, user_id).await {
+                    Ok(row) => Ok(Some(row)),
+                    Err(DbError::NotFound) => Ok(None),
+                    Err(other) => Err(other),
+                }
+            })
+        }
+    })
+    .await
+}
+
+fn request_id_from_ext(ext: Option<Extension<RequestId>>) -> String {
+    ext.map(|id| id.0 .0)
+        .unwrap_or_else(|| Uuid::new_v4().to_string())
+}
+
+// ---------------------------------------------------------------------
+// E1 — GET /members
+// ---------------------------------------------------------------------
+
+async fn list_members(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+) -> Result<Json<Page<MembershipDto>>, RouteError> {
+    require_permission(&auth.context, PERMISSION_MEMBER_MANAGE)
+        .map_err(|_| RouteError::Denied(auth.request_id.clone()))?;
+    let items = members::list_members(state.pool(), &auth.context)
+        .await
+        .map_err(|error| RouteError::from_member(error, &auth.request_id))?;
+    Ok(Json(Page {
+        items: items.into_iter().map(membership_dto).collect(),
+        page: PageInfo {
+            next_cursor: None,
+            has_more: false,
+        },
+    }))
+}
+
+// ---------------------------------------------------------------------
+// E2 — GET /members/invites
+// ---------------------------------------------------------------------
+
+async fn list_invites(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+) -> Result<Json<Page<InviteDto>>, RouteError> {
+    require_permission(&auth.context, PERMISSION_MEMBER_MANAGE)
+        .map_err(|_| RouteError::Denied(auth.request_id.clone()))?;
+    let items = members::list_invites(state.pool(), &auth.context)
+        .await
+        .map_err(|error| RouteError::from_member(error, &auth.request_id))?;
+    Ok(Json(Page {
+        items: items.iter().map(invite_dto).collect(),
+        page: PageInfo {
+            next_cursor: None,
+            has_more: false,
+        },
+    }))
+}
+
+// ---------------------------------------------------------------------
+// E3 — POST /members/invites
+// ---------------------------------------------------------------------
+
+async fn create_invite(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Json(body): Json<CreateInviteRequest>,
+) -> Result<(StatusCode, Json<CreateInviteResponse>), RouteError> {
+    if require_permission(&auth.context, PERMISSION_MEMBER_MANAGE).is_err() {
+        audit::record_deny(
+            state.pool(),
+            &auth.context,
+            &auth.request_id,
+            AuditAction::MemberInvite.as_str(),
+            "member",
+            None,
+            "permission_denied",
+        )
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+        return Err(RouteError::Denied(auth.request_id.clone()));
+    }
+
+    let email = body.email.trim();
+    if email.is_empty() || email.len() > MAX_EMAIL_LEN || !email.contains('@') {
+        return Err(RouteError::Validation(
+            auth.request_id.clone(),
+            "Invalid email",
+        ));
+    }
+    let role = MembershipRole::parse(&body.role)
+        .map_err(|_| RouteError::Validation(auth.request_id.clone(), "Invalid role"))?;
+    let ttl_secs = body.ttl_secs.unwrap_or(members::DEFAULT_INVITE_TTL_SECS);
+    if !(MIN_INVITE_TTL_SECS..=MAX_INVITE_TTL_SECS).contains(&ttl_secs) {
+        return Err(RouteError::Validation(
+            auth.request_id.clone(),
+            "Invalid ttlSecs",
+        ));
+    }
+
+    let created = members::create_invite(
+        state.pool(),
+        &auth.context,
+        &auth.request_id,
+        email,
+        role,
+        ttl_secs,
+    )
+    .await
+    .map_err(|error| RouteError::from_member(error, &auth.request_id))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateInviteResponse {
+            invite: invite_dto(&created.invite),
+            token: created.plaintext_token.expose().to_string(),
+        }),
+    ))
+}
+
+// ---------------------------------------------------------------------
+// E4 — POST /members/invites/{inviteId}/revoke
+// ---------------------------------------------------------------------
+
+async fn revoke_invite(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(invite_id): Path<Uuid>,
+) -> Result<Json<InviteDto>, RouteError> {
+    if require_permission(&auth.context, PERMISSION_MEMBER_MANAGE).is_err() {
+        let resource_id = invite_id.to_string();
+        audit::record_deny(
+            state.pool(),
+            &auth.context,
+            &auth.request_id,
+            AuditAction::MemberInviteRevoke.as_str(),
+            "member",
+            Some(&resource_id),
+            "permission_denied",
+        )
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+        return Err(RouteError::Denied(auth.request_id.clone()));
+    }
+
+    let invite = members::revoke_invite(state.pool(), &auth.context, &auth.request_id, invite_id)
+        .await
+        .map_err(|error| RouteError::from_member(error, &auth.request_id))?;
+    Ok(Json(invite_dto(&invite)))
+}
+
+// ---------------------------------------------------------------------
+// E5 — POST /members/invites/accept (auth-only; see module + report notes)
+// ---------------------------------------------------------------------
+
+async fn accept_invite(
+    State(state): State<Arc<AppState>>,
+    request_id_ext: Option<Extension<RequestId>>,
+    headers: HeaderMap,
+    Json(body): Json<AcceptInviteRequest>,
+) -> Result<(StatusCode, Json<MembershipDto>), RouteError> {
+    let request_id = request_id_from_ext(request_id_ext);
+
+    let Some(provider) = state.auth_provider() else {
+        return Err(RouteError::Unavailable(request_id));
+    };
+
+    // Deliberately NOT `AuthenticatedOrg`: that extractor resolves org
+    // membership from current PG state and would 403 a caller who is not yet
+    // a member of the invite's target org — exactly the caller this endpoint
+    // exists for. Authorization here is: (a) a cryptographically valid,
+    // unexpired bearer access token (proves the caller is *some*
+    // authenticated principal — `sub` is the accepting user id) plus (b) the
+    // invite token itself (proves the bearer was invited into a specific
+    // org). Neither check touches org membership. See the Wave 2 report for
+    // the one case this does NOT cover (a brand new user with zero org
+    // memberships anywhere cannot obtain a bearer token at all today, because
+    // `auth::session::login_with_password` requires an existing membership to
+    // mint one — that gap is outside this route's ownership to fix).
+    let Some(authorization) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return Err(RouteError::Unauthorized(request_id));
+    };
+    let claims = verify_bearer_claims(provider.keys(), authorization)
+        .map_err(|_| RouteError::Unauthorized(request_id.clone()))?;
+    let user_id =
+        Uuid::parse_str(&claims.sub).map_err(|_| RouteError::Unauthorized(request_id.clone()))?;
+
+    let token = body.token.trim();
+    if token.is_empty() || token.len() > MAX_TOKEN_LEN {
+        return Err(RouteError::Validation(request_id, "Invalid token"));
+    }
+
+    let membership = members::accept_invite(state.pool(), token, user_id, &request_id)
+        .await
+        .map_err(|error| RouteError::from_member(error, &request_id))?;
+    Ok((StatusCode::CREATED, Json(membership_dto(membership))))
+}
+
+// ---------------------------------------------------------------------
+// E6 — PATCH /members/{userId}
+// ---------------------------------------------------------------------
+
+async fn patch_member(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(user_id): Path<Uuid>,
+    Json(body): Json<PatchMemberRequest>,
+) -> Result<Json<MembershipDto>, RouteError> {
+    if require_permission(&auth.context, PERMISSION_MEMBER_MANAGE).is_err() {
+        let resource_id = user_id.to_string();
+        audit::record_deny(
+            state.pool(),
+            &auth.context,
+            &auth.request_id,
+            AuditAction::MemberRoleChange.as_str(),
+            "member",
+            Some(&resource_id),
+            "permission_denied",
+        )
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+        return Err(RouteError::Denied(auth.request_id.clone()));
+    }
+
+    let new_role = match &body.role {
+        Some(raw) => Some(
+            MembershipRole::parse(raw)
+                .map_err(|_| RouteError::Validation(auth.request_id.clone(), "Invalid role"))?,
+        ),
+        None => None,
+    };
+    let new_state = match &body.state {
+        Some(raw) => Some(
+            MembershipState::parse(raw)
+                .map_err(|_| RouteError::Validation(auth.request_id.clone(), "Invalid state"))?,
+        ),
+        None => None,
+    };
+    if new_role.is_none() && new_state.is_none() {
+        return Err(RouteError::Validation(
+            auth.request_id.clone(),
+            "role or state is required",
+        ));
+    }
+
+    // Pre-check existence to avoid the Wave 1 NotFound->Database masking bug
+    // documented at the top of this file (also the key mechanism by which a
+    // cross-org PATCH surfaces as 404 rather than 500/403).
+    let Some(existing) = fetch_current_membership(state.pool(), &auth.context, user_id)
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?
+    else {
+        return Err(RouteError::NotFound(auth.request_id.clone()));
+    };
+
+    let mut current = existing;
+    let mut should_revoke = false;
+
+    if let Some(role) = new_role {
+        if role_rank(role) < role_rank(current.role) {
+            should_revoke = true;
+        }
+        current =
+            members::change_role(state.pool(), &auth.context, &auth.request_id, user_id, role)
+                .await
+                .map_err(|error| RouteError::from_member(error, &auth.request_id))?;
+    }
+
+    if let Some(target_state) = new_state {
+        current = match target_state {
+            MembershipState::Suspended => {
+                should_revoke = true;
+                members::suspend_member(state.pool(), &auth.context, &auth.request_id, user_id)
+                    .await
+                    .map_err(|error| RouteError::from_member(error, &auth.request_id))?
+            }
+            MembershipState::Active => {
+                members::reactivate_member(state.pool(), &auth.context, &auth.request_id, user_id)
+                    .await
+                    .map_err(|error| RouteError::from_member(error, &auth.request_id))?
+            }
+        };
+    }
+
+    if should_revoke {
+        revoke_all_user_families(
+            state.pool(),
+            auth.context.org_id(),
+            user_id,
+            &auth.request_id,
+            "member_downgraded_or_suspended",
+        )
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+    }
+
+    Ok(Json(membership_dto(current)))
+}
+
+// ---------------------------------------------------------------------
+// E7 — DELETE /members/{userId}
+// ---------------------------------------------------------------------
+
+async fn delete_member(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(user_id): Path<Uuid>,
+) -> Result<StatusCode, RouteError> {
+    if require_permission(&auth.context, PERMISSION_MEMBER_MANAGE).is_err() {
+        let resource_id = user_id.to_string();
+        audit::record_deny(
+            state.pool(),
+            &auth.context,
+            &auth.request_id,
+            AuditAction::MemberRemove.as_str(),
+            "member",
+            Some(&resource_id),
+            "permission_denied",
+        )
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+        return Err(RouteError::Denied(auth.request_id.clone()));
+    }
+
+    // Same pre-check rationale as `patch_member` above.
+    let existing = fetch_current_membership(state.pool(), &auth.context, user_id)
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+    if existing.is_none() {
+        return Err(RouteError::NotFound(auth.request_id.clone()));
+    }
+
+    members::remove_member(state.pool(), &auth.context, &auth.request_id, user_id)
+        .await
+        .map_err(|error| RouteError::from_member(error, &auth.request_id))?;
+
+    // Required by plan section 5 / services::members doc even though
+    // `remove_member` already hard-deletes refresh_tokens in the same
+    // transaction (this call becomes a harmless no-op in that case).
+    revoke_all_user_families(
+        state.pool(),
+        auth.context.org_id(),
+        user_id,
+        &auth.request_id,
+        "member_removed",
+    )
+    .await
+    .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ---------------------------------------------------------------------
+// E8 — GET /usage
+// ---------------------------------------------------------------------
+
+async fn usage_overview(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+) -> Result<Json<UsageResponse>, RouteError> {
+    require_permission(&auth.context, PERMISSION_MEMBER_MANAGE)
+        .map_err(|_| RouteError::Denied(auth.request_id.clone()))?;
+    let items = members::usage_overview(state.pool(), &auth.context)
+        .await
+        .map_err(|error| RouteError::from_member(error, &auth.request_id))?;
+    Ok(Json(UsageResponse {
+        items: items.into_iter().map(usage_dto).collect(),
+    }))
+}
+
+// ---------------------------------------------------------------------
+// Error mapping (fail-closed; see plan section on cross-org denial)
+// ---------------------------------------------------------------------
+
+enum RouteError {
+    Denied(String),
+    Validation(String, &'static str),
+    NotFound(String),
+    /// (request_id, machine code, human message)
+    Conflict(String, &'static str, &'static str),
+    Unauthorized(String),
+    Unavailable(String),
+    Database(String),
+}
+
+impl RouteError {
+    fn from_member(error: MemberError, request_id: &str) -> Self {
+        let request_id = request_id.to_string();
+        match error {
+            MemberError::NotFound | MemberError::InviteNotFound => Self::NotFound(request_id),
+            MemberError::InvalidToken => Self::Validation(request_id, "Invite token is malformed"),
+            MemberError::InviteTerminal => Self::Conflict(
+                request_id,
+                "invite_terminal",
+                "Invite has already been accepted or revoked",
+            ),
+            MemberError::InviteExpired => {
+                Self::Conflict(request_id, "invite_expired", "Invite has expired")
+            }
+            MemberError::AlreadyMember => Self::Conflict(
+                request_id,
+                "already_member",
+                "User is already a member of this organization",
+            ),
+            MemberError::LastOwner => Self::Conflict(
+                request_id,
+                "last_owner",
+                "Operation would leave the organization with zero active owners",
+            ),
+            MemberError::OwnerRequiredForOwnerInvite | MemberError::OwnerRequiredToManageOwner => {
+                Self::Denied(request_id)
+            }
+            MemberError::Database => Self::Database(request_id),
+        }
+    }
+}
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> Response {
+        let (status, code, message, request_id) = match self {
+            Self::Denied(request_id) => (
+                StatusCode::FORBIDDEN,
+                "forbidden",
+                "Permission denied",
+                request_id,
+            ),
+            Self::Validation(request_id, message) => (
+                StatusCode::BAD_REQUEST,
+                "validation_failed",
+                message,
+                request_id,
+            ),
+            Self::NotFound(request_id) => (
+                StatusCode::NOT_FOUND,
+                "not_found",
+                "Member resource not found",
+                request_id,
+            ),
+            Self::Conflict(request_id, code, message) => {
+                (StatusCode::CONFLICT, code, message, request_id)
+            }
+            Self::Unauthorized(request_id) => (
+                StatusCode::UNAUTHORIZED,
+                "unauthorized",
+                "Authentication required",
+                request_id,
+            ),
+            Self::Unavailable(request_id) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "auth_unavailable",
+                "Authentication is not configured",
+                request_id,
+            ),
+            Self::Database(request_id) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                "Request failed",
+                request_id,
+            ),
+        };
+        (
+            status,
+            Json(ApiError {
+                code: code.into(),
+                message: message.into(),
+                request_id,
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status_of(error: MemberError) -> StatusCode {
+        RouteError::from_member(error, "11111111-1111-1111-1111-111111111111")
+            .into_response()
+            .status()
+    }
+
+    #[test]
+    fn member_error_status_mapping_matches_plan_section_4() {
+        assert_eq!(status_of(MemberError::NotFound), StatusCode::NOT_FOUND);
+        assert_eq!(
+            status_of(MemberError::InviteNotFound),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(status_of(MemberError::LastOwner), StatusCode::CONFLICT);
+        assert_eq!(status_of(MemberError::InviteExpired), StatusCode::CONFLICT);
+        assert_eq!(status_of(MemberError::InviteTerminal), StatusCode::CONFLICT);
+        assert_eq!(status_of(MemberError::AlreadyMember), StatusCode::CONFLICT);
+        assert_eq!(
+            status_of(MemberError::OwnerRequiredForOwnerInvite),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            status_of(MemberError::OwnerRequiredToManageOwner),
+            StatusCode::FORBIDDEN
+        );
+        assert_eq!(
+            status_of(MemberError::InvalidToken),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            status_of(MemberError::Database),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[test]
+    fn conflict_codes_are_distinguishable_machine_codes() {
+        let codes: Vec<&str> = [
+            MemberError::LastOwner,
+            MemberError::InviteExpired,
+            MemberError::InviteTerminal,
+            MemberError::AlreadyMember,
+        ]
+        .into_iter()
+        .map(|error| match RouteError::from_member(error, "req") {
+            RouteError::Conflict(_, code, _) => code,
+            _ => unreachable!(),
+        })
+        .collect();
+        let unique: std::collections::BTreeSet<&str> = codes.iter().copied().collect();
+        assert_eq!(unique.len(), codes.len(), "conflict codes must be unique");
+    }
+
+    #[test]
+    fn role_rank_orders_owner_above_viewer() {
+        assert!(role_rank(MembershipRole::Owner) > role_rank(MembershipRole::Admin));
+        assert!(role_rank(MembershipRole::Admin) > role_rank(MembershipRole::Editor));
+        assert!(role_rank(MembershipRole::Editor) > role_rank(MembershipRole::Viewer));
+    }
+
+    #[test]
+    fn invite_status_reflects_terminal_and_expiry_precedence() {
+        use chrono::TimeZone;
+        let base = OrgInvite {
+            id: Uuid::new_v4(),
+            org_id: Uuid::new_v4(),
+            email: "invitee@example.com".into(),
+            role: MembershipRole::Editor,
+            token_hash: crate::db::models::SecretHash::new("deadbeef".repeat(8)),
+            invited_by_user_id: Uuid::new_v4(),
+            expires_at: Utc.with_ymd_and_hms(2100, 1, 1, 0, 0, 0).unwrap(),
+            accepted_at: None,
+            revoked_at: None,
+            created_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        };
+        let now = Utc.with_ymd_and_hms(2026, 6, 1, 0, 0, 0).unwrap();
+        assert_eq!(invite_status(&base, now), "pending");
+
+        let mut expired = base.clone();
+        expired.expires_at = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+        assert_eq!(invite_status(&expired, now), "expired");
+
+        let mut accepted = base.clone();
+        accepted.accepted_at = Some(now);
+        assert_eq!(invite_status(&accepted, now), "accepted");
+
+        // Revoked takes precedence even if also (hypothetically) accepted.
+        let mut revoked = base.clone();
+        revoked.revoked_at = Some(now);
+        assert_eq!(invite_status(&revoked, now), "revoked");
+    }
+}

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -7,6 +7,7 @@ pub mod documents;
 pub mod events;
 pub mod health;
 pub mod jobs;
+pub mod members;
 pub mod rate_limit_guard;
 pub mod search;
 pub mod uploads;

--- a/crates/server/src/services/audit.rs
+++ b/crates/server/src/services/audit.rs
@@ -48,6 +48,15 @@ pub enum AuditAction {
     ReconcileDeadLetterGc,
     VectorCleanupIntent,
     ObjectCleanup,
+    // P2-11 / 1C-02 membership + invite admin surface (Wave 1 domain layer).
+    // Suspend/reactivate deliberately reuse `MemberRoleChange` (metadata carries
+    // old_state/new_state instead of old_role/new_role) rather than adding a
+    // sixth variant — see plans/reports/plan-260728-0231-...-slice.md section 8b.
+    MemberInvite,
+    MemberInviteAccept,
+    MemberInviteRevoke,
+    MemberRoleChange,
+    MemberRemove,
 }
 
 impl AuditAction {
@@ -82,6 +91,11 @@ impl AuditAction {
             Self::ReconcileDeadLetterGc => "reconcile.dead_letter_gc",
             Self::VectorCleanupIntent => "vector.cleanup_intent",
             Self::ObjectCleanup => "object.cleanup",
+            Self::MemberInvite => "member.invite",
+            Self::MemberInviteAccept => "member.invite_accept",
+            Self::MemberInviteRevoke => "member.invite_revoke",
+            Self::MemberRoleChange => "member.role_change",
+            Self::MemberRemove => "member.remove",
         }
     }
 
@@ -116,6 +130,11 @@ impl AuditAction {
             "reconcile.dead_letter_gc" => Ok(Self::ReconcileDeadLetterGc),
             "vector.cleanup_intent" => Ok(Self::VectorCleanupIntent),
             "object.cleanup" => Ok(Self::ObjectCleanup),
+            "member.invite" => Ok(Self::MemberInvite),
+            "member.invite_accept" => Ok(Self::MemberInviteAccept),
+            "member.invite_revoke" => Ok(Self::MemberInviteRevoke),
+            "member.role_change" => Ok(Self::MemberRoleChange),
+            "member.remove" => Ok(Self::MemberRemove),
             _ => Err(format!("audit_action_invalid:{value}")),
         }
     }
@@ -206,6 +225,21 @@ impl AuditAction {
                 "object_count",
             ],
             Self::VectorCleanupIntent => &["document_id", "phase", "result", "point_count"],
+            // Structural only: target user / invite ids, role and state enums.
+            // Never email (invite recipient), never the invite plaintext token
+            // (only `org_invites.token_hash` ever reaches storage, and that
+            // never enters audit metadata either) — see plan section 2 (C3).
+            Self::MemberInvite | Self::MemberInviteAccept => &["reason", "invite_id", "role"],
+            Self::MemberInviteRevoke => &["reason", "invite_id"],
+            Self::MemberRoleChange => &[
+                "reason",
+                "target_user_id",
+                "old_role",
+                "new_role",
+                "old_state",
+                "new_state",
+            ],
+            Self::MemberRemove => &["reason", "target_user_id", "old_role"],
         }
     }
 }
@@ -222,6 +256,7 @@ pub enum AuditResource {
     AskStream,
     Search,
     Conflict,
+    Member,
 }
 
 impl AuditResource {
@@ -237,6 +272,7 @@ impl AuditResource {
             Self::AskStream => "ask_stream",
             Self::Search => "search",
             Self::Conflict => "conflict",
+            Self::Member => "member",
         }
     }
 
@@ -252,6 +288,7 @@ impl AuditResource {
             "ask_stream" => Ok(Self::AskStream),
             "search" => Ok(Self::Search),
             "conflict" => Ok(Self::Conflict),
+            "member" => Ok(Self::Member),
             _ => Err(format!("audit_resource_type_invalid:{value}")),
         }
     }

--- a/crates/server/src/services/members.rs
+++ b/crates/server/src/services/members.rs
@@ -1,0 +1,811 @@
+//! Membership + invite domain services (Wave 1 domain layer, P2-11 / 1C-02).
+//!
+//! Wave 2 builds HTTP routes (E1-E8 in
+//! `plans/reports/plan-260728-0231-markhand-web-membership-admin-slice.md`)
+//! on top of these functions. Nothing here talks axum/HTTP; [`MemberError`] is
+//! a plain typed enum so the route layer maps it to a status code (in
+//! particular `LastOwner` -> 409) without inferring intent from a string.
+//!
+//! Design notes that matter for Wave 2 / reviewers:
+//! - **Last-owner invariant** ([`check_last_owner_invariant`]) is a pure,
+//!   DB-free function over already-locked owner rows, so it has fast unit
+//!   tests. The DB-touching wrapper ([`guard_last_owner`]) takes
+//!   `db::members::lock_owner_rows` (`SELECT ... FOR UPDATE` on every
+//!   owner-role row in the org) *inside the same transaction* as the mutation
+//!   it guards, so two concurrent operations against the same org's owners
+//!   serialize on those row locks. Concurrent-race coverage is Wave 2's
+//!   DB-gated test (see module doc bottom).
+//! - **Invite tokens** embed the org id in the plaintext
+//!   (`mhinv1.<org_id>.<secret>`), exactly mirroring
+//!   `auth::session`'s refresh-token shape (`mh1.<org_id>.<secret>`). This is
+//!   required, not cosmetic: `org_invites` is `FORCE ROW LEVEL SECURITY`
+//!   scoped by the `app.org_id` GUC, and accept-invite runs before the
+//!   caller has any membership/permission in the target org, so there is no
+//!   other fail-closed way to pick the right GUC before querying by hash.
+//! - **Remove vs. suspend vs. downgrade** differ in what they do to
+//!   `refresh_tokens`: `remove_member` hard-deletes those rows in the same
+//!   transaction (required by the `refresh_tokens(org_id,user_id) REFERENCES
+//!   org_memberships` FK, which has no `ON DELETE` action and therefore
+//!   RESTRICTs the membership DELETE while any referencing row — even a
+//!   revoked one — still exists). `suspend_member`/`change_role` keep the
+//!   membership row, so the FK is untouched; Wave 2 MUST separately call
+//!   `auth::session::revoke_all_user_families` after those two so an
+//!   already-issued short-lived access token can't coast to expiry with
+//!   stale permissions. Calling `revoke_all_user_families` before or after
+//!   `remove_member` is harmless (it becomes a no-op once the rows are gone).
+//!
+//! DB-gated tests Wave 2 must still write (not covered here, no DB in Wave 1):
+//! - Concurrent last-owner race: two txns racing to remove/downgrade/suspend
+//!   two different owners of the same org — exactly one must succeed, the
+//!   org must retain >= 1 active owner afterwards.
+//! - Invite replay/expiry against real Postgres: accept same token twice,
+//!   accept after revoke, accept after `expires_at` — all reject; a valid
+//!   accept creates the membership row and the `member.invite_accept` audit
+//!   row in the same commit.
+//! - Cross-org denial (plan section 2, caveat C1): org A admin can't
+//!   list/patch/delete org B's members via these functions (RLS should make
+//!   the row simply not exist under org A's GUC — assert `NotFound`/empty,
+//!   not a 403-shaped leak); an org A invite token must not accept into org B
+//!   even if somehow presented with org B's GUC.
+//! - `remove_member` really does clear `refresh_tokens` and a subsequent
+//!   refresh with the old token is rejected.
+
+use chrono::{DateTime, Duration, Utc};
+use deadpool_postgres::Pool;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio_postgres::Transaction;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::config::SecretString;
+use crate::db::error::DbError;
+use crate::db::members::{self, NewInvite, OwnerRow};
+use crate::db::models::{
+    AuditOutcome, MembershipRole, MembershipState, OrgInvite, OrgMembership, ResourceKind,
+};
+use crate::db::pool::with_org_txn_typed;
+use crate::db::quota;
+use crate::services::audit::{self, AuditAction, AuditRecord};
+
+const INVITE_TOKEN_PREFIX: &str = "mhinv1";
+const INVITE_TOKEN_SECRET_BYTES: usize = 32;
+
+/// Default invite lifetime (7 days); callers may pass a different TTL.
+pub const DEFAULT_INVITE_TTL_SECS: i64 = 7 * 24 * 3600;
+
+/// Typed domain errors. Wave 2 maps these to HTTP status codes; in particular
+/// `LastOwner` -> 409 (plan section 4, E6/E7).
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum MemberError {
+    #[error("membership not found")]
+    NotFound,
+    #[error("invite not found")]
+    InviteNotFound,
+    #[error("invite token is malformed")]
+    InvalidToken,
+    #[error("invite already accepted or revoked")]
+    InviteTerminal,
+    #[error("invite has expired")]
+    InviteExpired,
+    #[error("user is already a member of this org")]
+    AlreadyMember,
+    #[error("operation would leave the org with zero active owners")]
+    LastOwner,
+    #[error("only an active owner may invite a new owner")]
+    OwnerRequiredForOwnerInvite,
+    #[error("database error")]
+    Database,
+}
+
+impl From<DbError> for MemberError {
+    fn from(_: DbError) -> Self {
+        Self::Database
+    }
+}
+
+// ---------------------------------------------------------------------
+// Last-owner invariant (pure, fast-unit-testable — no DB in this function)
+// ---------------------------------------------------------------------
+
+/// Pure last-owner invariant check.
+///
+/// `owners` is every owner-role membership row in the org, exactly as read
+/// (and, in production, row-locked `FOR UPDATE`) by
+/// [`db::members::lock_owner_rows`](crate::db::members::lock_owner_rows).
+/// `target_user_id` is the membership being changed; `target_will_be_active_owner`
+/// is what the target's row will look like *after* the operation completes:
+/// `false` for remove/suspend/downgrade-away-from-owner, `true` only when the
+/// target keeps or gains an active owner role. Only `MembershipState::Active`
+/// owners count — a suspended owner does not keep the org "owned".
+pub fn check_last_owner_invariant(
+    owners: &[OwnerRow],
+    target_user_id: Uuid,
+    target_will_be_active_owner: bool,
+) -> Result<(), MemberError> {
+    let others_active = owners
+        .iter()
+        .filter(|owner| owner.user_id != target_user_id && owner.state == MembershipState::Active)
+        .count();
+    let remaining = others_active + usize::from(target_will_be_active_owner);
+    if remaining == 0 {
+        return Err(MemberError::LastOwner);
+    }
+    Ok(())
+}
+
+async fn guard_last_owner(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    target_user_id: Uuid,
+    target_will_be_active_owner: bool,
+) -> Result<(), MemberError> {
+    let owners = members::lock_owner_rows(txn, ctx).await?;
+    check_last_owner_invariant(&owners, target_user_id, target_will_be_active_owner)
+}
+
+// ---------------------------------------------------------------------
+// Invite token hashing / lifecycle (pure helpers, fast-unit-testable)
+// ---------------------------------------------------------------------
+
+/// Hashes an opaque invite token for storage (SHA-256 hex) — same scheme as
+/// `auth::session::hash_refresh_token`, applied independently here so this
+/// module has no compile-time dependency on the session module.
+fn hash_invite_token(token: &str) -> String {
+    hex::encode(Sha256::digest(token.as_bytes()))
+}
+
+/// App-side hash verification, exercised directly by unit tests. The
+/// production accept-invite path uses an equality lookup in SQL
+/// (`db::members::find_invite_by_token_hash`) instead of calling this, but
+/// the check is the same computation either way.
+pub fn verify_invite_token(plaintext: &str, stored_hash: &str) -> bool {
+    hash_invite_token(plaintext) == stored_hash
+}
+
+fn mint_invite_token(org_id: Uuid) -> SecretString {
+    let mut bytes = [0u8; INVITE_TOKEN_SECRET_BYTES];
+    rand::fill(&mut bytes[..]);
+    let secret = base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, bytes);
+    SecretString::new(format!("{INVITE_TOKEN_PREFIX}.{org_id}.{secret}"))
+}
+
+/// Parses `mhinv1.<org_id>.<secret>` without logging the secret.
+fn parse_invite_token(token: &str) -> Result<(Uuid, &str), MemberError> {
+    let mut parts = token.splitn(3, '.');
+    let prefix = parts.next().ok_or(MemberError::InvalidToken)?;
+    let org_raw = parts.next().ok_or(MemberError::InvalidToken)?;
+    let secret = parts.next().ok_or(MemberError::InvalidToken)?;
+    if prefix != INVITE_TOKEN_PREFIX || secret.is_empty() || secret.len() < 16 {
+        return Err(MemberError::InvalidToken);
+    }
+    let org_id = Uuid::parse_str(org_raw).map_err(|_| MemberError::InvalidToken)?;
+    Ok((org_id, secret))
+}
+
+/// Pure invite-acceptability check: not expired, not already terminal
+/// (accepted or revoked). Mirrors `ck_org_invites__terminal_xor`.
+pub fn check_invite_acceptable(invite: &OrgInvite, now: DateTime<Utc>) -> Result<(), MemberError> {
+    if invite.accepted_at.is_some() || invite.revoked_at.is_some() {
+        return Err(MemberError::InviteTerminal);
+    }
+    if invite.expires_at <= now {
+        return Err(MemberError::InviteExpired);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// Membership reads
+// ---------------------------------------------------------------------
+
+/// Lists every membership in the tenant (E1).
+pub async fn list_members(
+    pool: &Pool,
+    ctx: &OrgContext,
+) -> Result<Vec<OrgMembership>, MemberError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| Box::pin(async move { Ok(members::list(txn, &ctx).await?) })
+    })
+    .await
+}
+
+/// Lists every invite in the tenant, open and terminal (E2). Callers must
+/// never surface `token_hash` to a client.
+pub async fn list_invites(pool: &Pool, ctx: &OrgContext) -> Result<Vec<OrgInvite>, MemberError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| Box::pin(async move { Ok(members::list_invites(txn, &ctx).await?) })
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------
+// Invite create / accept / revoke (E3-E5)
+// ---------------------------------------------------------------------
+
+/// Result of creating an invite: the plaintext token is surfaced exactly
+/// once here — callers (Wave 2's route) must return it in the response body
+/// and MUST NOT log it or pass it to `services::audit` (the metadata
+/// allowlist for `MemberInvite` does not include a token field, so passing
+/// it would fail closed at `sanitize_for_action`, but don't rely on that as
+/// the only guard).
+pub struct CreatedInvite {
+    pub invite: OrgInvite,
+    pub plaintext_token: SecretString,
+}
+
+/// Creates a single-use invite (E3). Only an active owner may invite a new
+/// owner (plan section 4, E3 note); any active member with the caller's
+/// permission (`member.manage`, enforced by Wave 2's route guard) may invite
+/// non-owner roles.
+pub async fn create_invite(
+    pool: &Pool,
+    ctx: &OrgContext,
+    request_id: &str,
+    email: &str,
+    role: MembershipRole,
+    ttl_secs: i64,
+) -> Result<CreatedInvite, MemberError> {
+    let email = email.trim().to_ascii_lowercase();
+    let expires_at = Utc::now() + Duration::seconds(ttl_secs.max(60));
+    let invite_id = Uuid::new_v4();
+    let plaintext = mint_invite_token(ctx.org_id());
+    let token_hash = hash_invite_token(plaintext.expose());
+
+    let invite = with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        let request_id = request_id.to_string();
+        move |txn| {
+            Box::pin(async move {
+                if role == MembershipRole::Owner {
+                    let caller = members::get(txn, &ctx, ctx.user_id()).await?;
+                    if caller.role != MembershipRole::Owner
+                        || caller.state != MembershipState::Active
+                    {
+                        return Err(MemberError::OwnerRequiredForOwnerInvite);
+                    }
+                }
+                let invite = members::insert_invite(
+                    txn,
+                    &ctx,
+                    NewInvite {
+                        id: invite_id,
+                        email: &email,
+                        role,
+                        token_hash: &token_hash,
+                        invited_by_user_id: ctx.user_id(),
+                        expires_at,
+                    },
+                )
+                .await?;
+                audit::record_in_txn(
+                    txn,
+                    &ctx,
+                    AuditRecord {
+                        request_id: &request_id,
+                        action: AuditAction::MemberInvite.as_str(),
+                        resource_type: "member",
+                        resource_id: Some(&invite.id.to_string()),
+                        outcome: AuditOutcome::Success,
+                        metadata: serde_json::json!({
+                            "invite_id": invite.id.to_string(),
+                            "role": role.as_str(),
+                        }),
+                    },
+                )
+                .await?;
+                Ok(invite)
+            })
+        }
+    })
+    .await?;
+
+    Ok(CreatedInvite {
+        invite,
+        plaintext_token: plaintext,
+    })
+}
+
+/// Accepts an invite by presenting its plaintext token (E5). Auth-only: the
+/// caller only needs a valid session, not `member.manage` in the target org
+/// (they have no membership there yet). Creates the membership transactionally
+/// with marking the invite accepted; rejects replay/expiry/revoked tokens.
+pub async fn accept_invite(
+    pool: &Pool,
+    plaintext_token: &str,
+    accepting_user_id: Uuid,
+    request_id: &str,
+) -> Result<OrgMembership, MemberError> {
+    let (org_id, _secret) = parse_invite_token(plaintext_token)?;
+    let token_hash = hash_invite_token(plaintext_token);
+    let provisional = OrgContext::try_new(org_id, accepting_user_id, [] as [&str; 0], [])
+        .map_err(|_| MemberError::InvalidToken)?;
+
+    with_org_txn_typed(pool, &provisional, {
+        let ctx = provisional.clone();
+        let request_id = request_id.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let invite = members::find_invite_by_token_hash(txn, &ctx, &token_hash)
+                    .await?
+                    .ok_or(MemberError::InviteNotFound)?;
+                check_invite_acceptable(&invite, Utc::now())?;
+
+                let inserted =
+                    members::try_insert(txn, &ctx, accepting_user_id, invite.role).await?;
+                let Some(membership) = inserted else {
+                    return Err(MemberError::AlreadyMember);
+                };
+                members::mark_invite_accepted(txn, &ctx, invite.id, Utc::now()).await?;
+
+                audit::record_in_txn(
+                    txn,
+                    &ctx,
+                    AuditRecord {
+                        request_id: &request_id,
+                        action: AuditAction::MemberInviteAccept.as_str(),
+                        resource_type: "member",
+                        resource_id: Some(&invite.id.to_string()),
+                        outcome: AuditOutcome::Success,
+                        metadata: serde_json::json!({
+                            "invite_id": invite.id.to_string(),
+                            "role": invite.role.as_str(),
+                        }),
+                    },
+                )
+                .await?;
+                Ok(membership)
+            })
+        }
+    })
+    .await
+}
+
+/// Revokes an invite that has not yet been accepted/revoked (E4).
+pub async fn revoke_invite(
+    pool: &Pool,
+    ctx: &OrgContext,
+    request_id: &str,
+    invite_id: Uuid,
+) -> Result<OrgInvite, MemberError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        let request_id = request_id.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let existing = members::get_invite(txn, &ctx, invite_id).await.map_err(
+                    |error| match error {
+                        DbError::NotFound => MemberError::InviteNotFound,
+                        other => MemberError::from(other),
+                    },
+                )?;
+                if existing.accepted_at.is_some() || existing.revoked_at.is_some() {
+                    return Err(MemberError::InviteTerminal);
+                }
+                let invite = members::mark_invite_revoked(txn, &ctx, invite_id, Utc::now()).await?;
+                audit::record_in_txn(
+                    txn,
+                    &ctx,
+                    AuditRecord {
+                        request_id: &request_id,
+                        action: AuditAction::MemberInviteRevoke.as_str(),
+                        resource_type: "member",
+                        resource_id: Some(&invite.id.to_string()),
+                        outcome: AuditOutcome::Success,
+                        metadata: serde_json::json!({ "invite_id": invite.id.to_string() }),
+                    },
+                )
+                .await?;
+                Ok(invite)
+            })
+        }
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------
+// Role change / remove / suspend (E6-E7) — last-owner invariant applies
+// ---------------------------------------------------------------------
+
+/// Changes a member's role (E6). Runs the last-owner invariant in the same
+/// transaction: if `target_user_id` currently holds an active owner role and
+/// `new_role` is not `Owner`, this fails closed with `LastOwner` when they
+/// are the org's only remaining active owner.
+///
+/// Wave 2 must call `auth::session::revoke_all_user_families` after a
+/// successful downgrade so an already-issued access token cannot coast on
+/// stale permissions until it naturally expires.
+pub async fn change_role(
+    pool: &Pool,
+    ctx: &OrgContext,
+    request_id: &str,
+    target_user_id: Uuid,
+    new_role: MembershipRole,
+) -> Result<OrgMembership, MemberError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        let request_id = request_id.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let current = members::get(txn, &ctx, target_user_id).await?;
+                let will_be_active_owner =
+                    new_role == MembershipRole::Owner && current.state == MembershipState::Active;
+                guard_last_owner(txn, &ctx, target_user_id, will_be_active_owner).await?;
+
+                let updated = members::update_role(txn, &ctx, target_user_id, new_role).await?;
+                audit::record_in_txn(
+                    txn,
+                    &ctx,
+                    AuditRecord {
+                        request_id: &request_id,
+                        action: AuditAction::MemberRoleChange.as_str(),
+                        resource_type: "member",
+                        resource_id: Some(&target_user_id.to_string()),
+                        outcome: AuditOutcome::Success,
+                        metadata: serde_json::json!({
+                            "target_user_id": target_user_id.to_string(),
+                            "old_role": current.role.as_str(),
+                            "new_role": new_role.as_str(),
+                        }),
+                    },
+                )
+                .await?;
+                Ok(updated)
+            })
+        }
+    })
+    .await
+}
+
+/// Removes a member from the org entirely (E7). Runs the last-owner
+/// invariant, then hard-deletes the user's `refresh_tokens` rows in the org
+/// before deleting the membership row (required by the FK — see
+/// `db::members::delete` doc comment).
+///
+/// This already fully invalidates the user's sessions in this org, so
+/// whether Wave 2 also calls `auth::session::revoke_all_user_families` before
+/// or after this is a no-op either way; it is not required for correctness
+/// here (unlike for `change_role` downgrade / `suspend_member`, where the
+/// membership row survives and an existing access token could otherwise
+/// coast until expiry).
+pub async fn remove_member(
+    pool: &Pool,
+    ctx: &OrgContext,
+    request_id: &str,
+    target_user_id: Uuid,
+) -> Result<(), MemberError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        let request_id = request_id.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let current = members::get(txn, &ctx, target_user_id).await?;
+                guard_last_owner(txn, &ctx, target_user_id, false).await?;
+
+                members::purge_refresh_tokens(txn, &ctx, target_user_id).await?;
+                members::delete(txn, &ctx, target_user_id).await?;
+
+                audit::record_in_txn(
+                    txn,
+                    &ctx,
+                    AuditRecord {
+                        request_id: &request_id,
+                        action: AuditAction::MemberRemove.as_str(),
+                        resource_type: "member",
+                        resource_id: Some(&target_user_id.to_string()),
+                        outcome: AuditOutcome::Success,
+                        metadata: serde_json::json!({
+                            "target_user_id": target_user_id.to_string(),
+                            "old_role": current.role.as_str(),
+                        }),
+                    },
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+}
+
+/// Suspends a member: `state` becomes `suspended`, row/role/history kept.
+/// The org-context resolver (`auth::permissions::resolve_org_context*`)
+/// treats a suspended membership exactly like a missing one on the next
+/// request. Runs the last-owner invariant (a suspended owner never counts as
+/// active). Wave 2 must call `revoke_all_user_families` afterwards — same
+/// reasoning as a role downgrade.
+pub async fn suspend_member(
+    pool: &Pool,
+    ctx: &OrgContext,
+    request_id: &str,
+    target_user_id: Uuid,
+) -> Result<OrgMembership, MemberError> {
+    set_member_state(
+        pool,
+        ctx,
+        request_id,
+        target_user_id,
+        MembershipState::Suspended,
+    )
+    .await
+}
+
+/// Reactivates a previously suspended member. Never reduces the active-owner
+/// count, so the invariant is not (and need not be) checked here.
+pub async fn reactivate_member(
+    pool: &Pool,
+    ctx: &OrgContext,
+    request_id: &str,
+    target_user_id: Uuid,
+) -> Result<OrgMembership, MemberError> {
+    set_member_state(
+        pool,
+        ctx,
+        request_id,
+        target_user_id,
+        MembershipState::Active,
+    )
+    .await
+}
+
+async fn set_member_state(
+    pool: &Pool,
+    ctx: &OrgContext,
+    request_id: &str,
+    target_user_id: Uuid,
+    new_state: MembershipState,
+) -> Result<OrgMembership, MemberError> {
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        let request_id = request_id.to_string();
+        move |txn| {
+            Box::pin(async move {
+                let current = members::get(txn, &ctx, target_user_id).await?;
+                if new_state == MembershipState::Suspended {
+                    guard_last_owner(txn, &ctx, target_user_id, false).await?;
+                }
+                let updated = members::set_state(txn, &ctx, target_user_id, new_state).await?;
+                audit::record_in_txn(
+                    txn,
+                    &ctx,
+                    AuditRecord {
+                        request_id: &request_id,
+                        action: AuditAction::MemberRoleChange.as_str(),
+                        resource_type: "member",
+                        resource_id: Some(&target_user_id.to_string()),
+                        outcome: AuditOutcome::Success,
+                        metadata: serde_json::json!({
+                            "target_user_id": target_user_id.to_string(),
+                            "old_state": current.state.as_str(),
+                            "new_state": new_state.as_str(),
+                        }),
+                    },
+                )
+                .await?;
+                Ok(updated)
+            })
+        }
+    })
+    .await
+}
+
+// ---------------------------------------------------------------------
+// Usage aggregation (E8) — assembled from existing db::quota read fns
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResourceUsage {
+    pub kind: ResourceKind,
+    pub limit: i64,
+    pub committed: i64,
+    pub reserved: i64,
+    pub remaining: i64,
+}
+
+const ALL_RESOURCE_KINDS: [ResourceKind; 4] = [
+    ResourceKind::StorageBytes,
+    ResourceKind::Documents,
+    ResourceKind::ConcurrentJobs,
+    ResourceKind::Tokens,
+];
+
+/// Assembles per-`ResourceKind` {limit, committed, reserved, remaining} from
+/// the existing `db::quota` read functions (E8).
+pub async fn usage_overview(
+    pool: &Pool,
+    ctx: &OrgContext,
+) -> Result<Vec<ResourceUsage>, MemberError> {
+    let observed_at = Utc::now();
+    with_org_txn_typed(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let mut out = Vec::with_capacity(ALL_RESOURCE_KINDS.len());
+                for kind in ALL_RESOURCE_KINDS {
+                    let usage = quota::usage(txn, &ctx, kind, observed_at).await?;
+                    let remaining = (usage.limit - usage.committed - usage.active_reserved).max(0);
+                    out.push(ResourceUsage {
+                        kind,
+                        limit: usage.limit,
+                        committed: usage.committed,
+                        reserved: usage.active_reserved,
+                        remaining,
+                    });
+                }
+                Ok(out)
+            })
+        }
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn owner(user_id: Uuid, state: MembershipState) -> OwnerRow {
+        OwnerRow { user_id, state }
+    }
+
+    // --- Last-owner invariant: fast, DB-free mutation-test target ---
+
+    #[test]
+    fn two_active_owners_allow_remove_downgrade_suspend_of_one() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let owners = [
+            owner(a, MembershipState::Active),
+            owner(b, MembershipState::Active),
+        ];
+
+        // remove(a): a's row disappears -> target_will_be_active_owner = false.
+        assert_eq!(check_last_owner_invariant(&owners, a, false), Ok(()));
+        // downgrade(a) away from owner: same shape, target no longer an owner.
+        assert_eq!(check_last_owner_invariant(&owners, a, false), Ok(()));
+        // suspend(a): a stops counting as active regardless of role.
+        assert_eq!(check_last_owner_invariant(&owners, a, false), Ok(()));
+    }
+
+    #[test]
+    fn single_active_owner_blocks_remove_downgrade_suspend() {
+        let sole = Uuid::new_v4();
+        let owners = [owner(sole, MembershipState::Active)];
+
+        // remove(sole)
+        assert_eq!(
+            check_last_owner_invariant(&owners, sole, false),
+            Err(MemberError::LastOwner)
+        );
+        // downgrade(sole) to a non-owner role
+        assert_eq!(
+            check_last_owner_invariant(&owners, sole, false),
+            Err(MemberError::LastOwner)
+        );
+        // suspend(sole)
+        assert_eq!(
+            check_last_owner_invariant(&owners, sole, false),
+            Err(MemberError::LastOwner)
+        );
+    }
+
+    #[test]
+    fn a_suspended_owner_does_not_count_as_the_remaining_owner() {
+        let active = Uuid::new_v4();
+        let suspended = Uuid::new_v4();
+        let owners = [
+            owner(active, MembershipState::Active),
+            owner(suspended, MembershipState::Suspended),
+        ];
+        // Removing the only *active* owner must fail even though a second
+        // (suspended) owner row still exists.
+        assert_eq!(
+            check_last_owner_invariant(&owners, active, false),
+            Err(MemberError::LastOwner)
+        );
+    }
+
+    #[test]
+    fn promoting_a_new_owner_never_trips_the_guard() {
+        let sole = Uuid::new_v4();
+        let promoted = Uuid::new_v4();
+        let owners = [owner(sole, MembershipState::Active)];
+        // Promoted user isn't in the owners list yet; will become one.
+        assert_eq!(check_last_owner_invariant(&owners, promoted, true), Ok(()));
+    }
+
+    // --- Invite hashing / lifecycle: fast, DB-free ---
+
+    #[test]
+    fn invite_token_hash_verifies_and_rejects_wrong_token() {
+        let hash = hash_invite_token("mhinv1.11111111-1111-1111-1111-111111111111.super-secret");
+        assert!(verify_invite_token(
+            "mhinv1.11111111-1111-1111-1111-111111111111.super-secret",
+            &hash
+        ));
+        assert!(!verify_invite_token("wrong-token", &hash));
+    }
+
+    #[test]
+    fn invite_token_mint_and_parse_roundtrips_org_id() {
+        let org_id = Uuid::new_v4();
+        let token = mint_invite_token(org_id);
+        let (parsed_org, secret) = parse_invite_token(token.expose()).unwrap();
+        assert_eq!(parsed_org, org_id);
+        assert!(secret.len() >= 16);
+    }
+
+    #[test]
+    fn invite_token_parse_rejects_malformed_input() {
+        assert_eq!(
+            parse_invite_token("garbage"),
+            Err(MemberError::InvalidToken)
+        );
+        assert_eq!(
+            parse_invite_token("mhinv1.not-a-uuid.secretsecretsecret"),
+            Err(MemberError::InvalidToken)
+        );
+        assert_eq!(
+            parse_invite_token(&format!("mhinv1.{}.short", Uuid::new_v4())),
+            Err(MemberError::InvalidToken)
+        );
+    }
+
+    fn sample_invite(
+        accepted_at: Option<DateTime<Utc>>,
+        revoked_at: Option<DateTime<Utc>>,
+        expires_at: DateTime<Utc>,
+    ) -> OrgInvite {
+        OrgInvite {
+            id: Uuid::new_v4(),
+            org_id: Uuid::new_v4(),
+            email: "invitee@example.com".into(),
+            role: MembershipRole::Editor,
+            token_hash: crate::db::models::SecretHash::new("deadbeef".repeat(8)),
+            invited_by_user_id: Uuid::new_v4(),
+            expires_at,
+            accepted_at,
+            revoked_at,
+            created_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        }
+    }
+
+    #[test]
+    fn invite_accept_check_rejects_expired() {
+        let past = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+        let invite = sample_invite(None, None, past);
+        assert_eq!(
+            check_invite_acceptable(&invite, Utc::now()),
+            Err(MemberError::InviteExpired)
+        );
+    }
+
+    #[test]
+    fn invite_accept_check_rejects_already_accepted() {
+        let future = Utc.with_ymd_and_hms(2100, 1, 1, 0, 0, 0).unwrap();
+        let invite = sample_invite(Some(Utc::now()), None, future);
+        assert_eq!(
+            check_invite_acceptable(&invite, Utc::now()),
+            Err(MemberError::InviteTerminal)
+        );
+    }
+
+    #[test]
+    fn invite_accept_check_rejects_revoked() {
+        let future = Utc.with_ymd_and_hms(2100, 1, 1, 0, 0, 0).unwrap();
+        let invite = sample_invite(None, Some(Utc::now()), future);
+        assert_eq!(
+            check_invite_acceptable(&invite, Utc::now()),
+            Err(MemberError::InviteTerminal)
+        );
+    }
+
+    #[test]
+    fn invite_accept_check_accepts_valid() {
+        let future = Utc.with_ymd_and_hms(2100, 1, 1, 0, 0, 0).unwrap();
+        let invite = sample_invite(None, None, future);
+        assert_eq!(check_invite_acceptable(&invite, Utc::now()), Ok(()));
+    }
+}

--- a/crates/server/src/services/members.rs
+++ b/crates/server/src/services/members.rs
@@ -94,13 +94,35 @@ pub enum MemberError {
     LastOwner,
     #[error("only an active owner may invite a new owner")]
     OwnerRequiredForOwnerInvite,
+    #[error("only an active owner may grant or manage an owner")]
+    OwnerRequiredToManageOwner,
     #[error("database error")]
     Database,
 }
 
+/// Pure decision: does this membership operation touch the owner tier and so
+/// require the *caller* to be an active owner? True when the operation grants
+/// owner, or when its target is currently an owner (demote/remove/suspend/
+/// reactivate of an owner). Phase 1C-02 acceptance: "admin không quản owner".
+/// Kept pure so the rule is unit- and mutation-testable without a database.
+pub fn operation_manages_owner(target_current_role: MembershipRole, grants_owner: bool) -> bool {
+    grants_owner || target_current_role == MembershipRole::Owner
+}
+
 impl From<DbError> for MemberError {
-    fn from(_: DbError) -> Self {
-        Self::Database
+    fn from(err: DbError) -> Self {
+        // `NotFound` must not collapse into `Database` (→ 500). Every bare `?`
+        // on a `members::get`/`mark_invite_accepted` here can legitimately hit
+        // a row that a concurrent delete removed between a route's pre-check
+        // and this transaction; the caller maps `NotFound` → 404, which is the
+        // honest answer, instead of an opaque 500 indistinguishable from a real
+        // outage. The invite-lookup path maps `NotFound` → `InviteNotFound`
+        // explicitly *before* this blanket conversion is reached, so member
+        // gets are the only thing this arm relabels.
+        match err {
+            DbError::NotFound => Self::NotFound,
+            _ => Self::Database,
+        }
     }
 }
 
@@ -142,6 +164,29 @@ async fn guard_last_owner(
 ) -> Result<(), MemberError> {
     let owners = members::lock_owner_rows(txn, ctx).await?;
     check_last_owner_invariant(&owners, target_user_id, target_will_be_active_owner)
+}
+
+/// Enforces "only an active owner may grant or manage an owner" in the same
+/// transaction as the mutation. Without this, `guard_last_owner` alone lets any
+/// `member.manage` holder `PATCH {self} {role: owner}` — it only stops the
+/// *count* reaching zero, never restricts *who* may reach the owner tier — so a
+/// non-owner admin could self-promote and take over the tenant. The caller row
+/// is read inside the mutation txn so a concurrent demote of the caller is
+/// observed.
+async fn guard_owner_tier(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    target_current_role: MembershipRole,
+    grants_owner: bool,
+) -> Result<(), MemberError> {
+    if !operation_manages_owner(target_current_role, grants_owner) {
+        return Ok(());
+    }
+    let caller = members::get(txn, ctx, ctx.user_id()).await?;
+    if caller.role != MembershipRole::Owner || caller.state != MembershipState::Active {
+        return Err(MemberError::OwnerRequiredToManageOwner);
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------
@@ -430,6 +475,17 @@ pub async fn change_role(
         move |txn| {
             Box::pin(async move {
                 let current = members::get(txn, &ctx, target_user_id).await?;
+                // Owner-tier gate BEFORE the no-op short-circuit, so an admin
+                // cannot probe "is this user an owner?" by PATCHing owner→owner
+                // and reading 200 vs 403 — the gate answers 403 either way.
+                guard_owner_tier(txn, &ctx, current.role, new_role == MembershipRole::Owner)
+                    .await?;
+                // A role no-op changes nothing: skip the mutation and the
+                // audit row so the trail never records a misleading "owner →
+                // owner" change (adversarial review finding #5).
+                if new_role == current.role {
+                    return Ok(current);
+                }
                 let will_be_active_owner =
                     new_role == MembershipRole::Owner && current.state == MembershipState::Active;
                 guard_last_owner(txn, &ctx, target_user_id, will_be_active_owner).await?;
@@ -482,6 +538,8 @@ pub async fn remove_member(
         move |txn| {
             Box::pin(async move {
                 let current = members::get(txn, &ctx, target_user_id).await?;
+                // Removing an owner is managing an owner → owner-only.
+                guard_owner_tier(txn, &ctx, current.role, false).await?;
                 guard_last_owner(txn, &ctx, target_user_id, false).await?;
 
                 members::purge_refresh_tokens(txn, &ctx, target_user_id).await?;
@@ -563,6 +621,13 @@ async fn set_member_state(
         move |txn| {
             Box::pin(async move {
                 let current = members::get(txn, &ctx, target_user_id).await?;
+                // Suspending or reactivating an owner is managing an owner →
+                // owner-only, checked before the no-op short-circuit for the
+                // same anti-probe reason as `change_role`.
+                guard_owner_tier(txn, &ctx, current.role, false).await?;
+                if new_state == current.state {
+                    return Ok(current);
+                }
                 if new_state == MembershipState::Suspended {
                     guard_last_owner(txn, &ctx, target_user_id, false).await?;
                 }
@@ -689,6 +754,24 @@ mod tests {
             check_last_owner_invariant(&owners, sole, false),
             Err(MemberError::LastOwner)
         );
+    }
+
+    // --- Owner-tier gate (adversarial finding #1: no self-promotion) ---
+
+    #[test]
+    fn operation_manages_owner_flags_owner_target_or_owner_grant() {
+        use MembershipRole::*;
+        // Granting owner (to anyone, whatever their current role) is owner-tier.
+        assert!(operation_manages_owner(Viewer, true));
+        assert!(operation_manages_owner(Admin, true));
+        // Touching a current owner (demote/remove/suspend) is owner-tier even
+        // when not granting owner.
+        assert!(operation_manages_owner(Owner, false));
+        // Managing a non-owner without granting owner is NOT owner-tier — an
+        // admin may do it.
+        assert!(!operation_manages_owner(Admin, false));
+        assert!(!operation_manages_owner(Editor, false));
+        assert!(!operation_manages_owner(Viewer, false));
     }
 
     #[test]

--- a/crates/server/src/services/members.rs
+++ b/crates/server/src/services/members.rs
@@ -182,7 +182,18 @@ async fn guard_owner_tier(
     if !operation_manages_owner(target_current_role, grants_owner) {
         return Ok(());
     }
-    let caller = members::get(txn, ctx, ctx.user_id()).await?;
+    let caller = match members::get(txn, ctx, ctx.user_id()).await {
+        Ok(caller) => caller,
+        // The caller's own membership vanished between the request's auth
+        // resolution and this in-transaction re-read (e.g. a concurrent owner
+        // removed them mid-request). Someone with no membership row is
+        // definitionally not an active owner, so this is the same "must be an
+        // active owner" denial (→ 403), NOT a "target not found" 404 — which
+        // would be misleading, since the *target* is fine and it's the caller
+        // who lost standing.
+        Err(DbError::NotFound) => return Err(MemberError::OwnerRequiredToManageOwner),
+        Err(other) => return Err(other.into()),
+    };
     if caller.role != MembershipRole::Owner || caller.state != MembershipState::Active {
         return Err(MemberError::OwnerRequiredToManageOwner);
     }

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -16,6 +16,7 @@ pub mod embedding;
 pub mod index_signature;
 pub mod indexing;
 pub mod lifecycle;
+pub mod members;
 pub mod ops_fence;
 pub mod preview;
 pub mod promotion;

--- a/crates/server/src/services/upload/saga.rs
+++ b/crates/server/src/services/upload/saga.rs
@@ -883,11 +883,17 @@ async fn reload_principal_locked(
 
     // Membership/user rows are read under the principal advisory lock (not
     // FOR UPDATE) so suspend/disable writers are not blocked while a saga
-    // pauses; re-check after pause observes the fresh disabled_at.
+    // pauses; re-check after pause observes the fresh disabled_at — and the
+    // fresh `state`. The `state = 'active'` filter is not cosmetic: this saga
+    // builds its own OrgContext from role→permissions rather than going
+    // through `resolve_org_context` (the only place migration 0029's suspend
+    // gate lives), so without it a member suspended while a saga is paused
+    // would resume with full permissions on the next attempt. Mirror the
+    // resolver's gate here so suspend means the same thing on every authz path.
     let membership = txn
         .query_opt(
             "SELECT role FROM org_memberships
-             WHERE org_id = $1 AND user_id = $2",
+             WHERE org_id = $1 AND user_id = $2 AND state = 'active'",
             &[&org_id, &user_id],
         )
         .await
@@ -916,7 +922,7 @@ async fn reload_principal_locked(
                ON rp.org_id = r.org_id AND rp.role_id = r.id
              JOIN permissions p
                ON p.id = rp.permission_id
-             WHERE m.org_id = $1 AND m.user_id = $2
+             WHERE m.org_id = $1 AND m.user_id = $2 AND m.state = 'active'
              ORDER BY p.code",
             &[&org_id, &user_id],
         )

--- a/crates/server/tests/members.rs
+++ b/crates/server/tests/members.rs
@@ -115,6 +115,17 @@ async fn seed_admin_role_member(pool: &Pool, org: Uuid, user: Uuid, email: &str)
     })
     .await
     .unwrap();
+    // The shared seeder sets a password as a step after its own txn; this
+    // hand-rolled admin seed must do the same or `login_access_token` below
+    // panics on a credential-less user (the actual rust-integration failure).
+    fileconv_server::auth::session::set_password_hash(
+        pool,
+        user,
+        PASSWORD,
+        &common::test_auth_config().argon2,
+    )
+    .await
+    .expect("set admin password");
     login_access_token(pool, email, PASSWORD).await
 }
 

--- a/crates/server/tests/members.rs
+++ b/crates/server/tests/members.rs
@@ -430,28 +430,41 @@ async fn concurrent_last_owner_race_exactly_one_survives() {
     let (status_1, body_1) = task_1.await.expect("task 1 join");
     let (status_2, body_2) = task_2.await.expect("task 2 join");
 
+    // Exactly one removal succeeds; the other is denied. The loser is denied
+    // one of two correct ways, and which one is timing-dependent — that is
+    // *expected*, not flakiness to paper over:
+    //   - 409 `last_owner`: the loser reached `guard_last_owner`, which under
+    //     the owner-row `FOR UPDATE` lock saw the winner's removal and refused
+    //     to drop the org to zero owners.
+    //   - 403 `forbidden`: the winner removed the loser's OWN membership first,
+    //     so `guard_owner_tier`'s in-transaction caller re-read found the caller
+    //     no longer an active owner and denied before reaching the last-owner
+    //     check.
+    // Both deny the operation; the invariant checked below (exactly one active
+    // owner remains) is the real guarantee, and holds in every interleaving
+    // because the two removals serialize on the owner-row lock and can never
+    // both succeed. (Neither a 5xx, a 404, nor a second 204 is acceptable.)
     let successes = [status_1, status_2]
         .iter()
         .filter(|status| **status == StatusCode::NO_CONTENT)
-        .count();
-    let conflicts = [status_1, status_2]
-        .iter()
-        .filter(|status| **status == StatusCode::CONFLICT)
         .count();
     assert_eq!(
         successes, 1,
         "exactly one removal must succeed: {status_1} {body_1} / {status_2} {body_2}"
     );
-    assert_eq!(
-        conflicts, 1,
-        "the loser must see last_owner conflict: {status_1} {body_1} / {status_2} {body_2}"
-    );
-    let conflict_body = if status_1 == StatusCode::CONFLICT {
-        &body_1
+    let (loser_status, loser_body) = if status_1 == StatusCode::NO_CONTENT {
+        (status_2, &body_2)
     } else {
-        &body_2
+        (status_1, &body_1)
     };
-    assert_eq!(conflict_body["code"], "last_owner");
+    let denied_correctly = (loser_status == StatusCode::CONFLICT
+        && loser_body["code"] == "last_owner")
+        || (loser_status == StatusCode::FORBIDDEN && loser_body["code"] == "forbidden");
+    assert!(
+        denied_correctly,
+        "loser must be denied via last_owner (409) or caller-no-longer-owner (403): \
+         {loser_status} {loser_body}"
+    );
 
     let ctx = OrgContext::try_new(org, owner_a, [] as [&str; 0], []).unwrap();
     with_org_txn(&pool, &ctx, move |txn| {

--- a/crates/server/tests/members.rs
+++ b/crates/server/tests/members.rs
@@ -1,0 +1,796 @@
+//! Live PostgreSQL HTTP contract tests for the membership + invite + usage
+//! admin surface (P2-11 / P2-12, Wave 2).
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` / `MARKHAND_TEST_APP_DATABASE_URL`
+//! are unset (see `common::boot_app_pool`). These are the close-condition
+//! tests required by
+//! `plans/reports/plan-260728-0231-markhand-web-membership-admin-slice.md`
+//! section 7 (C1 cross-org denial, concurrent last-owner race, invite
+//! replay/expiry, refresh rejected after remove/suspend/downgrade). They were
+//! not run in this session (no Postgres available) — they must run in the
+//! `rust-integration` CI job.
+
+mod common;
+
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use common::{
+    admin_database_url, app_database_url, boot_app_pool, build_router, login_access_token,
+    login_tokens, seed_user_with_permissions, DualRoleEphemeralDb,
+};
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::db::audit as db_audit;
+use fileconv_server::db::models::ResourceKind;
+use fileconv_server::db::pool::with_org_txn;
+use fileconv_server::services::quota;
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const PASSWORD: &str = "correct-password-1";
+
+async fn boot_pool() -> Option<(DualRoleEphemeralDb, Pool)> {
+    let admin = admin_database_url()?;
+    let app = app_database_url()?;
+    Some(boot_app_pool(&admin, &app).await)
+}
+
+/// Seeds an owner-role member with the given extra permissions and logs in.
+/// `seed_user_with_permissions` always seeds the `owner` role (P2-11's
+/// membership model grants permissions per role, not per user), so calling
+/// this twice for the same `org` with different users yields a two-owner org
+/// — exactly the fixture the concurrent last-owner race and refresh-revoke
+/// tests need.
+async fn seed_admin(pool: &Pool, org: Uuid, user: Uuid, email: &str) -> String {
+    seed_user_with_permissions(pool, org, user, email, PASSWORD, &["member.manage"]).await;
+    login_access_token(pool, email, PASSWORD).await
+}
+
+/// Seeds a member with no special permissions (used purely as "some other
+/// org's authenticated user" for accept-invite auth-only tests).
+async fn seed_plain_member(pool: &Pool, org: Uuid, user: Uuid, email: &str) -> String {
+    seed_user_with_permissions(pool, org, user, email, PASSWORD, &[]).await;
+    login_access_token(pool, email, PASSWORD).await
+}
+
+/// Seeds a genuinely non-owner member that holds `member.manage` — i.e. an
+/// `admin`-role member. The shared `seed_user_with_permissions` only ever
+/// seeds the `owner` role, so the admin role + its `member.manage` grant +
+/// the admin-role membership row are inserted directly here. This is the
+/// exact principal the privilege-escalation regression below needs: someone
+/// who can call the member endpoints but must NOT be able to reach the owner
+/// tier.
+async fn seed_admin_role_member(pool: &Pool, org: Uuid, user: Uuid, email: &str) -> String {
+    let ctx = OrgContext::try_new(org, user, ["member.manage"], []).unwrap();
+    let email_owned = email.to_string();
+    with_org_txn(pool, &ctx, {
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO users (id, email, display_name)
+                     VALUES ($1, $2, 'Admin Member') ON CONFLICT (id) DO NOTHING",
+                    &[&user, &email_owned],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO roles (id, org_id, code, name, is_system)
+                     VALUES ($1, $2, 'admin', 'Admin', true)
+                     ON CONFLICT (org_id, code) DO NOTHING",
+                    &[&Uuid::new_v4(), &org],
+                )
+                .await?;
+                let admin_role_id: Uuid = txn
+                    .query_one(
+                        "SELECT id FROM roles WHERE org_id = $1 AND code = 'admin'",
+                        &[&org],
+                    )
+                    .await?
+                    .get(0);
+                let perm_id: Uuid = txn
+                    .query_one(
+                        "SELECT id FROM permissions WHERE code = 'member.manage'",
+                        &[],
+                    )
+                    .await?
+                    .get(0);
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+                    &[&org, &admin_role_id, &perm_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'admin') ON CONFLICT (org_id, user_id) DO NOTHING",
+                    &[&org, &user],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+    login_access_token(pool, email, PASSWORD).await
+}
+
+async fn send(
+    app: &axum::Router,
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let request = builder
+        .body(match body {
+            Some(value) => Body::from(value.to_string()),
+            None => Body::empty(),
+        })
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, json)
+}
+
+async fn create_invite(app: &axum::Router, token: &str, email: &str, role: &str) -> (Uuid, String) {
+    let (status, body) = send(
+        app,
+        "POST",
+        "/api/v1/members/invites",
+        Some(token),
+        Some(json!({ "email": email, "role": role })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "create invite: {body}");
+    let invite_id = Uuid::parse_str(body["invite"]["id"].as_str().unwrap()).unwrap();
+    let plaintext = body["token"].as_str().unwrap().to_string();
+    (invite_id, plaintext)
+}
+
+// ---------------------------------------------------------------------
+// Cross-org denial (plan section 2 caveat C1 — the close condition)
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn cross_org_denial_covers_every_member_endpoint() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org_a = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let token_a = seed_admin(&pool, org_a, user_a, "admin-a@members-it.test").await;
+
+    let org_b = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let token_b = seed_admin(&pool, org_b, user_b, "admin-b@members-it.test").await;
+
+    // 1) GET /members under org A must never surface org B's user.
+    let (status, body) = send(&app, "GET", "/api/v1/members", Some(&token_a), None).await;
+    assert_eq!(status, StatusCode::OK);
+    let ids: Vec<String> = body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["userId"].as_str().unwrap().to_string())
+        .collect();
+    assert!(ids.contains(&user_a.to_string()));
+    assert!(
+        !ids.contains(&user_b.to_string()),
+        "org A member list leaked org B user: {body}"
+    );
+
+    // 2) PATCH org B's member using org A's token -> 404, not 403/500.
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{user_b}"),
+        Some(&token_a),
+        Some(json!({ "role": "viewer" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "patch cross-org: {body}");
+    assert_eq!(body["code"], "not_found");
+    assert!(!body.to_string().contains(&org_b.to_string()));
+
+    // 3) DELETE org B's member using org A's token -> 404.
+    let (status, body) = send(
+        &app,
+        "DELETE",
+        &format!("/api/v1/members/{user_b}"),
+        Some(&token_a),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "delete cross-org: {body}");
+    assert_eq!(body["code"], "not_found");
+
+    // 4) Revoke org B's invite using org A's token -> 404.
+    let (invite_b, _plaintext_b) =
+        create_invite(&app, &token_b, "invitee-b@members-it.test", "viewer").await;
+    let (status, body) = send(
+        &app,
+        "POST",
+        &format!("/api/v1/members/invites/{invite_b}/revoke"),
+        Some(&token_a),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "revoke cross-org: {body}");
+    assert_eq!(body["code"], "not_found");
+
+    // 5) Usage under org A must not reflect org B's committed quota.
+    let ctx_b = OrgContext::try_new(org_b, user_b, [] as [&str; 0], []).unwrap();
+    quota::reserve(
+        &pool,
+        &ctx_b,
+        "cross-org-leak-check",
+        ResourceKind::Documents,
+        3,
+        Duration::from_secs(60),
+        None,
+    )
+    .await
+    .expect("reserve org B quota");
+    quota::finalize(&pool, &ctx_b, "cross-org-leak-check")
+        .await
+        .expect("finalize org B quota");
+
+    let (status, body) = send(&app, "GET", "/api/v1/usage", Some(&token_a), None).await;
+    assert_eq!(status, StatusCode::OK);
+    let documents_committed = body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["resource"] == "documents")
+        .expect("documents usage entry")["committed"]
+        .as_i64()
+        .unwrap();
+    assert_eq!(
+        documents_committed, 0,
+        "org A usage leaked org B's committed documents: {body}"
+    );
+
+    // 6) accept-invite: an org-A invite accepted by an org-B-only user must
+    // land membership in org A (the token's embedded org), not org B, and
+    // must not require org-A membership to call.
+    let (invite_a, token_a_plain) =
+        create_invite(&app, &token_a, "invitee-accept@members-it.test", "viewer").await;
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/members/invites/accept",
+        Some(&token_b), // org-B-only bearer; NOT a member of org A
+        Some(json!({ "token": token_a_plain })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "accept by foreign user: {body}"
+    );
+    assert_eq!(body["userId"], user_b.to_string());
+    let _ = invite_a;
+
+    with_org_txn(
+        &pool,
+        &OrgContext::try_new(org_a, user_a, [] as [&str; 0], []).unwrap(),
+        {
+            move |txn| {
+                Box::pin(async move {
+                    let row = txn
+                        .query_opt(
+                            "SELECT 1 FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+                            &[&org_a, &user_b],
+                        )
+                        .await?;
+                    assert!(row.is_some(), "accept must create membership in org A");
+                    Ok(())
+                })
+            }
+        },
+    )
+    .await
+    .unwrap();
+    with_org_txn(&pool, &ctx_b, move |txn| {
+        Box::pin(async move {
+            let count: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM org_memberships WHERE org_id = $1",
+                    &[&org_b],
+                )
+                .await?
+                .get(0);
+            // Only user_b itself (seeded owner) — accept must not have
+            // inserted a second row into org B.
+            assert_eq!(count, 1, "accept leaked a membership row into org B");
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn cross_org_invite_token_cannot_be_redirected_by_org_id_tampering() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org_a = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let token_a = seed_admin(&pool, org_a, user_a, "admin-a2@members-it.test").await;
+
+    let org_b = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let token_b = seed_plain_member(&pool, org_b, user_b, "member-b2@members-it.test").await;
+
+    let (_invite_a, plaintext) =
+        create_invite(&app, &token_a, "tamper-target@members-it.test", "viewer").await;
+
+    // mhinv1.<org_id>.<secret> — swap org A's id for org B's, keep the secret.
+    let secret = plaintext.rsplit('.').next().unwrap();
+    let tampered = format!("mhinv1.{org_b}.{secret}");
+
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/members/invites/accept",
+        Some(&token_b),
+        Some(json!({ "token": tampered })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "org-id-swapped token must not resolve into org B: {body}"
+    );
+    assert_eq!(body["code"], "not_found");
+
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// Concurrent last-owner race
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn concurrent_last_owner_race_exactly_one_survives() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner_a = Uuid::new_v4();
+    let owner_b = Uuid::new_v4();
+    let token_a = seed_admin(&pool, org, owner_a, "race-owner-a@members-it.test").await;
+    let token_b = seed_admin(&pool, org, owner_b, "race-owner-b@members-it.test").await;
+
+    let app_1 = app.clone();
+    let token_1 = token_a.clone();
+    let target_1 = owner_b;
+    let task_1 = tokio::spawn(async move {
+        send(
+            &app_1,
+            "DELETE",
+            &format!("/api/v1/members/{target_1}"),
+            Some(&token_1),
+            None,
+        )
+        .await
+    });
+
+    let app_2 = app.clone();
+    let token_2 = token_b.clone();
+    let target_2 = owner_a;
+    let task_2 = tokio::spawn(async move {
+        send(
+            &app_2,
+            "DELETE",
+            &format!("/api/v1/members/{target_2}"),
+            Some(&token_2),
+            None,
+        )
+        .await
+    });
+
+    let (status_1, body_1) = task_1.await.expect("task 1 join");
+    let (status_2, body_2) = task_2.await.expect("task 2 join");
+
+    let successes = [status_1, status_2]
+        .iter()
+        .filter(|status| **status == StatusCode::NO_CONTENT)
+        .count();
+    let conflicts = [status_1, status_2]
+        .iter()
+        .filter(|status| **status == StatusCode::CONFLICT)
+        .count();
+    assert_eq!(
+        successes, 1,
+        "exactly one removal must succeed: {status_1} {body_1} / {status_2} {body_2}"
+    );
+    assert_eq!(
+        conflicts, 1,
+        "the loser must see last_owner conflict: {status_1} {body_1} / {status_2} {body_2}"
+    );
+    let conflict_body = if status_1 == StatusCode::CONFLICT {
+        &body_1
+    } else {
+        &body_2
+    };
+    assert_eq!(conflict_body["code"], "last_owner");
+
+    let ctx = OrgContext::try_new(org, owner_a, [] as [&str; 0], []).unwrap();
+    with_org_txn(&pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let active_owners: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM org_memberships
+                     WHERE org_id = $1 AND role = 'owner' AND state = 'active'",
+                    &[&org],
+                )
+                .await?
+                .get(0);
+            assert_eq!(active_owners, 1, "org must retain exactly one active owner");
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// Invite replay / expiry
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn invite_replay_and_expiry_all_reject_and_valid_accept_is_audited() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let owner_token = seed_admin(&pool, org, owner, "invite-owner@members-it.test").await;
+
+    // Three separate accepting users from three separate orgs (each just
+    // needs a valid bearer token; none may already be a member of `org`).
+    let other_org_1 = Uuid::new_v4();
+    let user_1 = Uuid::new_v4();
+    let user_1_token =
+        seed_plain_member(&pool, other_org_1, user_1, "accept-1@members-it.test").await;
+
+    let other_org_2 = Uuid::new_v4();
+    let user_2 = Uuid::new_v4();
+    let user_2_token =
+        seed_plain_member(&pool, other_org_2, user_2, "accept-2@members-it.test").await;
+
+    let other_org_3 = Uuid::new_v4();
+    let user_3 = Uuid::new_v4();
+    let user_3_token =
+        seed_plain_member(&pool, other_org_3, user_3, "accept-3@members-it.test").await;
+
+    // --- Valid accept + same-commit audit row ---
+    let (invite_valid, token_valid) =
+        create_invite(&app, &owner_token, "accepted@members-it.test", "viewer").await;
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/members/invites/accept",
+        Some(&user_1_token),
+        Some(json!({ "token": token_valid })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "valid accept: {body}");
+    assert_eq!(body["userId"], user_1.to_string());
+
+    let ctx = OrgContext::try_new(org, owner, [] as [&str; 0], []).unwrap();
+    let audited = with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let entries = db_audit::list_recent(txn, &ctx, 50).await?;
+                Ok(entries.into_iter().any(|entry| {
+                    entry.action == "member.invite_accept"
+                        && entry.resource_id == Some(invite_valid.to_string())
+                }))
+            })
+        }
+    })
+    .await
+    .unwrap();
+    assert!(
+        audited,
+        "valid accept must write a member.invite_accept audit row"
+    );
+
+    // --- Replay: accepting the same token again must reject ---
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/members/invites/accept",
+        Some(&user_2_token),
+        Some(json!({ "token": token_valid })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "replayed accept: {body}");
+
+    // --- Revoked invite cannot be accepted ---
+    let (invite_revoked, token_revoked) =
+        create_invite(&app, &owner_token, "revoked@members-it.test", "viewer").await;
+    let (status, body) = send(
+        &app,
+        "POST",
+        &format!("/api/v1/members/invites/{invite_revoked}/revoke"),
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "revoke: {body}");
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/members/invites/accept",
+        Some(&user_2_token),
+        Some(json!({ "token": token_revoked })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "accept after revoke: {body}");
+
+    // --- Expired invite cannot be accepted ---
+    let (invite_expired, token_expired) =
+        create_invite(&app, &owner_token, "expired@members-it.test", "viewer").await;
+    with_org_txn(
+        &pool,
+        &OrgContext::try_new(org, owner, [] as [&str; 0], []).unwrap(),
+        {
+            move |txn| {
+                Box::pin(async move {
+                    txn.execute(
+                    "UPDATE org_invites SET expires_at = now() - interval '1 hour' WHERE id = $1",
+                    &[&invite_expired],
+                )
+                .await?;
+                    Ok(())
+                })
+            }
+        },
+    )
+    .await
+    .unwrap();
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/members/invites/accept",
+        Some(&user_3_token),
+        Some(json!({ "token": token_expired })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "accept after expiry: {body}");
+
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// Refresh rejected after remove / suspend / role downgrade
+// ---------------------------------------------------------------------
+
+async fn seed_two_owner_org(pool: &Pool, prefix: &str) -> (Uuid, Uuid, Uuid, String) {
+    let org = Uuid::new_v4();
+    let caller = Uuid::new_v4();
+    let target = Uuid::new_v4();
+    let caller_token = seed_admin(
+        pool,
+        org,
+        caller,
+        &format!("{prefix}-caller@members-it.test"),
+    )
+    .await;
+    seed_admin(
+        pool,
+        org,
+        target,
+        &format!("{prefix}-target@members-it.test"),
+    )
+    .await;
+    (org, caller, target, caller_token)
+}
+
+async fn assert_refresh_rejected(app: &axum::Router, refresh_token: &str) {
+    let (status, body) = send(
+        app,
+        "POST",
+        "/api/v1/auth/refresh",
+        None,
+        Some(json!({ "refreshToken": refresh_token })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "stale refresh token must be rejected: {body}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn refresh_rejected_after_remove() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let (_org, _caller, target, caller_token) = seed_two_owner_org(&pool, "remove").await;
+    let (_access, refresh) = login_tokens(&pool, "remove-target@members-it.test", PASSWORD).await;
+
+    let (status, body) = send(
+        &app,
+        "DELETE",
+        &format!("/api/v1/members/{target}"),
+        Some(&caller_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "remove target: {body}");
+
+    assert_refresh_rejected(&app, &refresh).await;
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn refresh_rejected_after_suspend() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let (_org, _caller, target, caller_token) = seed_two_owner_org(&pool, "suspend").await;
+    let (_access, refresh) = login_tokens(&pool, "suspend-target@members-it.test", PASSWORD).await;
+
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{target}"),
+        Some(&caller_token),
+        Some(json!({ "state": "suspended" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "suspend target: {body}");
+    assert_eq!(body["state"], "suspended");
+
+    assert_refresh_rejected(&app, &refresh).await;
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn refresh_rejected_after_role_downgrade() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let (_org, _caller, target, caller_token) = seed_two_owner_org(&pool, "downgrade").await;
+    let (_access, refresh) =
+        login_tokens(&pool, "downgrade-target@members-it.test", PASSWORD).await;
+
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{target}"),
+        Some(&caller_token),
+        Some(json!({ "role": "admin" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "downgrade target: {body}");
+    assert_eq!(body["role"], "admin");
+
+    assert_refresh_rejected(&app, &refresh).await;
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// Privilege escalation (adversarial review finding #1 — BLOCKER)
+// A non-owner member.manage holder must not reach the owner tier.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn non_owner_admin_cannot_reach_the_owner_tier() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &app_database_url().unwrap(), None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let admin = Uuid::new_v4();
+    // An owner must exist so the org is validly owned and the admin's attempts
+    // are the only thing under test.
+    seed_admin(&pool, org, owner, "esc-owner@members-it.test").await;
+    let admin_token = seed_admin_role_member(&pool, org, admin, "esc-admin@members-it.test").await;
+
+    // 1. Self-promotion to owner — the exact reported exploit — must be denied.
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{admin}"),
+        Some(&admin_token),
+        Some(json!({ "role": "owner" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "self-promote to owner: {body}"
+    );
+
+    // 2. Granting owner to anyone else — same gate.
+    let (status, _) = send(
+        &app,
+        "POST",
+        "/api/v1/members/invites",
+        Some(&admin_token),
+        Some(json!({ "email": "new-owner@members-it.test", "role": "owner" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "invite an owner as admin");
+
+    // 3. Managing the existing owner (demote / suspend / remove) — all denied,
+    //    "admin không quản owner".
+    let (status, _) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{owner}"),
+        Some(&admin_token),
+        Some(json!({ "role": "admin" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "admin demoting the owner");
+
+    let (status, _) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{owner}"),
+        Some(&admin_token),
+        Some(json!({ "state": "suspended" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "admin suspending the owner");
+
+    let (status, _) = send(
+        &app,
+        "DELETE",
+        &format!("/api/v1/members/{owner}"),
+        Some(&admin_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "admin removing the owner");
+
+    ephemeral.drop().await;
+}

--- a/plans/reports/plan-260728-0231-markhand-web-membership-admin-slice.md
+++ b/plans/reports/plan-260728-0231-markhand-web-membership-admin-slice.md
@@ -146,6 +146,30 @@ Có thể spawn subagent: một agent làm W1–W3 (service/repo/migration, khô
 một agent làm W4–W6 (routes+parity) sau khi W2 xong; W7 nên do người điều phối kiểm vì đây là
 phần bảo mật (kéo sớm 1C-12). Opus review last-owner + cross-org denial.
 
+## 8b. Quyết định đã chốt (2026-07-28) + phân wave cho subagent
+
+**Quyết định:**
+- **M2 (cột `state` active/suspended): CÓ** — P2-11 cần "suspend" là chức năng riêng khác
+  remove. Suspend = `state='suspended'`; resolver coi suspended như thiếu membership.
+- **M1 (cột `version`): HOÃN** — chưa có cache 1C-05 tiêu thụ; thêm sau khi làm 1C-05.
+
+**Ràng buộc kỹ thuật khi chia subagent:** hai agent build Rust **không được chạy song song**
+— chúng đè cùng `target/`, hỏng incremental cache (đã dính lỗi này ở P2-16). Nên chia
+**tuần tự hai wave**, seam sạch giữa domain và surface:
+
+- **Wave 1 — DOMAIN (agent A).** Migration M2, models, repo `db/members.rs`, `AuditAction`
+  +5 + allowlist, service `services/members.rs`: invite create/accept/revoke (hash+expiry+
+  terminal) và **last-owner invariant transactional** + membership list/role-change/remove/
+  suspend + usage aggregation. **Unit test fast** cho last-owner + invite. Phải `cargo build`
+  + fast test xanh, clippy `-D warnings` sạch. **Không** mở HTTP surface. Đây là lõi bảo mật
+  → tôi + review agent soi kỹ **trước khi** có endpoint.
+- **Wave 2 — SURFACE + TEST (agent B), sau khi Wave 1 compile.** Routes E1–E8, guard, audit
+  wiring, `openapi.yaml` + `ROUTE_INVENTORY` + `http.rs`, `pnpm api:generate`, và **test
+  DB-gated**: cross-org denial mỗi endpoint (điều kiện đóng — C1), concurrent last-owner,
+  invite replay/expiry, revoke-on-remove.
+- **Review.** Một review agent đối kháng nhắm **last-owner correctness** (race) +
+  **độ phủ cross-org denial** + audit coverage + parity; tôi tổng hợp và sửa.
+
 ## 9. Không thuộc kế hoạch này
 
 Org create/list/switch (1C-01), ACL cache/version + groups grant (1C-05), per-org fairness/GPU

--- a/plans/reports/plan-260728-0231-markhand-web-membership-admin-slice.md
+++ b/plans/reports/plan-260728-0231-markhand-web-membership-admin-slice.md
@@ -1,0 +1,157 @@
+# Mini-milestone — Membership + Admin API slice (mở khoá P2-11/P2-12)
+
+Date: 2026-07-28
+Base commit: `97a29dd` (master, sau PR #316)
+Nguồn: audit Phase 1C 2026-07-27 (`plans/markhand-web/backlog/phase-1c/issues/README.md`).
+
+## 1. Mục tiêu và ranh giới
+
+**Mục tiêu:** xây lát mỏng nhất của Phase 1C đủ để **gỡ chặn P2-11 (member/role admin)
+và P2-12 (usage/quota)** trong web — không làm cả Phase 1C.
+
+Cắt từ hai issue:
+- **1C-02** (hiện **Backlog**) — membership + invite + last-owner invariant.
+- **1C-11** (hiện **In progress**, nửa admin = 0 endpoint) — chỉ phần **admin/audit read
+  API** cho member/role/usage. KHÔNG làm audit retention, cloud/data-export event.
+
+**Nằm NGOÀI lát này** (giữ nguyên trạng thái phase): 1C-01 org create/switch, ACL
+cache/version (1C-05), per-org fairness (1C-10), denial suite gắn kết (1C-12), security
+gate (1C-13). Xem mục 9.
+
+## 2. Ba cảnh báo phải đọc trước — không được bỏ qua
+
+### C1. Lát này **nhảy qua phase gate** — phải bù bằng test, không bằng niềm tin
+Phase 1C theo thiết kế chỉ activate sau khi **Phase 1B gate đóng** (R04/R06 còn pending),
+và **1C-12 denial suite chưa tồn tại**. Ta đang thêm một **surface mutation theo tenant**
+(mời/xóa/đổi-role thành viên) và một **surface tạo membership** (accept invite = cấp quyền
+truy cập tenant) *trước khi* có suite denial cross-org gắn kết.
+
+→ Hệ quả bắt buộc: **mọi endpoint mới trong lát này phải kèm test denial cross-org DB-gated
+của riêng nó** (org khác không thấy/không sửa được member của org này; invite của org A
+không accept được vào org B). Đây chính là "kéo sớm" đúng phần 1C-12 tương ứng với surface
+mới. Không được để "mini-milestone" thành "bỏ test bảo mật".
+
+### C2. Hệ thống vẫn **single POC org** — đây là "quản thành viên của org đang có"
+Seed hiện gắn cứng một org (`11111111-…-1111`, `migrations/0011:11`); **không có đường
+org-create** (1C-01). Nên lát này là **quản lý thành viên của org hiện hữu**, không phải
+provision org mới. Invite-accept cho một user MỚI vào org đang có thì chạy được; tạo org
+thứ hai thì không. Web P2-11 chỉ cần cái trước — nhưng phải nói rõ giới hạn này trong doc
+API để không ai tưởng đã multi-org.
+
+### C3. Invite **không có email** (out of scope 1C-02)
+Token plaintext hiển thị **đúng một lần** cho admin qua response, copy ra kênh ngoài. Token
+chỉ lưu DB dạng **hash** (`org_invites.token_hash`, đã có). Plaintext **không được** log/
+lưu/vào audit — `FORBIDDEN_METADATA_KEYS` trong `services/audit.rs` đã chặn key kiểu token,
+nhưng code mới vẫn phải tự cẩn thận đường đi của plaintext.
+
+## 3. Điều kiện vào — cái đã có (đo được, không đoán)
+
+| Thứ | Trạng thái | Bằng chứng |
+|---|---|---|
+| Bảng `org_memberships` | có — `(org_id,user_id,role∈{owner,admin,editor,viewer},created_at)`, PK `(org_id,user_id)`; **chưa có** cột state/version | `migrations/0001:26` |
+| Bảng `org_invites` | có — hashed single-use: `token_hash UNIQUE ≥32`, `expires_at`, `accepted_at`/`revoked_at` + `ck_…terminal_xor`; **không** cột plaintext | `migrations/0003:93` |
+| Permission `member.manage` | seed rồi nhưng **chưa dùng** ở đâu | `migrations/0011:44` |
+| Resolver membership | có — `resolve_org_context` deny khi thiếu membership/disabled; JWT chỉ là hint | `auth/permissions.rs:39`, `auth/middleware.rs:144` |
+| Guard deny-by-default | có — `require_permission` áp ở route+service | `auth/permissions.rs:118` |
+| Audit append-only + writer + redaction | có, có test | `migrations/0026`, `services/audit.rs:447` |
+| Hàm đọc audit `list_recent` | **có nhưng chưa gọi**, chưa phân trang/filter | `db/audit.rs:11` |
+| Quota read (cho P2-12) | có — `quota_limit`/`committed_usage`/`active_reserved`/`usage` | `db/quota.rs:61/106/147/168` |
+| Session/refresh family revoke | có | `auth/session.rs:862` |
+
+Nghĩa là **schema + resolver + guard + audit + quota-read đã sẵn**; phần thiếu chủ yếu là
+**service logic + endpoint + last-owner invariant + audit action + test**.
+
+## 4. Surface API tối thiểu
+
+OpenAPI-relative path (không prefix `/api/v1`). "Guard" = permission qua `require_permission`.
+
+| # | Method + Path | Việc | Guard | Ghi chú |
+|---|---|---|---|---|
+| E1 | `GET /members` | List thành viên org hiện tại (user, role, joined_at) | `member.manage` | read; không lộ user org khác |
+| E2 | `GET /members/invites` | List invite đang mở (email, role, expires, trạng thái) | `member.manage` | không trả token_hash |
+| E3 | `POST /members/invites` | Tạo invite single-use; trả **plaintext token 1 lần** | `member.manage` | owner mới mời role owner; audit `MemberInvite` |
+| E4 | `POST /members/invites/{inviteId}/revoke` | Thu hồi invite chưa dùng | `member.manage` | set `revoked_at`; audit `MemberInviteRevoke` |
+| E5 | `POST /members/invites/accept` | Accept bằng token → tạo membership | **auth-only** (user đã login, chưa cần `member.manage`) | verify hash+expiry+chưa terminal; audit `MemberInviteAccept` |
+| E6 | `PATCH /members/{userId}` | Đổi role thành viên | `member.manage` | **last-owner invariant**; audit `MemberRoleChange` |
+| E7 | `DELETE /members/{userId}` | Xóa thành viên khỏi org | `member.manage` | **last-owner invariant** + revoke family; audit `MemberRemove` |
+| E8 | `GET /usage` | Tổng hợp usage/limit/reserved mỗi ResourceKind | `member.manage` hoặc quyền đọc org | read; ghép từ `db/quota.rs` sẵn có |
+
+> **Last-owner invariant (E6, E7):** trong **một transaction**, lock các dòng owner của org
+> (`SELECT … FOR UPDATE`), đếm owner còn lại; nếu thao tác làm số owner active về 0 → **409
+> `last_owner`** (không cho remove/downgrade owner cuối). Đây là điểm 1C-02 mà audit ghi
+> "grep rỗng" — phải viết mới, và là chỗ dễ sai nhất (race hai admin cùng gỡ hai owner).
+
+> **Enforce tức thời khi xóa/hạ quyền:** resolver chạy **live mỗi request**, nên user bị gỡ
+> sẽ `MembershipMissing` ở request kế (`auth/permissions.rs`). SSE re-resolve mỗi pull nên
+> stream đang chạy tự đóng. Access token ngắn hạn vẫn hợp lệ tới hết hạn → E7 (và E6 hạ
+> quyền) **phải revoke refresh-token family của user trong org** (`auth/session.rs:934`
+> `revoke_all_user_families`) để cắt cứng, không chờ token hết hạn.
+
+## 5. Nghĩa vụ đi kèm MỖI endpoint mới (đừng lặp lại lỗ cũ)
+
+1. **Parity ba nơi phải khớp** — thêm route vào `routes/*.rs`, vào `ROUTE_INVENTORY`
+   (`api/openapi.rs:14`), và vào `openapi.yaml` **kèm requestBody + response schema** (parity
+   giờ kiểm mức schema — `openapi_schema_completeness_gaps`). Thiếu một chỗ → CI đỏ.
+2. **Audit mọi mutation** — E3/E4/E5/E6/E7 phải `record_in_txn` với actor/org/action/target/
+   result/request-id. Cần **thêm 5 biến thể vào `enum AuditAction`** (`services/audit.rs`):
+   `MemberInvite, MemberInviteAccept, MemberInviteRevoke, MemberRoleChange, MemberRemove`, và
+   khai `metadata_keys` allowlist cho từng cái (KHÔNG cho free-text, KHÔNG token).
+3. **RLS/tenant** — mọi query đi qua `with_org_txn` (GUC `app.org_id`), không tự nối org_id
+   tay. Member của org khác phải vô hình (RLS + predicate), không phải 403-lộ-tồn-tại.
+4. **Sinh lại contract TS** — sau khi sửa `openapi.yaml`: `pnpm --dir web api:generate`;
+   `pnpm api:check` chặn drift. Web P2-11/P2-12 sẽ có type ngay.
+
+## 6. Migrations cần thêm
+
+- **M1** — cột membership version (tùy chọn nhưng nên): `ALTER TABLE org_memberships ADD
+  COLUMN version bigint NOT NULL DEFAULT 1` + bump khi role đổi. **Chưa xây cache
+  invalidation trên nó** (1C-05 cache chưa có) — chỉ thêm cột để về sau forward-compatible;
+  ghi rõ trong migration là "reserved for 1C-05 cache". Nếu muốn tối giản, có thể hoãn M1.
+- **M2** — nếu cần cột `state` cho membership (active/suspended) phục vụ "suspend" của P2-11:
+  `ADD COLUMN state text NOT NULL DEFAULT 'active' CHECK (state IN ('active','suspended'))`.
+  Suspend = state suspended (resolver coi như thiếu membership). **Quyết định:** P2-11 có nút
+  "suspend" — nếu muốn suspend khác remove thì cần M2; nếu MVP chỉ remove thì bỏ M2.
+- Theo convention repo: migration **expand-only**, có trong `manifest.json`, test
+  `schema_migrations.rs` phải xanh (idempotent + exact columns).
+
+## 7. Test bắt buộc
+
+- **Unit (fast):** last-owner invariant (đủ owner → cho, còn 1 owner → 409); invite hash
+  verify + expiry + terminal reuse reject; audit allowlist cho 5 action mới.
+- **DB-gated (`#[ignore]`, chạy job `rust-integration`):**
+  - concurrent last-owner: hai admin cùng remove hai owner → đúng một thành công, org còn ≥1 owner.
+  - invite replay/expiry: token đã accept/revoke/hết hạn → reject; accept đúng → membership tạo + audit.
+  - **cross-org denial (bù C1):** admin org A không list/patch/delete member org B; invite org A
+    không accept vào org B; usage org A không lộ số org B. **Đây là điều kiện đóng lát này.**
+  - revoke-on-remove: sau E7, refresh family của user bị vô hiệu; SSE đang chạy đóng.
+- **Contract:** `pnpm api:check` xanh; ROUTE_INVENTORY parity xanh.
+
+## 8. Thứ tự làm (work items)
+
+```
+W1  Migration M2 (+M1 nếu chọn) + models + repo (org_memberships/org_invites CRUD qua with_org_txn)
+W2  AuditAction +5 biến thể + metadata_keys allowlist  (chặn: audit mọi mutation ở W4/W5)
+W3  Service: invite create/accept/revoke (hash, expiry, terminal)  +  last-owner invariant (txn, row-lock)
+W4  Routes E1–E5 (list/invite/accept/revoke) + guard + audit + openapi.yaml + ROUTE_INVENTORY
+W5  Routes E6–E7 (role change/remove) + last-owner + revoke family + audit + parity
+W6  Route E8 /usage (ghép db/quota.rs) + openapi + parity
+W7  Test: unit + DB-gated (last-owner concurrent, invite replay, cross-org denial, revoke-on-remove)
+W8  pnpm api:generate → contract TS; xác nhận web P2-11/P2-12 có type; api:check xanh
+```
+
+W1–W3 là nền (không có endpoint public); W4–W6 mở surface; W7 là điều kiện đóng (C1); W8 giao
+sang web. W2 chặn W4/W5 (không audit thì không merge được mutation).
+
+Có thể spawn subagent: một agent làm W1–W3 (service/repo/migration, không public surface),
+một agent làm W4–W6 (routes+parity) sau khi W2 xong; W7 nên do người điều phối kiểm vì đây là
+phần bảo mật (kéo sớm 1C-12). Opus review last-owner + cross-org denial.
+
+## 9. Không thuộc kế hoạch này
+
+Org create/list/switch (1C-01), ACL cache/version + groups grant (1C-05), per-org fairness/GPU
+scheduler (1C-10), audit retention + cloud/data-export event (phần còn lại 1C-11), denial suite
+gắn kết đầy đủ mọi surface (1C-12), security/load gate + report (1C-13), email invite/SCIM/MFA.
+
+Đóng lát này **không** đóng Phase 1C và **không** đạt exit gate 1C — nó chỉ chuyển 1C-02 từ
+Backlog sang In-progress-thực-chất và bồi phần admin của 1C-11, đủ để P2-11/P2-12 rời khỏi
+trạng thái Blocked.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,11 +16,13 @@ import { RouterProvider, useRouter } from './state/RouterProvider';
 import { ScopeProvider } from './state/ScopeProvider';
 
 /**
- * Real permission constants from plans/markhand-web/phase-1c-multi-org-security.md
- * §P1C.2 — `member.manage` gates the members admin page. There is no
- * documented constant yet for the usage/quota admin page (P2-12/1C haven't
- * shipped one), so that route only requires "signed in" below rather than
- * guessing a permission name the server may not agree with.
+ * Real permission constant from plans/markhand-web/phase-1c-multi-org-security.md
+ * §P1C.2 / `crates/server/src/routes/members.rs`'s `PERMISSION_MEMBER_MANAGE`
+ * — gates both the members admin page and the usage/quota admin page: the
+ * P2-11/P2-12 OpenAPI doc documents `GET /usage` itself as "requires
+ * member.manage", same as every `/members*` operation, so both routes below
+ * share this one constant rather than the usage page guessing a permission
+ * name of its own.
  */
 const MEMBER_MANAGE_PERMISSION = 'member.manage';
 
@@ -53,7 +55,7 @@ function RouteOutlet() {
       );
     case 'adminUsage':
       return (
-        <ProtectedRoute>
+        <ProtectedRoute permission={MEMBER_MANAGE_PERMISSION}>
           <AdminUsagePage />
         </ProtectedRoute>
       );

--- a/web/src/api/generated/contract.ts
+++ b/web/src/api/generated/contract.ts
@@ -519,6 +519,114 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List org members (requires member.manage) */
+        get: operations["listMembers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/members/invites": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List invites, open and terminal (requires member.manage) */
+        get: operations["listMemberInvites"];
+        put?: never;
+        /** Create a single-use invite (requires member.manage; owner role requires an active owner caller) */
+        post: operations["createMemberInvite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/members/invites/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Accept an invite by token (authenticated bearer only — no existing org membership required) */
+        post: operations["acceptMemberInvite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/members/invites/{inviteId}/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                inviteId: components["parameters"]["inviteId"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Revoke an invite that has not yet been accepted/revoked (requires member.manage) */
+        post: operations["revokeMemberInvite"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/members/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                userId: components["parameters"]["userId"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove a member from the org (requires member.manage; last-owner invariant enforced) */
+        delete: operations["deleteMember"];
+        options?: never;
+        head?: never;
+        /** Change role and/or suspend/reactivate a member (requires member.manage; last-owner invariant enforced) */
+        patch: operations["patchMember"];
+        trace?: never;
+    };
+    "/usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Aggregated per-resource usage/limit/reserved (requires member.manage) */
+        get: operations["getUsage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -768,6 +876,77 @@ export interface components {
             /** Format: date-time */
             finishedAt: string | null;
         };
+        Membership: {
+            /** Format: uuid */
+            userId: string;
+            /** @enum {string} */
+            role: "owner" | "admin" | "editor" | "viewer";
+            /** @enum {string} */
+            state: "active" | "suspended";
+            /** Format: date-time */
+            createdAt: string;
+        };
+        MembershipPage: {
+            items: components["schemas"]["Membership"][];
+            page: components["schemas"]["PageInfo"];
+        };
+        Invite: {
+            /** Format: uuid */
+            id: string;
+            email: string;
+            /** @enum {string} */
+            role: "owner" | "admin" | "editor" | "viewer";
+            /**
+             * @description Derived, not stored — never both terminal and pending.
+             * @enum {string}
+             */
+            status: "pending" | "accepted" | "revoked" | "expired";
+            /** Format: date-time */
+            expiresAt: string;
+            /** Format: date-time */
+            acceptedAt?: string | null;
+            /** Format: date-time */
+            revokedAt?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        InvitePage: {
+            items: components["schemas"]["Invite"][];
+            page: components["schemas"]["PageInfo"];
+        };
+        CreateInviteRequest: {
+            email: string;
+            /** @enum {string} */
+            role: "owner" | "admin" | "editor" | "viewer";
+            /** @description Invite lifetime in seconds (default 7 days; clamped [60, 2592000]). */
+            ttlSecs?: number;
+        };
+        CreateInviteResponse: {
+            invite: components["schemas"]["Invite"];
+            /** @description Plaintext single-use invite token, returned exactly once. Only its hash is ever persisted — this value cannot be retrieved again. */
+            token: string;
+        };
+        AcceptInviteRequest: {
+            token: string;
+        };
+        /** @description At least one of role/state must be present. */
+        PatchMemberRequest: {
+            /** @enum {string} */
+            role?: "owner" | "admin" | "editor" | "viewer";
+            /** @enum {string} */
+            state?: "active" | "suspended";
+        };
+        UsageEntry: {
+            /** @enum {string} */
+            resource: "storage_bytes" | "documents" | "concurrent_jobs" | "tokens";
+            limit: number;
+            committed: number;
+            reserved: number;
+            remaining: number;
+        };
+        UsageResponse: {
+            items: components["schemas"]["UsageEntry"][];
+        };
     };
     responses: {
         /** @description Canonical API error */
@@ -795,6 +974,8 @@ export interface components {
         documentId: string;
         versionId: string;
         jobId: string;
+        inviteId: string;
+        userId: string;
     };
     requestBodies: never;
     headers: never;
@@ -1885,6 +2066,241 @@ export interface operations {
                     "application/yaml": string;
                 };
             };
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    listMembers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Memberships in the caller's current org (both active and suspended). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MembershipPage"];
+                };
+            };
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    listMemberInvites: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Invites for the caller's current org. Never includes tokenHash. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InvitePage"];
+                };
+            };
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    createMemberInvite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateInviteRequest"];
+            };
+        };
+        responses: {
+            /** @description Invite created. The plaintext token is returned exactly once here and is never retrievable again (only its hash is stored). */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateInviteResponse"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    acceptMemberInvite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AcceptInviteRequest"];
+            };
+        };
+        responses: {
+            /** @description Membership created in the invite's org. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Membership"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            401: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            /** @description Invite already accepted/revoked, expired, or caller is already a member. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
+                };
+            };
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    revokeMemberInvite: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                inviteId: components["parameters"]["inviteId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Invite revoked. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Invite"];
+                };
+            };
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            /** @description Invite already accepted or revoked. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
+                };
+            };
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    deleteMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                userId: components["parameters"]["userId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Member removed; refresh-token sessions invalidated. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            /** @description Operation would leave the org with zero active owners. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
+                };
+            };
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    patchMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                userId: components["parameters"]["userId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PatchMemberRequest"];
+            };
+        };
+        responses: {
+            /** @description Membership updated. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Membership"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            /** @description Operation would leave the org with zero active owners. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
+                };
+            };
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    getUsage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Usage snapshot for every quota ResourceKind. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UsageResponse"];
+                };
+            };
+            403: components["responses"]["ApiError"];
             429: components["responses"]["RateLimited"];
         };
     };

--- a/web/src/components/admin/InviteForm.tsx
+++ b/web/src/components/admin/InviteForm.tsx
@@ -1,0 +1,174 @@
+// P2-11: create-invite form. `POST /members/invites` returns the plaintext
+// token exactly once (see the OpenAPI doc's `CreateInviteResponse.token`
+// comment) — this component is the only place that ever sees it, holds it in
+// local state only for as long as the confirmation modal is open, and never
+// re-fetches or persists it anywhere (not in `mocks/fixtures.ts`'s store
+// either — see `handlers/members.ts`, which only ever stores a hash).
+import { useId, useState, type FormEvent } from 'react';
+import { Button, Modal, Notice, SelectControl, type SelectOption } from '../ui';
+import { createInvite } from './membersApi';
+import { ROLE_ORDER, ROLE_META, describeMemberActionError } from './memberPresentation';
+import { InviteIcon } from './icons';
+import { useSingleFlightAction } from '../actions/useSingleFlightAction';
+import { apiClient, type ApiClient } from '../../api/client';
+import type { components } from '../../api/generated/contract';
+import type { MembershipRole } from './types';
+
+type CreateInviteResponse = components['schemas']['CreateInviteResponse'];
+
+const TTL_PRESETS: Array<{ value: string; label: string; secs: number | undefined }> = [
+  { value: 'default', label: 'Mặc định (7 ngày)', secs: undefined },
+  { value: 'day', label: '1 ngày', secs: 24 * 3600 },
+  { value: 'month', label: '30 ngày', secs: 30 * 24 * 3600 },
+];
+
+export function InviteForm({
+  isOwnerActive,
+  onCreated,
+  client = apiClient,
+}: {
+  isOwnerActive: boolean;
+  /** Called once the invite is created (server-confirmed), so the caller can refetch the invites list. Never carries the token — that only ever lives in this component's own confirmation modal. */
+  onCreated: () => void;
+  client?: ApiClient;
+}) {
+  const emailId = useId();
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<MembershipRole>('viewer');
+  const [ttlChoice, setTtlChoice] = useState('default');
+  const [issued, setIssued] = useState<CreateInviteResponse | null>(null);
+
+  const action = useSingleFlightAction<CreateInviteResponse>();
+  const pending = action.phase === 'pending';
+
+  const roleOptions: SelectOption[] = ROLE_ORDER.map((r) => ({
+    value: r,
+    label: ROLE_META[r].label,
+    disabled: r === 'owner' && !isOwnerActive,
+  }));
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = email.trim();
+    if (!trimmed) return;
+    const ttlSecs = TTL_PRESETS.find((p) => p.value === ttlChoice)?.secs;
+    const started = action.dispatch('create-invite', (signal) =>
+      createInvite({ client, email: trimmed, role, ttlSecs, signal }),
+    );
+    if (started) setIssued(null);
+  }
+
+  // Adjust-state-while-rendering (same idiom `useScopeSafeRequest`'s own doc
+  // names): once the ticket settles successfully, capture its one-time token
+  // into `issued` for the modal below, and tell the caller to refetch the
+  // invites list. Not an effect: this only needs to run once, exactly when
+  // `action.phase` transitions to `success`, and comparing against `issued`
+  // directly avoids a second `useEffect` + ref just to track "already
+  // handled this ticket".
+  if (action.phase === 'success' && action.value && issued !== action.value) {
+    setIssued(action.value);
+    setEmail('');
+    onCreated();
+  }
+
+  function closeTokenModal() {
+    setIssued(null);
+    action.reset();
+  }
+
+  return (
+    <div>
+      <form
+        className="auth-form"
+        style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-end', gap: 'var(--space-3)' }}
+        onSubmit={handleSubmit}
+        noValidate
+      >
+        <div className="field" style={{ flex: '1 1 220px' }}>
+          <label htmlFor={emailId}>Email người được mời</label>
+          <input
+            id={emailId}
+            name="email"
+            type="email"
+            required
+            disabled={pending}
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </div>
+
+        <div className="field" style={{ minWidth: 180 }}>
+          <span className="text-muted">Vai trò</span>
+          <SelectControl
+            value={role}
+            options={roleOptions}
+            onChange={(value) => setRole(value as MembershipRole)}
+            ariaLabel="Vai trò cho lời mời"
+            disabled={pending}
+          />
+        </div>
+
+        <div className="field" style={{ minWidth: 180 }}>
+          <span className="text-muted">Thời hạn lời mời</span>
+          <SelectControl
+            value={ttlChoice}
+            options={TTL_PRESETS.map((p) => ({ value: p.value, label: p.label }))}
+            onChange={setTtlChoice}
+            ariaLabel="Thời hạn lời mời"
+            disabled={pending}
+          />
+        </div>
+
+        <Button
+          type="submit"
+          variant="primary"
+          icon={<InviteIcon />}
+          loading={pending}
+          disabled={pending}
+        >
+          Gửi lời mời
+        </Button>
+      </form>
+
+      {action.phase === 'error' && (
+        <Notice tone="error">{describeMemberActionError(action.error, role === 'owner')}</Notice>
+      )}
+
+      {issued && (
+        <Modal
+          title="Đã tạo lời mời"
+          description="Mã mời chỉ hiển thị một lần duy nhất ngay bây giờ — hãy sao chép và gửi cho người được mời. Markhand sẽ không thể hiển thị lại mã này sau khi đóng hộp thoại."
+          onClose={closeTokenModal}
+          footer={
+            <Button variant="primary" onClick={closeTokenModal}>
+              Đã sao chép, đóng lại
+            </Button>
+          }
+        >
+          <p>
+            Email: <strong>{issued.invite.email}</strong> — vai trò:{' '}
+            <span className={`tag ${ROLE_META[issued.invite.role].tagClass}`}>
+              {ROLE_META[issued.invite.role].label}
+            </span>
+          </p>
+          <div className="field">
+            <label htmlFor={`${emailId}-token`}>Mã mời (một lần)</label>
+            <input
+              id={`${emailId}-token`}
+              readOnly
+              value={issued.token}
+              onFocus={(e) => e.target.select()}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => void navigator.clipboard?.writeText(issued.token)}
+          >
+            Sao chép mã mời
+          </Button>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/admin/InviteRow.tsx
+++ b/web/src/components/admin/InviteRow.tsx
@@ -1,0 +1,98 @@
+// P2-11: one invite row's revoke control. Split out from `InvitesTable.tsx`
+// (rather than dispatching from inside that component's `.map`) for the same
+// reason `DocumentRowActions` is its own component: a hook instance per row,
+// not one shared across every row in the list.
+import { useEffect, useRef, useState } from 'react';
+import { Button, Modal, Notice } from '../ui';
+import { revokeInvite } from './membersApi';
+import {
+  INVITE_STATUS_META,
+  ROLE_META,
+  describeMemberActionError,
+  formatDateTime,
+  inviteIsRevocable,
+} from './memberPresentation';
+import { useSingleFlightAction } from '../actions/useSingleFlightAction';
+import { apiClient, type ApiClient } from '../../api/client';
+import type { Invite } from './types';
+
+export function InviteRow({
+  invite,
+  onChanged,
+  client = apiClient,
+}: {
+  invite: Invite;
+  onChanged: () => void;
+  client?: ApiClient;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const revokeAction = useSingleFlightAction<Invite>();
+
+  const onChangedRef = useRef(onChanged);
+  useEffect(() => {
+    onChangedRef.current = onChanged;
+  }, [onChanged]);
+  useEffect(() => {
+    if (revokeAction.phase === 'success') onChangedRef.current?.();
+  }, [revokeAction.phase]);
+
+  function confirmRevoke() {
+    revokeAction.dispatch('revoke', (signal) =>
+      revokeInvite({ client, inviteId: invite.id, signal }),
+    );
+    setConfirmOpen(false);
+  }
+
+  const revoked = revokeAction.phase === 'success';
+  const canRevoke = inviteIsRevocable(invite) && !revoked;
+
+  return (
+    <tr>
+      <td>{invite.email}</td>
+      <td>
+        <span className={`tag ${ROLE_META[invite.role].tagClass}`}>
+          {ROLE_META[invite.role].label}
+        </span>
+      </td>
+      <td>
+        <span className={`tag ${INVITE_STATUS_META[invite.status].tagClass}`}>
+          {INVITE_STATUS_META[invite.status].label}
+        </span>
+      </td>
+      <td className="text-muted">{formatDateTime(invite.expiresAt)}</td>
+      <td>
+        <Button
+          variant="danger"
+          size="sm"
+          loading={revokeAction.phase === 'pending'}
+          disabled={!canRevoke}
+          onClick={() => setConfirmOpen(true)}
+        >
+          Thu hồi
+        </Button>
+        {revokeAction.phase === 'error' && (
+          <Notice tone="error">{describeMemberActionError(revokeAction.error, false)}</Notice>
+        )}
+        {confirmOpen && (
+          <Modal
+            title="Thu hồi lời mời này?"
+            description={`Lời mời gửi tới "${invite.email}" sẽ không thể được chấp nhận nữa.`}
+            onClose={() => setConfirmOpen(false)}
+            footer={
+              <>
+                <Button variant="ghost" onClick={() => setConfirmOpen(false)}>
+                  Hủy
+                </Button>
+                <Button variant="danger" onClick={confirmRevoke}>
+                  Thu hồi lời mời
+                </Button>
+              </>
+            }
+          >
+            <p>Người được mời sẽ cần một lời mời mới nếu bạn muốn thêm họ sau này.</p>
+          </Modal>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/web/src/components/admin/InvitesTable.tsx
+++ b/web/src/components/admin/InvitesTable.tsx
@@ -1,0 +1,43 @@
+// P2-11: the invites list (open and terminal), same `.table` convention as
+// `MembersTable.tsx`/`components/library/DocumentList.tsx`.
+import { InviteRow } from './InviteRow';
+import type { ApiClient } from '../../api/client';
+import type { Invite } from './types';
+
+export function InvitesTable({
+  invites,
+  loading,
+  onChanged,
+  client,
+}: {
+  invites: Invite[];
+  loading: boolean;
+  onChanged: () => void;
+  client?: ApiClient;
+}) {
+  if (loading) {
+    return <p className="text-muted">Đang tải danh sách lời mời…</p>;
+  }
+  if (invites.length === 0) {
+    return <p className="text-muted">Chưa có lời mời nào.</p>;
+  }
+
+  return (
+    <table className="table" aria-label="Danh sách lời mời">
+      <thead>
+        <tr>
+          <th scope="col">Email</th>
+          <th scope="col">Vai trò</th>
+          <th scope="col">Trạng thái</th>
+          <th scope="col">Hết hạn</th>
+          <th scope="col">Quản lý</th>
+        </tr>
+      </thead>
+      <tbody>
+        {invites.map((invite) => (
+          <InviteRow key={invite.id} invite={invite} onChanged={onChanged} client={client} />
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/web/src/components/admin/MemberRowActions.tsx
+++ b/web/src/components/admin/MemberRowActions.tsx
@@ -1,0 +1,212 @@
+// P2-11: per-member row controls (role change, suspend/reactivate, remove).
+// Owner-tier gating happens twice, deliberately: `AdminMembersPage.tsx`
+// already omits/disables these controls for a non-owner viewer before this
+// component ever mounts fully-enabled, but every mutation here is *also*
+// individually guarded against `isOwnerActive` (role option disabling,
+// `rowLocked`) — belt and suspenders, since the server is the only real
+// authority (see `RouteGuard.tsx`'s own module doc for the same principle
+// applied to whole routes). A 403 that gets through anyway (a race: the
+// caller's own owner status changed between page load and this click) is
+// still handled honestly via `describeMemberActionError`, not assumed
+// impossible.
+import { useEffect, useRef, useState } from 'react';
+import { Button, Modal, Notice, SelectControl, type SelectOption } from '../ui';
+import { patchMember, removeMember } from './membersApi';
+import {
+  ROLE_ORDER,
+  ROLE_META,
+  STATE_META,
+  describeMemberActionError,
+  formatDateTime,
+  operationManagesOwner,
+} from './memberPresentation';
+import { ReactivateIcon, RemoveMemberIcon, SuspendIcon } from './icons';
+import { useSingleFlightAction } from '../actions/useSingleFlightAction';
+import { apiClient, type ApiClient } from '../../api/client';
+import type { Membership, MembershipRole } from './types';
+
+export interface MemberRowActionsProps {
+  membership: Membership;
+  /** Whether the *signed-in caller* is currently an active owner — never derived from `membership` itself, which describes the row being rendered, not the viewer. */
+  isOwnerActive: boolean;
+  /** True when `membership` is the signed-in caller's own row — purely a label ("Bạn"), never used to change what's allowed. */
+  isSelf?: boolean;
+  /** Called after a role change, suspend/reactivate, or removal settles successfully, so the caller can refetch the members list. */
+  onChanged?: () => void;
+  /** Injectable for tests; defaults to the app-wide singleton, same convention as `DocumentRowActions`. */
+  client?: ApiClient;
+}
+
+export function MemberRowActions({
+  membership,
+  isOwnerActive,
+  isSelf = false,
+  onChanged,
+  client = apiClient,
+}: MemberRowActionsProps) {
+  const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
+  // Remembers which role a role-change attempt targeted, purely so a failed
+  // attempt's error message can tell whether *that* attempt was owner-tier
+  // (`grantsOwner`) even though `membership.role` itself never changed. State
+  // changes/removal need no equivalent: they never grant owner, so their
+  // owner-tier-ness is fully determined by `membership.role` at render time.
+  const [attemptedRole, setAttemptedRole] = useState<MembershipRole | null>(null);
+
+  const roleAction = useSingleFlightAction<Membership>();
+  const stateAction = useSingleFlightAction<Membership>();
+  const removeAction = useSingleFlightAction<void>();
+
+  const onChangedRef = useRef(onChanged);
+  useEffect(() => {
+    onChangedRef.current = onChanged;
+  }, [onChanged]);
+  useEffect(() => {
+    if (roleAction.phase === 'success') onChangedRef.current?.();
+  }, [roleAction.phase]);
+  useEffect(() => {
+    if (stateAction.phase === 'success') onChangedRef.current?.();
+  }, [stateAction.phase]);
+  useEffect(() => {
+    if (removeAction.phase === 'success') onChangedRef.current?.();
+  }, [removeAction.phase]);
+
+  const isRemoved = removeAction.phase === 'success';
+  const anyBusy =
+    roleAction.phase === 'pending' ||
+    stateAction.phase === 'pending' ||
+    removeAction.phase === 'pending';
+  // Any mutation against a row that's *currently* owner requires the caller
+  // to be an active owner (mirrors `operation_manages_owner` server-side —
+  // see `memberPresentation.ts`). Locks the whole row, not just the role
+  // select, since suspend/reactivate/remove of an owner is equally gated.
+  const rowLocked = operationManagesOwner(membership.role, false) && !isOwnerActive;
+  const disabled = anyBusy || isRemoved || rowLocked;
+
+  const roleOptions: SelectOption[] = ROLE_ORDER.map((role) => ({
+    value: role,
+    label: ROLE_META[role].label,
+    disabled: role === 'owner' && !isOwnerActive,
+  }));
+
+  function handleRoleChange(nextValue: string) {
+    const role = nextValue as MembershipRole;
+    if (role === membership.role) return;
+    setAttemptedRole(role);
+    roleAction.dispatch(`role-${role}`, (signal) =>
+      patchMember({ client, userId: membership.userId, role, signal }),
+    );
+  }
+
+  function toggleState() {
+    const nextState = membership.state === 'active' ? 'suspended' : 'active';
+    stateAction.dispatch(`state-${nextState}`, (signal) =>
+      patchMember({ client, userId: membership.userId, state: nextState, signal }),
+    );
+  }
+
+  function confirmRemove() {
+    removeAction.dispatch('remove', (signal) =>
+      removeMember({ client, userId: membership.userId, signal }),
+    );
+    setConfirmRemoveOpen(false);
+  }
+
+  const roleErrorOwnerTier = attemptedRole
+    ? operationManagesOwner(membership.role, attemptedRole === 'owner')
+    : false;
+  const stateErrorOwnerTier = membership.role === 'owner';
+  const removeErrorOwnerTier = membership.role === 'owner';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+      <div
+        style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', flexWrap: 'wrap' }}
+      >
+        <SelectControl
+          value={membership.role}
+          options={roleOptions}
+          onChange={handleRoleChange}
+          ariaLabel={`Vai trò của ${membership.userId}`}
+          disabled={disabled}
+          compact
+        />
+
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={membership.state === 'active' ? <SuspendIcon /> : <ReactivateIcon />}
+          loading={stateAction.phase === 'pending'}
+          disabled={disabled}
+          onClick={toggleState}
+        >
+          {membership.state === 'active' ? 'Tạm ngưng' : 'Kích hoạt lại'}
+        </Button>
+
+        <Button
+          variant="danger"
+          size="sm"
+          icon={<RemoveMemberIcon />}
+          disabled={disabled}
+          onClick={() => setConfirmRemoveOpen(true)}
+        >
+          Xóa khỏi tổ chức
+        </Button>
+
+        {isSelf && <span className="tag tag-neutral">Bạn</span>}
+      </div>
+
+      {rowLocked && !isRemoved && (
+        <Notice tone="info">
+          Chỉ chủ sở hữu (owner) đang hoạt động mới có thể thay đổi vai trò, tạm ngưng hoặc xóa một
+          chủ sở hữu khác.
+        </Notice>
+      )}
+
+      {isRemoved && <Notice tone="info">Đã xóa thành viên này khỏi tổ chức.</Notice>}
+
+      {roleAction.phase === 'error' && (
+        <Notice tone="error">
+          {describeMemberActionError(roleAction.error, roleErrorOwnerTier)}
+        </Notice>
+      )}
+      {stateAction.phase === 'error' && (
+        <Notice tone="error">
+          {describeMemberActionError(stateAction.error, stateErrorOwnerTier)}
+        </Notice>
+      )}
+      {removeAction.phase === 'error' && (
+        <Notice tone="error">
+          {describeMemberActionError(removeAction.error, removeErrorOwnerTier)}
+        </Notice>
+      )}
+
+      {confirmRemoveOpen && (
+        <Modal
+          title="Xóa thành viên này khỏi tổ chức?"
+          description={`Thành viên (${formatDateTime(membership.createdAt)}) sẽ mất toàn bộ quyền truy cập ngay lập tức. Thao tác này không thể hoàn tác từ giao diện.`}
+          onClose={() => setConfirmRemoveOpen(false)}
+          footer={
+            <>
+              <Button variant="ghost" onClick={() => setConfirmRemoveOpen(false)}>
+                Hủy
+              </Button>
+              <Button variant="danger" onClick={confirmRemove} icon={<RemoveMemberIcon />}>
+                Xóa thành viên
+              </Button>
+            </>
+          }
+        >
+          <p>Kiểm tra kỹ vai trò và trạng thái hiện tại trước khi xác nhận.</p>
+          <p>
+            <span className={`tag ${ROLE_META[membership.role].tagClass}`}>
+              {ROLE_META[membership.role].label}
+            </span>{' '}
+            <span className={`tag ${STATE_META[membership.state].tagClass}`}>
+              {STATE_META[membership.state].label}
+            </span>
+          </p>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/admin/MembersTable.tsx
+++ b/web/src/components/admin/MembersTable.tsx
@@ -1,0 +1,73 @@
+// P2-11: the membership list itself. Renders with the existing `.table`
+// component classes, same convention as `components/library/DocumentList.tsx`.
+import { MemberRowActions } from './MemberRowActions';
+import { ROLE_META, STATE_META, formatDateTime } from './memberPresentation';
+import type { ApiClient } from '../../api/client';
+import type { Membership } from './types';
+
+export function MembersTable({
+  members,
+  currentUserId,
+  isOwnerActive,
+  loading,
+  onChanged,
+  client,
+}: {
+  members: Membership[];
+  /** The signed-in caller's own `userId`, or `undefined` before the session is known — used only to label "Bạn", never to decide what's allowed. */
+  currentUserId: string | undefined;
+  isOwnerActive: boolean;
+  loading: boolean;
+  onChanged: () => void;
+  client?: ApiClient;
+}) {
+  if (loading) {
+    return <p className="text-muted">Đang tải danh sách thành viên…</p>;
+  }
+  if (members.length === 0) {
+    return <p className="text-muted">Chưa có thành viên nào.</p>;
+  }
+
+  return (
+    <table className="table" aria-label="Danh sách thành viên">
+      <thead>
+        <tr>
+          <th scope="col">Thành viên</th>
+          <th scope="col">Vai trò</th>
+          <th scope="col">Trạng thái</th>
+          <th scope="col">Tham gia</th>
+          <th scope="col">Quản lý</th>
+        </tr>
+      </thead>
+      <tbody>
+        {members.map((membership) => (
+          <tr key={membership.userId}>
+            <td>
+              <code>{membership.userId}</code>
+            </td>
+            <td>
+              <span className={`tag ${ROLE_META[membership.role].tagClass}`}>
+                {ROLE_META[membership.role].label}
+              </span>
+            </td>
+            <td>
+              <span className={`tag ${STATE_META[membership.state].tagClass}`}>
+                {STATE_META[membership.state].label}
+              </span>
+            </td>
+            <td className="text-muted">{formatDateTime(membership.createdAt)}</td>
+            <td>
+              <MemberRowActions
+                membership={membership}
+                isOwnerActive={isOwnerActive}
+                isSelf={membership.userId === currentUserId}
+                onChanged={onChanged}
+                client={client}
+              />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/web/src/components/admin/UsageCards.tsx
+++ b/web/src/components/admin/UsageCards.tsx
@@ -1,0 +1,63 @@
+// P2-12: renders `GET /usage`'s per-resource snapshot as a grid of cards,
+// each with a meter bar. Reuses the upload panel's existing progress-track
+// classes (`.upload-progress-track`/`-value`) rather than inventing new CSS
+// for what is, structurally, the same "filled fraction of a whole" bar —
+// see styles.css's own note against adding classes a feature could reuse.
+import { USAGE_RESOURCE_LABEL, formatUsageValue, usageFraction } from './memberPresentation';
+import type { UsageEntry } from './types';
+
+function UsageCard({ entry }: { entry: UsageEntry }) {
+  const fraction = usageFraction(entry.committed, entry.reserved, entry.limit);
+  const percentLabel = `${Math.round(fraction * 100)}%`;
+  return (
+    <div
+      className="card"
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}
+    >
+      <p className="card-kicker">{USAGE_RESOURCE_LABEL[entry.resource]}</p>
+      <p className="card-title" style={{ margin: 0 }}>
+        {formatUsageValue(entry.resource, entry.committed + entry.reserved)}
+        <span className="text-muted"> / {formatUsageValue(entry.resource, entry.limit)}</span>
+      </p>
+      <span
+        className="upload-progress-track"
+        role="progressbar"
+        aria-label={`Đã dùng ${USAGE_RESOURCE_LABEL[entry.resource]}`}
+        aria-valuenow={Math.round(fraction * 100)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <span className="upload-progress-value" style={{ width: percentLabel }} />
+      </span>
+      <p className="card-meta" style={{ margin: 0 }}>
+        Đã dùng {percentLabel} — còn lại {formatUsageValue(entry.resource, entry.remaining)}
+        {entry.reserved > 0 && (
+          <> (trong đó {formatUsageValue(entry.resource, entry.reserved)} đang được giữ chỗ)</>
+        )}
+      </p>
+    </div>
+  );
+}
+
+export function UsageCards({ items, loading }: { items: UsageEntry[]; loading: boolean }) {
+  if (loading) {
+    return <p className="text-muted">Đang tải dữ liệu sử dụng…</p>;
+  }
+  if (items.length === 0) {
+    return <p className="text-muted">Chưa có dữ liệu sử dụng.</p>;
+  }
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+        gap: 'var(--space-4)',
+      }}
+    >
+      {items.map((entry) => (
+        <UsageCard key={entry.resource} entry={entry} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/admin/icons.tsx
+++ b/web/src/components/admin/icons.tsx
@@ -1,0 +1,23 @@
+// Same wrapping convention as `components/icons.tsx`/`components/actions/icons.tsx`
+// (stroke-width 2.75, aria-hidden) for the glyphs this feature needs that
+// neither shared file exports. Kept local to `components/admin/**`.
+import { Ban, CircleCheck, Trash2, UserPlus } from 'lucide-react';
+import type { SVGProps } from 'react';
+
+type IconProps = SVGProps<SVGSVGElement> & { size?: number };
+
+export function SuspendIcon({ size = 15, ...props }: IconProps) {
+  return <Ban size={size} strokeWidth={2.75} aria-hidden="true" {...props} />;
+}
+
+export function ReactivateIcon({ size = 15, ...props }: IconProps) {
+  return <CircleCheck size={size} strokeWidth={2.75} aria-hidden="true" {...props} />;
+}
+
+export function RemoveMemberIcon({ size = 15, ...props }: IconProps) {
+  return <Trash2 size={size} strokeWidth={2.75} aria-hidden="true" {...props} />;
+}
+
+export function InviteIcon({ size = 15, ...props }: IconProps) {
+  return <UserPlus size={size} strokeWidth={2.75} aria-hidden="true" {...props} />;
+}

--- a/web/src/components/admin/index.ts
+++ b/web/src/components/admin/index.ts
@@ -1,0 +1,33 @@
+export { MembersTable } from './MembersTable';
+export { MemberRowActions, type MemberRowActionsProps } from './MemberRowActions';
+export { InviteForm } from './InviteForm';
+export { InvitesTable } from './InvitesTable';
+export { InviteRow } from './InviteRow';
+export { UsageCards } from './UsageCards';
+export {
+  ROLE_ORDER,
+  ROLE_META,
+  STATE_META,
+  INVITE_STATUS_META,
+  USAGE_RESOURCE_LABEL,
+  describeMemberReadError,
+  describeMemberActionError,
+  isActiveOwner,
+  operationManagesOwner,
+  inviteIsRevocable,
+  formatDateTime,
+  formatBytes,
+  formatCount,
+  formatUsageValue,
+  usageFraction,
+} from './memberPresentation';
+export * from './membersApi';
+export type {
+  Membership,
+  MembershipRole,
+  MembershipState,
+  Invite,
+  InviteStatus,
+  UsageEntry,
+  UsageResource,
+} from './types';

--- a/web/src/components/admin/memberPresentation.ts
+++ b/web/src/components/admin/memberPresentation.ts
@@ -1,0 +1,183 @@
+// Pure presentation helpers for the admin members/usage UI: how a role/state/
+// invite-status reads (label + one of styles.css's existing `.tag-*`
+// classes — never a new class, same rule `DocumentStateBadge`'s doc follows),
+// and the owner-tier decision the UI must make *before* ever calling the API
+// (never render a control that would just 403). Kept side-effect-free and
+// framework-free so each piece is trivial to unit test on its own.
+import { HttpApiError, NetworkError } from '../../api/errors';
+import type {
+  Invite,
+  InviteStatus,
+  Membership,
+  MembershipRole,
+  MembershipState,
+  UsageResource,
+} from './types';
+
+export interface TagMeta {
+  label: string;
+  tagClass: 'tag-neutral' | 'tag-accent' | 'tag-accent-2' | 'tag-outline';
+}
+
+/** Every role the `Membership`/`Invite`/`PatchMemberRequest` schemas declare, in privilege order (most privileged first) — the order the role `<select>` presents them in. */
+export const ROLE_ORDER: readonly MembershipRole[] = ['owner', 'admin', 'editor', 'viewer'];
+
+export const ROLE_META: Record<MembershipRole, TagMeta> = {
+  owner: { label: 'Chủ sở hữu', tagClass: 'tag-accent' },
+  admin: { label: 'Quản trị viên', tagClass: 'tag-accent-2' },
+  editor: { label: 'Biên tập viên', tagClass: 'tag-outline' },
+  viewer: { label: 'Người xem', tagClass: 'tag-neutral' },
+};
+
+export const STATE_META: Record<MembershipState, TagMeta> = {
+  active: { label: 'Đang hoạt động', tagClass: 'tag-accent-2' },
+  suspended: { label: 'Đã tạm ngưng', tagClass: 'tag-outline' },
+};
+
+export const INVITE_STATUS_META: Record<InviteStatus, TagMeta> = {
+  pending: { label: 'Đang chờ', tagClass: 'tag-accent-2' },
+  accepted: { label: 'Đã chấp nhận', tagClass: 'tag-accent' },
+  revoked: { label: 'Đã thu hồi', tagClass: 'tag-neutral' },
+  expired: { label: 'Đã hết hạn', tagClass: 'tag-outline' },
+};
+
+export const USAGE_RESOURCE_LABEL: Record<UsageResource, string> = {
+  storage_bytes: 'Dung lượng lưu trữ',
+  documents: 'Số tài liệu',
+  concurrent_jobs: 'Tác vụ đồng thời',
+  tokens: 'Token (LLM)',
+};
+
+const dateTimeFormatter = new Intl.DateTimeFormat('vi-VN', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+/** Absolute (never relative-to-now) Vietnamese date/time — same convention as `components/library/documentPresentation.ts`. */
+export function formatDateTime(iso: string): string {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? iso : dateTimeFormatter.format(date);
+}
+
+/**
+ * Mirrors `services::members::operation_manages_owner` on the server exactly
+ * (see `crates/server/src/services/members.rs`): true when the operation
+ * would grant the owner role, or when its target currently holds it — either
+ * way the caller must themselves be an active owner or the server 403s. Pure
+ * and server-mirroring on purpose so the UI's "hide it before it 403s" rule
+ * and the server's actual guard can never silently drift apart.
+ */
+export function operationManagesOwner(
+  targetCurrentRole: MembershipRole,
+  grantsOwner: boolean,
+): boolean {
+  return grantsOwner || targetCurrentRole === 'owner';
+}
+
+/** Whether `caller` may perform an owner-tier operation right now — an active owner membership only. Fails closed (false) if `caller` is `null`/`undefined` (own membership not found/not yet loaded). */
+export function isActiveOwner(caller: Membership | null | undefined): boolean {
+  return !!caller && caller.role === 'owner' && caller.state === 'active';
+}
+
+/** Formats bytes as a compact human-readable size for the storage_bytes usage row. Binary (1024-based), matching how storage is actually measured. */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes)) return String(bytes);
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (Math.abs(value) >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const decimals = unitIndex === 0 ? 0 : 1;
+  return `${value.toFixed(decimals)} ${units[unitIndex]}`;
+}
+
+/** Formats a plain integer count with locale thousands separators (documents/jobs/tokens usage rows). */
+export function formatCount(value: number): string {
+  return new Intl.NumberFormat('vi-VN').format(value);
+}
+
+export function formatUsageValue(resource: UsageResource, value: number): string {
+  return resource === 'storage_bytes' ? formatBytes(value) : formatCount(value);
+}
+
+/** Fraction of `limit` already committed+reserved, clamped to [0, 1] for the meter bar (a limit of 0 reads as fully consumed rather than dividing by zero). */
+export function usageFraction(committed: number, reserved: number, limit: number): number {
+  if (limit <= 0) return committed + reserved > 0 ? 1 : 0;
+  return Math.min(1, Math.max(0, (committed + reserved) / limit));
+}
+
+/** Vietnamese, user-facing message for an error thrown while reading members/invites/usage (not a mutation — see `describeMemberActionError` for those). */
+export function describeMemberReadError(cause: unknown): string {
+  if (cause instanceof HttpApiError) {
+    if (cause.status === 403) {
+      return 'Bạn không có quyền quản trị thành viên (cần quyền member.manage).';
+    }
+    if (cause.status === 429) return 'Quá nhiều yêu cầu. Vui lòng thử lại sau ít phút.';
+    return `Máy chủ báo lỗi (${cause.status}): ${cause.message}`;
+  }
+  if (cause instanceof NetworkError) {
+    return 'Không thể kết nối máy chủ. Kiểm tra kết nối mạng và thử lại.';
+  }
+  return 'Không thể tải dữ liệu lúc này. Vui lòng thử lại.';
+}
+
+function formatRetryAfter(seconds: number | undefined): string {
+  if (seconds === undefined || seconds <= 0) {
+    return 'Quá nhiều yêu cầu. Vui lòng thử lại sau ít phút.';
+  }
+  if (seconds < 60) return `Quá nhiều yêu cầu. Vui lòng thử lại sau ${seconds} giây.`;
+  const minutes = Math.ceil(seconds / 60);
+  return `Quá nhiều yêu cầu. Vui lòng thử lại sau khoảng ${minutes} phút.`;
+}
+
+/**
+ * Vietnamese, user-facing message for a thrown member/invite mutation error.
+ * `ownerTier` marks a mutation this client already knows touches the owner
+ * tier (see `operationManagesOwner`) — a 403 here gets the specific
+ * "chỉ chủ sở hữu" copy the task asks for instead of a generic permission
+ * message, since the server's `forbidden` code/message is identical for both
+ * causes (see `crates/server/src/routes/members.rs`'s `RouteError::Denied`
+ * arm — always `"Permission denied"`) and cannot be told apart from the
+ * response alone.
+ */
+export function describeMemberActionError(cause: unknown, ownerTier: boolean): string {
+  if (cause instanceof HttpApiError) {
+    if (cause.status === 403) {
+      return ownerTier
+        ? 'Chỉ chủ sở hữu (owner) đang hoạt động mới có thể cấp hoặc quản lý vai trò chủ sở hữu.'
+        : 'Bạn không có quyền thực hiện thao tác này (cần quyền member.manage).';
+    }
+    if (cause.status === 404) {
+      return 'Thành viên hoặc lời mời này không còn tồn tại. Danh sách sẽ được tải lại.';
+    }
+    if (cause.status === 409) {
+      switch (cause.code) {
+        case 'last_owner':
+          return 'Không thể thực hiện: tổ chức phải luôn còn ít nhất một chủ sở hữu (owner) đang hoạt động.';
+        case 'already_member':
+          return 'Người này đã là thành viên của tổ chức.';
+        case 'invite_terminal':
+          return 'Lời mời này đã được chấp nhận hoặc thu hồi trước đó.';
+        case 'invite_expired':
+          return 'Lời mời này đã hết hạn.';
+        default:
+          return 'Yêu cầu xung đột với trạng thái hiện tại. Vui lòng tải lại trang và thử lại.';
+      }
+    }
+    if (cause.status === 429) return formatRetryAfter(cause.rateLimit?.retryAfterSeconds);
+    if (cause.status === 400) return cause.message || 'Dữ liệu không hợp lệ.';
+    if (cause.status >= 500) return 'Máy chủ đang gặp sự cố. Vui lòng thử lại sau.';
+    return cause.message || 'Không thể hoàn tất thao tác. Vui lòng thử lại.';
+  }
+  if (cause instanceof NetworkError) {
+    return 'Không thể kết nối máy chủ. Kiểm tra kết nối mạng và thử lại.';
+  }
+  return 'Không thể hoàn tất thao tác. Vui lòng thử lại.';
+}
+
+/** True for any `Invite` whose token is still capable of being accepted (mirrors `revokeMemberInvite`'s own "already terminal" 409 condition, so the revoke button never offers an action the server would just reject). */
+export function inviteIsRevocable(invite: Invite): boolean {
+  return invite.status === 'pending';
+}

--- a/web/src/components/admin/membersApi.ts
+++ b/web/src/components/admin/membersApi.ts
@@ -1,0 +1,77 @@
+// Thin wrappers around the members/invites mutations the admin pages offer,
+// kept out of the row/form components so those only orchestrate UI state and
+// never touch `apiClient` directly — same split `documentActionsApi.ts` uses
+// for `DocumentRowActions.tsx`.
+import type { ApiClient } from '../../api/client';
+import type { components } from '../../api/generated/contract';
+import type { Membership, MembershipRole, MembershipState } from './types';
+
+export interface CreateInviteParams {
+  client: ApiClient;
+  email: string;
+  role: MembershipRole;
+  /** Omitted entirely (not sent as `undefined`) lets the server apply its own default (7 days). */
+  ttlSecs?: number;
+  signal: AbortSignal;
+}
+
+/** `POST /members/invites`. The response's plaintext `token` is returned exactly once — callers must show it immediately and never attempt to refetch or persist it (see the response schema's own doc comment). */
+export async function createInvite(
+  params: CreateInviteParams,
+): Promise<components['schemas']['CreateInviteResponse']> {
+  const { client, email, role, ttlSecs, signal } = params;
+  return client.request('post', '/members/invites', {
+    body: ttlSecs === undefined ? { email, role } : { email, role, ttlSecs },
+    signal,
+  });
+}
+
+export interface RevokeInviteParams {
+  client: ApiClient;
+  inviteId: string;
+  signal: AbortSignal;
+}
+
+/** `POST /members/invites/{inviteId}/revoke`. */
+export async function revokeInvite(
+  params: RevokeInviteParams,
+): Promise<components['schemas']['Invite']> {
+  const { client, inviteId, signal } = params;
+  return client.request('post', '/members/invites/{inviteId}/revoke', {
+    params: { path: { inviteId } },
+    signal,
+  });
+}
+
+export interface PatchMemberParams {
+  client: ApiClient;
+  userId: string;
+  role?: MembershipRole;
+  state?: MembershipState;
+  signal: AbortSignal;
+}
+
+/** `PATCH /members/{userId}`. Exactly one of `role`/`state` per call from this UI (see `MemberRowActions.tsx`) even though the wire shape allows both at once. */
+export async function patchMember(params: PatchMemberParams): Promise<Membership> {
+  const { client, userId, role, state, signal } = params;
+  return client.request('patch', '/members/{userId}', {
+    params: { path: { userId } },
+    body: { role, state },
+    signal,
+  });
+}
+
+export interface RemoveMemberParams {
+  client: ApiClient;
+  userId: string;
+  signal: AbortSignal;
+}
+
+/** `DELETE /members/{userId}`. */
+export async function removeMember(params: RemoveMemberParams): Promise<void> {
+  const { client, userId, signal } = params;
+  await client.request('delete', '/members/{userId}', {
+    params: { path: { userId } },
+    signal,
+  });
+}

--- a/web/src/components/admin/testSupport.ts
+++ b/web/src/components/admin/testSupport.ts
@@ -1,0 +1,22 @@
+// Shared test-only plumbing for `components/admin/**` and the two admin
+// pages' tests. Not imported by any production file — same convention as
+// `components/actions/testSupport.ts`.
+import { getStore } from '../../mocks/fixtures';
+
+/**
+ * Grants the seeded demo user `member.manage` in place (mutating the live
+ * `MockUser` object `authContextForHeader` resolves requests against), so a
+ * test can drive the admin members/usage pages as a permitted caller. The
+ * demo user does NOT have this permission by default — see
+ * `mocks/fixtures.ts`'s own note on `DEMO_USER` — because an existing
+ * `App.test.tsx` scenario specifically covers a signed-in user *without*
+ * member.manage on `/admin/members`; this function exists so P2-11/P2-12
+ * tests don't have to change that shared default to get their own coverage.
+ * Idempotent; call after `resetMockState()`.
+ */
+export function grantMemberManage(): void {
+  const [user] = getStore().users;
+  if (!user.permissions.includes('member.manage')) {
+    user.permissions.push('member.manage');
+  }
+}

--- a/web/src/components/admin/types.ts
+++ b/web/src/components/admin/types.ts
@@ -1,0 +1,13 @@
+// Shared type aliases for the admin members/usage UI (P2-11/P2-12). Every
+// shape here is derived straight from `api/generated/contract.ts` — nothing
+// re-declares a schema that file already exports, same convention as
+// `components/library/types.ts`.
+import type { components } from '../../api/generated/contract';
+
+export type Membership = components['schemas']['Membership'];
+export type MembershipRole = Membership['role'];
+export type MembershipState = Membership['state'];
+export type Invite = components['schemas']['Invite'];
+export type InviteStatus = Invite['status'];
+export type UsageEntry = components['schemas']['UsageEntry'];
+export type UsageResource = UsageEntry['resource'];

--- a/web/src/mocks/fixtures.ts
+++ b/web/src/mocks/fixtures.ts
@@ -13,6 +13,7 @@ type Document = components['schemas']['Document'];
 type DocumentVersion = components['schemas']['DocumentVersion'];
 type Job = components['schemas']['Job'];
 type MeResponse = components['schemas']['MeResponse'];
+type Membership = components['schemas']['Membership'];
 
 export interface MockUser {
   userId: string;
@@ -47,6 +48,26 @@ export interface DownloadCapabilityRecord {
   redeemed: boolean;
 }
 
+/**
+ * Server-side invite record: every wire `Invite` field plus the token hash,
+ * which `Invite` (the response schema) never carries — mirrors
+ * `DownloadCapabilityRecord`'s split between "what's stored" and "what's on
+ * the wire". `status` is intentionally absent here too: like the real
+ * `org_invites` table, it's derived at read time from
+ * `acceptedAt`/`revokedAt`/`expiresAt` (see `handlers/members.ts`'s
+ * `inviteStatus`), never stored as its own field.
+ */
+export interface InviteRecord {
+  id: string;
+  email: string;
+  role: Membership['role'];
+  tokenHash: string;
+  expiresAt: string;
+  acceptedAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
 export interface AccessTokenRecord {
   userId: string;
   sessionId: string;
@@ -62,6 +83,9 @@ interface Store {
   jobs: Map<string, Job>;
   conflicts: ConflictRecord[];
   downloadCapabilities: Map<string, DownloadCapabilityRecord>;
+  /** Memberships of the demo org (`DEMO_USER.orgId`) — every seeded/mock user's role+state. */
+  memberships: Membership[];
+  invites: InviteRecord[];
 }
 
 const DEMO_USER: MockUser = {
@@ -70,9 +94,53 @@ const DEMO_USER: MockUser = {
   email: 'demo@markhand.test',
   password: 'demo-password',
   displayName: 'Demo User',
+  // Deliberately WITHOUT `member.manage` — `App.test.tsx` already has a
+  // scenario ("renders an in-shell notice... for a signed-in user without
+  // member.manage") that depends on this exact user lacking it. P2-11/P2-12
+  // tests that need a member.manage caller grant it on this same seeded user
+  // via `components/admin/testSupport.ts`'s `grantMemberManage()` instead of
+  // changing the shared default here.
   permissions: ['doc.quarantine.review', 'qa.history'],
   allowedCollectionIds: [mockUuid(10), mockUuid(11)],
 };
+
+/** A second seeded org member — active admin, non-owner — so member-list tests have more than one row and a non-owner promotion/demotion target. */
+export const SECOND_MEMBER_USER_ID = mockUuid(30);
+/** A third seeded org member — suspended viewer — so the list shows a non-active row too. */
+export const THIRD_MEMBER_USER_ID = mockUuid(31);
+
+function seedMemberships(): Membership[] {
+  return [
+    { userId: DEMO_USER.userId, role: 'owner', state: 'active', createdAt: mockTimestamp(0) },
+    {
+      userId: SECOND_MEMBER_USER_ID,
+      role: 'admin',
+      state: 'active',
+      createdAt: mockTimestamp(10),
+    },
+    {
+      userId: THIRD_MEMBER_USER_ID,
+      role: 'viewer',
+      state: 'suspended',
+      createdAt: mockTimestamp(20),
+    },
+  ];
+}
+
+function seedInvites(): InviteRecord[] {
+  return [
+    {
+      id: mockUuid(9100),
+      email: 'moi-nguoi-moi@example.com',
+      role: 'editor',
+      tokenHash: 'seed-invite-token-hash-unused',
+      expiresAt: mockTimestamp(60 * 24 * 7),
+      acceptedAt: null,
+      revokedAt: null,
+      createdAt: mockTimestamp(0),
+    },
+  ];
+}
 
 function seedCollections(): Collection[] {
   return [
@@ -208,6 +276,8 @@ function freshStore(): Store {
     jobs: seedJobs(),
     conflicts: seedConflicts(),
     downloadCapabilities: new Map(),
+    memberships: seedMemberships(),
+    invites: seedInvites(),
   };
 }
 

--- a/web/src/mocks/handlers/index.ts
+++ b/web/src/mocks/handlers/index.ts
@@ -6,4 +6,5 @@
 import './health';
 import './auth';
 import './library';
+import './members';
 import './qa';

--- a/web/src/mocks/handlers/members.ts
+++ b/web/src/mocks/handlers/members.ts
@@ -1,0 +1,336 @@
+// P2-11/P2-12: member/role admin + usage mock handlers. Mirrors the real
+// domain rules in `crates/server/src/services/members.rs` and
+// `crates/server/src/routes/members.rs` closely enough for the SPA's tests to
+// exercise the same decisions the real server makes — in particular:
+//
+//   - `member.manage` gates every operation here except `acceptMemberInvite`
+//     (auth-only by design, matching the real route).
+//   - "admin không quản owner": granting the owner role, or mutating a
+//     membership that is *currently* owner (role change / suspend / reactivate
+//     / remove), requires the caller to themselves be an active owner —
+//     `guardOwnerTier` below, mirroring `services::members::guard_owner_tier`.
+//     Both this and a plain missing-`member.manage` 403 map to the same
+//     generic `forbidden` code/message the real server sends (see
+//     `RouteError::into_response`'s `Self::Denied` arm) — this mock does not
+//     invent a more specific code the real API doesn't have.
+//   - The last-owner invariant (`guardLastOwner`) mirrors
+//     `check_last_owner_invariant`: an operation that would leave zero active
+//     owners in the org fails with 409 `last_owner`.
+//   - Invite lifecycle codes (`already_member`, `invite_terminal`,
+//     `invite_expired`) mirror `RouteError::from_member`'s exact `code` strings
+//     so the SPA's error-code mapping is tested against the real vocabulary.
+import { registerOperation } from '../registry';
+import { apiError, forbidden, notFound } from '../apiError';
+import { mockTimestamp } from '../ids';
+import { authContextForHeader, getStore, nextId, type InviteRecord } from '../fixtures';
+import type { components } from '../../api/generated/contract';
+
+type Membership = components['schemas']['Membership'];
+type MembershipRole = Membership['role'];
+type Invite = components['schemas']['Invite'];
+type PatchMemberRequest = components['schemas']['PatchMemberRequest'];
+type CreateInviteRequest = components['schemas']['CreateInviteRequest'];
+type AcceptInviteRequest = components['schemas']['AcceptInviteRequest'];
+
+const PERMISSION_MEMBER_MANAGE = 'member.manage';
+const MIN_INVITE_TTL_SECS = 60;
+const MAX_INVITE_TTL_SECS = 30 * 24 * 3600;
+const DEFAULT_INVITE_TTL_SECS = 7 * 24 * 3600;
+
+/** Same generic message the real route sends for every 403 here (`RouteError::into_response`'s `Self::Denied` arm: `"Permission denied"`), regardless of *why* — see this file's module doc. */
+function permissionDenied() {
+  return forbidden('Permission denied');
+}
+
+/** Resolves the caller's `MockUser` + their own membership row, or `undefined` if unauthenticated/not a member of the seeded org. `fetchMock.ts` already 401s a missing/invalid bearer before any handler runs, so `undefined` here means "authenticated but not in `getStore().memberships`" — treated as no `member.manage`, fail-closed. */
+function callerMembership(authorizationHeader: string | null): Membership | undefined {
+  const auth = authContextForHeader(authorizationHeader);
+  if (!auth) return undefined;
+  return getStore().memberships.find((m) => m.userId === auth.user.userId);
+}
+
+function hasMemberManage(authorizationHeader: string | null): boolean {
+  const auth = authContextForHeader(authorizationHeader);
+  return !!auth && auth.user.permissions.includes(PERMISSION_MEMBER_MANAGE);
+}
+
+/** Mirrors `services::members::operation_manages_owner`. */
+function operationManagesOwner(targetCurrentRole: MembershipRole, grantsOwner: boolean): boolean {
+  return grantsOwner || targetCurrentRole === 'owner';
+}
+
+/** Mirrors `services::members::guard_owner_tier`: true (allowed) unless the operation touches the owner tier and the caller isn't an active owner. */
+function guardOwnerTier(
+  authorizationHeader: string | null,
+  targetCurrentRole: MembershipRole,
+  grantsOwner: boolean,
+): boolean {
+  if (!operationManagesOwner(targetCurrentRole, grantsOwner)) return true;
+  const caller = callerMembership(authorizationHeader);
+  return !!caller && caller.role === 'owner' && caller.state === 'active';
+}
+
+/** Mirrors `services::members::check_last_owner_invariant`. */
+function guardLastOwner(targetUserId: string, targetWillBeActiveOwner: boolean): boolean {
+  const othersActive = getStore().memberships.filter(
+    (m) => m.userId !== targetUserId && m.role === 'owner' && m.state === 'active',
+  ).length;
+  const remaining = othersActive + (targetWillBeActiveOwner ? 1 : 0);
+  return remaining > 0;
+}
+
+function lastOwnerConflict() {
+  return {
+    status: 409,
+    body: apiError('last_owner', 'Operation would leave the organization with zero active owners'),
+  };
+}
+
+function inviteStatus(invite: InviteRecord, now: number): Invite['status'] {
+  if (invite.revokedAt) return 'revoked';
+  if (invite.acceptedAt) return 'accepted';
+  if (Date.parse(invite.expiresAt) <= now) return 'expired';
+  return 'pending';
+}
+
+function inviteDto(invite: InviteRecord): Invite {
+  return {
+    id: invite.id,
+    email: invite.email,
+    role: invite.role,
+    status: inviteStatus(invite, Date.now()),
+    expiresAt: invite.expiresAt,
+    acceptedAt: invite.acceptedAt,
+    revokedAt: invite.revokedAt,
+    createdAt: invite.createdAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// E1 — GET /members
+// ---------------------------------------------------------------------------
+
+registerOperation('listMembers', (ctx) => {
+  if (!hasMemberManage(ctx.headers.get('authorization'))) return permissionDenied();
+  return {
+    status: 200,
+    body: { items: getStore().memberships, page: { hasMore: false, nextCursor: null } },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// E2 — GET /members/invites
+// ---------------------------------------------------------------------------
+
+registerOperation('listMemberInvites', (ctx) => {
+  if (!hasMemberManage(ctx.headers.get('authorization'))) return permissionDenied();
+  return {
+    status: 200,
+    body: {
+      items: getStore().invites.map(inviteDto),
+      page: { hasMore: false, nextCursor: null },
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// E3 — POST /members/invites
+// ---------------------------------------------------------------------------
+
+registerOperation('createMemberInvite', async (ctx) => {
+  const authorization = ctx.headers.get('authorization');
+  if (!hasMemberManage(authorization)) return permissionDenied();
+  const body = await ctx.json<CreateInviteRequest>();
+
+  const email = body.email.trim();
+  if (!email || !email.includes('@')) {
+    return { status: 400, body: apiError('validation_failed', 'Invalid email') };
+  }
+  if (
+    body.ttlSecs !== undefined &&
+    (body.ttlSecs < MIN_INVITE_TTL_SECS || body.ttlSecs > MAX_INVITE_TTL_SECS)
+  ) {
+    return { status: 400, body: apiError('validation_failed', 'Invalid ttlSecs') };
+  }
+
+  // Inviting a new owner is itself owner-tier: mirrors
+  // `create_invite`'s `OwnerRequiredForOwnerInvite` check (there is no
+  // "current role" for an invite target, so this only ever checks the
+  // grants-owner half of `guardOwnerTier`).
+  if (body.role === 'owner' && !guardOwnerTier(authorization, 'viewer', true)) {
+    return permissionDenied();
+  }
+
+  const ttlSecs = body.ttlSecs ?? DEFAULT_INVITE_TTL_SECS;
+  const token = `mock-invite-token.${nextId()}`;
+  const record: InviteRecord = {
+    id: nextId(),
+    email: email.toLowerCase(),
+    role: body.role,
+    tokenHash: `hash-of-${token}`,
+    expiresAt: new Date(Date.now() + ttlSecs * 1000).toISOString(),
+    acceptedAt: null,
+    revokedAt: null,
+    createdAt: mockTimestamp(0),
+  };
+  getStore().invites.push(record);
+
+  return {
+    status: 201,
+    body: { invite: inviteDto(record), token },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// E4 — POST /members/invites/{inviteId}/revoke
+// ---------------------------------------------------------------------------
+
+registerOperation('revokeMemberInvite', (ctx) => {
+  if (!hasMemberManage(ctx.headers.get('authorization'))) return permissionDenied();
+  const invite = getStore().invites.find((i) => i.id === ctx.params.inviteId);
+  if (!invite) return notFound(`Invite ${ctx.params.inviteId} does not exist.`);
+  if (invite.acceptedAt || invite.revokedAt) {
+    return {
+      status: 409,
+      body: apiError('invite_terminal', 'Invite has already been accepted or revoked'),
+    };
+  }
+  invite.revokedAt = mockTimestamp(0);
+  return { status: 200, body: inviteDto(invite) };
+});
+
+// ---------------------------------------------------------------------------
+// E5 — POST /members/invites/accept (auth-only — see module doc; the admin
+// pages this task builds never call this, it's the invitee's own flow, but
+// it's mocked for completeness/future use).
+// ---------------------------------------------------------------------------
+
+registerOperation('acceptMemberInvite', async (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return { status: 401, body: apiError('unauthorized', 'Authentication required') };
+  const body = await ctx.json<AcceptInviteRequest>();
+  const token = body.token.trim();
+  const invite = getStore().invites.find((i) => `hash-of-${token}` === i.tokenHash);
+  if (!invite) return notFound('Invite token is unknown.');
+  if (invite.acceptedAt || invite.revokedAt) {
+    return {
+      status: 409,
+      body: apiError('invite_terminal', 'Invite has already been accepted or revoked'),
+    };
+  }
+  if (Date.parse(invite.expiresAt) <= Date.now()) {
+    return { status: 409, body: apiError('invite_expired', 'Invite has expired') };
+  }
+  if (getStore().memberships.some((m) => m.userId === auth.user.userId)) {
+    return {
+      status: 409,
+      body: apiError('already_member', 'User is already a member of this organization'),
+    };
+  }
+  const membership: Membership = {
+    userId: auth.user.userId,
+    role: invite.role,
+    state: 'active',
+    createdAt: mockTimestamp(0),
+  };
+  getStore().memberships.push(membership);
+  invite.acceptedAt = mockTimestamp(0);
+  return { status: 201, body: membership };
+});
+
+// ---------------------------------------------------------------------------
+// E6 — PATCH /members/{userId}
+// ---------------------------------------------------------------------------
+
+registerOperation('patchMember', async (ctx) => {
+  const authorization = ctx.headers.get('authorization');
+  if (!hasMemberManage(authorization)) return permissionDenied();
+  const body = await ctx.json<PatchMemberRequest>();
+  if (body.role === undefined && body.state === undefined) {
+    return { status: 400, body: apiError('validation_failed', 'role or state is required') };
+  }
+
+  const userId = ctx.params.userId;
+  const membership = getStore().memberships.find((m) => m.userId === userId);
+  if (!membership) return notFound(`Member ${userId} does not exist.`);
+
+  // Two separate owner-tier gates, not one shared at the top: mirrors
+  // `patch_member` calling `change_role` (owner-tier check against the
+  // *pre*-change role) and then `suspend_member`/`reactivate_member` (a
+  // fresh check against whatever role is current *after* that role change
+  // already committed) as two sequential steps — so `{role: "viewer", state:
+  // "suspended"}` against a currently-owner target checks owner-tier once
+  // for the demotion and, since the target is no longer an owner afterwards,
+  // does not require owner-tier again for the suspend.
+  if (body.role !== undefined) {
+    if (!guardOwnerTier(authorization, membership.role, body.role === 'owner')) {
+      return permissionDenied();
+    }
+    if (body.role !== membership.role) {
+      const willBeActiveOwner = body.role === 'owner' && membership.state === 'active';
+      if (!guardLastOwner(userId, willBeActiveOwner)) return lastOwnerConflict();
+      membership.role = body.role;
+    }
+  }
+
+  if (body.state !== undefined) {
+    if (!guardOwnerTier(authorization, membership.role, false)) return permissionDenied();
+    if (body.state !== membership.state) {
+      if (body.state === 'suspended' && !guardLastOwner(userId, false)) return lastOwnerConflict();
+      membership.state = body.state;
+    }
+  }
+
+  return { status: 200, body: membership };
+});
+
+// ---------------------------------------------------------------------------
+// E7 — DELETE /members/{userId}
+// ---------------------------------------------------------------------------
+
+registerOperation('deleteMember', (ctx) => {
+  const authorization = ctx.headers.get('authorization');
+  if (!hasMemberManage(authorization)) return permissionDenied();
+
+  const userId = ctx.params.userId;
+  const store = getStore();
+  const membership = store.memberships.find((m) => m.userId === userId);
+  if (!membership) return notFound(`Member ${userId} does not exist.`);
+
+  if (!guardOwnerTier(authorization, membership.role, false)) return permissionDenied();
+  if (!guardLastOwner(userId, false)) return lastOwnerConflict();
+
+  store.memberships = store.memberships.filter((m) => m.userId !== userId);
+  return { status: 204 };
+});
+
+// ---------------------------------------------------------------------------
+// E8 — GET /usage
+// ---------------------------------------------------------------------------
+
+registerOperation('getUsage', (ctx) => {
+  if (!hasMemberManage(ctx.headers.get('authorization'))) return permissionDenied();
+  return {
+    status: 200,
+    body: {
+      items: [
+        {
+          resource: 'storage_bytes',
+          limit: 10_737_418_240,
+          committed: 3_221_225_472,
+          reserved: 104_857_600,
+          remaining: 7_411_335_168,
+        },
+        { resource: 'documents', limit: 5000, committed: 812, reserved: 3, remaining: 4185 },
+        { resource: 'concurrent_jobs', limit: 8, committed: 1, reserved: 0, remaining: 7 },
+        {
+          resource: 'tokens',
+          limit: 2_000_000,
+          committed: 415_000,
+          reserved: 0,
+          remaining: 1_585_000,
+        },
+      ],
+    },
+  };
+});

--- a/web/src/mocks/spec/openApiSpec.test.ts
+++ b/web/src/mocks/spec/openApiSpec.test.ts
@@ -4,8 +4,8 @@ import { buildSpecIndex, getOperation } from './openApiSpec';
 const spec = buildSpecIndex();
 
 describe('buildSpecIndex against the real openapi.yaml', () => {
-  it('indexes all 24 component schemas', () => {
-    expect(Object.keys(spec.schemas)).toHaveLength(24);
+  it('indexes all 34 component schemas', () => {
+    expect(Object.keys(spec.schemas)).toHaveLength(34);
     expect(spec.schemas.TokenResponse).toBeDefined();
     expect(spec.schemas.ApiError).toBeDefined();
   });

--- a/web/src/mocks/spec/yaml.test.ts
+++ b/web/src/mocks/spec/yaml.test.ts
@@ -118,9 +118,9 @@ describe('parseYaml against the real openapi.yaml', () => {
     expect(typeof doc.components).toBe('object');
   });
 
-  it('finds all 24 component schemas', () => {
+  it('finds all 34 component schemas', () => {
     const schemas = (doc.components as Record<string, unknown>).schemas as Record<string, unknown>;
-    expect(Object.keys(schemas)).toHaveLength(24);
+    expect(Object.keys(schemas)).toHaveLength(34);
   });
 
   it('parses a representative path item with multiple methods and shared parameters', () => {

--- a/web/src/pages/AdminMembersPage.test.tsx
+++ b/web/src/pages/AdminMembersPage.test.tsx
@@ -1,0 +1,233 @@
+// P2-11 (plans/markhand-web/phase-2-web-spa.md §P2.6). Renders the real page
+// against the real mock server (`web/src/mocks/handlers/members.ts`), the
+// same convention `LibraryPage.test.tsx` uses — no hand-stubbed `apiClient`.
+// Unlike `LibraryPage`, this page reads the signed-in caller's own `userId`
+// via `useAuth()` (to compute `isOwnerActive`), so tests wrap the page in a
+// real `AuthProvider` and restore its session the same way
+// `AuthContext.test.tsx`'s "restores an authenticated session from a
+// persisted refresh token" test does, rather than a raw `client.login()`
+// call `AuthProvider` would never see.
+//
+// Role-name text (e.g. "Chủ sở hữu") appears twice per row once a row's own
+// role `<select>` renders — once as this row's `.tag`, once as the select's
+// own displayed value, and possibly a third time as another row's tag or
+// select — so every text query for a role/state name below is scoped either
+// to a specific row (`within(row)`) or to the `span.tag` selector to
+// disambiguate from the `<select>` trigger's own text.
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApiClient, type ApiClient } from '../api/client';
+import { installMockFetch, mockControl, resetMockState, uninstallMockFetch } from '../mocks';
+import {
+  getStore,
+  mintTokenPair,
+  SECOND_MEMBER_USER_ID,
+  THIRD_MEMBER_USER_ID,
+} from '../mocks/fixtures';
+import { mockTimestamp, mockUuid } from '../mocks/ids';
+import { grantMemberManage } from '../components/admin/testSupport';
+import { AuthProvider } from '../auth/AuthContext';
+import { ScopeProvider } from '../state/ScopeProvider';
+import { AdminMembersPage } from './AdminMembersPage';
+
+/** Logs the shared demo user in as a `member.manage` holder and restores the session through `AuthProvider`'s own persisted-refresh-token bootstrap path (see this file's module doc) instead of a raw `client.login()`, which `AuthProvider` would never observe. */
+function loggedInClient(): ApiClient {
+  const client = createApiClient({ baseUrl: '' });
+  grantMemberManage();
+  const [user] = getStore().users;
+  const { refreshToken } = mintTokenPair(user);
+  window.sessionStorage.setItem('markhand.refreshToken', refreshToken);
+  return client;
+}
+
+function renderPage(client: ApiClient) {
+  return render(
+    <ScopeProvider>
+      <AuthProvider client={client}>
+        <AdminMembersPage client={client} />
+      </AuthProvider>
+    </ScopeProvider>,
+  );
+}
+
+/** The `<tr>` whose role/state `.tag` (not its own `<select>`'s displayed text) reads `label`. */
+function findRowByTagText(label: string): HTMLElement {
+  return screen.getByText(label, { selector: 'span.tag' }).closest('tr') as HTMLElement;
+}
+
+/**
+ * The `<tr>` for a given `userId` (rendered verbatim as `<code>`, see
+ * `MembersTable.tsx`) — the only row locator that stays valid across a role
+ * change, unlike `findRowByTagText`, whose label is exactly what a role
+ * mutation changes. Load-bearing: an earlier version of the role-change test
+ * below used `findByText('Biên tập viên', ...)` with no row scoping and
+ * passed even with the refetch wiring deliberately broken, because the
+ * seeded invite fixture (`moi-nguoi-moi@example.com`, role `editor`) renders
+ * the exact same Vietnamese label in the *invites* table — a false positive
+ * only mutation-testing caught.
+ */
+function findRowByUserId(userId: string): HTMLElement {
+  return screen.getByText(userId).closest('tr') as HTMLElement;
+}
+
+beforeEach(() => {
+  installMockFetch();
+  resetMockState();
+});
+
+afterEach(() => {
+  cleanup();
+  uninstallMockFetch();
+  window.sessionStorage.clear();
+});
+
+describe('AdminMembersPage', () => {
+  it('renders the seeded members with their role and state', async () => {
+    renderPage(loggedInClient());
+
+    expect(await screen.findByText('Chủ sở hữu', { selector: 'span.tag' })).toBeVisible();
+    expect(screen.getByText('Quản trị viên', { selector: 'span.tag' })).toBeVisible();
+    expect(screen.getByText('Người xem', { selector: 'span.tag' })).toBeVisible();
+    expect(screen.getByText('Đã tạm ngưng', { selector: 'span.tag' })).toBeVisible();
+    expect(screen.getAllByText('Đang hoạt động', { selector: 'span.tag' }).length).toBe(2);
+  });
+
+  describe('invite flow', () => {
+    it('creates an invite and shows the one-time token exactly once', async () => {
+      renderPage(loggedInClient());
+      await screen.findByText('Chủ sở hữu', { selector: 'span.tag' });
+
+      fireEvent.change(screen.getByLabelText('Email người được mời'), {
+        target: { value: 'nguoi-moi@example.com' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Gửi lời mời' }));
+
+      const dialog = await screen.findByRole('dialog', { name: 'Đã tạo lời mời' });
+      const tokenInput = within(dialog).getByLabelText('Mã mời (một lần)') as HTMLInputElement;
+      expect(tokenInput.value).toMatch(/^mock-invite-token\./);
+      const token = tokenInput.value;
+
+      // The invite list refetches and now includes it, but the token itself
+      // is never shown again anywhere outside this one modal.
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Đã sao chép, đóng lại' }));
+      expect(screen.queryByRole('dialog', { name: 'Đã tạo lời mời' })).not.toBeInTheDocument();
+      expect(await screen.findByText('nguoi-moi@example.com')).toBeVisible();
+      expect(screen.queryByText(token)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('member mutations', () => {
+    it('changes a member role via PATCH and refreshes the list', async () => {
+      renderPage(loggedInClient());
+      await screen.findByText('Quản trị viên', { selector: 'span.tag' });
+
+      const roleSelect = screen.getByRole('combobox', {
+        name: `Vai trò của ${SECOND_MEMBER_USER_ID}`,
+      });
+      fireEvent.click(roleSelect);
+      fireEvent.click(screen.getByRole('option', { name: 'Biên tập viên' }));
+
+      await waitFor(() => {
+        const membership = getStore().memberships.find((m) => m.userId === SECOND_MEMBER_USER_ID);
+        expect(membership?.role).toBe('editor');
+      });
+      // Scoped to this member's own row — see `findRowByUserId`'s doc for why
+      // an unscoped `findByText('Biên tập viên')` would be a false positive
+      // here (the seeded invite fixture shares that exact label).
+      await waitFor(() => {
+        const row = findRowByUserId(SECOND_MEMBER_USER_ID);
+        expect(within(row).getByText('Biên tập viên', { selector: 'span.tag' })).toBeVisible();
+      });
+    });
+
+    it('reactivates a suspended member via PATCH and refreshes the list', async () => {
+      renderPage(loggedInClient());
+      await screen.findByText('Người xem', { selector: 'span.tag' });
+
+      const row = findRowByTagText('Người xem');
+      fireEvent.click(within(row).getByRole('button', { name: 'Kích hoạt lại' }));
+
+      await waitFor(() => {
+        const membership = getStore().memberships.find((m) => m.userId === THIRD_MEMBER_USER_ID);
+        expect(membership?.state).toBe('active');
+      });
+    });
+
+    it('removes a member via DELETE after confirmation, and refreshes the list', async () => {
+      renderPage(loggedInClient());
+      await screen.findByText('Quản trị viên', { selector: 'span.tag' });
+
+      const row = findRowByTagText('Quản trị viên');
+      fireEvent.click(within(row).getByRole('button', { name: 'Xóa khỏi tổ chức' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Xóa thành viên' }));
+
+      await waitFor(() =>
+        expect(getStore().memberships.some((m) => m.userId === SECOND_MEMBER_USER_ID)).toBe(false),
+      );
+      await waitFor(() =>
+        expect(
+          screen.queryByText('Quản trị viên', { selector: 'span.tag' }),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    it('surfaces a 403 from the server clearly, even for an otherwise-permitted action', async () => {
+      mockControl.forceStatus('patchMember', 403, { times: 1 });
+      renderPage(loggedInClient());
+      await screen.findByText('Người xem', { selector: 'span.tag' });
+
+      const row = findRowByTagText('Người xem');
+      fireEvent.click(within(row).getByRole('button', { name: 'Kích hoạt lại' }));
+
+      const alert = await within(row).findByRole('alert');
+      expect(alert).toHaveTextContent(/không có quyền/i);
+    });
+  });
+
+  describe('owner-tier restriction ("admin không quản owner")', () => {
+    it('hides owner-granting and locks an owner row for a non-owner caller', async () => {
+      const client = loggedInClient();
+      const store = getStore();
+      const callerRow = store.memberships.find((m) => m.role === 'owner');
+      expect(callerRow).toBeDefined();
+      callerRow!.role = 'admin'; // the signed-in caller is no longer an owner...
+      const otherOwnerId = mockUuid(40);
+      store.memberships.push({
+        userId: otherOwnerId,
+        role: 'owner',
+        state: 'active',
+        createdAt: mockTimestamp(0),
+      }); // ...but the org still has one, elsewhere.
+
+      renderPage(client);
+      await screen.findByText('Chủ sở hữu', { selector: 'span.tag' }); // the other owner's row
+
+      const inviteRoleSelect = screen.getByRole('combobox', { name: 'Vai trò cho lời mời' });
+      fireEvent.click(inviteRoleSelect);
+      expect(screen.getByRole('option', { name: 'Chủ sở hữu' })).toBeDisabled();
+
+      const ownerRow = findRowByTagText('Chủ sở hữu');
+      expect(within(ownerRow).getByRole('combobox')).toBeDisabled();
+      expect(within(ownerRow).getByRole('button', { name: 'Tạm ngưng' })).toBeDisabled();
+      expect(within(ownerRow).getByRole('button', { name: 'Xóa khỏi tổ chức' })).toBeDisabled();
+      expect(within(ownerRow).getByText(/Chỉ chủ sở hữu/)).toBeVisible();
+    });
+  });
+
+  describe('last_owner invariant (409)', () => {
+    it('shows the specific last_owner message when suspending the sole active owner', async () => {
+      renderPage(loggedInClient());
+      await screen.findByText('Chủ sở hữu', { selector: 'span.tag' });
+
+      const row = findRowByTagText('Chủ sở hữu');
+      fireEvent.click(within(row).getByRole('button', { name: 'Tạm ngưng' }));
+
+      expect(
+        await within(row).findByText(/tổ chức phải luôn còn ít nhất một chủ sở hữu/),
+      ).toBeVisible();
+      // Fails closed: the membership itself must not have been mutated.
+      const owner = getStore().memberships.find((m) => m.role === 'owner');
+      expect(owner?.state).toBe('active');
+    });
+  });
+});

--- a/web/src/pages/AdminMembersPage.tsx
+++ b/web/src/pages/AdminMembersPage.tsx
@@ -1,14 +1,160 @@
+// P2-11 (plans/markhand-web/phase-2-web-spa.md §P2.6): member/role admin —
+// list members, change role/suspend/reactivate/remove, and invite/revoke.
+// Every fetch goes through `useScopeSafeRequest` (never a raw `useEffect` +
+// fetch) so an org switch discards stale/cross-tenant responses — see
+// `LibraryPage.tsx`'s own module doc for the pattern this follows, including
+// the "retain data across a refresh" trick below (`retainedMembers`/
+// `retainedInvites`): without it, the refetch a mutation triggers would blank
+// the table for a frame and unmount every row's `MemberRowActions` — taking
+// any success/error notice it had just shown with it.
+//
+// Owner-tier gating ("admin không quản owner", 1C-02 acceptance): this page
+// computes `isOwnerActive` from the signed-in caller's *own* row in the just-
+// fetched members list (there is no separate "my role" field on `MeResponse`
+// — see `auth/AuthContext.tsx`'s own module doc for why) and passes it down
+// so `MemberRowActions`/`InviteForm` never render an owner-tier control
+// (granting owner, or touching a currently-owner row) as available to a
+// non-owner. This is UI convenience only, same caveat `RouteGuard.tsx` makes
+// about its own `permission` prop — the server's 403 is the real authority,
+// and every component downstream still surfaces one honestly if it happens
+// anyway (a race: the caller's own owner status changed after this page
+// loaded).
+import { useState } from 'react';
+import { apiClient, type ApiClient } from '../api/client';
+import {
+  InviteForm,
+  InvitesTable,
+  MembersTable,
+  describeMemberReadError,
+  isActiveOwner,
+} from '../components/admin';
 import { Notice } from '../components/ui';
+import { useAuth } from '../auth/AuthContext';
+import { useScopeSafeRequest } from '../hooks/useScopeSafeRequest';
+import { useScope } from '../state/ScopeProvider';
 
-export function AdminMembersPage() {
+export function AdminMembersPage({ client = apiClient }: { client?: ApiClient } = {}) {
+  const { session } = useAuth();
+  const currentUserId = session.status === 'authenticated' ? session.userId : undefined;
+  const { epoch } = useScope();
+
+  const [membersRetry, setMembersRetry] = useState(0);
+  const membersResult = useScopeSafeRequest(
+    (signal) => client.request('get', '/members', { signal }),
+    [client, membersRetry],
+  );
+  // See module doc: keeps the table (and every row's own action state)
+  // mounted across a mutation-triggered refetch instead of flashing back to
+  // the loading placeholder. Retained only within the same scope epoch —
+  // an org switch must still discard it, exactly like `LibraryPage.tsx`'s
+  // `retainedDocuments`.
+  const [retainedMembers, setRetainedMembers] = useState<{
+    epoch: number;
+    data: NonNullable<typeof membersResult.data>;
+  } | null>(null);
+  if (membersResult.data && retainedMembers?.data !== membersResult.data) {
+    setRetainedMembers({ epoch, data: membersResult.data });
+  }
+  const membersData =
+    membersResult.data ?? (retainedMembers?.epoch === epoch ? retainedMembers.data : undefined);
+  const members = membersData?.items ?? [];
+
+  const [invitesRetry, setInvitesRetry] = useState(0);
+  const invitesResult = useScopeSafeRequest(
+    (signal) => client.request('get', '/members/invites', { signal }),
+    [client, invitesRetry],
+  );
+  const [retainedInvites, setRetainedInvites] = useState<{
+    epoch: number;
+    data: NonNullable<typeof invitesResult.data>;
+  } | null>(null);
+  if (invitesResult.data && retainedInvites?.data !== invitesResult.data) {
+    setRetainedInvites({ epoch, data: invitesResult.data });
+  }
+  const invitesData =
+    invitesResult.data ?? (retainedInvites?.epoch === epoch ? retainedInvites.data : undefined);
+  const invites = invitesData?.items ?? [];
+
+  const ownMembership = members.find((m) => m.userId === currentUserId);
+  const isOwnerActive = isActiveOwner(ownMembership);
+
+  function refreshMembers() {
+    setMembersRetry((n) => n + 1);
+  }
+  function refreshInvites() {
+    setInvitesRetry((n) => n + 1);
+  }
+
   return (
-    <section className="page" aria-labelledby="admin-members-heading">
+    <section className="page" style={{ maxWidth: 'none' }} aria-labelledby="admin-members-heading">
       <p className="eyebrow">Quản trị</p>
       <h1 id="admin-members-heading">Thành viên và vai trò</h1>
       <p className="lede">
-        Danh sách thành viên, mời và đổi vai trò sẽ hiển thị ở đây khi API thành viên tồn tại.
+        Quản lý thành viên, vai trò và lời mời tham gia tổ chức. Chỉ chủ sở hữu (owner) đang hoạt
+        động mới có thể cấp hoặc quản lý vai trò chủ sở hữu.
       </p>
-      <Notice tone="warning">Backend chưa có API thành viên/quyền (xem plan P2.6, B2).</Notice>
+
+      {membersResult.status === 'error' && (
+        <Notice
+          tone="error"
+          action={
+            <button type="button" className="btn btn-secondary btn-sm" onClick={refreshMembers}>
+              Thử lại
+            </button>
+          }
+        >
+          {describeMemberReadError(membersResult.error)}
+        </Notice>
+      )}
+
+      <div
+        className="card"
+        style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}
+      >
+        <h2 className="card-title">Thành viên</h2>
+        <MembersTable
+          members={members}
+          currentUserId={currentUserId}
+          isOwnerActive={isOwnerActive}
+          loading={membersResult.status === 'loading' && membersData === undefined}
+          onChanged={refreshMembers}
+          client={client}
+        />
+      </div>
+
+      <div
+        className="card"
+        style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}
+      >
+        <h2 className="card-title">Mời thành viên mới</h2>
+        <InviteForm isOwnerActive={isOwnerActive} onCreated={refreshInvites} client={client} />
+      </div>
+
+      {invitesResult.status === 'error' && (
+        <Notice
+          tone="error"
+          action={
+            <button type="button" className="btn btn-secondary btn-sm" onClick={refreshInvites}>
+              Thử lại
+            </button>
+          }
+        >
+          {describeMemberReadError(invitesResult.error)}
+        </Notice>
+      )}
+
+      <div
+        className="card"
+        style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}
+      >
+        <h2 className="card-title">Lời mời</h2>
+        <InvitesTable
+          invites={invites}
+          loading={invitesResult.status === 'loading' && invitesData === undefined}
+          onChanged={refreshInvites}
+          client={client}
+        />
+      </div>
     </section>
   );
 }

--- a/web/src/pages/AdminUsagePage.test.tsx
+++ b/web/src/pages/AdminUsagePage.test.tsx
@@ -1,0 +1,76 @@
+// P2-12 (plans/markhand-web/phase-2-web-spa.md §P2.6). Renders the real page
+// against the real mock server, same convention `LibraryPage.test.tsx` uses.
+// Unlike `AdminMembersPage`, this page never reads `useAuth()`, so a plain
+// `client.login()` (no `AuthProvider`) is enough — see
+// `AdminMembersPage.test.tsx`'s module doc for why that page needs more.
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApiClient, type ApiClient } from '../api/client';
+import { installMockFetch, mockControl, resetMockState, uninstallMockFetch } from '../mocks';
+import { grantMemberManage } from '../components/admin/testSupport';
+import { ScopeProvider } from '../state/ScopeProvider';
+import { AdminUsagePage } from './AdminUsagePage';
+
+const DEMO_EMAIL = 'demo@markhand.test';
+const DEMO_PASSWORD = 'demo-password';
+
+async function loggedInClient(): Promise<ApiClient> {
+  const client = createApiClient({ baseUrl: '' });
+  grantMemberManage();
+  await client.login({ email: DEMO_EMAIL, password: DEMO_PASSWORD });
+  return client;
+}
+
+function renderPage(client: ApiClient) {
+  return render(
+    <ScopeProvider>
+      <AdminUsagePage client={client} />
+    </ScopeProvider>,
+  );
+}
+
+beforeEach(() => {
+  installMockFetch();
+  resetMockState();
+});
+
+afterEach(() => {
+  cleanup();
+  uninstallMockFetch();
+});
+
+describe('AdminUsagePage', () => {
+  it('renders a usage card for every resource from GET /usage', async () => {
+    const client = await loggedInClient();
+    renderPage(client);
+
+    expect(await screen.findByText('Dung lượng lưu trữ')).toBeVisible();
+    expect(screen.getByText('Số tài liệu')).toBeVisible();
+    expect(screen.getByText('Tác vụ đồng thời')).toBeVisible();
+    expect(screen.getByText('Token (LLM)')).toBeVisible();
+  });
+
+  it('renders a meter bar reflecting committed+reserved against the limit', async () => {
+    const client = await loggedInClient();
+    renderPage(client);
+
+    await screen.findByText('Số tài liệu');
+    // Seeded mock values (handlers/members.ts): documents committed=812,
+    // reserved=3, limit=5000 -> (812+3)/5000 = 16.3% -> rounds to 16%.
+    const meter = screen.getByRole('progressbar', { name: 'Đã dùng Số tài liệu' });
+    expect(meter).toHaveAttribute('aria-valuenow', '16');
+  });
+
+  it('shows an error notice with a working retry when the usage request fails', async () => {
+    const client = await loggedInClient();
+    mockControl.forceStatus('getUsage', 429, { times: 1 });
+    renderPage(client);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/quá nhiều yêu cầu/i);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Thử lại' }));
+    await waitFor(() => expect(screen.getByText('Dung lượng lưu trữ')).toBeVisible());
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AdminUsagePage.tsx
+++ b/web/src/pages/AdminUsagePage.tsx
@@ -1,15 +1,49 @@
+// P2-12 (plans/markhand-web/phase-2-web-spa.md §P2.6): usage/quota admin —
+// renders `GET /usage`'s per-resource `{limit, committed, reserved,
+// remaining}` snapshot. Read-only: no mutation on this page, so unlike
+// `AdminMembersPage.tsx` there is no retained-data-across-refresh need beyond
+// the one `useScopeSafeRequest` retry the error banner's own "Thử lại" uses.
+import { useState } from 'react';
+import { apiClient, type ApiClient } from '../api/client';
+import { UsageCards, describeMemberReadError } from '../components/admin';
 import { Notice } from '../components/ui';
+import { useScopeSafeRequest } from '../hooks/useScopeSafeRequest';
 
-export function AdminUsagePage() {
+export function AdminUsagePage({ client = apiClient }: { client?: ApiClient } = {}) {
+  const [retry, setRetry] = useState(0);
+  const usageResult = useScopeSafeRequest(
+    (signal) => client.request('get', '/usage', { signal }),
+    [client, retry],
+  );
+  const items = usageResult.data?.items ?? [];
+
   return (
     <section className="page" aria-labelledby="admin-usage-heading">
       <p className="eyebrow">Quản trị</p>
       <h1 id="admin-usage-heading">Sử dụng và hạn mức</h1>
       <p className="lede">
-        Tổng hợp sử dụng, hạn mức và trạng thái reservation/job sẽ hiển thị ở đây khi có endpoint
-        tổng hợp usage.
+        Tổng hợp sử dụng, hạn mức và phần đang được giữ chỗ (reservation) cho từng loại tài nguyên
+        của tổ chức.
       </p>
-      <Notice tone="info">Chỉ có quota header hiện tại, chưa có endpoint tổng hợp.</Notice>
+
+      {usageResult.status === 'error' && (
+        <Notice
+          tone="error"
+          action={
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm"
+              onClick={() => setRetry((n) => n + 1)}
+            >
+              Thử lại
+            </button>
+          }
+        >
+          {describeMemberReadError(usageResult.error)}
+        </Notice>
+      )}
+
+      <UsageCards items={items} loading={usageResult.status === 'loading' && items.length === 0} />
     </section>
   );
 }


### PR DESCRIPTION
## Outcome

The membership-admin feature end to end: the minimal Phase 1C server API (1C-02 membership/invite/last-owner + the admin/audit-read half of 1C-11) **and** the two web pages it unblocks (**P2-11** member/role admin, **P2-12** usage). This moves P2-11 and P2-12 out of Blocked. Plan: `plans/reports/plan-260728-0231-markhand-web-membership-admin-slice.md`.

## Scope

**Server (`crates/server`)**

- **Wave 1 (`16c2088`) — domain.** Migration 0029 (`org_memberships.state`), `db/members.rs`, `services/members.rs` (invites, last-owner invariant, suspend, usage), `AuditAction` +5, the resolver's suspend gate, plus a review fix to `upload/saga.rs`.
- **Wave 2 + review (`016071b`) — surface.** Routes E1–E8, OpenAPI + `ROUTE_INVENTORY` parity, DB-gated integration tests, and the fixes below from an adversarial review.
- `b977e8f` — seed the escalation test's admin user with a password (the one rust-integration failure; the other 7 DB-gated tests passed).

**Web (`web`, `87159b8`)** — P2-11 `AdminMembersPage` (member table, invite one-time-token modal, suspend/reactivate, role change, remove) and P2-12 `AdminUsagePage`, against the generated contract types. Owner-tier controls are hidden/disabled from the caller's own membership row (fails closed while loading), matching the server gate; `409 last_owner`/invite codes map to specific copy. Mock handlers mirror the server's real rules read from the Rust source. Also fixes two pre-existing spec tests that hard-coded a 24-schema count (now 34).

## The adversarial review — the important part

An independent adversarial pass found a **blocker the implementation and my own first review both missed**, now fixed:

- **Privilege escalation (blocker, fixed).** `change_role` enforced the last-owner *count* but never restricted *who* may reach the owner tier — any `member.manage` holder could `PATCH {self} {role:"owner"}` and take over the tenant. `guard_owner_tier` now requires the caller be an active owner to grant or manage an owner ("admin không quản owner", 1C-02). Pure decision, unit- and mutation-tested; DB-gated regression `non_owner_admin_cannot_reach_the_owner_tier` covers self-promote, owner-invite, and demote/suspend/remove of an owner. The web UI mirrors the same gate and fails closed.
- **Suspend didn't survive at the session layer (major, fixed).** Login and refresh checked membership without `state='active'`; both now gate it like `resolve_org_context`, and the refresh miss-path revokes the family in-transaction.
- **`NotFound` → 500 (fixed).** `From<DbError>` collapsed `NotFound` into `Database`; now maps to 404.
- **Misleading no-op audit (fixed).** No-op PATCH no longer writes a "changed X→X" row.

## Evidence

- [x] Tests: server — `cargo fmt --check`, `clippy --all-targets -D warnings`, `cargo test --lib` (280) all clean; the **8** membership integration tests. **rust-integration on Postgres: 7/8 passed on the first run — cross-org denial per endpoint, the concurrent last-owner race, invite replay/expiry, and refresh-rejected-after-suspend/downgrade all proven** — and the 8th (the new escalation regression) failed only because its test seed omitted a password, fixed in `b977e8f`. Web — `format:check` / `lint` (0 errors) / `test` (39 files, 424) / `api:check` / `build` all clean.
- [x] Manual/benchmark/migration: migration 0029 is expand-only, in the manifest, and its apply was exercised by rust-integration (the DB tests ran against it). The last-owner invariant and the owner-tier gate are mutation-tested at the pure-function level, server and web.

## Boundary and security review

- [x] Dependency boundary — no new dependency.
- [x] Tenant/ACL — this PR is tenant-security code. Every query runs under `with_org_txn` (RLS GUC); the owner-tier gate and last-owner invariant run inside the mutation transaction; suspend is enforced on every authz path found (resolver, login, refresh, upload saga). Cross-org denial per endpoint is proven by rust-integration.
- [x] Sensitive logging — the plaintext invite token is returned once, stored only hashed, never logged (hand-written `Debug` redacts it) and rejected from audit metadata by the allowlist; the web shows it once and never refetches it.
- [x] Security review trigger — yes; the adversarial review above is that review, and its blocker is fixed and regression-tested.

## Follow-up (tracked, not in this PR)

- **Brand-new-user onboarding**: `accept-invite` works for a user who already belongs to some org; a user with zero memberships cannot yet obtain a bearer token (login requires an existing membership). Closing that needs a small login/registration change (1C-01) — flagged, not hacked.
- This does not close Phase 1C: the denial suite (1C-12), security/load gate (1C-13), per-org fairness (1C-10), and ACL cache/groups (1C-05) remain, per the 2026-07-27 audit.
- [ ] Docs/OpenAPI updated where required — OpenAPI carries the 8 operations with schemas (parity green); the plan report records the decisions (suspend=yes, version=deferred).