### PR TITLE
Web: Playwright E2E suite on a mock-mode build, run in CI (P2-15, mock half)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,29 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: make check-web
 
+  web-e2e:
+    needs: changes-and-static
+    if: needs.changes-and-static.outputs.web == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.33.3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      # The runner has no pre-installed browser (unlike the dev environment,
+      # where playwright.config.ts points at a fixed path); install just
+      # Chromium + its OS deps here so Playwright resolves the browser itself.
+      - run: pnpm --dir web exec playwright install --with-deps chromium
+      # Playwright starts its own mock-mode vite dev server (see
+      # playwright.config.ts `webServer`); no backend stack required.
+      - run: pnpm --dir web e2e
+
   dev-stack:
     needs: changes-and-static
     if: needs.changes-and-static.outputs.dev_stack == 'true'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.7.0)
+      '@playwright/test':
+        specifier: ^1.55.0
+        version: 1.62.0
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -728,6 +731,11 @@ packages:
   '@napi-rs/canvas@1.0.2':
     resolution: {integrity: sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==}
     engines: {node: '>= 10'}
+
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@redocly/ajv@8.11.2':
     resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
@@ -1483,6 +1491,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1908,6 +1921,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -2841,6 +2864,10 @@ snapshots:
       '@napi-rs/canvas-win32-x64-msvc': 1.0.2
     optional: true
 
+  '@playwright/test@1.62.0':
+    dependencies:
+      playwright: 1.62.0
+
   '@redocly/ajv@8.11.2':
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3586,6 +3613,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4262,6 +4292,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,5 @@
+# Playwright E2E outputs (P2-15)
+/test-results/
+/playwright-report/
+/blob-report/
+/.playwright/

--- a/web/e2e/admin.spec.ts
+++ b/web/e2e/admin.spec.ts
@@ -1,0 +1,118 @@
+// Member/role admin (P2-15 flow 7, P2-11) and usage (flow 8, P2-12). The demo
+// user holds `member.manage` in mock mode and is seeded as an active owner, so
+// the admin pages are reachable and owner-tier controls are enabled.
+import { expect, test } from '@playwright/test';
+import { forceStatus, IDS, login } from './support';
+
+async function openMembers(page: import('@playwright/test').Page): Promise<void> {
+  await page.getByRole('link', { name: 'Thành viên' }).click();
+  await expect(page.getByRole('heading', { name: 'Thành viên và vai trò' })).toBeVisible();
+  // The seeded owner row is enough to know the list has loaded.
+  await expect(page.getByRole('row').filter({ hasText: IDS.demoUser })).toBeVisible();
+}
+
+test('inviting a member shows the one-time token', async ({ page }) => {
+  await login(page);
+  await openMembers(page);
+
+  await page.getByLabel('Email người được mời').fill('nguoi-moi@example.com');
+  await page.getByRole('button', { name: 'Gửi lời mời' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Đã tạo lời mời' });
+  await expect(dialog).toBeVisible();
+  // The plaintext invite token is shown exactly once, here.
+  await expect(dialog.getByLabel('Mã mời (một lần)')).toHaveValue(/^mock-invite-token\./);
+  await expect(dialog.getByText('nguoi-moi@example.com')).toBeVisible();
+});
+
+test("changing a member's role persists after refetch", async ({ page }) => {
+  await login(page);
+  await openMembers(page);
+
+  // The second member is seeded `admin`; demote to editor.
+  const roleSelect = page.getByRole('combobox', { name: `Vai trò của ${IDS.secondMember}` });
+  await expect(roleSelect).toContainText('Quản trị viên');
+  await roleSelect.click();
+  await page.getByRole('option', { name: 'Biên tập viên' }).click();
+
+  // After the PATCH + members refetch, the row reflects the new role.
+  await expect(roleSelect).toContainText('Biên tập viên');
+});
+
+test('suspending then reactivating a member toggles their state', async ({ page }) => {
+  await login(page);
+  await openMembers(page);
+
+  // Second member is seeded active — suspend, then bring back.
+  const secondRow = page.getByRole('row').filter({ hasText: IDS.secondMember });
+  await secondRow.getByRole('button', { name: 'Tạm ngưng' }).click();
+  await expect(secondRow.getByText('Đã tạm ngưng')).toBeVisible();
+
+  await secondRow.getByRole('button', { name: 'Kích hoạt lại' }).click();
+  await expect(secondRow.getByText('Đang hoạt động')).toBeVisible();
+});
+
+test('the seeded suspended member can be reactivated', async ({ page }) => {
+  await login(page);
+  await openMembers(page);
+
+  // Third member is seeded `viewer` / `suspended`.
+  const thirdRow = page.getByRole('row').filter({ hasText: IDS.thirdMember });
+  await expect(thirdRow.getByText('Đã tạm ngưng')).toBeVisible();
+  await thirdRow.getByRole('button', { name: 'Kích hoạt lại' }).click();
+  await expect(thirdRow.getByText('Đang hoạt động')).toBeVisible();
+});
+
+test('suspending the sole active owner is blocked by the last-owner invariant (409)', async ({
+  page,
+}) => {
+  await login(page);
+  await openMembers(page);
+
+  // The demo user is the only active owner; the server's last-owner invariant
+  // rejects suspending them with a 409, surfaced as its specific message.
+  const ownerRow = page.getByRole('row').filter({ hasText: IDS.demoUser });
+  await ownerRow.getByRole('button', { name: 'Tạm ngưng' }).click();
+
+  await expect(
+    page.getByText(
+      'Không thể thực hiện: tổ chức phải luôn còn ít nhất một chủ sở hữu (owner) đang hoạt động.',
+    ),
+  ).toBeVisible();
+});
+
+test('an owner-tier mutation that 403s shows the owner-tier denial message', async ({ page }) => {
+  await login(page);
+  await openMembers(page);
+
+  // Promoting to owner is an owner-tier action. Force it to 403 (a race the UI
+  // handles honestly rather than assuming impossible) and assert the specific
+  // owner-tier copy — not the generic permission message.
+  await forceStatus(page, 'patchMember', 403, 1);
+  const roleSelect = page.getByRole('combobox', { name: `Vai trò của ${IDS.secondMember}` });
+  await roleSelect.click();
+  await page.getByRole('option', { name: 'Chủ sở hữu' }).click();
+
+  // Scoped to the members table: the same sentence also appears in the page's
+  // intro `lede`, so an unscoped match would be ambiguous. The row's error
+  // notice is the owner-tier denial copy (not the generic permission message).
+  await expect(
+    page
+      .getByRole('table', { name: 'Danh sách thành viên' })
+      .getByText(
+        'Chỉ chủ sở hữu (owner) đang hoạt động mới có thể cấp hoặc quản lý vai trò chủ sở hữu.',
+      ),
+  ).toBeVisible();
+});
+
+test('the usage page renders cards from GET /usage', async ({ page }) => {
+  await login(page);
+  await page.getByRole('link', { name: 'Sử dụng' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Sử dụng và hạn mức' })).toBeVisible();
+  // One card per seeded usage resource (handlers/members.ts getUsage).
+  await expect(page.getByText('Dung lượng lưu trữ')).toBeVisible();
+  await expect(page.getByText('Số tài liệu')).toBeVisible();
+  await expect(page.getByText('Tác vụ đồng thời')).toBeVisible();
+  await expect(page.getByText('Token (LLM)')).toBeVisible();
+});

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -1,0 +1,65 @@
+// Auth flows (P2-15 flow 1). The happy-path login is covered by
+// smoke.spec.ts; this extends it with logout, an anonymous deep-link redirect
+// that preserves `?next=`, and silent token-refresh recovery on a one-time
+// 401.
+import { expect, test } from '@playwright/test';
+import { DEMO, forceStatus, login } from './support';
+
+test('logout returns to /login', async ({ page }) => {
+  await login(page);
+
+  // The rail avatar is the account-menu trigger (UserMenu.tsx).
+  await page.getByRole('button', { name: /^Tài khoản:/ }).click();
+  await page.getByRole('button', { name: 'Đăng xuất' }).click();
+
+  await expect(page).toHaveURL(/\/login/);
+  await expect(page.getByRole('heading', { name: 'Đăng nhập vào Markhand' })).toBeVisible();
+  // The rail is chrome-free on /login — its destinations are gone.
+  await expect(page.getByRole('link', { name: 'Thư viện' })).toHaveCount(0);
+});
+
+test('deep-linking a protected route while anonymous redirects to /login with ?next= preserved', async ({
+  page,
+}) => {
+  // No login: a fresh context is anonymous. ProtectedRoute bounces to /login,
+  // preserving the intended location (path AND query) as `?next=`.
+  await page.goto('/library/some-collection?tab=recent');
+
+  await expect(page).toHaveURL(/\/login\?next=/);
+  await expect(page.getByRole('heading', { name: 'Đăng nhập vào Markhand' })).toBeVisible();
+
+  const next = new URL(page.url()).searchParams.get('next');
+  expect(next).toBe('/library/some-collection?tab=recent');
+});
+
+test('a one-time 401 on an authenticated read is silently recovered via refresh (no bounce to /login)', async ({
+  page,
+}) => {
+  // Verified against api/client.ts + api/session.ts: `authedFetch` retries a
+  // request exactly once after a single `refreshNow()` on a 401, and the
+  // session manager's single-flight refresh hits `POST /auth/refresh` (mocked
+  // in handlers/auth.ts). Only a *failed* refresh triggers session-loss ->
+  // anonymous -> /login; a recovered one is invisible.
+  //
+  // The read we force to 401 is `GET /auth/me` (`authMe`), performed as part
+  // of the login round-trip (AuthContext.login -> client.me). It is used here
+  // for a mock-harness reason, not by accident: forced responses go through
+  // the mock's drift guard (fetchMock `emit` -> `assertStatusDeclared`), which
+  // rejects any status an operation's contract doesn't declare. `authMe` is
+  // one of the few operations whose contract actually declares 401, so it is
+  // the operation that can be *forced* to 401 without the guard turning it
+  // into a synthetic network error. At the point `me()` runs, login has
+  // already installed valid tokens, so the client's single-flight refresh
+  // recovers: attempt #1 (401) -> refresh -> attempt #2 (200) -> authenticated.
+  await page.goto('/login');
+  await forceStatus(page, 'authMe', 401, 1);
+
+  await page.getByLabel('Email').fill(DEMO.email);
+  await page.getByLabel('Mật khẩu').fill(DEMO.password);
+  await page.getByRole('button', { name: 'Đăng nhập' }).click();
+
+  // Login completed despite the injected 401 — the app landed in the shell
+  // rather than surfacing a login error and staying on /login.
+  await expect(page.getByRole('link', { name: 'Thư viện' })).toBeVisible();
+  await expect(page).not.toHaveURL(/\/login/);
+});

--- a/web/e2e/library.spec.ts
+++ b/web/e2e/library.spec.ts
@@ -1,0 +1,106 @@
+// Library flows (P2-15 flows 3, 5, 6): per-document actions (preview /
+// reindex / delete), permission-deny on a document mutation, and the
+// actionable rate-limit / quota message.
+//
+// UNCOVERED HERE, and why (flows 2 & 6's upload half):
+//   - The upload → indexed flow and the 429-on-upload quota flow CANNOT be
+//     driven by this mock-based suite. `UploadPanel`/`uploadTransport.ts`
+//     performs the multipart POST via `XMLHttpRequest` (deliberately — real
+//     progress needs XHR, per the P2-08 brief), but the browser mock only
+//     overrides `globalThis.fetch`; XHR is never intercepted. vite then
+//     proxies `/api` to a backend that isn't running under E2E, so the upload
+//     resolves to a transport/HTTP failure ("Tải tệp lên thất bại"), not the
+//     mock's 201/429. Driving upload end-to-end belongs to the real-deployment
+//     E2E half of P2-15, not this one. The quota *message shape* is still
+//     exercised below via a document action that does go through `fetch`.
+//   - Separately, the mock never advances a `pending` job, so even if an
+//     upload landed, a fresh document would settle at `converting`, not
+//     `indexed`; the `indexed` state is shown by the seeded document instead.
+//
+// FORCED-STATUS CONSTRAINT: `forceStatus` responses pass through the mock's
+// drift guard (`assertStatusDeclared`), so a status can only be forced on an
+// operation whose contract declares it. `deleteDocument`/`reindexDocument` do
+// NOT declare 403 (see actionErrors.ts's own note), so the permission-deny
+// below uses the download-capability action, which does declare 403.
+import { expect, test } from '@playwright/test';
+import { forceStatus, login, openEmployeeHandbook } from './support';
+
+test('selecting a document previews sanitized markdown, reindex enqueues, delete removes the row', async ({
+  page,
+}) => {
+  await login(page);
+  await openEmployeeHandbook(page);
+
+  const table = page.getByRole('table', { name: 'Danh sách tài liệu' });
+  // The seeded `indexed` document is present in the list.
+  await expect(table.getByRole('button', { name: /Onboarding Guide\.pdf/ })).toBeVisible();
+  await expect(table.getByText('Đã lập chỉ mục')).toBeVisible();
+
+  await table.getByRole('button', { name: /Onboarding Guide\.pdf/ }).click();
+
+  // Preview renders through SafeMarkdown into the preview slot.
+  const preview = page.getByTestId('document-preview-markdown');
+  await expect(preview).toContainText('Mock preview content for version 1');
+  // Sanitized markdown: the `#` heading became a real <h1>, not literal text.
+  await expect(preview.getByRole('heading', { name: 'Onboarding Guide.pdf' })).toBeVisible();
+
+  // Reindex enqueues and shows the success notice.
+  await page.getByRole('button', { name: 'Lập chỉ mục lại' }).click();
+  await expect(page.getByText('Đã đưa tài liệu vào hàng đợi lập chỉ mục.')).toBeVisible();
+
+  // Delete asks for confirmation, then the row disappears after the refetch.
+  await page.getByRole('button', { name: 'Xóa', exact: true }).click();
+  const dialog = page.getByRole('dialog', { name: 'Xóa tài liệu này?' });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: 'Xóa tài liệu' }).click();
+
+  await expect(table.getByRole('button', { name: /Onboarding Guide\.pdf/ })).toHaveCount(0);
+});
+
+test('a 403 on a document mutation surfaces the specific permission-denied message, not a crash', async ({
+  page,
+}) => {
+  await login(page);
+  await openEmployeeHandbook(page);
+
+  await page
+    .getByRole('table', { name: 'Danh sách tài liệu' })
+    .getByRole('button', { name: /Onboarding Guide\.pdf/ })
+    .click();
+
+  // The download-capability action is the document mutation whose contract
+  // declares 403 (deleteDocument/reindexDocument do not — see file header).
+  await forceStatus(page, 'issueDownloadCapability', 403, 1);
+  await page.getByRole('button', { name: 'Tải xuống' }).click();
+  await page.getByRole('menuitem', { name: 'Markdown (.md)' }).click();
+
+  await expect(
+    page.getByText('Bạn không có quyền thực hiện thao tác này với tài liệu này.'),
+  ).toBeVisible();
+  // The document is untouched and still selectable.
+  await expect(
+    page
+      .getByRole('table', { name: 'Danh sách tài liệu' })
+      .getByRole('button', { name: /Onboarding Guide\.pdf/ }),
+  ).toBeVisible();
+});
+
+test('a 429 on a document action surfaces the actionable rate-limit / quota message', async ({
+  page,
+}) => {
+  await login(page);
+  await openEmployeeHandbook(page);
+
+  await page
+    .getByRole('table', { name: 'Danh sách tài liệu' })
+    .getByRole('button', { name: /Onboarding Guide\.pdf/ })
+    .click();
+
+  // reindexDocument declares 429; the mock's forced 429 carries a Retry-After,
+  // which actionErrors.ts turns into an actionable "try again in N seconds"
+  // message — the same quota/rate-limit copy path a 429-on-upload would use.
+  await forceStatus(page, 'reindexDocument', 429, 1);
+  await page.getByRole('button', { name: 'Lập chỉ mục lại' }).click();
+
+  await expect(page.getByText(/Quá nhiều yêu cầu\. Vui lòng thử lại sau \d+ giây\./)).toBeVisible();
+});

--- a/web/e2e/org-scope.spec.ts
+++ b/web/e2e/org-scope.spec.ts
@@ -1,0 +1,35 @@
+// Org scope safety (P2-15 flow 4, P2-06).
+//
+// HONEST GAP — the cross-org "switch org, assert the previous org's documents
+// are gone" flow CANNOT be driven through the UI as it exists today, and this
+// spec does not fake it. Reason, from the app itself (OrgSwitch.tsx's module
+// doc): the session's `Scope` carries exactly one `orgId`, and the generated
+// contract (api/generated/contract.ts) exposes no org-list or org-switch
+// endpoint — only /auth/{login,logout,me,refresh}. There is literally nothing
+// to switch *to*, so the rail's "org switch" control deliberately shows the
+// current org identity and states that switching isn't wired yet, rather than
+// fabricating a second org.
+//
+// The scope-safety machinery that flow 4 is meant to exercise (the epoch guard
+// in useScopeSafeRequest / state/scope.ts that discards a previous org's
+// in-flight responses after a switch) is real and unit-tested at the module
+// level, but has no UI affordance to trigger a second org here. So this spec
+// verifies the switcher's actual, honest behavior; the cross-tenant assertion
+// is reported as an untestable gap for this mock-based suite.
+import { expect, test } from '@playwright/test';
+import { IDS, login } from './support';
+
+test('the org switcher shows the single bound org and states no cross-org switch is wired', async ({
+  page,
+}) => {
+  await login(page);
+
+  await page.getByRole('button', { name: 'Đơn vị hiện tại' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Đơn vị hiện tại' });
+  await expect(dialog).toBeVisible();
+  // Real, current scope identity — the seeded org id, straight from useScope().
+  await expect(dialog).toContainText(`org ${IDS.org}`);
+  // …and the honest statement that switching orgs isn't available.
+  await expect(dialog).toContainText('chưa có API để liệt kê hoặc chuyển sang đơn vị khác');
+});

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+// Foundation smoke: proves the mock-mode app boots in a real browser and the
+// in-browser mock backend answers a full login round-trip. The broad flow
+// coverage (upload, actions, org switch, member admin, quota/permission
+// denials) builds on this once the harness is proven.
+test('the mock-mode app boots and logs in with the demo user', async ({ page }) => {
+  await page.goto('/login');
+
+  await expect(page.getByRole('heading', { name: 'Đăng nhập vào Markhand' })).toBeVisible();
+
+  await page.getByLabel('Email').fill('demo@markhand.test');
+  await page.getByLabel('Mật khẩu').fill('demo-password');
+  await page.getByRole('button', { name: 'Đăng nhập' }).click();
+
+  // Successful login leaves /login and mounts the application rail; the
+  // "Thư viện" destination is present on every in-app route.
+  await expect(page.getByRole('link', { name: 'Thư viện' })).toBeVisible();
+  await expect(page).not.toHaveURL(/\/login/);
+});

--- a/web/e2e/support.ts
+++ b/web/e2e/support.ts
@@ -81,6 +81,13 @@ export async function forceStatus(
   status: ForcedStatus,
   times = 1,
 ): Promise<void> {
+  // The mock control is installed by `main.tsx`'s async bootstrap (a dynamic
+  // `import('./mocks/browser')` awaited before render). A test that calls this
+  // immediately after `goto` — before any UI it would otherwise wait on has
+  // rendered — can race that install; on a fast CI run `__markhandMockControl`
+  // was still undefined here (flaky `forceStatus` TypeError). Wait for it so
+  // the helper is deterministic regardless of when it's called.
+  await page.waitForFunction(() => window.__markhandMockControl !== undefined);
   await page.evaluate(
     ([op, kind, n]) => {
       window.__markhandMockControl!.forceStatus(op as string, kind as ForcedStatus, {

--- a/web/e2e/support.ts
+++ b/web/e2e/support.ts
@@ -1,0 +1,101 @@
+// Shared helpers + fixture constants for the P2-15 mock-based E2E suite.
+//
+// SCOPE OF THIS SUITE (read this first):
+//   - This is the *mock-based* half of P2-15: a real Chromium driving the SPA
+//     against the in-browser fetch mock (`VITE_MARKHAND_MOCK=1`). The
+//     real-deployment E2E half (against Postgres/Qdrant/MinIO) is out of
+//     scope here — see playwright.config.ts's own header.
+//   - `ask -> citation` is deliberately ABSENT. The Q&A page (`QaPage.tsx`) is
+//     a placeholder — "Chưa kết nối tới API hỏi đáp." — because P2-10 is
+//     blocked on R02/R03/R05. There is no Q&A UI to drive, so this suite does
+//     NOT contain an ask/citation spec (a skipped-but-named test would falsely
+//     imply the flow exists). Its absence is intentional and noted here.
+//
+// FIXTURE GROUND TRUTH (src/mocks/fixtures.ts): every assertion below is
+// against these seeded values, not invented ones. ids come from `mockUuid(n)`
+// (src/mocks/ids.ts): a fixed uuid whose last 12 hex digits are `n`.
+import { expect, type Page } from '@playwright/test';
+
+/** Deterministic seeded ids (`mockUuid(n)` — last 12 hex digits are `n` in hex). */
+export const IDS = {
+  /** Demo user / signed-in caller — seeded `owner`, `active`. */
+  demoUser: '00000000-0000-4000-8000-000000000001',
+  /** The demo org the whole session is bound to. */
+  org: '00000000-0000-4000-8000-000000000002',
+  /** Second seeded member — `admin`, `active` (a non-owner promotion/demotion target). */
+  secondMember: '00000000-0000-4000-8000-00000000001e',
+  /** Third seeded member — `viewer`, `suspended` (the non-active row). */
+  thirdMember: '00000000-0000-4000-8000-00000000001f',
+} as const;
+
+export const DEMO = {
+  email: 'demo@markhand.test',
+  password: 'demo-password',
+} as const;
+
+/** Statuses `mockControl.forceStatus` accepts (src/mocks/control.ts). */
+type ForcedStatus = 401 | 403 | 404 | 409 | 429 | 503;
+
+declare global {
+  interface Window {
+    __markhandMockReset?: () => void;
+    __markhandMockControl?: {
+      forceStatus: (
+        operationId: string,
+        kind: ForcedStatus,
+        opts?: { times?: number; quota?: unknown },
+      ) => void;
+      clear: (operationId: string) => void;
+      reset: () => void;
+    };
+  }
+}
+
+/**
+ * Logs in with the demo user via the real /login form and waits until the
+ * in-app shell (the "Thư viện" rail link) is mounted. Every test starts here:
+ * `page.goto('/login')` is a full load, which re-runs the mock bootstrap and
+ * re-seeds the store, so each test gets isolated fixtures. In-app navigation
+ * afterwards must go through rail links / route links (NOT `page.goto`): a
+ * full reload re-seeds the store and drops the seeded refresh token, which
+ * logs the session out.
+ */
+export async function login(page: Page): Promise<void> {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(DEMO.email);
+  await page.getByLabel('Mật khẩu').fill(DEMO.password);
+  await page.getByRole('button', { name: 'Đăng nhập' }).click();
+  await expect(page.getByRole('link', { name: 'Thư viện' })).toBeVisible();
+  await expect(page).not.toHaveURL(/\/login/);
+}
+
+/**
+ * Forces the next `times` call(s) of `operationId` to answer `status`, via the
+ * mock control exposed on `window`. Set this BEFORE the request it targets
+ * fires (e.g. before `setInputFiles` for an upload, before confirming a
+ * delete).
+ */
+export async function forceStatus(
+  page: Page,
+  operationId: string,
+  status: ForcedStatus,
+  times = 1,
+): Promise<void> {
+  await page.evaluate(
+    ([op, kind, n]) => {
+      window.__markhandMockControl!.forceStatus(op as string, kind as ForcedStatus, {
+        times: n as number,
+      });
+    },
+    [operationId, status, times] as const,
+  );
+}
+
+/** Opens the seeded "Employee Handbook" collection from the library's collection nav. */
+export async function openEmployeeHandbook(page: Page): Promise<void> {
+  await page.getByRole('link', { name: 'Thư viện' }).click();
+  await page.getByRole('link', { name: 'Employee Handbook' }).click();
+  // The upload panel only renders once a collection is open — a reliable
+  // "collection is loaded" signal.
+  await expect(page.getByLabel('Chọn tệp để tải lên')).toBeVisible();
+}

--- a/web/package.json
+++ b/web/package.json
@@ -8,8 +8,8 @@
     "build": "tsc && vite build",
     "test": "vitest run",
     "lint": "eslint .",
-    "format": "prettier --write \"src/**/*.{ts,tsx,css}\" \"*.{ts,json}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"*.{ts,json}\"",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\" \"e2e/**/*.ts\" \"*.{ts,json}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"e2e/**/*.ts\" \"*.{ts,json}\"",
     "api:generate": "openapi-typescript ../crates/server/openapi/openapi.yaml -o src/api/generated/contract.ts",
     "api:check": "pnpm api:generate && git diff --exit-code -- src/api/generated/contract.ts",
     "e2e": "playwright test"

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\" \"*.{ts,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"*.{ts,json}\"",
     "api:generate": "openapi-typescript ../crates/server/openapi/openapi.yaml -o src/api/generated/contract.ts",
-    "api:check": "pnpm api:generate && git diff --exit-code -- src/api/generated/contract.ts"
+    "api:check": "pnpm api:generate && git diff --exit-code -- src/api/generated/contract.ts",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "lucide-react": "^1.22.0",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,44 @@
+import { existsSync } from 'node:fs';
+import { defineConfig, devices } from '@playwright/test';
+
+// The P2-15 E2E suite drives a real browser against a *mock-mode* dev server
+// (`VITE_MARKHAND_MOCK=1`), so the whole flow is deterministic and needs no
+// live backend. The real-deployment half of P2-15 (against Postgres/Qdrant/
+// MinIO) is out of this config's scope — it belongs to the `dev-stack` job and
+// is deferred until a stack is available. `ask → citation` is likewise absent:
+// the Q&A page is a placeholder until P2-10 ships (blocked on R02/R03/R05).
+
+// This environment ships a pre-installed Chromium at a fixed path and blocks
+// re-downloads; CI (GitHub ubuntu) has none, so it runs `playwright install
+// chromium` first and Playwright resolves the browser itself. Use the fixed
+// path only when it exists, so the same config works in both places.
+const PREINSTALLED_CHROMIUM = '/opt/pw-browsers/chromium';
+const executablePath = existsSync(PREINSTALLED_CHROMIUM) ? PREINSTALLED_CHROMIUM : undefined;
+
+const PORT = 4173;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], launchOptions: { executablePath } },
+    },
+  ],
+  webServer: {
+    // Vite dev is enough for E2E and avoids a separate build step; the mock
+    // flag is read at runtime via `import.meta.env`.
+    command: `VITE_MARKHAND_MOCK=1 pnpm exec vite --port ${PORT} --strictPort`,
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -34,11 +34,16 @@ export default defineConfig({
     },
   ],
   webServer: {
-    // Vite dev is enough for E2E and avoids a separate build step; the mock
-    // flag is read at runtime via `import.meta.env`.
-    command: `VITE_MARKHAND_MOCK=1 pnpm exec vite --port ${PORT} --strictPort`,
+    // Bind the dev server explicitly to 127.0.0.1 so it matches the IPv4 `url`
+    // Playwright polls: with a bare `localhost` bind, a CI runner that resolves
+    // `localhost` to `::1` first leaves the IPv4 health check hanging until the
+    // timeout (observed on GitHub Actions). The mock flag is read at runtime
+    // via `import.meta.env`, so `vite` dev needs no separate build step.
+    command: `VITE_MARKHAND_MOCK=1 pnpm exec vite --host 127.0.0.1 --port ${PORT} --strictPort`,
     url: `http://127.0.0.1:${PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
   },
 });

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,4 +2,17 @@ import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import './styles.css';
 
-createRoot(document.getElementById('root')!).render(<App />);
+// In a mock-mode build (`VITE_MARKHAND_MOCK=1`, used only by the Playwright
+// E2E suite — see playwright.config.ts) install the in-browser fetch mock
+// before rendering, so React's first request already hits the deterministic
+// store. The dynamic import keeps every `mocks/**` module out of the normal
+// production bundle: with the flag unset this branch is dead code Rollup drops.
+async function bootstrap(): Promise<void> {
+  if (import.meta.env.VITE_MARKHAND_MOCK) {
+    const { installBrowserMocks } = await import('./mocks/browser');
+    installBrowserMocks();
+  }
+  createRoot(document.getElementById('root')!).render(<App />);
+}
+
+void bootstrap();

--- a/web/src/mocks/browser.ts
+++ b/web/src/mocks/browser.ts
@@ -1,0 +1,46 @@
+// Browser-side mock bootstrap for the Playwright E2E suite (P2-15).
+//
+// The vitest suite installs the mock fetch per test (`installMockFetch()` in a
+// `beforeEach`); Playwright drives a *real* browser against a served build, so
+// the mock has to be installed once, at app bootstrap, before React renders
+// and fires its first request. `main.tsx` calls this only when the app was
+// built with `VITE_MARKHAND_MOCK` set, so none of `mocks/**` reaches a
+// production bundle (main.tsx `import()`s it dynamically behind the flag).
+//
+// Each Playwright test starts from a fresh full page load, which re-imports
+// this module and re-seeds the store, so tests are deterministic without a
+// per-test reset hook. `window.__markhandMockReset` is also exposed so a test
+// can re-seed mid-scenario (e.g. after a destructive flow) without a reload.
+import { grantMemberManage } from '../components/admin/testSupport';
+import { installMockFetch, mockControl, resetMockState } from './index';
+
+declare global {
+  interface Window {
+    /** Re-seed the in-memory mock store to its initial fixtures. E2E-only. */
+    __markhandMockReset?: () => void;
+    /**
+     * The same `mockControl` the vitest suite uses, exposed so a Playwright
+     * test can force a status (`forceStatus('deleteDocument', 403)`) from the
+     * page context to drive permission-deny / quota-exceed flows. E2E-only.
+     */
+    __markhandMockControl?: typeof mockControl;
+  }
+}
+
+/**
+ * Installs the fetch mock and seeds the fixture store. Grants the seeded demo
+ * user `member.manage` so the P2-11/P2-12 admin flows are reachable in E2E —
+ * the vitest suite deliberately does NOT grant it (it would change an
+ * `App.test.tsx` assertion), but in mock-mode the demo user is the only user
+ * and the admin pages are part of what E2E must cover.
+ */
+export function installBrowserMocks(): void {
+  installMockFetch();
+  resetMockState();
+  grantMemberManage();
+  window.__markhandMockReset = () => {
+    resetMockState();
+    grantMemberManage();
+  };
+  window.__markhandMockControl = mockControl;
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,1 +1,13 @@
 /// <reference types="vite/client" />
+
+// Augments vite/client's `ImportMetaEnv` with the two app-specific vars.
+interface ImportMetaEnv {
+  /**
+   * Truthy (`"1"`) only for the mock-mode build the Playwright E2E suite
+   * drives (playwright.config.ts). When set, `main.tsx` installs the in-browser
+   * fetch mock before rendering. Unset in every real build.
+   */
+  readonly VITE_MARKHAND_MOCK?: string;
+  /** Overrides the API base URL; see `api/client.ts`. */
+  readonly VITE_MARKHAND_API_BASE_URL?: string;
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig(({ mode }) => {
     test: {
       environment: 'jsdom',
       setupFiles: './src/test/setup.ts',
+      // Keep vitest to the in-source unit/component tests. The Playwright E2E
+      // specs live in `e2e/` and also match `*.spec.ts`; without this bound
+      // vitest would try to run them and fail on Playwright's `test()`.
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
     },
   };
 });


### PR DESCRIPTION
## Outcome

The mock-based half of P2-15: a Playwright E2E harness driving a real browser against a deterministic mock-mode build (no backend), 15 specs covering the flows the SPA actually has today, wired into CI as a `web-e2e` job so it runs — not just compiles.

## Scope

- **Harness (`b35418c`)**: `main.tsx` installs the in-browser fetch mock behind `VITE_MARKHAND_MOCK` via a dynamic import (no `mocks/**` in production bundles); `mocks/browser.ts` seeds the store, grants the demo user `member.manage`, and exposes `__markhandMockReset` / `__markhandMockControl`; `playwright.config.ts` launches the pre-installed Chromium by path where it exists and lets Playwright resolve its own in CI, starting the mock-mode vite dev server as its `webServer`; vitest is bounded to `src/**` so it no longer picks up the `e2e/*.spec` files; a `web-e2e` CI job installs Chromium and runs the suite.
- **Flow suite (`ff9359a`)**: `auth` (logout, anonymous deep-link → `?next=`, one-time-401 silent refresh), `library` (preview/reindex/delete, 403 message, 429 message), `admin` (invite one-time token, role change, suspend↔reactivate, last-owner 409, owner-tier 403, usage cards). `format:check` now globs `e2e/`.
- `12016db`: gitignore Playwright output dirs.

## Coverage boundaries — stated, not faked

Three flows from the P2-15 brief are not drivable here, and are documented in the specs rather than given misleading green tests:

- **Org-switch scope safety** — `OrgSwitch` binds a single org and the contract exposes no org-list/switch endpoint, so there is nothing to switch to. The spec asserts the switcher's real behavior (shows the bound org, states switching isn't wired). The P2-06 epoch guarantee stays covered by the unit/component suite.
- **Upload → indexed** — `uploadTransport` uploads via `XMLHttpRequest` for real progress (P2-08), but the browser mock only overrides `fetch`, so uploads don't reach the mock. This belongs to the deferred real-deployment E2E half. The 429 message path is covered through a fetch-based document action instead.
- **ask → citation** — the Q&A page is a placeholder until P2-10 (blocked on R02/R03/R05).

The **real-deployment E2E** half of P2-15 (against Postgres/Qdrant/MinIO) and an **OWASP baseline** scan are also deferred — the repo already has dependency-policy and license scans.

## Evidence

- [x] Tests: `pnpm exec playwright test` → **15 passed** (verified locally against the pre-installed Chromium). `pnpm --dir web lint` (0 errors), `format:check`, `test` (39 vitest files), `build` all clean.
- [x] Manual/benchmark/migration evidence: N/A — test-only, no app or backend change. The refresh spec forces a one-time 401 on `authMe` and asserts the client's single-flight refresh recovers to the shell (a broken refresh would leave the user on `/login`) — a real assertion, not a smoke check.

## Boundary and security review

- [x] Dependency boundary — one new **devDependency**, `@playwright/test`; it cannot reach any runtime bundle. The mock bootstrap is behind `VITE_MARKHAND_MOCK` and dynamically imported, so `mocks/**` stays out of production builds.
- [x] Tenant/ACL impact — N/A to runtime; the suite exercises the existing UI against a mock. The admin specs assert the server-mirrored owner-tier 403 and last-owner 409 behave in the browser.
- [x] Sensitive logging/secret/egress — N/A; the mock serves synthetic fixtures, no real credentials or data.
- [x] Security review trigger — none; no runtime surface added.

## Follow-up

- [ ] Docs/roadmap — P2-15 is partially satisfied (mock half). The deferred real-deployment E2E, org-switch (needs a multi-org endpoint / 1C-01), upload→indexed E2E (needs the real backend since it's XHR), and ask→citation (needs P2-10) are the remaining pieces; I can update the roadmap catalog to mark P2-15 in-progress with this breakdown if you want.
- The `web-e2e` CI job is **not** proposed as a required status check yet — that's your call once you've seen it run green here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1aW1B4YfpWERwjsVVficE)_