### PR TITLE
[intern-04] Test chuẩn hoá Unicode NFC trên output convert

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -473,21 +473,43 @@ mod tests {
     /// Tài liệu chứa tiếng Việt dạng NFD (dấu rời) phải ra NFC sau convert.
     #[test]
     fn output_normalized_to_nfc() {
-        // "tiếng Việt" ở dạng NFD: e + U+0302 + U+0301, ê tách dấu.
+        use unicode_normalization::{is_nfc_quick, IsNormalized};
+
+        // 1) Chuỗi NFD tường minh (không gõ "tiếng" trực tiếp — editor có thể NFC hoá).
         let nfd = "ti\u{0065}\u{0302}\u{0301}ng Vi\u{0065}\u{0323}\u{0302}t,ok\n";
+        let nfc_expected = "tiếng Việt,ok\n"; // literal NFC trong source
+
+        // 2) Chứng minh hai form KHÁC nhau (nếu bằng nhau thì test vô nghĩa).
+        assert_ne!(nfd.as_bytes(), nfc_expected.as_bytes());
+        assert_ne!(nfd, nfc_expected);
+
+        // 3) Input đi qua đường convert thật (CSV → markdown).
         let dir = std::env::temp_dir().join(format!("fileconv_nfc_{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let f = dir.join("nfd.csv");
         std::fs::write(&f, nfd).unwrap();
 
         let out = Converter::new().convert_path(&f).unwrap().markdown;
+
+        // 4) Output chứa literal NFC (CSV có thể bọc table — chỉ check substring).
         assert!(
-            out.contains("tiếng"),
-            "phải chứa 'tiếng' dạng NFC, got: {out:?}"
+            out.contains("tiếng") && out.contains("Việt"),
+            "phải chứa 'tiếng'/'Việt' NFC, got: {out:?}"
         );
-        assert!(out.contains("Việt"), "phải chứa 'Việt' dạng NFC");
-        // Không còn combining mark rời nào.
-        assert!(!out.chars().any(|c| ('\u{0300}'..='\u{036F}').contains(&c)));
+
+        // 5) Toàn bộ markdown đã NFC (gate production chạy).
+        assert_eq!(
+            is_nfc_quick(out.chars()),
+            IsNormalized::Yes,
+            "output chưa NFC: {out:?}"
+        );
+
+        // 6) Không còn combining mark — fail nếu ai đó xoá gate NFC.
+        assert!(
+            !out.chars().any(|c| ('\u{0300}'..='\u{036F}').contains(&c)),
+            "còn dấu rời NFD trong output: {out:?}"
+        );
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
Closes #287

cc @anhnth24 — em xin gửi PR intern-04 để anh review ạ.

## Summary

- Siết unit test `output_normalized_to_nfc` trong `crates/core/src/lib.rs` (`mod tests`): đưa chuỗi tiếng Việt dạng NFD (base + combining marks) qua `Converter::convert_path` (file CSV tạm), assert output đã NFC.
- Không đổi hành vi production (gate NFC trong `convert_path_detailed` giữ nguyên).

## Thay đổi file

### `crates/core/src/lib.rs`

Chỉ sửa thân test `output_normalized_to_nfc`:

1. Tạo input NFD tường minh bằng `\u{...}` (tránh editor tự gộp NFC) + `nfc_expected` literal để `assert_ne!` chứng minh hai form khác nhau.
2. Ghi file `.csv` tạm → gọi `Converter::convert_path` (đi đúng pipeline convert).
3. Assert mạnh hơn bản cũ:
   - `out.contains("tiếng")` / `"Việt"` (literal NFC),
   - `is_nfc_quick(out.chars()) == IsNormalized::Yes`,
   - không còn combining mark trong khoảng `U+0300..=U+036F`.

Mục tiêu: nếu ai đó bỏ bước chuẩn hoá NFC ở `convert_path_detailed`, test này phải fail.

## NFC vs NFD (tiếng Việt)

- **NFC:** chữ gộp sẵn — ví dụ `"ế"` = một code point `U+1EBF`.
- **NFD:** chữ gốc + dấu rời — `"ế"` = `e` + `U+0302` + `U+0301` (nhìn giống, bytes/code point khác).
- macOS / PDF cũ hay emit NFD → `"tiếng" == nfd_form` là `false` dù mắt đọc giống nhau.

### Nếu bỏ bước NFC sẽ sao?

- **CER/WER** lệch dù chữ “đúng mắt” (metric so code point).
- **Search/FTS** miss: query NFC không khớp document NFD.
- **Embedding/RAG** tách cùng từ thành hai vector khác nhau.

## Test plan

- [x] `cargo test -p fileconv-core output_normalized_to_nfc`
- [x] `cargo test -p fileconv-core conversion_result_uses_first_heading`
- [x] Đã thử phá local (không commit): tạm thay gate NFC trong `convert_path_detailed` bằng `let md = output.markdown;` → `output_normalized_to_nfc` **đỏ** (assert `contains` / `is_nfc_quick` / combining marks) → restore lại code production → test xanh lại.