### PR TITLE
Q&A UI (P2-10) + audit-read (1C-11) + login race fix + R03/R05 & 1C-02 test hardening

### DIFF
--- a/crates/server/openapi/openapi.yaml
+++ b/crates/server/openapi/openapi.yaml
@@ -1243,6 +1243,69 @@ paths:
           $ref: "#/components/responses/ApiError"
         "429":
           $ref: "#/components/responses/RateLimited"
+  /audit:
+    get:
+      operationId: listAudit
+      summary: >-
+        List org audit log entries, newest first (requires audit.view).
+        Read-only; audit_log is append-only and org-isolated by RLS.
+      parameters:
+        - name: limit
+          in: query
+          description: Page size (server default 50, clamped to [1, 100]).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: cursor
+          in: query
+          description: Opaque pagination cursor from a previous page's nextCursor.
+          schema:
+            type: string
+        - name: action
+          in: query
+          description: >-
+            Exact audit action code filter (closed enum, e.g.
+            member.role_change, document.upload). Unknown values are rejected
+            with 400.
+          schema:
+            type: string
+        - name: actor
+          in: query
+          description: Filter to a specific actor user id.
+          schema:
+            type: string
+            format: uuid
+        - name: from
+          in: query
+          description: Inclusive lower bound on occurredAt (RFC 3339).
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          description: Inclusive upper bound on occurredAt (RFC 3339).
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: Paginated audit log entries for the caller's current org.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuditPage"
+        "400":
+          description: Invalid action/actor/from/to/cursor.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
 components:
   securitySchemes:
     bearerAuth:
@@ -1990,3 +2053,53 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/UsageEntry"
+    AuditEntry:
+      type: object
+      required:
+        - id
+        - seq
+        - action
+        - targetType
+        - outcome
+        - metadata
+        - occurredAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        seq:
+          type: integer
+          format: int64
+        actorId:
+          type: [string, "null"]
+          format: uuid
+        action:
+          type: string
+        targetType:
+          type: string
+        targetId:
+          type: [string, "null"]
+        outcome:
+          type: string
+          enum: [success, deny, error, intent]
+        metadata:
+          type: object
+          description: >-
+            Per-action scalar allowlist only (services::audit::sanitize_for_action)
+            — never document content, prompts, tokens, or PII.
+        requestId:
+          type: [string, "null"]
+          format: uuid
+        occurredAt:
+          type: string
+          format: date-time
+    AuditPage:
+      type: object
+      required: [items, page]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuditEntry"
+        page:
+          $ref: "#/components/schemas/PageInfo"

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -122,6 +122,9 @@ pub const ROUTE_INVENTORY: &[(&str, &str, &[&str])] = &[
         &["204", "403", "404", "409", "429"],
     ),
     ("get", "/usage", &["200", "403", "429"]),
+    // 1C-11 audit-log read endpoint (write path pre-existing; this is the
+    // first read surface — see routes/audit.rs).
+    ("get", "/audit", &["200", "400", "403", "429"]),
 ];
 
 const HEALTH_PATHS: &[&str] = &["/health/live", "/health/ready", "/health/start"];

--- a/crates/server/src/api/types.rs
+++ b/crates/server/src/api/types.rs
@@ -67,3 +67,25 @@ pub struct Page<T> {
     pub items: Vec<T>,
     pub page: PageInfo,
 }
+
+/// 1C-11 audit log read entry. Field names follow the existing telemetry
+/// envelope vocabulary (`occurred_at`/`actor_id`/`target_type`/`target_id`,
+/// see `telemetry::AuditEvent`) rather than the raw `audit_log` column names.
+/// `metadata` is passed through verbatim — it was already reduced to the
+/// per-action scalar allowlist at write time
+/// (`services::audit::sanitize_for_action`), so no extra filtering happens
+/// here; this endpoint must never add fields beyond that allowlist.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEntryDto {
+    pub id: Uuid,
+    pub seq: i64,
+    pub actor_id: Option<Uuid>,
+    pub action: String,
+    pub target_type: String,
+    pub target_id: Option<String>,
+    pub outcome: String,
+    pub metadata: serde_json::Value,
+    pub request_id: Option<String>,
+    pub occurred_at: DateTime<Utc>,
+}

--- a/crates/server/src/db/audit.rs
+++ b/crates/server/src/db/audit.rs
@@ -1,5 +1,7 @@
-//! Append-oriented audit log reads (P1B-O01). Writes go through auth::session.
+//! Append-oriented audit log reads (P1B-O01 / 1C-11). Writes go through
+//! auth::session / services::audit — this module is read-only.
 
+use chrono::{DateTime, Utc};
 use tokio_postgres::{Row, Transaction};
 use uuid::Uuid;
 
@@ -23,6 +25,72 @@ pub async fn list_recent(
              ORDER BY seq DESC
              LIMIT $2",
             &[&ctx.org_id(), &limit],
+        )
+        .await?;
+    rows.iter().map(map_entry).collect()
+}
+
+/// Optional exact-match / bound filters for [`list_page`]. `None` means
+/// "no constraint on this field" — never a wildcard footgun since every
+/// predicate below is parameterized (`$n IS NULL OR ...`).
+#[derive(Debug, Clone, Default)]
+pub struct AuditListFilter {
+    /// Exact `action` string match (e.g. `"member.role_change"`).
+    pub action: Option<String>,
+    /// Exact `actor_user_id` match.
+    pub actor_user_id: Option<Uuid>,
+    /// Inclusive lower bound on `created_at`.
+    pub from: Option<DateTime<Utc>>,
+    /// Inclusive upper bound on `created_at`.
+    pub to: Option<DateTime<Utc>>,
+}
+
+/// Cursor-paginated, filtered audit rows for the tenant (1C-11 read endpoint).
+///
+/// Ordering is `(created_at DESC, id DESC)` — the same stable
+/// newest-first tuple cursor convention as `db::documents::list_in_collection`.
+/// `org_id = $1` plus RLS (`audit_log_org_isolation`, migration `0010`) both
+/// enforce tenant isolation; this predicate is defense-in-depth, not the only
+/// gate.
+pub async fn list_page(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    filter: &AuditListFilter,
+    limit: i64,
+    after_created_at: Option<DateTime<Utc>>,
+    after_id: Option<Uuid>,
+) -> Result<Vec<AuditLogEntry>, DbError> {
+    // Callers pass `Pagination::from_query(..).limit + 1` (max 100 + 1 = 101)
+    // to detect `has_more` without an extra COUNT query — clamp to 101, not
+    // 100, or that sentinel row would get silently clamped away right at the
+    // page-size boundary and `has_more` would go stale exactly at limit=100.
+    let limit = limit.clamp(1, 101);
+    let rows = txn
+        .query(
+            "SELECT id, org_id, seq, actor_user_id, action, resource_type, resource_id,
+                    outcome, metadata, request_id, created_at
+             FROM audit_log
+             WHERE org_id = $1
+               AND ($2::text IS NULL OR action = $2)
+               AND ($3::uuid IS NULL OR actor_user_id = $3)
+               AND ($4::timestamptz IS NULL OR created_at >= $4)
+               AND ($5::timestamptz IS NULL OR created_at <= $5)
+               AND (
+                    $6::timestamptz IS NULL
+                    OR (created_at, id) < ($6::timestamptz, $7::uuid)
+               )
+             ORDER BY created_at DESC, id DESC
+             LIMIT $8",
+            &[
+                &ctx.org_id(),
+                &filter.action,
+                &filter.actor_user_id,
+                &filter.from,
+                &filter.to,
+                &after_created_at,
+                &after_id,
+                &limit,
+            ],
         )
         .await?;
     rows.iter().map(map_entry).collect()

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -491,6 +491,7 @@ pub fn router(state: AppState) -> Router {
         .merge(routes::jobs::router())
         .merge(routes::members::router())
         .merge(routes::orgs::router())
+        .merge(routes::audit::router())
         .merge(routes::search::router())
         .merge(routes::ask::router())
         .merge(routes::events::router())

--- a/crates/server/src/routes/audit.rs
+++ b/crates/server/src/routes/audit.rs
@@ -1,0 +1,220 @@
+//! GET /api/v1/audit — org-scoped, permission-gated audit log read (1C-11).
+//!
+//! `audit_log` is append-only and write-only up to this slice (writes go
+//! through `services::audit` / `auth::session::write_audit`, co-committed
+//! with the mutation they describe — see `db/audit.rs` module doc). This is
+//! the first and only *read* surface. Scope is deliberately narrow: list with
+//! cursor pagination + `action`/`actor`/`from`/`to` filters, org isolation via
+//! `org_id = $1` (defense-in-depth; RLS `audit_log_org_isolation` from
+//! migration `0010` is the real gate), and the `audit.view` permission guard.
+//! No retention/export/SIEM surface here — see the 1C-11 backlog entry for
+//! what remains out of scope.
+
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::api::{
+    decode_cursor, encode_cursor, ApiError, AuditEntryDto, Page, PageInfo, Pagination,
+};
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::auth::permissions::require_permission;
+use crate::db::audit::{self as db_audit, AuditListFilter};
+use crate::db::error::DbError;
+use crate::db::models::AuditLogEntry;
+use crate::db::pool::with_org_txn;
+use crate::http::AppState;
+use crate::services::audit::{self, AuditAction};
+
+/// Seeded in `migrations/0011` (POC catalog) and `migrations/0030` (global
+/// role catalog) — owner/admin roles hold it by default, matching the task's
+/// "already seeded, owner/admin have it" note.
+const PERMISSION_AUDIT_VIEW: &str = "audit.view";
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().route("/api/v1/audit", get(list_audit))
+}
+
+#[derive(Debug, Deserialize)]
+struct ListQuery {
+    limit: Option<i64>,
+    cursor: Option<String>,
+    action: Option<String>,
+    actor: Option<Uuid>,
+    from: Option<DateTime<Utc>>,
+    to: Option<DateTime<Utc>>,
+}
+
+fn audit_entry_dto(row: AuditLogEntry) -> AuditEntryDto {
+    AuditEntryDto {
+        id: row.id,
+        seq: row.seq,
+        actor_id: row.actor_user_id,
+        action: row.action,
+        target_type: row.resource_type,
+        target_id: row.resource_id,
+        outcome: row.outcome.as_str().into(),
+        metadata: row.metadata,
+        request_id: row.request_id,
+        occurred_at: row.created_at,
+    }
+}
+
+async fn list_audit(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<Page<AuditEntryDto>>, RouteError> {
+    if require_permission(&auth.context, PERMISSION_AUDIT_VIEW).is_err() {
+        // Reading the audit trail is itself sensitive enough to audit the
+        // denial (unlike plain list_members/list_invites/usage, which do
+        // not audit at all) — mirrors search.query/ask.query's deny audit.
+        audit::record_deny(
+            state.pool(),
+            &auth.context,
+            &auth.request_id,
+            AuditAction::AuditRead.as_str(),
+            "audit",
+            None,
+            "permission_denied",
+        )
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+        return Err(RouteError::Denied(auth.request_id.clone()));
+    }
+
+    // Exact-match action filter validated against the closed action enum —
+    // same "reject unknown enum value up front" convention as
+    // MembershipRole::parse in routes/members.rs. Never a free-text LIKE.
+    let action = match query.action.as_deref() {
+        Some(raw) => Some(
+            AuditAction::parse(raw)
+                .map_err(|_| RouteError::Validation(auth.request_id.clone(), "Invalid action"))?
+                .as_str()
+                .to_string(),
+        ),
+        None => None,
+    };
+
+    if let (Some(from), Some(to)) = (query.from, query.to) {
+        if from > to {
+            return Err(RouteError::Validation(
+                auth.request_id.clone(),
+                "from must not be after to",
+            ));
+        }
+    }
+
+    let pagination = Pagination::from_query(query.limit);
+    let (after_at, after_id) = match query.cursor.as_deref() {
+        Some(raw) => decode_cursor(raw)
+            .map(|(at, id)| (Some(at), Some(id)))
+            .ok_or_else(|| RouteError::Validation(auth.request_id.clone(), "Invalid cursor"))?,
+        None => (None, None),
+    };
+
+    let filter = AuditListFilter {
+        action,
+        actor_user_id: query.actor,
+        from: query.from,
+        to: query.to,
+    };
+
+    let mut rows = with_org_txn(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let filter = filter.clone();
+        move |txn| {
+            Box::pin(async move {
+                db_audit::list_page(txn, &ctx, &filter, pagination.limit + 1, after_at, after_id)
+                    .await
+            })
+        }
+    })
+    .await
+    .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
+
+    let has_more = rows.len() as i64 > pagination.limit;
+    if has_more {
+        rows.truncate(pagination.limit as usize);
+    }
+    let next_cursor = rows.last().map(|row| encode_cursor(row.created_at, row.id));
+    let result_count = rows.len();
+
+    audit::record(
+        state.pool(),
+        &auth.context,
+        audit::AuditRecord {
+            request_id: &auth.request_id,
+            action: AuditAction::AuditRead.as_str(),
+            resource_type: "audit",
+            resource_id: None,
+            outcome: crate::db::models::AuditOutcome::Success,
+            metadata: serde_json::json!({ "result_count": result_count as i64 }),
+        },
+    )
+    .await
+    .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+
+    Ok(Json(Page {
+        items: rows.into_iter().map(audit_entry_dto).collect(),
+        page: PageInfo {
+            next_cursor,
+            has_more,
+        },
+    }))
+}
+
+enum RouteError {
+    Denied(String),
+    Validation(String, &'static str),
+    Database(String),
+}
+
+impl RouteError {
+    fn from_db(error: DbError, request_id: &str) -> Self {
+        let _ = error;
+        Self::Database(request_id.to_string())
+    }
+}
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> Response {
+        let (status, code, message, request_id) = match self {
+            Self::Denied(request_id) => (
+                StatusCode::FORBIDDEN,
+                "forbidden",
+                "Permission denied",
+                request_id,
+            ),
+            Self::Validation(request_id, message) => (
+                StatusCode::BAD_REQUEST,
+                "validation_failed",
+                message,
+                request_id,
+            ),
+            Self::Database(request_id) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                "Request failed",
+                request_id,
+            ),
+        };
+        (
+            status,
+            Json(ApiError {
+                code: code.into(),
+                message: message.into(),
+                request_id,
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP route modules.
 
 pub mod ask;
+pub mod audit;
 pub mod auth;
 pub mod collections;
 pub mod documents;

--- a/crates/server/src/services/audit.rs
+++ b/crates/server/src/services/audit.rs
@@ -66,6 +66,10 @@ pub enum AuditAction {
     MemberInviteRevoke,
     MemberRoleChange,
     MemberRemove,
+    // 1C-11 audit-log read endpoint. Reading the audit trail is itself
+    // sensitive enough to audit (both the deny and the success path,
+    // mirroring search.query/ask.query below) — see routes/audit.rs.
+    AuditRead,
 }
 
 impl AuditAction {
@@ -107,6 +111,7 @@ impl AuditAction {
             Self::MemberInviteRevoke => "member.invite_revoke",
             Self::MemberRoleChange => "member.role_change",
             Self::MemberRemove => "member.remove",
+            Self::AuditRead => "audit.read",
         }
     }
 
@@ -148,6 +153,7 @@ impl AuditAction {
             "member.invite_revoke" => Ok(Self::MemberInviteRevoke),
             "member.role_change" => Ok(Self::MemberRoleChange),
             "member.remove" => Ok(Self::MemberRemove),
+            "audit.read" => Ok(Self::AuditRead),
             _ => Err(format!("audit_action_invalid:{value}")),
         }
     }
@@ -257,6 +263,10 @@ impl AuditAction {
                 "new_state",
             ],
             Self::MemberRemove => &["reason", "target_user_id", "old_role"],
+            // Never the filter values themselves (actor/action/time range are
+            // caller-supplied query params, not durable facts worth auditing
+            // verbatim) — only a bounded result count and the deny reason.
+            Self::AuditRead => &["reason", "result_count"],
         }
     }
 }
@@ -275,6 +285,7 @@ pub enum AuditResource {
     Search,
     Conflict,
     Member,
+    Audit,
 }
 
 impl AuditResource {
@@ -292,6 +303,7 @@ impl AuditResource {
             Self::Search => "search",
             Self::Conflict => "conflict",
             Self::Member => "member",
+            Self::Audit => "audit",
         }
     }
 
@@ -309,6 +321,7 @@ impl AuditResource {
             "search" => Ok(Self::Search),
             "conflict" => Ok(Self::Conflict),
             "member" => Ok(Self::Member),
+            "audit" => Ok(Self::Audit),
             _ => Err(format!("audit_resource_type_invalid:{value}")),
         }
     }

--- a/crates/server/tests/ask_grounding_matrix.rs
+++ b/crates/server/tests/ask_grounding_matrix.rs
@@ -446,3 +446,418 @@ async fn live_ask_is_extractive_and_delete_during_stream_closes() {
     cleanup.cleanup().await.expect("clean ask grounding bucket");
     ephemeral.drop().await;
 }
+
+/// Seeds an org/user + collection/document with one published+current version
+/// (PG only; conflict warnings never require MinIO/Qdrant/chunks).
+async fn seed_conflict_capable_doc(
+    pool: &deadpool_postgres::Pool,
+    label: &str,
+) -> (OrgContext, Uuid, Uuid) {
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let perms = ["qa.query", "qa.history", "doc.upload", "doc.delete"];
+    seed_user_with_permissions(
+        pool,
+        org,
+        user,
+        &format!("{user}@{label}.test"),
+        "correct-password-1",
+        &perms,
+    )
+    .await;
+    let collection_id = Uuid::new_v4();
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let ctx = OrgContext::try_new(org, user, perms, [collection_id]).unwrap();
+    with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: collection_id,
+                        name: "Conflict collection",
+                        slug: &format!("conflict-{}", collection_id.simple()),
+                        description: None,
+                        visibility: fileconv_server::db::models::CollectionVisibility::Org,
+                    },
+                )
+                .await?;
+                documents::insert(
+                    txn,
+                    &ctx,
+                    NewDocument {
+                        id: document_id,
+                        collection_id,
+                        title: "Conflict doc",
+                    },
+                )
+                .await?;
+                let sha = format!("{:0>64}", version_id.as_u128());
+                let key = format!("org/{}/doc/{document_id}/v/{version_id}/source", ctx.org_id());
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key, markdown_object_key,
+                        source_content_type, byte_size, created_by_user_id
+                     ) VALUES ($1,$2,$3,1,'published',true,$4,$5,$5,'text/markdown',1,$6)",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &sha,
+                        &key,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                let indexed = DocumentState::Indexed.as_str();
+                txn.execute(
+                    "UPDATE documents SET state=$3, current_version_id=$4 WHERE org_id=$1 AND id=$2",
+                    &[&ctx.org_id(), &document_id, &indexed, &version_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed conflict-capable doc");
+    (ctx, document_id, version_id)
+}
+
+/// Inserts two claims on the same current+published version plus an `open`
+/// numeric conflict between them (canonical `claim_a_id < claim_b_id`).
+async fn seed_open_conflict(
+    pool: &deadpool_postgres::Pool,
+    ctx: &OrgContext,
+    document_id: Uuid,
+    version_id: Uuid,
+    value_low: i64,
+    value_high: i64,
+) -> Uuid {
+    let claim_x = Uuid::new_v4();
+    let claim_y = Uuid::new_v4();
+    let (claim_a, claim_b) = if claim_x < claim_y {
+        (claim_x, claim_y)
+    } else {
+        (claim_y, claim_x)
+    };
+    let conflict_id = Uuid::new_v4();
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let value_low_decimal = rust_decimal::Decimal::from(value_low);
+                let value_high_decimal = rust_decimal::Decimal::from(value_high);
+                let quote_low = format!("Kinh phí là {value_low} triệu đồng.");
+                let quote_high = format!("Kinh phí là {value_high} triệu đồng.");
+                txn.execute(
+                    "INSERT INTO claims (
+                        id, org_id, document_id, version_id, claim_key, subject, predicate,
+                        value_type, value_money, unit, scope, effective_from, citation_quote
+                     ) VALUES ($1,$2,$3,$4,'budget','Kinh phí','is','money',$5,'triệu','', now(),$6)",
+                    &[
+                        &claim_a,
+                        &ctx.org_id(),
+                        &document_id,
+                        &version_id,
+                        &value_low_decimal,
+                        &quote_low,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO claims (
+                        id, org_id, document_id, version_id, claim_key, subject, predicate,
+                        value_type, value_money, unit, scope, effective_from, citation_quote
+                     ) VALUES ($1,$2,$3,$4,'budget','Kinh phí','is','money',$5,'triệu','', now(),$6)",
+                    &[
+                        &claim_b,
+                        &ctx.org_id(),
+                        &document_id,
+                        &version_id,
+                        &value_high_decimal,
+                        &quote_high,
+                    ],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO conflicts (
+                        id, org_id, status, severity, conflict_type, claim_a_id, claim_b_id,
+                        first_detected_version_id
+                     ) VALUES ($1,$2,'open','warning','numeric',$3,$4,$5)",
+                    &[&conflict_id, &ctx.org_id(), &claim_a, &claim_b, &version_id],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed open conflict");
+    conflict_id
+}
+
+/// P1B-R03 "Remaining for Done" (b): triage-then-current/history matrix on a
+/// real DB. Current mode must warn only while a conflict is `open`; history
+/// mode must surface the resolution note once terminal, across every terminal
+/// status (`resolved`/`accepted_exception`/`false_positive`).
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL/APP"]
+async fn live_ask_conflict_triage_then_current_and_history_matrix() {
+    use fileconv_server::services::access::triage_authorized_conflict;
+
+    let Some(admin) = admin_database_url() else {
+        return;
+    };
+    let Some(app) = app_database_url() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_app_pool(&admin, &app).await;
+    assert_markhand_app_role(&pool).await;
+
+    // No embedder is configured anywhere in this test, so the vector leg is
+    // never dispatched (see `search_all_vector_legs`'s `query_vector` guard) —
+    // this Qdrant client is constructed but never dialed over the network.
+    let qdrant =
+        fileconv_server::storage::QdrantClient::new("http://127.0.0.1:6333").expect("qdrant");
+
+    for status in ["resolved", "accepted_exception", "false_positive"] {
+        let (ctx, document_id, version_id) =
+            seed_conflict_capable_doc(&pool, &format!("conflict-{status}")).await;
+        let conflict_id = seed_open_conflict(&pool, &ctx, document_id, version_id, 10, 15).await;
+        let collection_id = *ctx.allowed_collection_ids().iter().next().unwrap();
+
+        let current_before = ask(
+            &pool,
+            &qdrant,
+            None,
+            None,
+            &ctx,
+            AskRequest {
+                question: "Kinh phí là bao nhiêu?".into(),
+                collection_ids: Some([collection_id].into_iter().collect()),
+                mode: VersionMode::Current,
+                limit: 5,
+                conflict_ids: vec![conflict_id],
+            },
+        )
+        .await
+        .expect("ask current before triage");
+        assert!(
+            current_before
+                .warnings
+                .iter()
+                .any(|w| w.contains("Unresolved conflict") && w.contains(&conflict_id.to_string())),
+            "status={status} expected open-conflict warning before triage: {:?}",
+            current_before.warnings
+        );
+
+        let history_before = ask(
+            &pool,
+            &qdrant,
+            None,
+            None,
+            &ctx,
+            AskRequest {
+                question: "Lịch sử kinh phí?".into(),
+                collection_ids: Some([collection_id].into_iter().collect()),
+                mode: VersionMode::History { document_id },
+                limit: 5,
+                conflict_ids: vec![conflict_id],
+            },
+        )
+        .await
+        .expect("ask history before triage");
+        assert!(
+            !history_before
+                .warnings
+                .iter()
+                .any(|w| w.starts_with("Conflict ") && w.contains("status=")),
+            "status={status} unexpected resolution note before triage: {:?}",
+            history_before.warnings
+        );
+
+        let note = format!("Đã thống nhất theo bản mới nhất ({status}).");
+        triage_authorized_conflict(&pool, &ctx, conflict_id, status, Some(&note))
+            .await
+            .expect("triage conflict");
+
+        let current_after = ask(
+            &pool,
+            &qdrant,
+            None,
+            None,
+            &ctx,
+            AskRequest {
+                question: "Kinh phí là bao nhiêu?".into(),
+                collection_ids: Some([collection_id].into_iter().collect()),
+                mode: VersionMode::Current,
+                limit: 5,
+                conflict_ids: vec![conflict_id],
+            },
+        )
+        .await
+        .expect("ask current after triage");
+        assert!(
+            !current_after
+                .warnings
+                .iter()
+                .any(|w| w.contains("Unresolved conflict")),
+            "status={status} triaged conflict must stop warning current-mode: {:?}",
+            current_after.warnings
+        );
+
+        let history_after = ask(
+            &pool,
+            &qdrant,
+            None,
+            None,
+            &ctx,
+            AskRequest {
+                question: "Lịch sử kinh phí?".into(),
+                collection_ids: Some([collection_id].into_iter().collect()),
+                mode: VersionMode::History { document_id },
+                limit: 5,
+                conflict_ids: vec![conflict_id],
+            },
+        )
+        .await
+        .expect("ask history after triage");
+        assert!(
+            history_after.warnings.iter().any(|w| {
+                w.contains(&conflict_id.to_string())
+                    && w.contains(&format!("status={status}"))
+                    && w.contains(&note)
+            }),
+            "status={status} expected resolution note in history mode: {:?}",
+            history_after.warnings
+        );
+    }
+
+    ephemeral.drop().await;
+}
+
+/// P1B-R03 "Remaining for Done" (c): wrong-delta/same-topic contradiction
+/// soak through the production `ask()` path. `force_extractive_only()` is
+/// hardcoded fail-closed while structured entailment is unavailable
+/// (see `services::qa::STRUCTURED_ENTAILMENT_AVAILABLE`), so this asserts the
+/// *practical* guarantee under concurrent/repeated load: no wrong-delta or
+/// same-topic-contradiction LLM answer can ever leak through `ask()` as a
+/// claimed-grounded response, and no citation/answer cross-contaminates
+/// across concurrent callers sharing one pool.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL/APP"]
+async fn live_ask_wrong_delta_and_contradiction_soak_stays_fail_closed() {
+    let Some(admin) = admin_database_url() else {
+        return;
+    };
+    let Some(app) = app_database_url() else {
+        return;
+    };
+    let Some(store) = test_minio_client() else {
+        return;
+    };
+    let (ephemeral, pool) = boot_app_pool(&admin, &app).await;
+    assert_markhand_app_role(&pool).await;
+    let cleanup = MinioCleanupGuard::new(store.clone());
+
+    const SOAK_ITERATIONS: usize = 20;
+    // Two independent tenants, each with a distinct real budget value. Every
+    // provider deliberately fabricates a wrong-delta/contradiction answer
+    // that quotes the *other* tenant's value, so any cross-tenant leak or
+    // wrong-delta pass-through is directly observable in the final text.
+    let markdown_a = "# BA\n\nKinh phí được phê duyệt là 15 triệu đồng.\n";
+    let markdown_b = "# BA\n\nKinh phí được phê duyệt là 76 triệu đồng.\n";
+    let (ctx_a, _document_id_a, _version_id_a, _token_a) =
+        seed_ask_doc(&pool, &store, markdown_a).await;
+    let (ctx_b, _document_id_b, _version_id_b, _token_b) =
+        seed_ask_doc(&pool, &store, markdown_b).await;
+    let collection_a = *ctx_a.allowed_collection_ids().iter().next().unwrap();
+    let collection_b = *ctx_b.allowed_collection_ids().iter().next().unwrap();
+
+    // Tenant A's provider fabricates B's value (wrong-delta); vice versa.
+    let provider_a = ChatProvider::Static(StaticChatProvider::new(
+        "Kinh phí được phê duyệt là 76 triệu đồng, không phải 15 triệu [CITE-0001].",
+        AnswerMode::LocalLlm,
+    ));
+    let provider_b = ChatProvider::Static(StaticChatProvider::new(
+        "Kinh phí được phê duyệt là 15 triệu đồng, không phải 76 triệu [CITE-0001].",
+        AnswerMode::LocalLlm,
+    ));
+
+    let mut handles = Vec::with_capacity(SOAK_ITERATIONS);
+    for iteration in 0..SOAK_ITERATIONS {
+        let pool = pool.clone();
+        let is_a = iteration % 2 == 0;
+        let ctx = if is_a { ctx_a.clone() } else { ctx_b.clone() };
+        let collection_id = if is_a { collection_a } else { collection_b };
+        let provider = if is_a {
+            provider_a.clone()
+        } else {
+            provider_b.clone()
+        };
+        handles.push(tokio::spawn(async move {
+            let qdrant = fileconv_server::storage::QdrantClient::new("http://127.0.0.1:6333")
+                .expect("qdrant");
+            let response = ask(
+                &pool,
+                &qdrant,
+                None,
+                Some(&provider),
+                &ctx,
+                AskRequest {
+                    question: "Kinh phí được phê duyệt là bao nhiêu?".into(),
+                    collection_ids: Some([collection_id].into_iter().collect()),
+                    mode: VersionMode::Current,
+                    limit: 5,
+                    conflict_ids: vec![],
+                },
+            )
+            .await
+            .unwrap_or_else(|error| panic!("ask iteration {iteration} failed: {error}"));
+            (iteration, is_a, ctx.org_id(), response)
+        }));
+    }
+
+    let mut fabricated_leaked = 0usize;
+    for handle in handles {
+        let (iteration, is_a, org_id, response) = handle.await.expect("soak task join");
+        let (own_value, other_value) = if is_a { ("15", "76") } else { ("76", "15") };
+        assert_eq!(
+            response.mode,
+            AnswerMode::OfflineExtractive,
+            "iteration {iteration}: fail-closed must stay extractive-only while entailment is unavailable: {response:?}"
+        );
+        assert!(
+            response.warnings.iter().any(|w| w.contains("fail-closed")),
+            "iteration {iteration}: expected fail-closed warning: {:?}",
+            response.warnings
+        );
+        if response.answer.contains(&format!("{other_value} triệu")) {
+            fabricated_leaked += 1;
+        }
+        assert!(
+            response.answer.contains(own_value) || response.citations.is_empty(),
+            "iteration {iteration}: extractive answer must ground in this tenant's own value: {}",
+            response.answer
+        );
+        // No cross-tenant contamination under concurrent soak against one pool.
+        for citation in &response.citations {
+            assert_eq!(
+                citation.org_id, org_id,
+                "iteration {iteration}: cross-tenant citation leaked under concurrency"
+            );
+        }
+    }
+    assert_eq!(
+        fabricated_leaked, 0,
+        "wrong-delta/contradiction provider text must never leak into an ask() answer"
+    );
+
+    cleanup.cleanup().await.expect("clean soak bucket");
+    ephemeral.drop().await;
+}

--- a/crates/server/tests/audit_read.rs
+++ b/crates/server/tests/audit_read.rs
@@ -1,0 +1,593 @@
+//! Live PostgreSQL HTTP contract tests for `GET /api/v1/audit` (1C-11 read
+//! endpoint). `audit_log` was write-only before this slice; these are the
+//! close-condition tests for the read surface: happy list + stable cursor
+//! pagination, `action`/`actor`/`from`/`to` filters, 403 (+audit) without
+//! `audit.view`, org isolation, and no metadata beyond the existing per-action
+//! allowlist.
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` / `MARKHAND_TEST_APP_DATABASE_URL`
+//! are unset (see `common::boot_app_pool`). Must run in the `rust-integration`
+//! CI job (not run in this session without a live Postgres).
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::{DateTime, Utc};
+use common::{
+    admin_database_url, app_database_url, boot_app_pool, build_router, login_access_token,
+    seed_user_with_permissions, test_auth_config, DualRoleEphemeralDb,
+};
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::db::pool::with_org_txn;
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+/// Parses a `occurredAt` field back into a real timestamp for ordering
+/// assertions. Chrono's default serde format trims trailing-zero fractional
+/// digits (`AutoSi`), so two RFC 3339 strings are NOT always lexicographically
+/// comparable in the same order as their instants — comparisons below always
+/// go through this, never raw string `<=`/`>=`.
+fn occurred_at(item: &Value) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(item["occurredAt"].as_str().expect("occurredAt is a string"))
+        .expect("occurredAt is RFC 3339")
+        .with_timezone(&Utc)
+}
+
+const PASSWORD: &str = "correct-password-1";
+
+async fn boot_pool() -> Option<(DualRoleEphemeralDb, Pool)> {
+    let admin = admin_database_url()?;
+    let app = app_database_url()?;
+    Some(boot_app_pool(&admin, &app).await)
+}
+
+async fn send(
+    app: &axum::Router,
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let request = builder
+        .body(match body {
+            Some(value) => Body::from(value.to_string()),
+            None => Body::empty(),
+        })
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, json)
+}
+
+/// Seeds a member holding both `member.manage` (to generate audit rows via
+/// invite create/revoke) and `audit.view` (to read them back).
+async fn seed_auditor_admin(pool: &Pool, org: Uuid, user: Uuid, email: &str) -> String {
+    seed_user_with_permissions(
+        pool,
+        org,
+        user,
+        email,
+        PASSWORD,
+        &["member.manage", "audit.view"],
+    )
+    .await;
+    login_access_token(pool, email, PASSWORD).await
+}
+
+/// Seeds a member holding `member.manage` but deliberately WITHOUT
+/// `audit.view` — the exact principal the 403+deny-audit test needs.
+///
+/// Must NOT reuse `seed_user_with_permissions` (it always seeds the `owner`
+/// role — see its doc comment). `role_permissions` are per-*role*, not
+/// per-user: if this hand-seeded user shared the org's `owner` role with a
+/// caller already seeded via `seed_auditor_admin`, it would silently inherit
+/// `audit.view` too. So this creates a genuinely separate `admin` role in
+/// the same org, granted only `member.manage`, exactly mirroring
+/// `seed_admin_role_member` in `tests/members.rs` (same underlying
+/// privilege-separation reason).
+async fn seed_manager_without_audit_view(
+    pool: &Pool,
+    org: Uuid,
+    user: Uuid,
+    email: &str,
+) -> String {
+    let ctx = OrgContext::try_new(org, user, ["member.manage"], []).unwrap();
+    let email_owned = email.to_string();
+    with_org_txn(pool, &ctx, {
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO users (id, email, display_name)
+                     VALUES ($1, $2, 'Audit Test Manager') ON CONFLICT (id) DO NOTHING",
+                    &[&user, &email_owned],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO roles (id, org_id, code, name, is_system)
+                     VALUES ($1, $2, 'admin', 'Admin', true)
+                     ON CONFLICT (org_id, code) DO NOTHING",
+                    &[&Uuid::new_v4(), &org],
+                )
+                .await?;
+                let admin_role_id: Uuid = txn
+                    .query_one(
+                        "SELECT id FROM roles WHERE org_id = $1 AND code = 'admin'",
+                        &[&org],
+                    )
+                    .await?
+                    .get(0);
+                let perm_id: Uuid = txn
+                    .query_one(
+                        "SELECT id FROM permissions WHERE code = 'member.manage'",
+                        &[],
+                    )
+                    .await?
+                    .get(0);
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+                    &[&org, &admin_role_id, &perm_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'admin') ON CONFLICT (org_id, user_id) DO NOTHING",
+                    &[&org, &user],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed admin-role member without audit.view");
+    fileconv_server::auth::session::set_password_hash(
+        pool,
+        user,
+        PASSWORD,
+        &test_auth_config().argon2,
+    )
+    .await
+    .expect("set password");
+    login_access_token(pool, email, PASSWORD).await
+}
+
+async fn create_invite(app: &axum::Router, token: &str, email: &str) -> Value {
+    let (status, body) = send(
+        app,
+        "POST",
+        "/api/v1/members/invites",
+        Some(token),
+        Some(json!({ "email": email, "role": "viewer" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "create invite: {body}");
+    body
+}
+
+fn items_of(body: &Value) -> Vec<Value> {
+    body["items"].as_array().cloned().unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------
+// Permission guard + deny audit
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn list_audit_requires_audit_view_and_audits_the_denial() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let owner_token = seed_auditor_admin(&pool, org, owner, "auditor@audit-read-it.test").await;
+
+    let unprivileged = Uuid::new_v4();
+    let unprivileged_token =
+        seed_manager_without_audit_view(&pool, org, unprivileged, "manager@audit-read-it.test")
+            .await;
+
+    let (status, body) = send(
+        &app,
+        "GET",
+        "/api/v1/audit",
+        Some(&unprivileged_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "denied read: {body}");
+    assert_eq!(body["code"], "forbidden");
+
+    // The denial itself must be durably audited (unlike plain
+    // list_members/list_invites/usage, reading the audit trail is sensitive
+    // enough to audit even the failed attempt) — the owner, who does hold
+    // audit.view, must be able to see that row.
+    let (status, body) = send(&app, "GET", "/api/v1/audit", Some(&owner_token), None).await;
+    assert_eq!(status, StatusCode::OK, "owner read: {body}");
+    let items = items_of(&body);
+    let deny_row = items.iter().find(|entry| {
+        entry["action"] == "audit.read"
+            && entry["outcome"] == "deny"
+            && entry["actorId"] == unprivileged.to_string()
+    });
+    assert!(
+        deny_row.is_some(),
+        "expected an audit.read/deny row for the unprivileged caller: {items:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn list_audit_requires_a_bearer_token() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let (status, _) = send(&app, "GET", "/api/v1/audit", None, None).await;
+    assert_ne!(status, StatusCode::OK);
+}
+
+// ---------------------------------------------------------------------
+// Happy path + stable cursor pagination
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn list_audit_paginates_stably_newest_first_with_no_gaps_or_dupes() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let owner_token = seed_auditor_admin(&pool, org, owner, "owner@audit-read-it.test").await;
+
+    for i in 0..5 {
+        create_invite(
+            &app,
+            &owner_token,
+            &format!("invitee-{i}@audit-read-it.test"),
+        )
+        .await;
+    }
+
+    // Walk every page at limit=2, collecting occurredAt in visit order.
+    let mut seen_ids = std::collections::HashSet::new();
+    let mut ordered_ats: Vec<DateTime<Utc>> = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut pages = 0;
+    loop {
+        pages += 1;
+        assert!(pages < 100, "pagination loop did not terminate");
+        let uri = match &cursor {
+            Some(c) => format!("/api/v1/audit?limit=2&cursor={c}"),
+            None => "/api/v1/audit?limit=2".to_string(),
+        };
+        let (status, body) = send(&app, "GET", &uri, Some(&owner_token), None).await;
+        assert_eq!(status, StatusCode::OK, "list page: {body}");
+        let items = items_of(&body);
+        assert!(items.len() <= 2, "page exceeded requested limit: {body}");
+        for item in &items {
+            let id = item["id"].as_str().unwrap().to_string();
+            assert!(
+                seen_ids.insert(id.clone()),
+                "duplicate id across pages: {id}"
+            );
+            ordered_ats.push(occurred_at(item));
+        }
+        let has_more = body["page"]["hasMore"].as_bool().unwrap();
+        if !has_more {
+            // `hasMore` alone is the authoritative "stop paginating" signal
+            // (matches `db::documents::list_in_collection`'s route
+            // convention: `nextCursor` is still populated from the last row
+            // even on a terminal page, it just must not be followed).
+            break;
+        }
+        cursor = Some(body["page"]["nextCursor"].as_str().unwrap().to_string());
+    }
+
+    // Newest-first: occurredAt must be non-increasing across the whole walk.
+    for window in ordered_ats.windows(2) {
+        assert!(
+            window[0] >= window[1],
+            "page ordering is not newest-first: {ordered_ats:?}"
+        );
+    }
+    // At least the 5 member.invite rows must show up somewhere in the walk.
+    assert!(
+        seen_ids.len() >= 5,
+        "expected at least 5 audit rows from the 5 invites, saw {}",
+        seen_ids.len()
+    );
+}
+
+// ---------------------------------------------------------------------
+// Filters: action / actor / from / to
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn list_audit_filters_by_action_and_actor() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let actor_a = Uuid::new_v4();
+    let token_a = seed_auditor_admin(&pool, org, actor_a, "actor-a@audit-read-it.test").await;
+    let actor_b = Uuid::new_v4();
+    let token_b = seed_auditor_admin(&pool, org, actor_b, "actor-b@audit-read-it.test").await;
+
+    create_invite(&app, &token_a, "from-a@audit-read-it.test").await;
+    create_invite(&app, &token_b, "from-b@audit-read-it.test").await;
+
+    // Filter by actor=A: every row must be attributed to A (includes A's own
+    // member.invite and any audit.read rows A's own queries generate), never B.
+    let (status, body) = send(
+        &app,
+        "GET",
+        &format!("/api/v1/audit?actor={actor_a}"),
+        Some(&token_a),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "filter by actor: {body}");
+    let items = items_of(&body);
+    assert!(
+        !items.is_empty(),
+        "expected at least actor A's own invite row"
+    );
+    for item in &items {
+        assert_eq!(
+            item["actorId"],
+            actor_a.to_string(),
+            "leaked non-A actor: {item}"
+        );
+    }
+
+    // Filter by action=member.invite: only that action, from either actor.
+    let (status, body) = send(
+        &app,
+        "GET",
+        "/api/v1/audit?action=member.invite",
+        Some(&token_a),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "filter by action: {body}");
+    let items = items_of(&body);
+    assert!(items.len() >= 2, "expected both invite rows: {items:?}");
+    for item in &items {
+        assert_eq!(item["action"], "member.invite");
+    }
+    let actor_ids: std::collections::HashSet<String> = items
+        .iter()
+        .map(|item| item["actorId"].as_str().unwrap().to_string())
+        .collect();
+    assert!(actor_ids.contains(&actor_a.to_string()));
+    assert!(actor_ids.contains(&actor_b.to_string()));
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn list_audit_filters_by_time_range() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let owner_token = seed_auditor_admin(&pool, org, owner, "owner@audit-read-it.test").await;
+
+    create_invite(&app, &owner_token, "first@audit-read-it.test").await;
+    create_invite(&app, &owner_token, "second@audit-read-it.test").await;
+    create_invite(&app, &owner_token, "third@audit-read-it.test").await;
+
+    let (status, body) = send(
+        &app,
+        "GET",
+        "/api/v1/audit?action=member.invite",
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "unfiltered baseline: {body}");
+    let all = items_of(&body);
+    assert_eq!(
+        all.len(),
+        3,
+        "expected exactly 3 member.invite rows: {all:?}"
+    );
+    // `all` is newest-first; pick the middle row's timestamp as an inclusive
+    // upper bound and expect only itself + the older one to survive.
+    let to_bound_at = occurred_at(&all[1]);
+    let to_bound = all[1]["occurredAt"].as_str().unwrap().to_string();
+
+    let (status, body) = send(
+        &app,
+        "GET",
+        &format!("/api/v1/audit?action=member.invite&to={to_bound}"),
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "to-bounded: {body}");
+    let bounded = items_of(&body);
+    assert_eq!(
+        bounded.len(),
+        2,
+        "expected the newest row excluded by `to`: {bounded:?}"
+    );
+    assert!(bounded.iter().all(|item| occurred_at(item) <= to_bound_at));
+
+    let (status, body) = send(
+        &app,
+        "GET",
+        &format!("/api/v1/audit?action=member.invite&from={to_bound}"),
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "from-bounded: {body}");
+    let bounded_from = items_of(&body);
+    assert_eq!(
+        bounded_from.len(),
+        2,
+        "expected the oldest row excluded by `from`: {bounded_from:?}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn list_audit_rejects_invalid_action_cursor_and_inverted_time_range() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let owner_token = seed_auditor_admin(&pool, org, owner, "owner@audit-read-it.test").await;
+
+    let (status, body) = send(
+        &app,
+        "GET",
+        "/api/v1/audit?action=not_a_real_action",
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "invalid action: {body}");
+    assert_eq!(body["code"], "validation_failed");
+
+    let (status, body) = send(
+        &app,
+        "GET",
+        "/api/v1/audit?cursor=%%%not-base64%%%",
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "invalid cursor: {body}");
+    assert_eq!(body["code"], "validation_failed");
+
+    let (status, body) = send(
+        &app,
+        "GET",
+        "/api/v1/audit?from=2030-01-01T00:00:00Z&to=2020-01-01T00:00:00Z",
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "inverted range: {body}");
+    assert_eq!(body["code"], "validation_failed");
+}
+
+// ---------------------------------------------------------------------
+// Org isolation + no metadata beyond the existing allowlist
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn list_audit_never_leaks_across_orgs() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org_a = Uuid::new_v4();
+    let owner_a = Uuid::new_v4();
+    let token_a = seed_auditor_admin(&pool, org_a, owner_a, "owner-a@audit-read-it.test").await;
+
+    let org_b = Uuid::new_v4();
+    let owner_b = Uuid::new_v4();
+    let token_b = seed_auditor_admin(&pool, org_b, owner_b, "owner-b@audit-read-it.test").await;
+
+    create_invite(&app, &token_a, "secret-org-a@audit-read-it.test").await;
+
+    let (status, body) = send(&app, "GET", "/api/v1/audit", Some(&token_b), None).await;
+    assert_eq!(status, StatusCode::OK, "org b read: {body}");
+    let items = items_of(&body);
+    for item in &items {
+        assert_ne!(
+            item["actorId"],
+            owner_a.to_string(),
+            "org B audit read leaked org A's actor: {item}"
+        );
+    }
+    assert!(
+        !body.to_string().contains("secret-org-a@audit-read-it.test"),
+        "org B response body must never contain org A's invite email: {body}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn list_audit_entries_never_expose_metadata_beyond_the_allowlist() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let owner_token = seed_auditor_admin(&pool, org, owner, "owner@audit-read-it.test").await;
+
+    create_invite(&app, &owner_token, "allowlist-check@audit-read-it.test").await;
+
+    let (status, body) = send(
+        &app,
+        "GET",
+        "/api/v1/audit?action=member.invite",
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let items = items_of(&body);
+    assert!(!items.is_empty());
+    for item in &items {
+        let metadata = item["metadata"]
+            .as_object()
+            .expect("metadata must be an object");
+        // member.invite's allowlist is exactly {reason, invite_id, role} —
+        // see services::audit::AuditAction::metadata_keys. Never the
+        // recipient email, even though the route handler received it.
+        for key in metadata.keys() {
+            assert!(
+                ["reason", "invite_id", "role"].contains(&key.as_str()),
+                "unexpected metadata key {key} on member.invite row: {item}"
+            );
+        }
+        assert!(
+            !item
+                .to_string()
+                .contains("allowlist-check@audit-read-it.test"),
+            "invite email leaked into an audit entry: {item}"
+        );
+    }
+}

--- a/crates/server/tests/members.rs
+++ b/crates/server/tests/members.rs
@@ -818,3 +818,318 @@ async fn non_owner_admin_cannot_reach_the_owner_tier() {
 
     ephemeral.drop().await;
 }
+
+// ---------------------------------------------------------------------
+// Deterministic last-owner denial (complements the concurrent race above,
+// which is inherently racy about 409 vs 403). A single-owner org acting on
+// itself has no interleaving to race against: the caller IS the sole owner,
+// so `guard_owner_tier` always passes (an active owner may always manage an
+// owner) and `guard_last_owner` is the only gate — this must deterministically
+// 409, including when the owner targets their own membership.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn sole_owner_cannot_downgrade_or_remove_themselves() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let owner_token = seed_admin(&pool, org, owner, "sole-owner@members-it.test").await;
+
+    // Self-downgrade: the org's only active owner may not demote themselves.
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{owner}"),
+        Some(&owner_token),
+        Some(json!({ "role": "admin" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "self-downgrade sole owner: {body}"
+    );
+    assert_eq!(body["code"], "last_owner");
+
+    // Self-remove: same invariant, the DELETE path.
+    let (status, body) = send(
+        &app,
+        "DELETE",
+        &format!("/api/v1/members/{owner}"),
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "self-remove sole owner: {body}"
+    );
+    assert_eq!(body["code"], "last_owner");
+
+    // Self-suspend: state transitions share the same guard.
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{owner}"),
+        Some(&owner_token),
+        Some(json!({ "state": "suspended" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "self-suspend sole owner: {body}"
+    );
+    assert_eq!(body["code"], "last_owner");
+
+    // The membership must be untouched by all three rejected attempts.
+    let ctx = OrgContext::try_new(org, owner, [] as [&str; 0], []).unwrap();
+    with_org_txn(&pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let row = txn
+                .query_one(
+                    "SELECT role, state FROM org_memberships WHERE org_id = $1 AND user_id = $2",
+                    &[&org, &owner],
+                )
+                .await?;
+            let role: String = row.get(0);
+            let state: String = row.get(1);
+            assert_eq!(
+                role, "owner",
+                "role must be unchanged after rejected downgrade"
+            );
+            assert_eq!(
+                state, "active",
+                "state must be unchanged after rejected suspend"
+            );
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// Missing `member.manage` permission must deny PATCH/DELETE with 403, not
+// leak whether the target user id exists (permission check runs before the
+// existence pre-check in both route handlers).
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn member_manage_permission_required_for_patch_and_delete() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let plain_user = Uuid::new_v4();
+    // Same org, but zero permissions granted (see `seed_plain_member` doc) —
+    // an authenticated caller with no `member.manage`.
+    let plain_token = seed_plain_member(&pool, org, plain_user, "no-perm@members-it.test").await;
+
+    // Target need not exist: the permission gate must deny before any lookup.
+    let some_target = Uuid::new_v4();
+
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{some_target}"),
+        Some(&plain_token),
+        Some(json!({ "role": "admin" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "patch without member.manage: {body}"
+    );
+    assert_eq!(body["code"], "forbidden");
+
+    let (status, body) = send(
+        &app,
+        "DELETE",
+        &format!("/api/v1/members/{some_target}"),
+        Some(&plain_token),
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "delete without member.manage: {body}"
+    );
+    assert_eq!(body["code"], "forbidden");
+
+    // Both denials must have been audited (route layer calls
+    // `audit::record_deny` before returning, see routes/members.rs).
+    let ctx = OrgContext::try_new(org, plain_user, [] as [&str; 0], []).unwrap();
+    let (role_change_denied, remove_denied) = with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let entries = db_audit::list_recent(txn, &ctx, 50).await?;
+                let role_change_denied = entries.iter().any(|entry| {
+                    entry.action == "member.role_change"
+                        && entry.resource_id == Some(some_target.to_string())
+                        && entry.outcome == fileconv_server::db::models::AuditOutcome::Deny
+                });
+                let remove_denied = entries.iter().any(|entry| {
+                    entry.action == "member.remove"
+                        && entry.resource_id == Some(some_target.to_string())
+                        && entry.outcome == fileconv_server::db::models::AuditOutcome::Deny
+                });
+                Ok((role_change_denied, remove_denied))
+            })
+        }
+    })
+    .await
+    .unwrap();
+    assert!(
+        role_change_denied,
+        "PATCH permission denial must be audited"
+    );
+    assert!(remove_denied, "DELETE permission denial must be audited");
+
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// A user id that never had a membership row in the caller's own org (not a
+// cross-org row hidden by RLS, but a genuinely nonexistent one) must also
+// 404 — same no-oracle contract as the cross-org case.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn nonexistent_member_returns_404_for_patch_and_delete() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let owner_token = seed_admin(&pool, org, owner, "nonexistent-owner@members-it.test").await;
+    let never_seeded = Uuid::new_v4();
+
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{never_seeded}"),
+        Some(&owner_token),
+        Some(json!({ "role": "admin" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "patch nonexistent member: {body}"
+    );
+    assert_eq!(body["code"], "not_found");
+
+    let (status, body) = send(
+        &app,
+        "DELETE",
+        &format!("/api/v1/members/{never_seeded}"),
+        Some(&owner_token),
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "delete nonexistent member: {body}"
+    );
+    assert_eq!(body["code"], "not_found");
+
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// Happy-path role change and remove must each write an audit row carrying
+// old->new (role change) / old role (remove) in metadata, in addition to the
+// session-revocation behavior already covered by the `refresh_rejected_*`
+// tests above.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn role_change_and_remove_write_audit_rows_with_before_after() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    // Two-owner org so downgrading/removing one target never trips the
+    // last-owner invariant.
+    let (org, _caller, target, caller_token) = seed_two_owner_org(&pool, "audit-role-remove").await;
+
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{target}"),
+        Some(&caller_token),
+        Some(json!({ "role": "admin" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "downgrade target: {body}");
+
+    let ctx = OrgContext::try_new(org, target, [] as [&str; 0], []).unwrap();
+    let role_change_entry = with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let entries = db_audit::list_recent(txn, &ctx, 50).await?;
+                Ok(entries.into_iter().find(|entry| {
+                    entry.action == "member.role_change"
+                        && entry.resource_id == Some(target.to_string())
+                }))
+            })
+        }
+    })
+    .await
+    .unwrap();
+    let role_change_entry = role_change_entry.expect("role_change audit row must exist");
+    assert_eq!(role_change_entry.metadata["old_role"], "owner");
+    assert_eq!(role_change_entry.metadata["new_role"], "admin");
+
+    let (status, body) = send(
+        &app,
+        "DELETE",
+        &format!("/api/v1/members/{target}"),
+        Some(&caller_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT, "remove target: {body}");
+
+    let remove_entry = with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let entries = db_audit::list_recent(txn, &ctx, 50).await?;
+                Ok(entries.into_iter().find(|entry| {
+                    entry.action == "member.remove" && entry.resource_id == Some(target.to_string())
+                }))
+            })
+        }
+    })
+    .await
+    .unwrap();
+    let remove_entry = remove_entry.expect("member.remove audit row must exist");
+    // `target` was downgraded to `admin` just above, so the removed row's
+    // last known role is `admin`, not the original `owner`.
+    assert_eq!(remove_entry.metadata["old_role"], "admin");
+
+    ephemeral.drop().await;
+}

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -259,9 +259,31 @@ ghi trong issue đã `Done`.
   (Static/Failing/Timeout) but never claims GLM grounded while structured
   entailment is unavailable. Conflict hydrate exposes status/resolutionNote;
   current warns only `open`; history emits resolution notes for
-  resolved/accepted_exception/false_positive. Remaining for Done: live router SSE
-  consume + delete-between-batches `citation_revoked`; triage-then-current/history
-  matrix on real DB; wrong-delta/same-topic contradiction soak through ask path.
+  resolved/accepted_exception/false_positive. 2026-07-29 re-verify on local
+  PG16+MinIO (no Qdrant): all three "Remaining for Done" items closed —
+  (a) `live_ask_stream_slow_trickle_concurrent_delete_releases_locks` +
+  `live_ask_stream_jwt_exp_membership_and_delete_barriers` already drive the
+  production router SSE live-tail through a delete/ACL-revoke *between* two
+  trickled batches and assert `citation_revoked`/`stream.closed` with no
+  post-commit content sequence — this was already Done, the backlog text was
+  stale; (b) new `live_ask_conflict_triage_then_current_and_history_matrix`
+  (`tests/ask_grounding_matrix.rs`) drives `services::access::triage_authorized_conflict`
+  against a real open conflict across all three terminal statuses
+  (resolved/accepted_exception/false_positive) and asserts current-mode warns
+  only pre-triage while history-mode surfaces the exact resolution note only
+  post-triage; (c) new `live_ask_wrong_delta_and_contradiction_soak_stays_fail_closed`
+  runs 20 concurrent `ask()` calls across two tenants, each fed a
+  StaticChatProvider that fabricates the *other* tenant's value (wrong-delta/
+  same-topic contradiction), and asserts the fail-closed extractive guarantee
+  and citation tenant-scoping hold under concurrency — no fabricated value or
+  cross-tenant citation ever leaks. Note: `force_extractive_only()` is a
+  hardcoded `true` while `STRUCTURED_ENTAILMENT_AVAILABLE` is `false`
+  (`services/qa/mod.rs`), so `validate_answer_citations`'s wrong-delta/
+  contradiction detectors are exercised today only via the existing hermetic
+  unit tests in `services/qa/grounding.rs`, not via the live `ask()` branch
+  (that branch is dead code until a trusted structured-entailment verifier
+  ships) — this is intentional fail-closed design, not a bug, and out of this
+  session's scope (provider/GLM readiness).
 - **Plan:** Policy-separated prompt, untrusted passage framing, GLM, version-aware
   citation validation, current answer + history/change note, token stream,
   current unresolved-conflict warnings + resolved-history note, token stream,
@@ -304,9 +326,24 @@ ghi trong issue đã `Done`.
   ≤1 event under fixed pull deadline → non-blocking permit enqueue; production
   `/auth/logout` router barriers (≤1 in-flight, no buffered batch after commit);
   concurrent delete trickle + `acl_mutate` role/collection barriers assert no new
-  sequenced content after commit. Gaps remaining for Done: delayed-producer
-  reconnect matrix green on CI agent; live purge/load bound evidence; production
-  ask still often extractive when entailment fail-closed.
+  sequenced content after commit. 2026-07-29 re-verify on local PG16+MinIO (no
+  Qdrant reachable in this sandbox): the delayed-producer reconnect matrix
+  (`live_ask_stream_last_event_id_purge_and_delayed_reconnect`) and the live
+  purge/load bound evidence (`live_ask_stream_maintenance_converges_under_bounded_load`)
+  both already exist in `tests/sse_stream_readiness.rs` and pass green —
+  neither actually dials Qdrant: every test in this file configures
+  `embedder: None`, so `hybrid_search`'s vector leg (`search_all_vector_legs`)
+  is never dispatched (`query_vector.as_deref()` short-circuits to
+  `Ok(Ok(Vec::new()))`) and retrieval runs FTS-only; the `QdrantClient` values
+  built in these tests are constructed but never make a network call. So both
+  gaps were already Done — the "green on CI agent" framing was the only
+  outstanding piece, and this run supplies that PG(+MinIO)-only evidence
+  locally. Remaining, unchanged: production ask still routes through the
+  fail-closed extractive path whenever entailment is unavailable (by design,
+  see P1B-R03 status — `STRUCTURED_ENTAILMENT_AVAILABLE = false` is a hardcoded
+  constant, not a bug; unblocking it needs a trusted structured-entailment
+  verifier / GLM readiness decision outside this session's scope, not more
+  test code).
 - **Plan:** Search/ask/stream routes; versioned sequence; Last-Event-ID replay;
   heartbeat/bounded buffering; auth expiry/revoke close.
 - **Files:** `routes/{search,ask,events}.rs`, `api/{sse,last_event_id}.rs`,

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -46,16 +46,54 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-02 — Membership, invites và last-owner invariant
 
-- **Status:** Backlog — chỉ có **schema** (`org_invites` hashed single-use `migrations/0003:93`, `org_memberships` `0001:26`). KHÔNG có service/route invite (create/accept/revoke/expiry), KHÔNG có last-owner invariant (grep rỗng), không có membership state/version, `member.manage` seed nhưng chưa dùng. Session-family revoke có (`auth/session.rs:862`) nhưng thuộc auth 1B.
+- **Status:** In progress (gần Done) — **đã landed đầy đủ trong #317** (đọc code xác
+  minh 2026-07-28, không phải backlog cũ ghi "Backlog"): invite create/accept/revoke/list
+  hashed single-use `routes/members.rs` E1-E5, **`PATCH /api/v1/members/{userId}`** (đổi
+  role/state, `routes/members.rs:450 patch_member`) và **`DELETE /api/v1/members/{userId}`**
+  (`routes/members.rs:551 delete_member`) đều đã có — không chỉ GET như một đợt audit
+  trước từng nêu. Last-owner invariant transactional + row-lock: `check_last_owner_invariant`
+  (pure, `services/members.rs:143`) + `guard_last_owner` (`FOR UPDATE` qua
+  `db::members::lock_owner_rows`, `services/members.rs:159`) chạy cùng transaction với
+  `change_role`/`remove_member`/`suspend_member` (`services/members.rs:476/540`); riêng
+  cả tự-hạ-role/tự-xóa của owner cuối cũng 409 (không có ngoại lệ cho "chính mình").
+  `guard_owner_tier` (`services/members.rs:176`) chặn thêm escalation: chỉ active owner
+  mới được cấp/thao tác owner khác — admin có `member.manage` không tự thăng owner hay
+  quản owner khác (403). Membership **state** (`active|suspended`, KHÔNG có "removed" —
+  remove là hard-delete có chủ đích vì FK `refresh_tokens` không có `ON DELETE`, xem
+  migration `0029_expand_org_membership_state.sql` + doc `services/members.rs:25-35`)
+  đã dùng cho suspend/reactivate; **version** cho ACL cache (1C-05) cố ý CHƯA thêm (chưa
+  có cache để invalidate). Downgrade/suspend/remove đều gọi
+  `auth::session::revoke_all_user_families` (route layer, `routes/members.rs:532/587`)
+  để refresh-token family cũ không sống quá TTL. Audit `member.role_change` (old→new
+  role/state trong metadata) và `member.remove` (old_role) ghi cùng transaction
+  (`services/audit.rs` allowlist `member.role_change`/`member.remove`). OpenAPI
+  (`openapi/openapi.yaml:1180`, `ROUTE_INVENTORY`/`BODY_TAKING_OPERATIONS` trong
+  `api/openapi.rs`) + web codegen + admin UI (`web/src/components/admin/membersApi.ts`,
+  `memberPresentation.ts`) đã có, pin-count schema vẫn 38 (không schema mới). Migration
+  MỚI không cần — `0029` đã đủ.
+  **Bổ sung trong phiên này** (worktree, chưa chạy DB-gated CI): thêm vào
+  `tests/members.rs` 4 test còn thiếu so với danh sách acceptance — last-owner 409
+  *deterministic* (không chỉ qua race) cho tự-downgrade/tự-remove/tự-suspend của owner
+  cuối cùng, 403 khi thiếu `member.manage` (kèm audit-deny), 404 cho user id chưa từng
+  tồn tại trong org (khác case cross-org RLS-hidden), và audit before/after cho
+  role-change + remove trên happy path.
+  **Còn thiếu thật** (không phải của 1C-02, thuộc issue khác): 1C-05 chưa có ACL
+  version/cache nên chưa cần cột `version`; 1C-11 vẫn chưa có endpoint đọc audit log
+  (chỉ ghi, `db::audit::list_recent` chưa có route). MVP token invite vẫn chỉ hiển thị
+  1 lần qua response body — automated email delivery vẫn out of scope như thiết kế.
 
 - **Plan/files:** Hashed single-use invite; membership state; transactional last-owner;
-  membership version; session revoke. MVP chưa có mail dùng invite URL/token hiển thị
-  đúng một lần cho admin copy qua kênh được tổ chức phê duyệt; expiry/revoke/audit
-  bắt buộc.
-- **Depends:** 1C-01. **Acceptance/tests:** Không remove/downgrade last owner; admin
-  không quản owner; concurrent owner removal, invite replay/expiry, escalation tests.
-- **Security/migration:** Row lock, expand/backfill version; plaintext invite không
-  lưu DB/log. **Out:** automated email delivery/SCIM/MFA.
+  membership version (deferred to 1C-05); session revoke. MVP chưa có mail dùng invite
+  URL/token hiển thị đúng một lần cho admin copy qua kênh được tổ chức phê duyệt;
+  expiry/revoke/audit bắt buộc — **tất cả đã landed**.
+- **Depends:** 1C-01. **Acceptance/tests:** Không remove/downgrade last owner (kể cả tự
+  thao tác chính mình); admin không quản owner; concurrent owner removal, invite
+  replay/expiry, escalation tests — **đã có trong `tests/members.rs`, DB-gated
+  `#[ignore]`, cần chạy trong CI `rust-integration` (`MARKHAND_TEST_DATABASE_URL`) để
+  đóng gate, chưa tự chạy trong `cargo test` mặc định**.
+- **Security/migration:** Row lock (`FOR UPDATE` trên owner rows), expand/backfill
+  version (deferred, xem trên); plaintext invite không lưu DB/log (chỉ trả 1 lần trong
+  response). **Out:** automated email delivery/SCIM/MFA.
 
 ## 1C-03 — Canonical RBAC seed
 

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -177,13 +177,55 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-11 — Audit/admin APIs
 
-- **Status:** In progress — `audit_log` append-only (trigger immutability `migrations/0026`) + writer co-commit trong txn mutation (`services/audit.rs:447`) + redaction forbidden-keys + test tốt (DB-gated + unit). **Nhưng nửa admin = 0**: KHÔNG có endpoint audit/member/role/usage nào (openapi grep rỗng), hàm đọc `db/audit.rs:11 list_recent` **chưa được gọi** và không phân trang/filter, không có code quản membership, không có audit action cho member/role/config, không có retention.
+- **Status:** In progress — audit **READ** endpoint landed (phiên này, worktree,
+  chưa chạy DB-gated CI): `GET /api/v1/audit` (`routes/audit.rs`), org-scoped
+  (`org_id = $1` defense-in-depth + RLS `audit_log_org_isolation` migration `0010`
+  là gate thật), guard `audit.view` (đã seed sẵn `migrations/0011`/`0030`, owner/admin
+  có) — 403 khi thiếu, và **tự ghi audit `audit.read`/deny cho chính lần đọc bị từ
+  chối** (đọc audit log đủ nhạy cảm để audit cả deny lẫn success, giống pattern
+  `search.query`/`ask.query`, không giống `list_members`/`list_invites`/`usage`
+  không audit gì). Cursor pagination `(created_at, id)` DESC ổn định — cùng convention
+  `db::documents::list_in_collection` (tái dùng `api::pagination::{encode_cursor,
+  decode_cursor}` sẵn có, không thêm cơ chế mới). Filter: `action` (exact, validate
+  qua `AuditAction::parse` — 400 nếu không thuộc enum đóng), `actor` (uuid),
+  `from`/`to` (RFC3339, validate `from <= to`); limit mặc định 50 / max 100 (route
+  clamp qua `Pagination::from_query`, `db::audit::list_page` clamp 101 để chừa chỗ
+  cho hàng dò-thêm phát hiện `hasMore` đúng tại limit=100). Hàm mới `db::audit::list_page`
+  (giữ nguyên `list_recent` cũ — vẫn được gọi trực tiếp trong `tests/members.rs`).
+  OpenAPI: path `/audit` + schema `AuditEntry`/`AuditPage` mới trong `openapi.yaml`,
+  `ROUTE_INVENTORY`/`BODY_TAKING_OPERATIONS` cập nhật trong `api/openapi.rs`; web
+  codegen (`pnpm --dir web api:generate`) + pin-count schema 38→40 (2 test web) +
+  `pnpm --dir web test` xanh (446/446, xem ghi chú dưới về 1 fail không liên quan).
+  Test DB-gated mới `tests/audit_read.rs` (8 test, chạy xanh cục bộ với Postgres 16
+  local): happy list + cursor pagination không gap/không trùng qua nhiều trang,
+  filter theo action/actor/time-range, 403 thiếu `audit.view` **và** audit deny row
+  đó phải đọc lại được bởi người có quyền, org isolation 2-org (org B không thấy
+  actor/email của org A), và metadata trả về không vượt allowlist hiện có của từng
+  action (vd `member.invite` chỉ `{reason, invite_id, role}`, không bao giờ email).
+  **Sửa 1 chỗ status cũ đã stale**: dòng trên từng ghi "KHÔNG có endpoint audit/
+  member/role/usage nào (openapi grep rỗng)" — sai, `GET /members`, `GET /members/
+  invites`, `GET /usage` (và CRUD member) đã landed từ 1C-02 (`routes/members.rs`,
+  xem mục 1C-02 ở trên); chỉ riêng **đọc audit log** là thật sự thiếu trước phiên này.
+  **Ngoài phạm vi issue-con "đọc audit log" này** (xem `Out` bên dưới): action set
+  KHÔNG đổi ngoài `audit.read` mới — không thêm audit action nào cho ACL/config/
+  quota/cloud event (đó là ghi audit ở nơi khác, không phải endpoint đọc); retention/
+  archival không làm; owner-only admin *mutation* controls (member/role/ACL/config/
+  quota khác) không thuộc "đọc log" nên không đụng.
 
-- **Plan/files:** Member/role/ACL/config/quota/data/cloud events; read-only pagination/
-  filter/retention; owner-only controls.
+- **Plan/files:** Member/role/ACL/config/quota/data/cloud events (**out of scope của
+  đợt này — chỉ audit READ**); read-only pagination/filter (**done**: `routes/audit.rs`,
+  `db/audit.rs::list_page`)/retention (**out**); owner-only controls (**out — không
+  phải đọc log**).
 - **Depends:** 1C-02…10. **Acceptance/tests:** Mọi mutation có actor/org/action/target/
-  result/request ID; coverage/access/pagination/redaction/retention tests.
-- **Security/migration:** No document/prompt/token/PII/URL. **Out:** SIEM archive.
+  result/request ID (pre-existing, không đổi ở đây); coverage (pre-existing, không
+  đổi)/access (**done**: 403 + deny-audit test)/pagination (**done**: cursor stable
+  test)/redaction (**done**: no-leak-beyond-allowlist test)/retention (**out of
+  scope**, chưa làm).
+- **Security/migration:** No document/prompt/token/PII/URL (allowlist per-action giữ
+  nguyên, `audit.read` chỉ thêm `result_count`). Không migration mới — RLS/seed
+  permission đã có sẵn. **Out:** SIEM archive, retention/TTL, audit coverage mở
+  rộng sang action mới cho ACL/config/quota/cloud mutation, owner-only admin
+  controls khác ngoài đọc log.
 
 ## 1C-12 — Multi-org denial suite
 

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -46,7 +46,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-02 — Membership, invites và last-owner invariant
 
-- **Status:** In progress (gần Done) — **đã landed đầy đủ trong #317** (đọc code xác
+- **Status:** In progress — gần Done; **đã landed đầy đủ trong #317** (đọc code xác
   minh 2026-07-28, không phải backlog cũ ghi "Backlog"): invite create/accept/revoke/list
   hashed single-use `routes/members.rs` E1-E5, **`PATCH /api/v1/members/{userId}`** (đổi
   role/state, `routes/members.rs:450 patch_member`) và **`DELETE /api/v1/members/{userId}`**

--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -4,11 +4,11 @@ Parent plan: [`../../../phase-2-web-spa.md`](../../../phase-2-web-spa.md)
 
 <!-- roadmap-default-status: backlog -->
 
-**Trạng thái tổng quan (cập nhật 2026-07-28).** MVP xây trên mock server đã merge vào
+**Trạng thái tổng quan (cập nhật 2026-07-29).** MVP xây trên mock server đã merge vào
 `master`: **13/16 issue Done** (P2-01…09, P2-11, P2-12, P2-13, P2-14, P2-16 phần build
-+ serve). **1 In progress**: P2-15 (E2E — nửa mock-based xong, nửa real-deployment hoãn).
-**P2-10 (Q&A) rời Blocked** — owner hạ gate (dev/test) 2026-07-29, xây trên mock/contract
-không chờ full R02/R03/R05. P2-11/P2-12 rời khỏi Blocked nhờ lát
++ serve). **2 In progress**: P2-10 (Q&A — UI/mock/stream xây xong trên contract hiện có,
+xem chi tiết bên dưới), P2-15 (E2E — nửa mock-based xong, nay có thêm flow ask→citation
+của P2-10; nửa real-deployment hoãn). P2-11/P2-12 rời khỏi Blocked nhờ lát
 membership API (1C-02/1C-11 slice) landed ở #317.
 
 > Ranh giới quan trọng: "Done" ở đây nghĩa là **hành vi client đã build và test trên
@@ -132,16 +132,71 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-10 — Streaming search/Q&A/citations
 
-- **Status:** In progress — **owner hạ gate 2026-07-29** (môi trường dev/test, không chờ full live-evidence R02/R03/R05): UI xây trên OpenAPI/SSE contract hiện có + mock server như P2-01..09; semantics đã có trong contract (`citation_revoked`, Last-Event-ID, fallback extractive) làm theo contract, phần server chưa chốt hẳn (soak/purge/GLM entailment) KHÔNG chặn UI — nếu backend đổi semantics sau này thì cập nhật theo, rủi ro rework được owner chấp nhận. `QaPage` trước đó là placeholder.
+- **Status:** In progress — **owner hạ gate 2026-07-29** (môi trường dev/test, không chờ
+  full live-evidence R02/R03/R05): UI xây trên OpenAPI/SSE contract hiện có + mock server
+  như P2-01..09. `QaPage` không còn là placeholder: `search`/`ask` (đồng bộ) và
+  `POST /ask/stream` (mock mới, `mocks/handlers/qa.ts`) đều hoạt động; stream reducer
+  (`state/askStream.ts`) xử lý đúng thứ tự sự kiện `ask.started → ask.token* →
+  [ask.warning]* → ask.citations → ask.version_context → ask.completed → stream.closed`
+  (mirror `services/qa/ask_stream.rs`), có dedupe-guard độc lập với transport, và các
+  trạng thái `completed`/`revoked` (`citation_revoked` giữa chừng)/`error` (mọi
+  `stream.closed` reason + network/session-lost) đều accessible qua `aria-live="polite"`.
+  Mock kịch bản `citation_revoked` và fallback extractive điều khiển được qua marker cố
+  định trong câu hỏi (`QA_STREAM_MARKERS`, export từ `mocks/handlers/qa.ts` — seam cho
+  test, cùng quy ước `__markhandMock*`). current/as-of/compare/history đều có UI thật
+  (mode selector + document/version picker qua `GET /documents/{id}/versions` — không
+  phải chỉ current), vì cả bốn field đều có sẵn trong `AskRequest`/`SearchRequest`.
+  **Gap đã xác minh trong contract (không tự chế client-side):** `CitationPin`
+  (`openapi.yaml`, `components.schemas.CitationPin`) KHÔNG có `logicalDocumentId`/
+  `versionId` — chỉ `ResolveCitationRequest` (`/citations/resolve`) đòi hỏi hai field đó,
+  và caller phải *đã biết* chúng trước khi gọi, nên không có đường nào từ một citation
+  thô của `ask`/`ask/stream` quay lại "tài liệu/phiên bản nào" để deep-link preview —
+  `CitationCard.tsx`/`AskPanel.tsx` nói rõ điều này trong UI (không hiện nút "Xem trước"
+  chết) thay vì bịa một id. Deep-link + version badge **có** hoạt động đầy đủ cho kết quả
+  `search` (hits mang `documentId`/`versionId` — quy ước riêng của mock vì
+  `SearchResponse.hits` là `additionalProperties: true` trong spec, không phải trường bắt
+  buộc theo hợp đồng). Conflict warning demo: chỉ mô phỏng đúng một luật thật của server
+  (`services/qa/grounding.rs`: chế độ `current` trích một phiên bản không phải hiện hành
+  → warning) — kịch bản "BA 10 triệu vs thiết kế 15 triệu, cảnh báo rồi v2 resolved" đầy
+  đủ cần dữ liệu conflict-claim liên kết version mà thời lượng việc này không cho phép
+  dựng cho đúng cả 3 chế độ; ghi nhận là gap còn lại, không phải đã làm.
+  "Trạng thái reconnect" chỉ hiển thị chung là "đang stream" — transport P2-04
+  (`api/sse.ts`) không phát một `SseMessage` kind riêng cho "đang thử kết nối lại" (chỉ
+  âm thầm retry/backoff nội bộ), nên UI không bịa tín hiệu không có thật; chỉ có trạng
+  thái cuối (`completed`/`revoked`/`error` với lý do) là quan sát được.
 
 - **Plan/files:** Search/ask panel, current/as-of/compare/history selector, index
   readiness, stream reducer, fallback + version-change notes, citation deep-link with
   version badge/effective date, current conflict warning + resolved conflict note,
   abort scope change.
+  - `web/src/mocks/handlers/qa.ts` — `search`/`ask` (đồng bộ, giữ tương thích) + `askStream`
+    mới: toàn bộ response `/ask/stream` là một chuỗi `text/event-stream` dựng sẵn (mọi sự
+    kiện đã quyết định xong trước khi trả response — không có gì thật sự bất đồng bộ như
+    `jobEvents`), trả qua `rawBody` — deterministic, không `setTimeout`/sleep-race.
+    `registerOperation('askStream', ...)` khiến nó được match trước khi rơi vào
+    `DELIBERATELY_UNMOCKED_OPERATIONS` fallback của `registry.ts`/`fetchMock.ts` (2 file đó
+    ngoài phạm vi sửa của task này — comment ở đó vẫn liệt kê `askStream` là "deliberately
+    unmocked", nay không còn đúng cho riêng operation này; để lại làm việc chưa xong, xem
+    report cuối).
+  - `web/src/mocks/fixtures.ts` — thêm thuần túy (không sửa fixture cũ): một tài liệu 2
+    phiên bản (`QA_COMPARE_DOCUMENT_ID`) cho demo compare/history có dữ liệu thật để so
+    sánh.
+  - `web/src/state/askStream.ts` (+ test) — reducer thuần, `describeAskStreamError`.
+  - `web/src/components/qa/**` — `SearchPanel`, `AskPanel`, `CitationCard`,
+    `DocumentPreviewPanel`, `useAskStream`/`askStreamSource` (SSE qua P2-04, không
+    `EventSource`).
+  - `web/src/pages/QaPage.tsx`, `web/src/pages/QaPage.test.tsx`,
+    `web/e2e/qa.spec.ts` (4 spec mới, tổng suite E2E mock 24).
 - **Depends:** P2-04…07 + backend ACL. **Acceptance/tests:** `aria-live`; current source
   citation; multi-document citations; old/new amount example labels v1/v2 and delta;
-  BA 10m vs design 15m warning then v2 resolved; as-of/history/deep-link/sequence/
-  fallback/no-answer/revoke/switch-mid-answer tests.
+  BA 10m vs design 15m warning then v2 resolved (**chưa làm** — xem gap ở trên);
+  as-of/history/deep-link (**search only**, xem gap ở trên)/sequence/fallback/no-answer/
+  revoke tests đã có (`askStream.test.ts` + `QaPage.test.tsx` + `qa.spec.ts`).
+  switch-mid-answer: **chưa có test riêng cho `AskPanel`** — `useAskStream` đi qua
+  `useScopeSafeSse` (P2-06) như mọi live source khác nên được kế thừa cùng bảo đảm
+  (abort-on-scope-change), nhưng bảo đảm đó chỉ được kiểm chứng trực tiếp ở
+  `hooks/useScopeSafeSse.test.tsx` (generic), không phải một kịch bản org-switch cụ thể
+  gắn với `AskPanel`/`QaPage` — ghi nhận là gap còn lại, không tự nhận đã test.
 - **Security:** Sanitized Markdown/server route IDs. **Out:** intelligence/conversation memory.
 
 ## P2-11 — Member/role admin
@@ -183,7 +238,7 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-15 — Contract/integration/E2E suite
 
-- **Status:** In progress — #318 + follow-up. **Nửa mock-based xong**: harness Playwright (mock-mode build, Chromium) + 17 spec chạy trong CI (job `web-e2e`) — auth/library/actions/member-admin/usage/permission-deny/quota, và **upload→indexed đã hết hoãn** (`web/e2e/upload.spec.ts`: chặn XHR bằng `page.route()` rồi replay qua fetch-mock trong page — happy path + 413). **Harness real-deployment đã landed**: `deploy/scripts/web-e2e-real.sh` + Playwright project `real` (`web/e2e-real/`, smoke login + library trên credential seed), chạy trong CI job `dev-stack` tier full (classifier đã có carve-out full-tier cho harness); lần chạy live đầu tiên là chính CI của PR chứa nó. **Còn hoãn**: ask→citation (P2-10 chặn), upload→indexed real-mode, OWASP baseline. Org-switch đã hết hoãn: 1C-01 ship list/switch, UI switcher + E2E `org-switch.spec.ts` chứng minh "no stale org-A render" (mock 20 spec). Unit/component đã có (424 test).
+- **Status:** In progress — #318 + follow-up. **Nửa mock-based xong**: harness Playwright (mock-mode build, Chromium) + 17 spec chạy trong CI (job `web-e2e`) — auth/library/actions/member-admin/usage/permission-deny/quota, và **upload→indexed đã hết hoãn** (`web/e2e/upload.spec.ts`: chặn XHR bằng `page.route()` rồi replay qua fetch-mock trong page — happy path + 413). **Harness real-deployment đã landed**: `deploy/scripts/web-e2e-real.sh` + Playwright project `real` (`web/e2e-real/`, smoke login + library trên credential seed), chạy trong CI job `dev-stack` tier full (classifier đã có carve-out full-tier cho harness); lần chạy live đầu tiên là chính CI của PR chứa nó. **ask→citation đã hết hoãn** (P2-10): `web/e2e/qa.spec.ts` — search→preview, ask→stream→citations, kịch bản `citation_revoked` giữa chừng, kịch bản fallback extractive (mock 24 spec, xem chi tiết ở mục P2-10). **Còn hoãn**: upload→indexed real-mode, OWASP baseline. Org-switch đã hết hoãn: 1C-01 ship list/switch, UI switcher + E2E `org-switch.spec.ts` chứng minh "no stale org-A render" (mock 24 spec). Unit/component đã có (462 test, tăng từ P2-10's reducer/QaPage suite).
 
 - **Plan/files:** Unit API/SSE/cache; component auth/library/Q&A/admin; Playwright full
   flows, org switch, deny/quota; CI artifacts redacted.

--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -7,7 +7,8 @@ Parent plan: [`../../../phase-2-web-spa.md`](../../../phase-2-web-spa.md)
 **Trạng thái tổng quan (cập nhật 2026-07-28).** MVP xây trên mock server đã merge vào
 `master`: **13/16 issue Done** (P2-01…09, P2-11, P2-12, P2-13, P2-14, P2-16 phần build
 + serve). **1 In progress**: P2-15 (E2E — nửa mock-based xong, nửa real-deployment hoãn).
-**1 Blocked**: P2-10 (Q&A) chờ R02/R03/R05. P2-11/P2-12 rời khỏi Blocked nhờ lát
+**P2-10 (Q&A) rời Blocked** — owner hạ gate (dev/test) 2026-07-29, xây trên mock/contract
+không chờ full R02/R03/R05. P2-11/P2-12 rời khỏi Blocked nhờ lát
 membership API (1C-02/1C-11 slice) landed ở #317.
 
 > Ranh giới quan trọng: "Done" ở đây nghĩa là **hành vi client đã build và test trên
@@ -131,7 +132,7 @@ P2-15 + Phase 1C gate → P2-16
 
 ## P2-10 — Streaming search/Q&A/citations
 
-- **Status:** Blocked — chờ backend R02/R03/R05 (semantics `citation_revoked` khi xóa xen giữa 2 batch, reconnect/Last-Event-ID/purge, entailment fail-closed). UI chưa khóa để tránh làm trên hành vi server chưa chốt. `QaPage` hiện là placeholder.
+- **Status:** In progress — **owner hạ gate 2026-07-29** (môi trường dev/test, không chờ full live-evidence R02/R03/R05): UI xây trên OpenAPI/SSE contract hiện có + mock server như P2-01..09; semantics đã có trong contract (`citation_revoked`, Last-Event-ID, fallback extractive) làm theo contract, phần server chưa chốt hẳn (soak/purge/GLM entailment) KHÔNG chặn UI — nếu backend đổi semantics sau này thì cập nhật theo, rủi ro rework được owner chấp nhận. `QaPage` trước đó là placeholder.
 
 - **Plan/files:** Search/ask panel, current/as-of/compare/history selector, index
   readiness, stream reducer, fallback + version-change notes, citation deep-link with

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "8e2b346fbf6726e9";
+    const ROADMAP_SOURCE_HASH = "2ba31d282e56e162";
     const phases = [
       {
         "id": "phase-f",
@@ -1257,7 +1257,7 @@
           [
             "1C-02",
             "Membership, invites và last-owner invariant",
-            "backlog"
+            "in_progress"
           ],
           [
             "1C-03",
@@ -1372,7 +1372,7 @@
           [
             "P2-10",
             "Streaming search/Q&A/citations",
-            "blocked"
+            "in_progress"
           ],
           [
             "P2-11",

--- a/web/e2e/org-switch.spec.ts
+++ b/web/e2e/org-switch.spec.ts
@@ -8,7 +8,7 @@
 // somewhere" flow the old `org-scope.spec.ts` could not drive before 1C-01
 // shipped `GET /orgs` / `POST /orgs/switch`.
 import { expect, test } from '@playwright/test';
-import { forceStatus, login, openEmployeeHandbook } from './support';
+import { forceStatus, IDS, login, openEmployeeHandbook } from './support';
 
 test('switching org replaces org A data with org B data — no stale org A render survives', async ({
   page,
@@ -55,6 +55,18 @@ test('switching org replaces org A data with org B data — no stale org A rende
     'true',
   );
   await expect(dialog.getByRole('button', { name: /Acme Co/ })).toBeEnabled();
+  await page.keyboard.press('Escape');
+
+  // The admin members page (`handlers/members.ts`'s org-scoping gap, now
+  // closed) also moved with the switch: org B's own roster renders — the
+  // demo user's row plus its distinct second member — and neither of org A's
+  // member ids (`secondMember`/`thirdMember`) appears anywhere.
+  await page.getByRole('link', { name: 'Thành viên' }).click();
+  await expect(page.getByRole('heading', { name: 'Thành viên và vai trò' })).toBeVisible();
+  await expect(page.getByRole('row').filter({ hasText: IDS.demoUser })).toBeVisible();
+  await expect(page.getByRole('row').filter({ hasText: IDS.globexMember })).toBeVisible();
+  await expect(page.getByRole('row').filter({ hasText: IDS.secondMember })).toHaveCount(0);
+  await expect(page.getByRole('row').filter({ hasText: IDS.thirdMember })).toHaveCount(0);
 });
 
 test('a denied switch (membership_missing) leaves org A active and shows an accessible error', async ({

--- a/web/e2e/qa.spec.ts
+++ b/web/e2e/qa.spec.ts
@@ -1,0 +1,92 @@
+// P2-10 Q&A flow (P2-15 flow addition). Previously absent from this suite —
+// `web/e2e/support.ts`'s module doc used to note "ask -> citation is
+// deliberately ABSENT... QaPage.tsx is a placeholder" (owner gate,
+// R02/R03/R05 not yet live-evidenced). The owner lowered that gate
+// 2026-07-29 (`plans/markhand-web/backlog/phase-2/issues/README.md`, P2-10):
+// build on the OpenAPI contract + mock server like every other P2-0x flow,
+// don't wait for full backend live-evidence. This is that flow.
+//
+// `POST /ask/stream` reaches the SPA's real fetch-based SSE transport
+// (`api/sse.ts`'s `SseConnection`, never native `EventSource`) the same way
+// any other fetch-mocked operation does here — unlike `upload.spec.ts`'s
+// XHR gap, there is no `page.route()` layer needed: `mocks/handlers/qa.ts`
+// registers `askStream` against the same in-page `fetch` patch every other
+// mocked operation uses, so Playwright's page-context `fetch` override
+// already covers it.
+import { expect, test } from '@playwright/test';
+import { login } from './support';
+
+const ASK_QUESTION = 'Lộ trình quý 3 tập trung vào việc gì?';
+// Mirrors `mocks/handlers/qa.ts`'s `QA_STREAM_MARKERS` — kept as a literal
+// here (rather than importing the mock module into Playwright's Node
+// process) since e2e drives the built app through the browser, not the
+// mock's TS source directly; a drift between the two strings would just
+// make these scenarios stop matching, which is exactly what the assertions
+// below would catch.
+const REVOKE_MARKER = '[[qa-e2e:citation-revoked]]';
+const FALLBACK_MARKER = '[[qa-e2e:provider-fallback]]';
+
+test('search finds an indexed document and opens its sanitized preview', async ({ page }) => {
+  await login(page);
+  await page.getByRole('link', { name: 'Hỏi đáp' }).click();
+
+  await page.getByLabel('Từ khóa').fill('hội nhập');
+  await page.getByRole('button', { name: 'Tìm kiếm' }).click();
+
+  await expect(page.getByText('Onboarding Guide.pdf')).toBeVisible();
+  await page.getByRole('button', { name: 'Xem trước' }).click();
+  await expect(page.getByTestId('qa-preview-markdown')).toContainText(
+    'Mock preview content for version',
+  );
+});
+
+test('ask streams a grounded answer token-by-token, then citations', async ({ page }) => {
+  await login(page);
+  await page.getByRole('link', { name: 'Hỏi đáp' }).click();
+
+  await page.getByRole('textbox', { name: 'Câu hỏi' }).fill(ASK_QUESTION);
+  await page.getByRole('button', { name: 'Hỏi' }).click();
+
+  await expect(page.getByTestId('qa-answer')).toContainText(
+    'Lộ trình quý 3 tập trung vào tối ưu hiệu năng lập chỉ mục.',
+  );
+  await expect(page.getByText('CITE-0001', { exact: true })).toBeVisible();
+  // No preview deep-link here on purpose: `CitationPin` (contract.ts) carries
+  // no document/version id, so `AskPanel` cannot resolve one — it says so
+  // instead of a silently-dead "Xem trước" button (see `CitationCard.tsx`'s
+  // module doc for the verified contract gap this documents).
+  await expect(
+    page.getByText(/Trích dẫn ở đây chưa kèm định danh tài liệu\/phiên bản/),
+  ).toBeVisible();
+});
+
+test('citation_revoked mid-answer surfaces an accessible revoked notice without losing the partial answer', async ({
+  page,
+}) => {
+  await login(page);
+  await page.getByRole('link', { name: 'Hỏi đáp' }).click();
+
+  await page.getByRole('textbox', { name: 'Câu hỏi' }).fill(`${ASK_QUESTION} ${REVOKE_MARKER}`);
+  await page.getByRole('button', { name: 'Hỏi' }).click();
+
+  await expect(page.getByText(/Trích dẫn đã bị thu hồi giữa chừng/)).toBeVisible();
+  await expect(page.getByTestId('qa-answer')).not.toHaveText('');
+  // The revoke closes the stream before `ask.citations` ever arrives.
+  await expect(page.getByText('CITE-0001', { exact: true })).not.toBeVisible();
+});
+
+test('provider fallback still answers (extractive), labelled honestly, with a warning', async ({
+  page,
+}) => {
+  await login(page);
+  await page.getByRole('link', { name: 'Hỏi đáp' }).click();
+
+  await page.getByRole('textbox', { name: 'Câu hỏi' }).fill(`${ASK_QUESTION} ${FALLBACK_MARKER}`);
+  await page.getByRole('button', { name: 'Hỏi' }).click();
+
+  await expect(page.getByText('Trả lời trích xuất (không qua LLM)')).toBeVisible();
+  await expect(page.getByText(/Nhà cung cấp LLM tạm thời không khả dụng/)).toBeVisible();
+  await expect(page.getByTestId('qa-answer')).toContainText(
+    'Lộ trình quý 3 tập trung vào tối ưu hiệu năng lập chỉ mục.',
+  );
+});

--- a/web/e2e/support.ts
+++ b/web/e2e/support.ts
@@ -5,11 +5,13 @@
 //     against the in-browser fetch mock (`VITE_MARKHAND_MOCK=1`). The
 //     real-deployment E2E half (against Postgres/Qdrant/MinIO) is out of
 //     scope here — see playwright.config.ts's own header.
-//   - `ask -> citation` is deliberately ABSENT. The Q&A page (`QaPage.tsx`) is
-//     a placeholder — "Chưa kết nối tới API hỏi đáp." — because P2-10 is
-//     blocked on R02/R03/R05. There is no Q&A UI to drive, so this suite does
-//     NOT contain an ask/citation spec (a skipped-but-named test would falsely
-//     imply the flow exists). Its absence is intentional and noted here.
+//   - `ask -> citation` (`qa.spec.ts`, P2-10): the owner lowered P2-10's gate
+//     2026-07-29 (`plans/markhand-web/backlog/phase-2/issues/README.md`) to
+//     build on the OpenAPI contract + mock server, same as every other P2-0x
+//     flow, rather than waiting for full R02/R03/R05 live-evidence. `QaPage`
+//     is real now (search/ask/stream/citations/revoke/fallback) — see
+//     `qa.spec.ts` for the covered scenarios, and `mocks/handlers/qa.ts`'s
+//     module doc for how `/ask/stream` is mocked deterministically.
 //
 // FIXTURE GROUND TRUTH (src/mocks/fixtures.ts): every assertion below is
 // against these seeded values, not invented ones. ids come from `mockUuid(n)`

--- a/web/e2e/support.ts
+++ b/web/e2e/support.ts
@@ -32,6 +32,8 @@ export const IDS = {
   orgB: '00000000-0000-4000-8000-000000000003',
   /** Org B's own collection — seeded with content distinct from every org A fixture, so a switch has something visibly different to render. */
   orgBCollection: '00000000-0000-4000-8000-00000000000c',
+  /** Org B's own second member (`editor`, active) on its admin members roster — distinct from every org A member id, so a post-switch members page reads as genuinely different data. */
+  globexMember: '00000000-0000-4000-8000-000000000020',
 } as const;
 
 export const DEMO = {

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -3,8 +3,9 @@ import { defineConfig, devices } from '@playwright/test';
 
 // The P2-15 E2E suite drives a real browser against a *mock-mode* dev server
 // (`VITE_MARKHAND_MOCK=1`), so the whole flow is deterministic and needs no
-// live backend. `ask → citation` is absent: the Q&A page is a placeholder
-// until P2-10 ships (blocked on R02/R03/R05).
+// live backend. `ask → citation` (P2-10, `e2e/qa.spec.ts`) is covered here
+// too now — the owner lowered P2-10's gate 2026-07-29 to build on the
+// contract + mock server rather than waiting on R02/R03/R05.
 //
 // The real-deployment half of P2-15 lives in `e2e-real/` and runs as the
 // `real` project below, driven only by `deploy/scripts/web-e2e-real.sh`

--- a/web/src/api/generated/contract.ts
+++ b/web/src/api/generated/contract.ts
@@ -693,6 +693,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/audit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List org audit log entries, newest first (requires audit.view). Read-only; audit_log is append-only and org-isolated by RLS. */
+        get: operations["listAudit"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1038,6 +1055,29 @@ export interface components {
         };
         UsageResponse: {
             items: components["schemas"]["UsageEntry"][];
+        };
+        AuditEntry: {
+            /** Format: uuid */
+            id: string;
+            /** Format: int64 */
+            seq: number;
+            /** Format: uuid */
+            actorId?: string | null;
+            action: string;
+            targetType: string;
+            targetId?: string | null;
+            /** @enum {string} */
+            outcome: "success" | "deny" | "error" | "intent";
+            /** @description Per-action scalar allowlist only (services::audit::sanitize_for_action) — never document content, prompts, tokens, or PII. */
+            metadata: Record<string, never>;
+            /** Format: uuid */
+            requestId?: string | null;
+            /** Format: date-time */
+            occurredAt: string;
+        };
+        AuditPage: {
+            items: components["schemas"]["AuditEntry"][];
+            page: components["schemas"]["PageInfo"];
         };
     };
     responses: {
@@ -2509,6 +2549,50 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UsageResponse"];
+                };
+            };
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    listAudit: {
+        parameters: {
+            query?: {
+                /** @description Page size (server default 50, clamped to [1, 100]). */
+                limit?: number;
+                /** @description Opaque pagination cursor from a previous page's nextCursor. */
+                cursor?: string;
+                /** @description Exact audit action code filter (closed enum, e.g. member.role_change, document.upload). Unknown values are rejected with 400. */
+                action?: string;
+                /** @description Filter to a specific actor user id. */
+                actor?: string;
+                /** @description Inclusive lower bound on occurredAt (RFC 3339). */
+                from?: string;
+                /** @description Inclusive upper bound on occurredAt (RFC 3339). */
+                to?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated audit log entries for the caller's current org. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuditPage"];
+                };
+            };
+            /** @description Invalid action/actor/from/to/cursor. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
                 };
             };
             403: components["responses"]["ApiError"];

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -354,6 +354,146 @@ describe('AuthContext login/logout', () => {
 
     expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
   });
+
+  // Race hardening (PR #323 follow-up): `switchOrg` already guarded its own
+  // out-of-order resolution with `if (epochRef.current !== epoch) return;`
+  // right after its await; `login()` previously had no equivalent guard at
+  // all, so a login that resolved late enough could install stale tokens
+  // over a newer login or logout that had already won. These two tests drive
+  // that same shape of race through `login()` — deliberately resolving the
+  // *stale* attempt's `client.login()` only after the superseding
+  // logout/login has already run, out of order, to prove the stale one is
+  // discarded rather than merely "usually loses the race".
+  describe('login() out-of-order resolution', () => {
+    it('login vs logout: a login that resolves after logout() must not persist tokens or repopulate the shell', async () => {
+      const { client } = createFakeClient();
+      const pendingLogin = deferred<SessionTokens>();
+      (client.login as ReturnType<typeof vi.fn>).mockReturnValue(pendingLogin.promise);
+      (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+      function Harness() {
+        const { session, login, logout } = useAuth();
+        return (
+          <>
+            <span data-testid="status">{session.status}</span>
+            <button onClick={() => void login(DEMO_EMAIL, DEMO_PASSWORD).catch(() => {})}>
+              go
+            </button>
+            <button onClick={() => void logout()}>bye</button>
+          </>
+        );
+      }
+
+      render(
+        <ScopeProvider>
+          <AuthProvider client={client}>
+            <Harness />
+          </AuthProvider>
+        </ScopeProvider>,
+      );
+      await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+
+      await act(async () => {
+        screen.getByText('go').click();
+        await Promise.resolve();
+      });
+      expect(client.login).toHaveBeenCalledTimes(1);
+
+      // logout() fires while the login's own client.login() call is still
+      // pending — it supersedes the login (bumps the epoch) well before the
+      // stale login ever resolves.
+      await act(async () => {
+        screen.getByText('bye').click();
+        await Promise.resolve();
+      });
+      expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
+
+      // The stale login's client.login() now resolves successfully — after
+      // logout already ran. Without the epoch guard right after this await,
+      // this would call savePersistedRefreshToken() and go on to applyMe().
+      await act(async () => {
+        pendingLogin.resolve(sampleTokens());
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(screen.getByTestId('status')).toHaveTextContent('anonymous');
+      expect(client.me).not.toHaveBeenCalled();
+      expect(loadPersistedRefreshToken()).toBeNull();
+    });
+
+    it('login vs login: a rapid second login supersedes the first — the first stale resolution never applies', async () => {
+      const { client } = createFakeClient();
+      const loginCalls: Array<{ resolve: (tokens: SessionTokens) => void }> = [];
+      (client.login as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        const pending = deferred<SessionTokens>();
+        loginCalls.push(pending);
+        return pending.promise;
+      });
+      (client.me as ReturnType<typeof vi.fn>).mockResolvedValue(SAMPLE_ME);
+
+      function Harness() {
+        const { session, login } = useAuth();
+        return (
+          <>
+            <span data-testid="status">{session.status}</span>
+            <button onClick={() => void login('first@markhand.test', 'pw').catch(() => {})}>
+              first
+            </button>
+            <button onClick={() => void login('second@markhand.test', 'pw').catch(() => {})}>
+              second
+            </button>
+          </>
+        );
+      }
+
+      render(
+        <ScopeProvider>
+          <AuthProvider client={client}>
+            <Harness />
+          </AuthProvider>
+        </ScopeProvider>,
+      );
+      await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('anonymous'));
+
+      await act(async () => {
+        screen.getByText('first').click();
+        await Promise.resolve();
+        screen.getByText('second').click();
+        await Promise.resolve();
+      });
+      expect(loginCalls.length).toBe(2);
+
+      // Resolve the FIRST (superseded) login's client.login() only after the
+      // second one already started — out of order, to prove it's discarded
+      // rather than merely "usually resolves last".
+      await act(async () => {
+        loginCalls[0].resolve(
+          sampleTokens({ accessToken: 'access-first', refreshToken: 'refresh-first' }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // Discarded: no me() call and no persisted token from the stale first
+      // login — only the second login's own client.login() can produce those.
+      expect(client.me).not.toHaveBeenCalled();
+      expect(loadPersistedRefreshToken()).not.toBe('refresh-first');
+
+      await act(async () => {
+        loginCalls[1].resolve(
+          sampleTokens({ accessToken: 'access-second', refreshToken: 'refresh-second' }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
+      expect(client.me).toHaveBeenCalledTimes(1);
+      expect(loadPersistedRefreshToken()).toBe('refresh-second');
+    });
+  });
 });
 
 describe('AuthContext session loss', () => {

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -26,7 +26,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { apiClient, type ApiClient } from '../api/client';
+import { apiClient, type ApiClient, type SessionTokens } from '../api/client';
 import { isAbortError } from '../api/errors';
 import type { components } from '../api/generated/contract';
 import { useScope } from '../state/ScopeProvider';
@@ -221,10 +221,43 @@ export function AuthProvider({ children, client = apiClient }: AuthProviderProps
     async (email: string, password: string) => {
       abortRef.current?.abort();
       const epoch = (epochRef.current += 1);
-      const tokens = await client.login({ email, password });
-      savePersistedRefreshToken(tokens.refreshToken);
       const controller = new AbortController();
       abortRef.current = controller;
+      // `client.login()` (api/client.ts) is not side-effect-free like the
+      // bare `client.request()` POST `switchOrg` above uses — on a
+      // successful response it installs the returned tokens into the
+      // session manager itself (`sessionManager.setTokens(tokens)`, asserted
+      // by `api/client.test.ts`'s own "installs the returned tokens..."
+      // case), before this function ever gets to look at the epoch. An
+      // epoch guard placed only *after* `await client.login(...)` — the
+      // `switchOrg` shape — would stop a stale login from being *rendered*,
+      // but would not stop it from clobbering the session manager's tokens
+      // out from under a newer login/logout/switchOrg that already won by
+      // the time this one's HTTP response arrives. Passing `controller.signal`
+      // here (previously only `me()` got a signal) is what actually closes
+      // that: a login superseded by a newer call has this same controller
+      // aborted at the top of that newer call, so `rawFetch` rethrows the
+      // abort before `client.login()` ever reaches its `setTokens(...)`
+      // line — the stale install never happens, rather than merely going
+      // unrendered. (The one gap this can't close: if the response has
+      // already been fully received by the time `abort()` runs, the browser
+      // Fetch API's abort is a no-op on an already-settled request — the
+      // same inherent limit every abort-based cancellation here has. The
+      // epoch check right below still stops that outcome from being
+      // *rendered*, which is the tightest guarantee available without
+      // changing `client.login()`'s own documented contract.)
+      let tokens: SessionTokens;
+      try {
+        tokens = await client.login({ email, password }, controller.signal);
+      } catch (cause) {
+        // A non-abort failure (wrong password, network, ...) touches
+        // nothing here yet — same as before this change — so it just
+        // propagates for the caller (e.g. `LoginPage.tsx`) to show.
+        if (epochRef.current !== epoch || isAbortError(cause)) return;
+        throw cause;
+      }
+      if (epochRef.current !== epoch) return;
+      savePersistedRefreshToken(tokens.refreshToken);
       try {
         const me = await client.me(controller.signal);
         if (epochRef.current !== epoch) return;

--- a/web/src/components/qa/AskPanel.tsx
+++ b/web/src/components/qa/AskPanel.tsx
@@ -1,0 +1,290 @@
+// Ask panel: question + current/as-of/compare/history mode selector (every
+// field here — `mode`/`asOf`/`documentId`/`versionA`/`versionB` — is a real
+// `AskRequest` field, `api/generated/contract.ts`; nothing invented
+// client-side) streamed through `POST /ask/stream` via `useAskStream`
+// (P2-04 transport, never native `EventSource`).
+//
+// Document/version pickers for compare/history reuse whatever documents a
+// search already turned up (`candidateDocuments`, from `SearchPanel`) plus
+// the real `GET /documents/{documentId}/versions` endpoint — no invented
+// picker data.
+//
+// Citation deep-link gap (see `CitationCard.tsx`'s own doc for the full
+// reasoning): the `CitationPin` the contract returns from `ask`/`ask/stream`
+// carries no document/version id, so citations here render content only —
+// the muted note below the list says so instead of a silently-dead link.
+import { useId, useState, type FormEvent } from 'react';
+import { apiClient, type ApiClient } from '../../api/client';
+import type { components } from '../../api/generated/contract';
+import { useScopeSafeRequest } from '../../hooks/useScopeSafeRequest';
+import { Notice, SelectControl, type SelectOption } from '../ui';
+import { describeAskStreamError } from '../../state/askStream';
+import { CitationCard } from './CitationCard';
+import { useAskStream } from './useAskStream';
+import type { SearchHit } from './SearchPanel';
+
+type AskRequest = components['schemas']['AskRequest'];
+type AskMode = NonNullable<AskRequest['mode']>;
+type DocumentVersion = components['schemas']['DocumentVersion'];
+
+const MODE_OPTIONS: SelectOption[] = [
+  { value: 'current', label: 'Hiện hành' },
+  { value: 'as_of', label: 'Tại một thời điểm (as-of)' },
+  { value: 'compare', label: 'So sánh 2 phiên bản' },
+  { value: 'history', label: 'Lịch sử phiên bản' },
+];
+
+function versionLabel(version: DocumentVersion): string {
+  return `Phiên bản ${version.versionNumber}${version.isCurrent ? ' (hiện hành)' : ''}`;
+}
+
+export function AskPanel({
+  collectionIds,
+  client = apiClient,
+  candidateDocuments,
+}: {
+  collectionIds?: string[];
+  client?: ApiClient;
+  /** Documents a search already found — feeds the compare/history document picker below instead of asking for a raw UUID. */
+  candidateDocuments: SearchHit[];
+}) {
+  const questionId = useId();
+  const asOfId = useId();
+  const [question, setQuestion] = useState('');
+  const [mode, setMode] = useState<AskMode>('current');
+  const [asOf, setAsOf] = useState('');
+  const [documentId, setDocumentId] = useState('');
+  const [versionA, setVersionA] = useState('');
+  const [versionB, setVersionB] = useState('');
+
+  const needsDocument = mode === 'compare' || mode === 'history';
+  const versionsResult = useScopeSafeRequest(
+    async (signal) => {
+      if (!documentId || !needsDocument) return null;
+      return client.request('get', '/documents/{documentId}/versions', {
+        params: { path: { documentId } },
+        signal,
+      });
+    },
+    [client, documentId, needsDocument],
+  );
+  const versions: DocumentVersion[] = versionsResult.data?.items ?? [];
+
+  const documentOptions: SelectOption[] = [
+    { value: '', label: 'Chọn tài liệu…' },
+    ...[
+      ...new Map(
+        candidateDocuments.filter((h) => h.documentId).map((h) => [h.documentId!, h]),
+      ).values(),
+    ].map((h) => ({ value: h.documentId!, label: h.title ?? h.documentId! })),
+  ];
+  const versionOptions: SelectOption[] = versions.map((v) => ({
+    value: v.id,
+    label: versionLabel(v),
+  }));
+
+  const { state, ask, reset, isActive } = useAskStream(client.tokenProvider);
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    if (question.trim() === '') return;
+    const request: AskRequest = { question, collectionIds, mode, limit: 10 };
+    if (mode === 'as_of' && asOf) request.asOf = new Date(asOf).toISOString();
+    if (needsDocument && documentId) request.documentId = documentId;
+    if (mode === 'compare') {
+      if (versionA) request.versionA = versionA;
+      if (versionB) request.versionB = versionB;
+    }
+    ask(request);
+  }
+
+  const showFallbackBadge = state.answerMode === 'fallback_extractive';
+  const isDone =
+    state.status === 'completed' || state.status === 'revoked' || state.status === 'error';
+
+  return (
+    <div className="card" aria-labelledby="qa-ask-heading">
+      <p className="eyebrow">Hỏi đáp</p>
+      <h2 id="qa-ask-heading">Đặt câu hỏi có trích dẫn</h2>
+
+      <form onSubmit={submit} style={{ display: 'grid', gap: 'var(--space-3)' }}>
+        <div className="field">
+          <label htmlFor={questionId}>Câu hỏi</label>
+          <input
+            id={questionId}
+            className="input"
+            type="text"
+            value={question}
+            onChange={(event) => setQuestion(event.target.value)}
+            placeholder="Ví dụ: Chính sách nghỉ phép hiện tại là gì?"
+          />
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            gap: 'var(--space-3)',
+            flexWrap: 'wrap',
+            alignItems: 'flex-end',
+          }}
+        >
+          <div>
+            <span id="qa-mode-label" className="field-label">
+              Chế độ truy vấn
+            </span>
+            <SelectControl
+              value={mode}
+              options={MODE_OPTIONS}
+              onChange={(value) => setMode(value as AskMode)}
+              ariaLabel="Chế độ truy vấn"
+            />
+          </div>
+
+          {mode === 'as_of' && (
+            <div className="field">
+              <label htmlFor={asOfId}>Thời điểm (as-of)</label>
+              <input
+                id={asOfId}
+                className="input"
+                type="datetime-local"
+                value={asOf}
+                onChange={(event) => setAsOf(event.target.value)}
+              />
+            </div>
+          )}
+
+          {needsDocument && (
+            <div>
+              <span className="field-label">Tài liệu</span>
+              <SelectControl
+                value={documentId}
+                options={
+                  documentOptions.length > 1
+                    ? documentOptions
+                    : [{ value: '', label: 'Tìm kiếm trước để chọn tài liệu' }]
+                }
+                onChange={setDocumentId}
+                ariaLabel="Tài liệu để so sánh hoặc xem lịch sử"
+              />
+            </div>
+          )}
+
+          {mode === 'compare' && documentId && (
+            <>
+              <div>
+                <span className="field-label">Phiên bản A (cũ)</span>
+                <SelectControl
+                  value={versionA}
+                  options={[{ value: '', label: 'Chọn…' }, ...versionOptions]}
+                  onChange={setVersionA}
+                  ariaLabel="Phiên bản A"
+                />
+              </div>
+              <div>
+                <span className="field-label">Phiên bản B (mới)</span>
+                <SelectControl
+                  value={versionB}
+                  options={[{ value: '', label: 'Chọn…' }, ...versionOptions]}
+                  onChange={setVersionB}
+                  ariaLabel="Phiên bản B"
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+          <button type="submit" className="btn btn-primary" disabled={question.trim() === ''}>
+            Hỏi
+          </button>
+          {isActive && !isDone && (
+            <button type="button" className="btn btn-secondary" onClick={reset}>
+              Hủy
+            </button>
+          )}
+        </div>
+      </form>
+
+      {isActive && (
+        <div style={{ marginTop: 'var(--space-4)' }}>
+          {/* P2-14: accessible streaming status. `aria-live="polite"` on the
+              growing answer text itself (not just a separate status line) is
+              what the backlog acceptance asks for; screen readers coalesce
+              rapid mutations to a polite region rather than announcing every
+              token, which is the deliberate trade-off here over
+              `aria-live="off"` (silent until the end) or `"assertive"`
+              (would interrupt on every token). */}
+          <div aria-live="polite" role="status">
+            {state.status === 'streaming' && !state.answer && (
+              <p className="text-muted">Đang tạo câu trả lời…</p>
+            )}
+            {state.answer && (
+              <p data-testid="qa-answer" style={{ whiteSpace: 'pre-wrap' }}>
+                {state.answer}
+              </p>
+            )}
+            {state.status === 'completed' && showFallbackBadge && (
+              <p>
+                <span className="tag tag-neutral">Trả lời trích xuất (không qua LLM)</span>
+              </p>
+            )}
+            {state.status === 'revoked' && (
+              <Notice tone="warning">
+                Trích dẫn đã bị thu hồi giữa chừng — câu trả lời phía trên có thể không đầy đủ.{' '}
+                {describeAskStreamError(state.errorReason)}
+              </Notice>
+            )}
+            {state.status === 'error' && (
+              <Notice tone="error">{describeAskStreamError(state.errorReason)}</Notice>
+            )}
+          </div>
+
+          {state.notices.map((notice, i) => (
+            <p key={i} className="text-muted" role="status">
+              {notice}
+            </p>
+          ))}
+
+          {state.warnings.length > 0 && (
+            <div style={{ marginTop: 'var(--space-2)' }}>
+              {state.warnings.map((warning, i) => (
+                <Notice key={i} tone="warning">
+                  {warning}
+                </Notice>
+              ))}
+            </div>
+          )}
+
+          {state.versionContext?.changeNote && (
+            <p className="text-muted" style={{ marginTop: 'var(--space-2)' }}>
+              {state.versionContext.changeNote}
+            </p>
+          )}
+
+          {state.citations.length > 0 && (
+            <div style={{ marginTop: 'var(--space-3)' }}>
+              <p className="eyebrow">Trích dẫn</p>
+              <ul
+                style={{
+                  listStyle: 'none',
+                  margin: 0,
+                  padding: 0,
+                  display: 'grid',
+                  gap: 'var(--space-2)',
+                }}
+              >
+                {state.citations.map((citation) => (
+                  <CitationCard key={citation.citeId} citation={citation} />
+                ))}
+              </ul>
+              <p className="text-muted" style={{ marginTop: 'var(--space-2)' }}>
+                Trích dẫn ở đây chưa kèm định danh tài liệu/phiên bản theo hợp đồng hiện tại — dùng
+                ô Tìm kiếm phía trên để mở bản xem trước theo tài liệu.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/qa/CitationCard.tsx
+++ b/web/src/components/qa/CitationCard.tsx
@@ -1,0 +1,44 @@
+// Renders one `CitationPin` (contract.ts) exactly as the wire shape carries
+// it. Deliberately does NOT attempt a "go to this document" link: the
+// `CitationPin` schema (`crates/server/openapi/openapi.yaml`) has no
+// `logicalDocumentId`/`versionId` field — only `resolveCitation`'s *request*
+// shape (`ResolveCitationRequest`) requires those, which the caller would
+// already need to know before calling it, so there is no contract-given path
+// from a bare ask/search citation back to "which document/version". This is
+// a verified gap (see the P2-10 report), not a client oversight — search
+// *hits* carry a `documentId` (that shape is mock-convention/generic per the
+// spec, not the citation itself) and get a working deep-link via
+// `DocumentPreviewPanel`; ask's `citations` do not.
+import type { components } from '../../api/generated/contract';
+
+export type CitationPin = components['schemas']['CitationPin'];
+
+function locationLabel(citation: CitationPin): string | null {
+  if (citation.page !== undefined) return `Trang ${citation.page}`;
+  if (citation.slide !== undefined) return `Slide ${citation.slide}`;
+  if (citation.sheet !== undefined) return `Sheet ${citation.sheet}`;
+  return null;
+}
+
+export function CitationCard({ citation }: { citation: CitationPin }) {
+  const location = locationLabel(citation);
+  return (
+    <li className="card" style={{ padding: 'var(--space-3)' }}>
+      <div
+        style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center', flexWrap: 'wrap' }}
+      >
+        <span className="tag tag-outline">{citation.citeId}</span>
+        {citation.isCurrent === false && (
+          <span className="tag tag-neutral" title="Trích dẫn từ phiên bản không phải bản mới nhất">
+            Không phải bản hiện hành
+          </span>
+        )}
+        {citation.isCurrent === true && <span className="tag tag-accent-2">Bản hiện hành</span>}
+        {location && <span className="text-muted">{location}</span>}
+      </div>
+      <blockquote style={{ margin: 'var(--space-2) 0 0', fontStyle: 'italic' }}>
+        “{citation.quote}”
+      </blockquote>
+    </li>
+  );
+}

--- a/web/src/components/qa/DocumentPreviewPanel.tsx
+++ b/web/src/components/qa/DocumentPreviewPanel.tsx
@@ -1,0 +1,50 @@
+// Search-hit deep-link target: `GET /documents/{documentId}/preview`, the
+// same endpoint/`SafeMarkdown` pattern P2-07's `DocumentPreview` uses — kept
+// as its own small component here (rather than reusing that one directly)
+// because this panel is keyed off a *search hit* (`documentId`/`versionId`
+// the mock's `hits` shape carries — see `mocks/handlers/qa.ts`), not a
+// `LibraryDocument` row, and has no per-document actions slot to render.
+import { apiClient, type ApiClient } from '../../api/client';
+import { SafeMarkdown } from '../SafeMarkdown';
+import { Notice } from '../ui';
+import { useScopeSafeRequest } from '../../hooks/useScopeSafeRequest';
+
+export function DocumentPreviewPanel({
+  documentId,
+  versionId,
+  client = apiClient,
+}: {
+  documentId: string;
+  /** The specific version this citation/hit came from — passed as the `versionId` query param so a non-current hit previews *that* version, not silently the current one. */
+  versionId?: string;
+  client?: ApiClient;
+}) {
+  const result = useScopeSafeRequest(
+    (signal) =>
+      client.request('get', '/documents/{documentId}/preview', {
+        params: { path: { documentId }, query: versionId ? { versionId } : undefined },
+        signal,
+      }),
+    [client, documentId, versionId],
+  );
+
+  return (
+    <aside className="card" aria-labelledby="qa-preview-heading" data-testid="qa-preview-panel">
+      <p className="eyebrow">Xem trước tài liệu</p>
+      <h3 id="qa-preview-heading">Bản xem trước</h3>
+      {result.status === 'loading' && <p className="text-muted">Đang tải nội dung xem trước…</p>}
+      {result.status === 'error' && <Notice tone="error">Không tải được bản xem trước.</Notice>}
+      {result.status === 'success' && result.data && (
+        <>
+          <p className="text-muted">
+            Phiên bản {result.data.versionNumber}
+            {result.data.isCurrent === false ? ' (không phải bản hiện hành)' : ' (bản hiện hành)'}
+          </p>
+          <div className="card-body" data-testid="qa-preview-markdown">
+            <SafeMarkdown>{result.data.markdown}</SafeMarkdown>
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/web/src/components/qa/SearchPanel.tsx
+++ b/web/src/components/qa/SearchPanel.tsx
@@ -1,0 +1,201 @@
+// Search box + result list + citations + a per-hit preview deep-link.
+// `SearchResponse.hits` is `{ additionalProperties: true }[]` in the contract
+// (openapi.yaml) — no fixed wire shape — so this file's `toSearchHit` is a
+// mock-side *convention* (`mocks/handlers/qa.ts` is the one place that shape
+// is actually decided), read defensively here rather than trusted blindly:
+// a field this mock happens to add (`documentId`/`versionId`/`collectionId`)
+// is what makes the preview deep-link possible at all, but a real server's
+// `hits` could omit it, so every consumer below tolerates it being absent.
+import { useId, useState, type FormEvent } from 'react';
+import { apiClient, type ApiClient } from '../../api/client';
+import type { components } from '../../api/generated/contract';
+import { useScopeSafeRequest } from '../../hooks/useScopeSafeRequest';
+import { Notice } from '../ui';
+import { CitationCard, type CitationPin } from './CitationCard';
+import { DocumentPreviewPanel } from './DocumentPreviewPanel';
+
+type SearchResponse = components['schemas']['SearchResponse'];
+
+export interface SearchHit {
+  citeId?: string;
+  documentId?: string;
+  collectionId?: string;
+  versionId?: string;
+  title?: string;
+  score?: number;
+  snippet?: string;
+}
+
+function toSearchHit(raw: Record<string, unknown>): SearchHit {
+  return {
+    citeId: typeof raw.citeId === 'string' ? raw.citeId : undefined,
+    documentId: typeof raw.documentId === 'string' ? raw.documentId : undefined,
+    collectionId: typeof raw.collectionId === 'string' ? raw.collectionId : undefined,
+    versionId: typeof raw.versionId === 'string' ? raw.versionId : undefined,
+    title: typeof raw.title === 'string' ? raw.title : undefined,
+    score: typeof raw.score === 'number' ? raw.score : undefined,
+    snippet: typeof raw.snippet === 'string' ? raw.snippet : undefined,
+  };
+}
+
+export function SearchPanel({
+  collectionIds,
+  client = apiClient,
+  onHitsChanged,
+}: {
+  collectionIds?: string[];
+  client?: ApiClient;
+  /** Lets `AskPanel`'s compare/history document picker reuse whichever documents a search already turned up, instead of asking the user to type a UUID. */
+  onHitsChanged?: (hits: SearchHit[]) => void;
+}) {
+  const inputId = useId();
+  const [query, setQuery] = useState('');
+  const [submitted, setSubmitted] = useState<string | undefined>(undefined);
+  const [selected, setSelected] = useState<SearchHit | undefined>(undefined);
+
+  const result = useScopeSafeRequest<SearchResponse | null>(
+    async (signal) => {
+      if (submitted === undefined) return null;
+      return client.request('post', '/search', {
+        body: { query: submitted, collectionIds, limit: 10 },
+        signal,
+      });
+    },
+    [client, submitted, collectionIds?.join(',')],
+  );
+
+  const hits = (result.data?.hits ?? []).map((h) => toSearchHit(h as Record<string, unknown>));
+  const citations = (result.data?.citations ?? []) as CitationPin[];
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    setSelected(undefined);
+    setSubmitted(query);
+  }
+
+  // Adjust-state-while-rendering (same idiom as `LibraryPage.tsx`'s retained
+  // list): report the newly-arrived hits to the parent once, the render this
+  // response first becomes visible, rather than from an extra effect.
+  const [reportedFor, setReportedFor] = useState<unknown>(undefined);
+  if (result.data && reportedFor !== result.data) {
+    setReportedFor(result.data);
+    onHitsChanged?.(hits);
+  }
+
+  return (
+    <div className="card" aria-labelledby="qa-search-heading">
+      <p className="eyebrow">Tìm kiếm</p>
+      <h2 id="qa-search-heading">Tìm trong tài liệu đã lập chỉ mục</h2>
+      <form
+        onSubmit={submit}
+        style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'flex-end', flexWrap: 'wrap' }}
+      >
+        <div className="field" style={{ flex: '1 1 260px' }}>
+          <label htmlFor={inputId}>Từ khóa</label>
+          <input
+            id={inputId}
+            className="input"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Ví dụ: nghỉ phép, ngân sách, lộ trình…"
+          />
+        </div>
+        <button type="submit" className="btn btn-primary" disabled={query.trim() === ''}>
+          Tìm kiếm
+        </button>
+      </form>
+
+      <div aria-live="polite">
+        {result.status === 'loading' && submitted !== undefined && (
+          <p className="text-muted">Đang tìm kiếm…</p>
+        )}
+        {result.status === 'error' && <Notice tone="error">Không thể thực hiện tìm kiếm.</Notice>}
+        {result.status === 'success' && submitted !== undefined && hits.length === 0 && (
+          <Notice tone="info">Không tìm thấy kết quả phù hợp với "{submitted}".</Notice>
+        )}
+      </div>
+
+      {hits.length > 0 && (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'minmax(0, 1.3fr) minmax(0, 1fr)',
+            gap: 'var(--space-4)',
+            alignItems: 'start',
+            marginTop: 'var(--space-3)',
+          }}
+        >
+          <ul
+            style={{
+              listStyle: 'none',
+              margin: 0,
+              padding: 0,
+              display: 'grid',
+              gap: 'var(--space-2)',
+            }}
+          >
+            {hits.map((hit, i) => (
+              <li key={hit.documentId ?? i} className="card" style={{ padding: 'var(--space-3)' }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    gap: 'var(--space-2)',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  <strong>{hit.title ?? 'Tài liệu'}</strong>
+                  {hit.score !== undefined && (
+                    <span className="text-muted">Điểm khớp {hit.score.toFixed(2)}</span>
+                  )}
+                </div>
+                {hit.snippet && <p style={{ margin: 'var(--space-1) 0' }}>{hit.snippet}</p>}
+                {hit.documentId && (
+                  <button
+                    type="button"
+                    className="btn btn-secondary btn-sm"
+                    onClick={() => setSelected(hit)}
+                  >
+                    Xem trước
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          {selected?.documentId ? (
+            <DocumentPreviewPanel
+              documentId={selected.documentId}
+              versionId={selected.versionId}
+              client={client}
+            />
+          ) : (
+            <aside className="card">
+              <p className="text-muted">Chọn "Xem trước" ở một kết quả để xem nội dung tài liệu.</p>
+            </aside>
+          )}
+        </div>
+      )}
+
+      {citations.length > 0 && (
+        <div style={{ marginTop: 'var(--space-3)' }}>
+          <p className="eyebrow">Trích dẫn</p>
+          <ul
+            style={{
+              listStyle: 'none',
+              margin: 0,
+              padding: 0,
+              display: 'grid',
+              gap: 'var(--space-2)',
+            }}
+          >
+            {citations.map((citation) => (
+              <CitationCard key={citation.citeId} citation={citation} />
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/qa/askStreamSource.ts
+++ b/web/src/components/qa/askStreamSource.ts
@@ -1,0 +1,59 @@
+// Thin seam between `AskPanel` and `api/sse.ts`'s `SseConnection`, building
+// the `POST /ask/stream` request — same shape as
+// `components/upload/jobEventsSource.ts`'s `createJobEventsSource` for
+// `GET /jobs/{jobId}/events`, minus that file's "mocks never mock SSE" caveat:
+// `mocks/handlers/qa.ts` registers `askStream` as a real fetch-mocked
+// operation (see that file's module doc for why that's safe here even though
+// `jobEvents` still isn't), so this reaches the mock the same way it reaches
+// a real deployment — no test-only substitution needed for the happy path.
+import type { components } from '../../api/generated/contract';
+import type { TokenProvider } from '../../api/client';
+import { SseConnection, type SseMessage } from '../../api/sse';
+import type { ScopeSafeSseSource } from '../../hooks/useScopeSafeSse';
+
+type AskRequest = components['schemas']['AskRequest'];
+
+const API_PREFIX = '/api/v1';
+
+function apiBaseUrl(): string {
+  const configured = import.meta.env.VITE_MARKHAND_API_BASE_URL as string | undefined;
+  return configured?.replace(/\/$/, '') ?? '';
+}
+
+export function buildAskStreamUrl(): string {
+  return `${apiBaseUrl()}${API_PREFIX}/ask/stream`;
+}
+
+/**
+ * A resumable, bearer-authenticated `/ask/stream` connection, ready to hand
+ * to `useScopeSafeSse`. `request` is sent as the POST body on the first
+ * connect; per `SseRequestFactory`'s own doc (`api/sse.ts`), the *same*
+ * descriptor is asked for again on every reconnect, so once the first
+ * `ask.started` event reports a `streamSessionId` (via `onStreamSessionId`,
+ * called by the caller's message handler), later (re)connects can resume
+ * against the pinned retrieval snapshot instead of asking the server to
+ * re-run retrieval/provider — `getStreamSessionId` closes over whatever the
+ * caller has learned by the time each connect attempt happens.
+ */
+export function createAskStreamSource(
+  request: AskRequest,
+  tokenProvider: TokenProvider,
+  getStreamSessionId: () => string | undefined,
+): ScopeSafeSseSource<SseMessage> {
+  const body = JSON.stringify(request);
+  return new SseConnection(
+    () => {
+      const streamSessionId = getStreamSessionId();
+      const url = streamSessionId
+        ? `${buildAskStreamUrl()}?streamSessionId=${encodeURIComponent(streamSessionId)}`
+        : buildAskStreamUrl();
+      return {
+        url,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      };
+    },
+    { tokenProvider },
+  );
+}

--- a/web/src/components/qa/index.ts
+++ b/web/src/components/qa/index.ts
@@ -1,0 +1,6 @@
+export { SearchPanel, type SearchHit } from './SearchPanel';
+export { AskPanel } from './AskPanel';
+export { CitationCard, type CitationPin } from './CitationCard';
+export { DocumentPreviewPanel } from './DocumentPreviewPanel';
+export { useAskStream, type UseAskStreamResult } from './useAskStream';
+export { createAskStreamSource, buildAskStreamUrl } from './askStreamSource';

--- a/web/src/components/qa/useAskStream.ts
+++ b/web/src/components/qa/useAskStream.ts
@@ -1,0 +1,60 @@
+// P2-10. Wires `askStreamSource.ts` + the pure reducer (`state/askStream.ts`)
+// through `useScopeSafeSse` (P2-06) so an org switch / logout mid-answer
+// aborts the stream and discards any late message — same scope-safety every
+// other live data source in this app gets, never a bespoke `useEffect`.
+import { useCallback, useRef, useState } from 'react';
+import type { components } from '../../api/generated/contract';
+import type { TokenProvider } from '../../api/client';
+import { useScopeSafeSse } from '../../hooks/useScopeSafeSse';
+import {
+  initialAskStreamState,
+  reduceAskStreamMessage,
+  type AskStreamState,
+} from '../../state/askStream';
+import { createAskStreamSource } from './askStreamSource';
+
+type AskRequest = components['schemas']['AskRequest'];
+
+export interface UseAskStreamResult {
+  readonly state: AskStreamState;
+  readonly isActive: boolean;
+  /** Starts a brand-new ask/stream turn, replacing whatever was in flight (a fresh submit always wins — this is not a queue). */
+  ask(request: AskRequest): void;
+  /** Aborts the in-flight stream (if any) and returns to `idle` — used by "hủy"/unmount-equivalent UI and between demo scenarios. */
+  reset(): void;
+}
+
+export function useAskStream(tokenProvider: TokenProvider): UseAskStreamResult {
+  const [request, setRequest] = useState<AskRequest | undefined>(undefined);
+  const [state, setState] = useState<AskStreamState>(() => initialAskStreamState());
+  const sessionIdRef = useRef<string | undefined>(undefined);
+
+  useScopeSafeSse(
+    () => {
+      if (!request) return undefined;
+      sessionIdRef.current = undefined;
+      return createAskStreamSource(request, tokenProvider, () => sessionIdRef.current);
+    },
+    (message) => {
+      setState((prev) => {
+        const next = reduceAskStreamMessage(prev, message);
+        sessionIdRef.current = next.streamSessionId ?? sessionIdRef.current;
+        return next;
+      });
+    },
+    [request],
+  );
+
+  const ask = useCallback((next: AskRequest) => {
+    sessionIdRef.current = undefined;
+    setState(initialAskStreamState());
+    setRequest(next);
+  }, []);
+
+  const reset = useCallback(() => {
+    setRequest(undefined);
+    setState(initialAskStreamState());
+  }, []);
+
+  return { state, isActive: request !== undefined, ask, reset };
+}

--- a/web/src/mocks/fetchMock.test.ts
+++ b/web/src/mocks/fetchMock.test.ts
@@ -261,10 +261,18 @@ describe('fetchMock', () => {
     });
   });
 
-  it('throws a clear error for the SSE streaming endpoints instead of returning wrong data', async () => {
+  it('throws a clear error for the still-unmocked SSE streaming endpoint instead of returning wrong data', async () => {
+    // `askStream` moved out of `DELIBERATELY_UNMOCKED_OPERATIONS`'s effective
+    // set in P2-10 — `mocks/handlers/qa.ts` registers a real handler for it
+    // (a pre-serialized `text/event-stream` body, since every event it will
+    // ever emit is already decided before the response is built — see that
+    // file's module doc), so it's no longer this test's example. `jobEvents`
+    // remains genuinely unmocked (a real job's live progress cannot be
+    // pre-decided the same way), so it's the one still exercised here.
     const { accessToken } = await login();
-    await expect(
-      fetch(`${API_PREFIX}/ask/stream`, authed(accessToken, { method: 'POST' })),
-    ).rejects.toThrow(/deliberately not mocked/);
+    const jobId = getStore().jobs.keys().next().value;
+    await expect(fetch(`${API_PREFIX}/jobs/${jobId}/events`, authed(accessToken))).rejects.toThrow(
+      /deliberately not mocked/,
+    );
   });
 });

--- a/web/src/mocks/fixtures.ts
+++ b/web/src/mocks/fixtures.ts
@@ -448,6 +448,65 @@ function seedCollectionOrgId(): Map<string, string> {
   ]);
 }
 
+/**
+ * P2-10 (Q&A) demo document — the one seeded document with **two** published
+ * versions, so `mode: 'compare'`/`'history'` ask requests (and the version
+ * picker that drives them, `components/qa/AskPanel.tsx`) have something real
+ * to compare instead of every other seeded document's single version. Added
+ * into the existing "Product Specs" collection (`mockUuid(11)`, already in
+ * `DEMO_USER.allowedCollectionIds`) rather than a new collection, and purely
+ * additive to `seedDocuments()`/`seedVersions()` above — no existing id's data
+ * changes, so `LibraryPage.test.tsx`/`DocumentRowActions.test.tsx` (which key
+ * off specific pre-existing titles/ids, not "how many documents total") stay
+ * unaffected. Numeric id range (150/1500/1501) is disjoint from every id used
+ * elsewhere in this file.
+ */
+export const QA_COMPARE_DOCUMENT_ID = mockUuid(150);
+export const QA_COMPARE_VERSION_A_ID = mockUuid(1500);
+export const QA_COMPARE_VERSION_B_ID = mockUuid(1501);
+
+function seedQaCompareDocument(
+  documents: Map<string, Document[]>,
+  versions: Map<string, DocumentVersion[]>,
+): void {
+  const collectionId = mockUuid(11);
+  const docs = documents.get(collectionId) ?? [];
+  docs.push({
+    id: QA_COMPARE_DOCUMENT_ID,
+    collectionId,
+    title: 'Chính sách ngân sách vận hành.pdf',
+    state: 'indexed',
+    currentVersionId: QA_COMPARE_VERSION_B_ID,
+    createdAt: mockTimestamp(50),
+    updatedAt: mockTimestamp(95),
+  });
+  documents.set(collectionId, docs);
+  versions.set(QA_COMPARE_DOCUMENT_ID, [
+    {
+      id: QA_COMPARE_VERSION_A_ID,
+      documentId: QA_COMPARE_DOCUMENT_ID,
+      versionNumber: 1,
+      isCurrent: false,
+      sourceContentSha256: 'd'.repeat(64),
+      effectiveFrom: mockTimestamp(50),
+      effectiveTo: mockTimestamp(95),
+      changeSummary: 'Ngân sách vận hành được phê duyệt ban đầu.',
+      createdAt: mockTimestamp(50),
+    },
+    {
+      id: QA_COMPARE_VERSION_B_ID,
+      documentId: QA_COMPARE_DOCUMENT_ID,
+      versionNumber: 2,
+      isCurrent: true,
+      sourceContentSha256: 'e'.repeat(64),
+      effectiveFrom: mockTimestamp(95),
+      effectiveTo: null,
+      changeSummary: 'Điều chỉnh ngân sách vận hành theo thiết kế mới.',
+      createdAt: mockTimestamp(95),
+    },
+  ]);
+}
+
 function seedJobs(): Map<string, Job> {
   const map = new Map<string, Job>();
   const job: Job = {
@@ -484,14 +543,17 @@ function seedConflicts(): ConflictRecord[] {
 }
 
 function freshStore(): Store {
+  const documents = seedDocuments();
+  const versions = seedVersions();
+  seedQaCompareDocument(documents, versions);
   return {
     users: [{ ...DEMO_USER }],
     refreshTokens: new Map(),
     accessTokens: new Map(),
     collections: seedCollections(),
     collectionOrgId: seedCollectionOrgId(),
-    documents: seedDocuments(),
-    versions: seedVersions(),
+    documents,
+    versions,
     jobs: seedJobs(),
     conflicts: seedConflicts(),
     downloadCapabilities: new Map(),

--- a/web/src/mocks/fixtures.ts
+++ b/web/src/mocks/fixtures.ts
@@ -17,6 +17,7 @@ type Membership = components['schemas']['Membership'];
 type Org = components['schemas']['Org'];
 type OrgRole = Org['role'];
 type OrgState = Membership['state'];
+type UsageEntry = components['schemas']['UsageEntry'];
 
 export interface MockUser {
   userId: string;
@@ -118,15 +119,26 @@ interface Store {
   jobs: Map<string, Job>;
   conflicts: ConflictRecord[];
   downloadCapabilities: Map<string, DownloadCapabilityRecord>;
-  /** Memberships of the demo org (`DEMO_USER.orgId`) — every seeded/mock user's role+state. Unaffected by org switch: the admin member/invite/usage pages are out of scope for the org-switch task and stay pinned to this one org's roster. */
-  memberships: Membership[];
-  invites: InviteRecord[];
+  /**
+   * orgId -> that org's member roster (role/state per user) for the admin
+   * members page (`handlers/members.ts` E1/E6/E7). Each org gets its own
+   * roster — a member row seeded for org A says nothing about org B, mirroring
+   * `collectionOrgId`'s "org isolation lives in the mock store, not on the
+   * wire shape" pattern above. Read/written through `getOrgMemberships()`,
+   * never indexed directly, so a lookup for an org with nothing seeded gets an
+   * (auto-vivified) empty roster instead of `undefined`.
+   */
+  membershipsByOrg: Map<string, Membership[]>;
+  /** orgId -> that org's invites (E2-E5), same per-org shape as `membershipsByOrg`. Read/written through `getOrgInvites()`/`findInviteAcrossOrgs()`. */
+  invitesByOrg: Map<string, InviteRecord[]>;
   /** Org catalog for `listOrgs`/`getOrg`/`switchOrg` (1C-01). */
   orgs: OrgRecord[];
   /** Every user's org memberships, across every org — not just the demo org's roster above. */
   orgMemberships: OrgMembershipRecord[];
   /** orgId -> permissions/allowedCollectionIds `GET /auth/me` reports once a session is scoped to that org. */
   orgProfiles: Map<string, OrgProfile>;
+  /** orgId -> `GET /usage` snapshot (E8), read through `getOrgUsage()`. */
+  usageByOrg: Map<string, UsageEntry[]>;
 }
 
 const DEMO_USER: MockUser = {
@@ -166,6 +178,8 @@ export const ORG_B_ID = mockUuid(3);
 export const ORG_B_COLLECTION_ID = mockUuid(12);
 export const ORG_B_DOCUMENT_ID = mockUuid(120);
 const ORG_B_VERSION_ID = mockUuid(1200);
+/** Org B's second seeded member (`editor`, active) — so its admin members roster has more than the demo user's own row, same reason `SECOND_MEMBER_USER_ID` exists for org A. */
+export const GLOBEX_MEMBER_USER_ID = mockUuid(32);
 
 function seedOrgs(): OrgRecord[] {
   return [
@@ -222,6 +236,84 @@ function seedInvites(): InviteRecord[] {
       createdAt: mockTimestamp(0),
     },
   ];
+}
+
+/**
+ * Org B's own admin members roster — deliberately small and deliberately
+ * different from org A's (`seedMemberships()`): the demo user is `owner` here
+ * (not `admin`, its org A role) and the second row is a distinct user id
+ * (`GLOBEX_MEMBER_USER_ID`, not `SECOND_MEMBER_USER_ID`) with a different
+ * role/state combination, so a test asserting "org B's list, not org A's" has
+ * more than an orgId to go on.
+ */
+function seedOrgBMemberships(): Membership[] {
+  return [
+    { userId: DEMO_USER.userId, role: 'owner', state: 'active', createdAt: mockTimestamp(90) },
+    {
+      userId: GLOBEX_MEMBER_USER_ID,
+      role: 'editor',
+      state: 'active',
+      createdAt: mockTimestamp(91),
+    },
+  ];
+}
+
+/** Org B's own invite — different email/role from org A's seeded invite (`seedInvites()`), so the two lists are never accidentally interchangeable in an assertion. */
+function seedOrgBInvites(): InviteRecord[] {
+  return [
+    {
+      id: mockUuid(9200),
+      email: 'khach-moi-globex@example.com',
+      role: 'viewer',
+      tokenHash: 'seed-invite-token-hash-unused-org-b',
+      expiresAt: mockTimestamp(60 * 24 * 7),
+      acceptedAt: null,
+      revokedAt: null,
+      createdAt: mockTimestamp(90),
+    },
+  ];
+}
+
+/** Per-org `GET /usage` snapshots (E8) — org A keeps the original hand-picked values `AdminUsagePage.test.tsx` asserts exact numbers against; org B's are deliberately smaller/different so a post-switch usage page reads as genuinely different data, not the same numbers under a new orgId. */
+function seedUsageByOrg(): Map<string, UsageEntry[]> {
+  return new Map([
+    [
+      ORG_A_ID,
+      [
+        {
+          resource: 'storage_bytes',
+          limit: 10_737_418_240,
+          committed: 3_221_225_472,
+          reserved: 104_857_600,
+          remaining: 7_411_335_168,
+        },
+        { resource: 'documents', limit: 5000, committed: 812, reserved: 3, remaining: 4185 },
+        { resource: 'concurrent_jobs', limit: 8, committed: 1, reserved: 0, remaining: 7 },
+        {
+          resource: 'tokens',
+          limit: 2_000_000,
+          committed: 415_000,
+          reserved: 0,
+          remaining: 1_585_000,
+        },
+      ],
+    ],
+    [
+      ORG_B_ID,
+      [
+        {
+          resource: 'storage_bytes',
+          limit: 2_147_483_648,
+          committed: 268_435_456,
+          reserved: 0,
+          remaining: 1_879_048_192,
+        },
+        { resource: 'documents', limit: 500, committed: 42, reserved: 0, remaining: 458 },
+        { resource: 'concurrent_jobs', limit: 2, committed: 0, reserved: 0, remaining: 2 },
+        { resource: 'tokens', limit: 200_000, committed: 12_000, reserved: 0, remaining: 188_000 },
+      ],
+    ],
+  ]);
 }
 
 function seedCollections(): Collection[] {
@@ -403,11 +495,18 @@ function freshStore(): Store {
     jobs: seedJobs(),
     conflicts: seedConflicts(),
     downloadCapabilities: new Map(),
-    memberships: seedMemberships(),
-    invites: seedInvites(),
+    membershipsByOrg: new Map([
+      [ORG_A_ID, seedMemberships()],
+      [ORG_B_ID, seedOrgBMemberships()],
+    ]),
+    invitesByOrg: new Map([
+      [ORG_A_ID, seedInvites()],
+      [ORG_B_ID, seedOrgBInvites()],
+    ]),
     orgs: seedOrgs(),
     orgMemberships: seedOrgMemberships(),
     orgProfiles: seedOrgProfiles(),
+    usageByOrg: seedUsageByOrg(),
   };
 }
 
@@ -482,6 +581,50 @@ export function toMeResponse(
     allowedCollectionIds: profile?.allowedCollectionIds ?? user.allowedCollectionIds,
     sessionId,
   };
+}
+
+/** `orgId`'s admin members roster, auto-vivifying an empty one for an org with nothing seeded (rather than returning `undefined`) — the same "always an array to push/splice against" convention `documents`/`versions` already rely on via `?? []`/`.set(...)` at their call sites. */
+export function getOrgMemberships(orgId: string): Membership[] {
+  let roster = store.membershipsByOrg.get(orgId);
+  if (!roster) {
+    roster = [];
+    store.membershipsByOrg.set(orgId, roster);
+  }
+  return roster;
+}
+
+/** `orgId`'s invites, same auto-vivifying shape as `getOrgMemberships`. */
+export function getOrgInvites(orgId: string): InviteRecord[] {
+  let invites = store.invitesByOrg.get(orgId);
+  if (!invites) {
+    invites = [];
+    store.invitesByOrg.set(orgId, invites);
+  }
+  return invites;
+}
+
+/**
+ * Searches every org's invite list for one matching `predicate`. Accepting an
+ * invite (`acceptMemberInvite`) is the one flow in `handlers/members.ts` that
+ * cannot scope by the caller's *current* org (`authContextForHeader(...).orgId`)
+ * the way every other operation here does — the invite may belong to an org
+ * the caller isn't a member of yet (that's the entire point of the invite),
+ * so their bearer token's org tells you nothing about which org's invite list
+ * to search.
+ */
+export function findInviteAcrossOrgs(
+  predicate: (invite: InviteRecord) => boolean,
+): { orgId: string; invite: InviteRecord } | undefined {
+  for (const [orgId, invites] of store.invitesByOrg) {
+    const invite = invites.find(predicate);
+    if (invite) return { orgId, invite };
+  }
+  return undefined;
+}
+
+/** `orgId`'s `GET /usage` snapshot — `[]` for an org with none seeded rather than throwing, matching every other per-org accessor's "empty, not an error" default. */
+export function getOrgUsage(orgId: string): UsageEntry[] {
+  return store.usageByOrg.get(orgId) ?? [];
 }
 
 export { encodeCursor, decodeCursor };

--- a/web/src/mocks/handlers/members.test.ts
+++ b/web/src/mocks/handlers/members.test.ts
@@ -1,0 +1,207 @@
+// Org scoping for the admin members/invites/usage mock handlers (gap noted in
+// `fixtures.ts`'s old `memberships`/`invites` doc comment: these previously
+// stayed pinned to one fixed roster regardless of which org the caller's
+// access token was actually scoped to — switching org never changed what
+// `/members`, `/members/invites`, or `/usage` returned). Exercised through a
+// real `ApiClient` against `installMockFetch()`, the same "no hand-stubbed
+// handler" convention `AdminMembersPage.test.tsx`/`OrgSwitch.test.tsx` use —
+// just at the handler level (no page/component in the way) so each operation
+// in `handlers/members.ts` is checked directly.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApiClient, type ApiClient } from '../../api/client';
+import { grantMemberManage } from '../../components/admin/testSupport';
+import { installMockFetch, resetMockState, uninstallMockFetch } from '../index';
+import { mockUuid } from '../ids';
+import {
+  getOrgInvites,
+  getOrgMemberships,
+  getStore,
+  GLOBEX_MEMBER_USER_ID,
+  mintTokenPair,
+  ORG_A_ID,
+  ORG_B_ID,
+  SECOND_MEMBER_USER_ID,
+  type MockUser,
+} from '../fixtures';
+
+/** A live, ready-to-use client whose bearer token is scoped to `orgId` — no login/refresh round trip needed since these tests only exercise `client.request`. */
+function clientScopedTo(orgId: string): ApiClient {
+  const client = createApiClient({ baseUrl: '' });
+  const [user] = getStore().users;
+  const { accessToken, refreshToken } = mintTokenPair(user, orgId);
+  client.sessionManager.setTokens({
+    accessToken,
+    refreshToken,
+    tokenType: 'Bearer',
+    expiresIn: 3600,
+    orgId,
+    userId: user.userId,
+  });
+  return client;
+}
+
+beforeEach(() => {
+  installMockFetch();
+  resetMockState();
+  grantMemberManage(); // same permissions array backs every org's profile — see fixtures.ts's DEMO_USER doc.
+});
+
+afterEach(() => {
+  uninstallMockFetch();
+});
+
+describe('GET /members — org scoping', () => {
+  it("returns each org's own roster, not a shared/fixed one", async () => {
+    const orgAMembers = await clientScopedTo(ORG_A_ID).request('get', '/members');
+    const orgBMembers = await clientScopedTo(ORG_B_ID).request('get', '/members');
+
+    expect(orgAMembers.items.some((m) => m.userId === SECOND_MEMBER_USER_ID)).toBe(true);
+    expect(orgBMembers.items.some((m) => m.userId === SECOND_MEMBER_USER_ID)).toBe(false);
+    expect(orgBMembers.items.some((m) => m.userId === GLOBEX_MEMBER_USER_ID)).toBe(true);
+    expect(orgAMembers.items.some((m) => m.userId === GLOBEX_MEMBER_USER_ID)).toBe(false);
+  });
+});
+
+describe('GET /members/invites — org scoping', () => {
+  it("returns each org's own invites", async () => {
+    const orgAInvites = await clientScopedTo(ORG_A_ID).request('get', '/members/invites');
+    const orgBInvites = await clientScopedTo(ORG_B_ID).request('get', '/members/invites');
+
+    expect(orgAInvites.items.some((i) => i.email === 'moi-nguoi-moi@example.com')).toBe(true);
+    expect(orgAInvites.items.some((i) => i.email === 'khach-moi-globex@example.com')).toBe(false);
+    expect(orgBInvites.items.some((i) => i.email === 'khach-moi-globex@example.com')).toBe(true);
+    expect(orgBInvites.items.some((i) => i.email === 'moi-nguoi-moi@example.com')).toBe(false);
+  });
+});
+
+describe('POST /members/invites — org scoping', () => {
+  it('creates the invite only in the caller org, invisible from the other org', async () => {
+    await clientScopedTo(ORG_B_ID).request('post', '/members/invites', {
+      body: { email: 'chi-moi-org-b@example.com', role: 'viewer' },
+    });
+
+    expect(getOrgInvites(ORG_B_ID).some((i) => i.email === 'chi-moi-org-b@example.com')).toBe(true);
+    expect(getOrgInvites(ORG_A_ID).some((i) => i.email === 'chi-moi-org-b@example.com')).toBe(
+      false,
+    );
+  });
+});
+
+describe('POST /members/invites/{inviteId}/revoke — org scoping', () => {
+  it("404s revoking org A's invite id through an org B token", async () => {
+    const [orgAInvite] = getOrgInvites(ORG_A_ID);
+    await expect(
+      clientScopedTo(ORG_B_ID).request('post', '/members/invites/{inviteId}/revoke', {
+        params: { path: { inviteId: orgAInvite.id } },
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+    // Untouched: a 404 from the wrong org must not revoke it either.
+    expect(getOrgInvites(ORG_A_ID).find((i) => i.id === orgAInvite.id)?.revokedAt).toBeNull();
+  });
+
+  it("revokes org B's own invite through an org B token", async () => {
+    const [orgBInvite] = getOrgInvites(ORG_B_ID);
+    await clientScopedTo(ORG_B_ID).request('post', '/members/invites/{inviteId}/revoke', {
+      params: { path: { inviteId: orgBInvite.id } },
+    });
+    expect(getOrgInvites(ORG_B_ID).find((i) => i.id === orgBInvite.id)?.revokedAt).not.toBeNull();
+  });
+});
+
+describe('PATCH /members/{userId} — org scoping', () => {
+  it("404s patching org A's member id through an org B token", async () => {
+    await expect(
+      clientScopedTo(ORG_B_ID).request('patch', '/members/{userId}', {
+        params: { path: { userId: SECOND_MEMBER_USER_ID } },
+        body: { role: 'viewer' },
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+    // Org A's own copy of that member is untouched.
+    expect(getOrgMemberships(ORG_A_ID).find((m) => m.userId === SECOND_MEMBER_USER_ID)?.role).toBe(
+      'admin',
+    );
+  });
+
+  it("patches org B's own member through an org B token", async () => {
+    await clientScopedTo(ORG_B_ID).request('patch', '/members/{userId}', {
+      params: { path: { userId: GLOBEX_MEMBER_USER_ID } },
+      body: { role: 'viewer' },
+    });
+    expect(getOrgMemberships(ORG_B_ID).find((m) => m.userId === GLOBEX_MEMBER_USER_ID)?.role).toBe(
+      'viewer',
+    );
+  });
+});
+
+describe('DELETE /members/{userId} — org scoping', () => {
+  it("404s removing org A's member id through an org B token, leaving org A untouched", async () => {
+    await expect(
+      clientScopedTo(ORG_B_ID).request('delete', '/members/{userId}', {
+        params: { path: { userId: SECOND_MEMBER_USER_ID } },
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+    expect(getOrgMemberships(ORG_A_ID).some((m) => m.userId === SECOND_MEMBER_USER_ID)).toBe(true);
+  });
+});
+
+describe('GET /usage — org scoping', () => {
+  it('returns different snapshots per org', async () => {
+    const orgAUsage = await clientScopedTo(ORG_A_ID).request('get', '/usage');
+    const orgBUsage = await clientScopedTo(ORG_B_ID).request('get', '/usage');
+
+    const orgADocs = orgAUsage.items.find((i) => i.resource === 'documents');
+    const orgBDocs = orgBUsage.items.find((i) => i.resource === 'documents');
+    expect(orgADocs?.limit).toBe(5000);
+    expect(orgBDocs?.limit).toBe(500);
+    expect(orgADocs).not.toEqual(orgBDocs);
+  });
+});
+
+describe('POST /members/invites/accept — cross-org lookup', () => {
+  it("adds the membership to the invite's own org, not the caller's current-token org", async () => {
+    const inviteResponse = await clientScopedTo(ORG_A_ID).request('post', '/members/invites', {
+      body: { email: 'nguoi-duoc-moi-b@example.com', role: 'viewer' },
+    });
+    // Move it to org B's list to simulate "invited into org B" without a
+    // second create endpoint per org — same effect, less duplication.
+    const orgAInvites = getOrgInvites(ORG_A_ID);
+    const idx = orgAInvites.findIndex((i) => i.id === inviteResponse.invite.id);
+    const [moved] = orgAInvites.splice(idx, 1);
+    getOrgInvites(ORG_B_ID).push(moved);
+
+    // A brand-new user, currently a member of org A only (not yet seeded on
+    // `store.users` at all — `mintTokenPair`/`authContextForHeader` both
+    // resolve a token back to a real entry there), accepts an org B invite.
+    // A real `mockUuid` id (not an arbitrary string): the response is checked
+    // against the spec schema, which requires `Membership.userId` to be a uuid.
+    const newUserId = mockUuid(33);
+    const newUser: MockUser = {
+      userId: newUserId,
+      orgId: ORG_A_ID,
+      email: 'nguoi-duoc-moi-b@example.com',
+      password: 'unused',
+      displayName: 'Người được mời B',
+      permissions: [],
+      allowedCollectionIds: [],
+    };
+    getStore().users.push(newUser);
+    const acceptingClient = createApiClient({ baseUrl: '' });
+    const { accessToken, refreshToken } = mintTokenPair(newUser, ORG_A_ID);
+    acceptingClient.sessionManager.setTokens({
+      accessToken,
+      refreshToken,
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      orgId: ORG_A_ID,
+      userId: newUserId,
+    });
+
+    const membership = await acceptingClient.request('post', '/members/invites/accept', {
+      body: { token: inviteResponse.token },
+    });
+
+    expect(membership.userId).toBe(newUserId);
+    expect(getOrgMemberships(ORG_B_ID).some((m) => m.userId === newUserId)).toBe(true);
+    expect(getOrgMemberships(ORG_A_ID).some((m) => m.userId === newUserId)).toBe(false);
+  });
+});

--- a/web/src/mocks/handlers/members.ts
+++ b/web/src/mocks/handlers/members.ts
@@ -3,6 +3,14 @@
 // `crates/server/src/routes/members.rs` closely enough for the SPA's tests to
 // exercise the same decisions the real server makes — in particular:
 //
+//   - Org scoping (P2-06/P2-15 org switch): every operation below (except
+//     `acceptMemberInvite`, see its own note) reads/writes through
+//     `getOrgMemberships(auth.orgId)`/`getOrgInvites(auth.orgId)`/
+//     `getOrgUsage(auth.orgId)` — `auth.orgId` from `authContextForHeader(...)`,
+//     i.e. whichever org the caller's *current* access token is scoped to, not
+//     any fixed org. Same pattern `handlers/library.ts`'s `listCollections`
+//     already established for collections; this file previously stayed pinned
+//     to one org's roster regardless of `switchOrg` (a known gap, now closed).
 //   - `member.manage` gates every operation here except `acceptMemberInvite`
 //     (auth-only by design, matching the real route).
 //   - "admin không quản owner": granting the owner role, or mutating a
@@ -22,7 +30,16 @@
 import { registerOperation } from '../registry';
 import { apiError, forbidden, notFound } from '../apiError';
 import { mockTimestamp } from '../ids';
-import { authContextForHeader, getStore, nextId, type InviteRecord } from '../fixtures';
+import {
+  authContextForHeader,
+  findInviteAcrossOrgs,
+  getOrgInvites,
+  getOrgMemberships,
+  getOrgUsage,
+  nextId,
+  type InviteRecord,
+  type MockUser,
+} from '../fixtures';
 import type { components } from '../../api/generated/contract';
 
 type Membership = components['schemas']['Membership'];
@@ -42,16 +59,23 @@ function permissionDenied() {
   return forbidden('Permission denied');
 }
 
-/** Resolves the caller's `MockUser` + their own membership row, or `undefined` if unauthenticated/not a member of the seeded org. `fetchMock.ts` already 401s a missing/invalid bearer before any handler runs, so `undefined` here means "authenticated but not in `getStore().memberships`" — treated as no `member.manage`, fail-closed. */
-function callerMembership(authorizationHeader: string | null): Membership | undefined {
+/** Resolves the caller's `MockUser` + their own membership row in `orgId`, or `undefined` if unauthenticated/not on that org's roster. `fetchMock.ts` already 401s a missing/invalid bearer before any handler runs, so `undefined` here means "authenticated but not in `getOrgMemberships(orgId)`" — treated as no `member.manage`, fail-closed. */
+function callerMembership(
+  authorizationHeader: string | null,
+  orgId: string,
+): Membership | undefined {
   const auth = authContextForHeader(authorizationHeader);
   if (!auth) return undefined;
-  return getStore().memberships.find((m) => m.userId === auth.user.userId);
+  return getOrgMemberships(orgId).find((m) => m.userId === auth.user.userId);
 }
 
-function hasMemberManage(authorizationHeader: string | null): boolean {
+/** Resolves the caller if authenticated AND holding `member.manage`, `undefined` otherwise — one call gets both the permission check and the `orgId` every operation below scopes its store access to. */
+function authWithMemberManage(
+  authorizationHeader: string | null,
+): { user: MockUser; sessionId: string; orgId: string } | undefined {
   const auth = authContextForHeader(authorizationHeader);
-  return !!auth && auth.user.permissions.includes(PERMISSION_MEMBER_MANAGE);
+  if (!auth || !auth.user.permissions.includes(PERMISSION_MEMBER_MANAGE)) return undefined;
+  return auth;
 }
 
 /** Mirrors `services::members::operation_manages_owner`. */
@@ -59,20 +83,25 @@ function operationManagesOwner(targetCurrentRole: MembershipRole, grantsOwner: b
   return grantsOwner || targetCurrentRole === 'owner';
 }
 
-/** Mirrors `services::members::guard_owner_tier`: true (allowed) unless the operation touches the owner tier and the caller isn't an active owner. */
+/** Mirrors `services::members::guard_owner_tier`: true (allowed) unless the operation touches the owner tier and the caller isn't an active owner in `orgId`. */
 function guardOwnerTier(
   authorizationHeader: string | null,
+  orgId: string,
   targetCurrentRole: MembershipRole,
   grantsOwner: boolean,
 ): boolean {
   if (!operationManagesOwner(targetCurrentRole, grantsOwner)) return true;
-  const caller = callerMembership(authorizationHeader);
+  const caller = callerMembership(authorizationHeader, orgId);
   return !!caller && caller.role === 'owner' && caller.state === 'active';
 }
 
-/** Mirrors `services::members::check_last_owner_invariant`. */
-function guardLastOwner(targetUserId: string, targetWillBeActiveOwner: boolean): boolean {
-  const othersActive = getStore().memberships.filter(
+/** Mirrors `services::members::check_last_owner_invariant`, scoped to `orgId`'s own roster. */
+function guardLastOwner(
+  orgId: string,
+  targetUserId: string,
+  targetWillBeActiveOwner: boolean,
+): boolean {
+  const othersActive = getOrgMemberships(orgId).filter(
     (m) => m.userId !== targetUserId && m.role === 'owner' && m.state === 'active',
   ).length;
   const remaining = othersActive + (targetWillBeActiveOwner ? 1 : 0);
@@ -111,10 +140,11 @@ function inviteDto(invite: InviteRecord): Invite {
 // ---------------------------------------------------------------------------
 
 registerOperation('listMembers', (ctx) => {
-  if (!hasMemberManage(ctx.headers.get('authorization'))) return permissionDenied();
+  const auth = authWithMemberManage(ctx.headers.get('authorization'));
+  if (!auth) return permissionDenied();
   return {
     status: 200,
-    body: { items: getStore().memberships, page: { hasMore: false, nextCursor: null } },
+    body: { items: getOrgMemberships(auth.orgId), page: { hasMore: false, nextCursor: null } },
   };
 });
 
@@ -123,11 +153,12 @@ registerOperation('listMembers', (ctx) => {
 // ---------------------------------------------------------------------------
 
 registerOperation('listMemberInvites', (ctx) => {
-  if (!hasMemberManage(ctx.headers.get('authorization'))) return permissionDenied();
+  const auth = authWithMemberManage(ctx.headers.get('authorization'));
+  if (!auth) return permissionDenied();
   return {
     status: 200,
     body: {
-      items: getStore().invites.map(inviteDto),
+      items: getOrgInvites(auth.orgId).map(inviteDto),
       page: { hasMore: false, nextCursor: null },
     },
   };
@@ -139,7 +170,8 @@ registerOperation('listMemberInvites', (ctx) => {
 
 registerOperation('createMemberInvite', async (ctx) => {
   const authorization = ctx.headers.get('authorization');
-  if (!hasMemberManage(authorization)) return permissionDenied();
+  const auth = authWithMemberManage(authorization);
+  if (!auth) return permissionDenied();
   const body = await ctx.json<CreateInviteRequest>();
 
   const email = body.email.trim();
@@ -157,7 +189,7 @@ registerOperation('createMemberInvite', async (ctx) => {
   // `create_invite`'s `OwnerRequiredForOwnerInvite` check (there is no
   // "current role" for an invite target, so this only ever checks the
   // grants-owner half of `guardOwnerTier`).
-  if (body.role === 'owner' && !guardOwnerTier(authorization, 'viewer', true)) {
+  if (body.role === 'owner' && !guardOwnerTier(authorization, auth.orgId, 'viewer', true)) {
     return permissionDenied();
   }
 
@@ -173,7 +205,7 @@ registerOperation('createMemberInvite', async (ctx) => {
     revokedAt: null,
     createdAt: mockTimestamp(0),
   };
-  getStore().invites.push(record);
+  getOrgInvites(auth.orgId).push(record);
 
   return {
     status: 201,
@@ -186,8 +218,9 @@ registerOperation('createMemberInvite', async (ctx) => {
 // ---------------------------------------------------------------------------
 
 registerOperation('revokeMemberInvite', (ctx) => {
-  if (!hasMemberManage(ctx.headers.get('authorization'))) return permissionDenied();
-  const invite = getStore().invites.find((i) => i.id === ctx.params.inviteId);
+  const auth = authWithMemberManage(ctx.headers.get('authorization'));
+  if (!auth) return permissionDenied();
+  const invite = getOrgInvites(auth.orgId).find((i) => i.id === ctx.params.inviteId);
   if (!invite) return notFound(`Invite ${ctx.params.inviteId} does not exist.`);
   if (invite.acceptedAt || invite.revokedAt) {
     return {
@@ -203,6 +236,13 @@ registerOperation('revokeMemberInvite', (ctx) => {
 // E5 — POST /members/invites/accept (auth-only — see module doc; the admin
 // pages this task builds never call this, it's the invitee's own flow, but
 // it's mocked for completeness/future use).
+//
+// Deliberately NOT scoped by `auth.orgId` like every other operation above:
+// the invite being accepted belongs to whichever org issued it, which is not
+// necessarily the org the accepting caller's *current* access token is scoped
+// to (they may not even be a member of it yet — that is the whole point of an
+// invite), so `findInviteAcrossOrgs` searches every org's invite list by
+// token hash instead.
 // ---------------------------------------------------------------------------
 
 registerOperation('acceptMemberInvite', async (ctx) => {
@@ -210,8 +250,9 @@ registerOperation('acceptMemberInvite', async (ctx) => {
   if (!auth) return { status: 401, body: apiError('unauthorized', 'Authentication required') };
   const body = await ctx.json<AcceptInviteRequest>();
   const token = body.token.trim();
-  const invite = getStore().invites.find((i) => `hash-of-${token}` === i.tokenHash);
-  if (!invite) return notFound('Invite token is unknown.');
+  const found = findInviteAcrossOrgs((i) => `hash-of-${token}` === i.tokenHash);
+  if (!found) return notFound('Invite token is unknown.');
+  const { orgId, invite } = found;
   if (invite.acceptedAt || invite.revokedAt) {
     return {
       status: 409,
@@ -221,7 +262,7 @@ registerOperation('acceptMemberInvite', async (ctx) => {
   if (Date.parse(invite.expiresAt) <= Date.now()) {
     return { status: 409, body: apiError('invite_expired', 'Invite has expired') };
   }
-  if (getStore().memberships.some((m) => m.userId === auth.user.userId)) {
+  if (getOrgMemberships(orgId).some((m) => m.userId === auth.user.userId)) {
     return {
       status: 409,
       body: apiError('already_member', 'User is already a member of this organization'),
@@ -233,7 +274,7 @@ registerOperation('acceptMemberInvite', async (ctx) => {
     state: 'active',
     createdAt: mockTimestamp(0),
   };
-  getStore().memberships.push(membership);
+  getOrgMemberships(orgId).push(membership);
   invite.acceptedAt = mockTimestamp(0);
   return { status: 201, body: membership };
 });
@@ -244,14 +285,15 @@ registerOperation('acceptMemberInvite', async (ctx) => {
 
 registerOperation('patchMember', async (ctx) => {
   const authorization = ctx.headers.get('authorization');
-  if (!hasMemberManage(authorization)) return permissionDenied();
+  const auth = authWithMemberManage(authorization);
+  if (!auth) return permissionDenied();
   const body = await ctx.json<PatchMemberRequest>();
   if (body.role === undefined && body.state === undefined) {
     return { status: 400, body: apiError('validation_failed', 'role or state is required') };
   }
 
   const userId = ctx.params.userId;
-  const membership = getStore().memberships.find((m) => m.userId === userId);
+  const membership = getOrgMemberships(auth.orgId).find((m) => m.userId === userId);
   if (!membership) return notFound(`Member ${userId} does not exist.`);
 
   // Two separate owner-tier gates, not one shared at the top: mirrors
@@ -263,20 +305,24 @@ registerOperation('patchMember', async (ctx) => {
   // for the demotion and, since the target is no longer an owner afterwards,
   // does not require owner-tier again for the suspend.
   if (body.role !== undefined) {
-    if (!guardOwnerTier(authorization, membership.role, body.role === 'owner')) {
+    if (!guardOwnerTier(authorization, auth.orgId, membership.role, body.role === 'owner')) {
       return permissionDenied();
     }
     if (body.role !== membership.role) {
       const willBeActiveOwner = body.role === 'owner' && membership.state === 'active';
-      if (!guardLastOwner(userId, willBeActiveOwner)) return lastOwnerConflict();
+      if (!guardLastOwner(auth.orgId, userId, willBeActiveOwner)) return lastOwnerConflict();
       membership.role = body.role;
     }
   }
 
   if (body.state !== undefined) {
-    if (!guardOwnerTier(authorization, membership.role, false)) return permissionDenied();
+    if (!guardOwnerTier(authorization, auth.orgId, membership.role, false)) {
+      return permissionDenied();
+    }
     if (body.state !== membership.state) {
-      if (body.state === 'suspended' && !guardLastOwner(userId, false)) return lastOwnerConflict();
+      if (body.state === 'suspended' && !guardLastOwner(auth.orgId, userId, false)) {
+        return lastOwnerConflict();
+      }
       membership.state = body.state;
     }
   }
@@ -290,17 +336,19 @@ registerOperation('patchMember', async (ctx) => {
 
 registerOperation('deleteMember', (ctx) => {
   const authorization = ctx.headers.get('authorization');
-  if (!hasMemberManage(authorization)) return permissionDenied();
+  const auth = authWithMemberManage(authorization);
+  if (!auth) return permissionDenied();
 
   const userId = ctx.params.userId;
-  const store = getStore();
-  const membership = store.memberships.find((m) => m.userId === userId);
-  if (!membership) return notFound(`Member ${userId} does not exist.`);
+  const roster = getOrgMemberships(auth.orgId);
+  const idx = roster.findIndex((m) => m.userId === userId);
+  if (idx === -1) return notFound(`Member ${userId} does not exist.`);
+  const membership = roster[idx];
 
-  if (!guardOwnerTier(authorization, membership.role, false)) return permissionDenied();
-  if (!guardLastOwner(userId, false)) return lastOwnerConflict();
+  if (!guardOwnerTier(authorization, auth.orgId, membership.role, false)) return permissionDenied();
+  if (!guardLastOwner(auth.orgId, userId, false)) return lastOwnerConflict();
 
-  store.memberships = store.memberships.filter((m) => m.userId !== userId);
+  roster.splice(idx, 1);
   return { status: 204 };
 });
 
@@ -309,28 +357,7 @@ registerOperation('deleteMember', (ctx) => {
 // ---------------------------------------------------------------------------
 
 registerOperation('getUsage', (ctx) => {
-  if (!hasMemberManage(ctx.headers.get('authorization'))) return permissionDenied();
-  return {
-    status: 200,
-    body: {
-      items: [
-        {
-          resource: 'storage_bytes',
-          limit: 10_737_418_240,
-          committed: 3_221_225_472,
-          reserved: 104_857_600,
-          remaining: 7_411_335_168,
-        },
-        { resource: 'documents', limit: 5000, committed: 812, reserved: 3, remaining: 4185 },
-        { resource: 'concurrent_jobs', limit: 8, committed: 1, reserved: 0, remaining: 7 },
-        {
-          resource: 'tokens',
-          limit: 2_000_000,
-          committed: 415_000,
-          reserved: 0,
-          remaining: 1_585_000,
-        },
-      ],
-    },
-  };
+  const auth = authWithMemberManage(ctx.headers.get('authorization'));
+  if (!auth) return permissionDenied();
+  return { status: 200, body: { items: getOrgUsage(auth.orgId) } };
 });

--- a/web/src/mocks/handlers/qa.ts
+++ b/web/src/mocks/handlers/qa.ts
@@ -1,55 +1,495 @@
+// P2-10 (Q&A). `search`/`ask` were the P2-02 baseline (synchronous, still kept
+// below for back-compat with anything that calls them directly); `askStream`
+// is new here.
+//
+// `askStream` is one of the two operations `registry.ts`'s
+// `DELIBERATELY_UNMOCKED_OPERATIONS` still lists (alongside `jobEvents`) —
+// that comment predates P2-10 and describes a real, still-true limitation:
+// `mocks/**` is fetch-*level*, and a genuinely live `ReadableStream` (bytes
+// trickling in over real ticks, the way `jobEvents` would need to for a
+// long-lived job) is out of scope for it. `/ask/stream`'s shape sidesteps
+// that rather than needing a fix to it: every event this mock will ever emit
+// for one ask is already fully decided (from the request body) before the
+// response is even built — nothing is genuinely asynchronous the way a job's
+// live progress is — so the whole `text/event-stream` body is pre-serialized
+// as one static string (`buildAskStreamBody` below) and returned as a normal
+// `rawBody`, same mechanism `redeemDownload` already uses for a non-JSON
+// response. `registerOperation('askStream', ...)` below is what actually
+// makes this reachable — `DELIBERATELY_UNMOCKED_OPERATIONS` is scanned by
+// `fetchMock.ts` only as a *fallback* once no registered route matches, so a
+// registered handler wins first and that stale doc comment in `registry.ts`
+// is the one loose end this leaves (out of this task's edit scope — see the
+// P2-10 report). Reading the whole body at once, with no `setTimeout`
+// between events, is also exactly what "deterministic, no sleep-race" (the
+// task's own requirement) asks for: `SseConnection` (`api/sse.ts`) yields one
+// parsed message at a time regardless of how many arrived in a single
+// underlying chunk, so the client-side reducer still sees the same ordered
+// sequence of dispatches a real trickle would produce — just without any
+// wall-clock delay to race against in a test.
+//
+// Wire shape mirrored here, byte-for-byte against the real producer (cited so
+// a change on that side is a deliberate decision to update this file, not a
+// silent drift):
+//   - Event names/data and their order — `ask.started` -> `ask.token`* ->
+//     [`ask.warning`]* -> `ask.citations` -> `ask.version_context` ->
+//     `ask.completed` -> terminal `stream.closed` (durable, carries an SSE
+//     `id:`) — `crates/server/src/services/qa/ask_stream.rs` `run_producer`.
+//   - `VersionContext`'s camelCase fields (`mode`/`currentVersionIds`/
+//     `citedVersionIds`/`changeNote`) — `services/qa/grounding.rs`.
+//   - The "current mode cited a non-current version" warning —
+//     `services/qa/grounding.rs`'s `validate_answer_citations`.
+//   - `stream.closed` reasons (`completed`, `citation_revoked`, ...) —
+//     `services/qa/ask_stream.rs`'s `config_reason`, consumed client-side by
+//     `api/sse.ts`'s `classifySseCloseCode`.
 import { registerOperation } from '../registry';
 import { nextRequestId } from '../ids';
-import { getStore } from '../fixtures';
+import { getStore, nextId, QA_COMPARE_DOCUMENT_ID } from '../fixtures';
 import type { components } from '../../api/generated/contract';
 
 type SearchRequest = components['schemas']['SearchRequest'];
 type AskRequest = components['schemas']['AskRequest'];
 type CitationPin = components['schemas']['CitationPin'];
+type SseEnvelope = components['schemas']['SseEnvelope'];
 
-function sampleCitation(seed: number): CitationPin {
+// ---------------------------------------------------------------------------
+// Scenario markers — a test seam. Appending one of these tokens to a
+// `question`/`query` string selects a deterministic mock scenario instead of
+// the default grounded-answer path. Exported so `web/e2e/qa.spec.ts` and
+// component tests import the exact token rather than hand-rolling a string
+// that could silently drift from what this handler actually checks for —
+// same "single source of truth" reasoning as `mocks/control.ts`'s
+// `ForcedFailureKind` union.
+export const QA_STREAM_MARKERS = {
+  /** Mid-answer citation revocation: a few tokens stream, then the durable terminal closes with `reason: "citation_revoked"` — no citations/completed event ever arrives, matching `ask_stream.rs`'s `append()` failing closed the instant a cited document/version becomes inaccessible. */
+  citationRevoked: '[[qa-e2e:citation-revoked]]',
+  /** Provider-outage fallback: tokens still stream (from the same extractive answer, per `ask_stream.rs`'s `!streamed_any || FallbackExtractive` branch), plus an `ask.warning` and `ask.completed.mode: "fallback_extractive"`. */
+  providerFallback: '[[qa-e2e:provider-fallback]]',
+} as const;
+
+function stripMarkers(text: string): string {
+  return text
+    .replace(QA_STREAM_MARKERS.citationRevoked, '')
+    .replace(QA_STREAM_MARKERS.providerFallback, '')
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Passage catalog — the mock's stand-in for "what hybrid retrieval would
+// find". Every seeded document (`mocks/fixtures.ts`) that ought to be
+// citable gets one synthetic Vietnamese passage per published version here;
+// nothing about it is derived from the contract (there is no ground-truth
+// *content* to derive — same caveat `fixtures.ts`'s own module doc makes for
+// its records).
+// ---------------------------------------------------------------------------
+
+interface Passage {
+  documentId: string;
+  collectionId: string;
+  versionId: string;
+  versionNumber: number;
+  isCurrent: boolean;
+  title: string;
+  quote: string;
+}
+
+function passageCatalog(): Passage[] {
+  const store = getStore();
+  const passages: Passage[] = [];
+  // Keyed by title, one passage per document that actually has a published
+  // (`isCurrent`) version to cite — "Leave Policy.docx" (`mocks/fixtures.ts`)
+  // is deliberately absent: it's seeded `state: 'converting'`/no version yet,
+  // so real retrieval would have nothing to cite there either.
+  const staticQuotes: Record<string, string> = {
+    'Onboarding Guide.pdf':
+      'Nhân viên mới cần hoàn thành khóa đào tạo hội nhập trong 30 ngày đầu tiên.',
+    'Roadmap.xlsx': 'Lộ trình quý 3 tập trung vào tối ưu hiệu năng lập chỉ mục.',
+  };
+  for (const [collectionId, docs] of store.documents) {
+    for (const doc of docs) {
+      if (doc.id === QA_COMPARE_DOCUMENT_ID) continue; // handled separately below (2 versions)
+      const versions = store.versions.get(doc.id) ?? [];
+      const current = versions.find((v) => v.isCurrent);
+      const quote = staticQuotes[doc.title];
+      if (!current || !quote) continue; // no published version, or nothing seeded to say about it
+      passages.push({
+        documentId: doc.id,
+        collectionId,
+        versionId: current.id,
+        versionNumber: current.versionNumber,
+        isCurrent: true,
+        title: doc.title,
+        quote,
+      });
+    }
+  }
+  // The one multi-version document — both versions are individually citable
+  // (mode: 'current' only ever surfaces the current one; 'compare'/'history'
+  // ask for both explicitly — see `resolveCompareOrHistoryPassages` below).
+  const compareVersions = store.versions.get(QA_COMPARE_DOCUMENT_ID) ?? [];
+  const compareDoc = [...store.documents.values()]
+    .flat()
+    .find((d) => d.id === QA_COMPARE_DOCUMENT_ID);
+  const compareCollectionId = compareDoc?.collectionId ?? '';
+  const compareQuotes: Record<number, string> = {
+    1: 'Ngân sách vận hành được duyệt là 10 triệu đồng mỗi quý.',
+    2: 'Ngân sách vận hành được điều chỉnh thành 15 triệu đồng mỗi quý theo thiết kế mới.',
+  };
+  for (const version of compareVersions) {
+    const quote = compareQuotes[version.versionNumber];
+    if (!quote || !compareDoc) continue;
+    passages.push({
+      documentId: compareDoc.id,
+      collectionId: compareCollectionId,
+      versionId: version.id,
+      versionNumber: version.versionNumber,
+      isCurrent: version.isCurrent,
+      title: compareDoc.title,
+      quote,
+    });
+  }
+  return passages;
+}
+
+/** Word-level tokens (Unicode-aware, so Vietnamese diacritics survive), 2+ characters — a whole-question "does this substring literally appear in the passage" check would almost never hit, since a real question is never phrased as an exact quote of its answer. */
+function tokenizeForMatch(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter((token) => token.length >= 2);
+}
+
+function matchPassages(
+  query: string,
+  collectionIds: string[] | undefined,
+  limit: number,
+): Passage[] {
+  const queryTokens = tokenizeForMatch(query);
+  const scoped = passageCatalog().filter(
+    (p) => !collectionIds?.length || collectionIds.includes(p.collectionId),
+  );
+  // Only the current version of each document participates in plain
+  // search/current-mode matching — compare/history reach the non-current one
+  // through `resolveCompareOrHistoryPassages` instead, same as the real
+  // server never surfacing a superseded version from ordinary retrieval.
+  const current = scoped.filter((p) => p.isCurrent);
+  const matched =
+    queryTokens.length === 0
+      ? current
+      : current.filter((p) => {
+          const passageTokens = new Set(tokenizeForMatch(`${p.title} ${p.quote}`));
+          return queryTokens.some((token) => passageTokens.has(token));
+        });
+  return matched.slice(0, limit);
+}
+
+function citeIdFor(index: number): string {
+  return `CITE-${String(index + 1).padStart(4, '0')}`;
+}
+
+function passageToCitation(passage: Passage, citeId: string): CitationPin {
   return {
-    citeId: `cite-${seed}`,
-    sourceContentSha256: 'a'.repeat(64),
-    canonicalMarkdownSha256: 'b'.repeat(64),
-    quoteSha256: 'c'.repeat(64),
-    chunkIdentitySha256: 'd'.repeat(64),
-    quote: 'Employees accrue fifteen days of paid leave per year.',
-    sourceSpanStart: 120,
-    sourceSpanEnd: 178,
+    citeId,
+    sourceContentSha256: `src-${passage.versionId}`,
+    canonicalMarkdownSha256: `md-${passage.versionId}`,
+    quoteSha256: `quote-${passage.versionId}`,
+    chunkIdentitySha256: `chunk-${passage.versionId}`,
+    quote: passage.quote,
+    sourceSpanStart: 0,
+    sourceSpanEnd: passage.quote.length,
     quoteLocalStart: 0,
-    quoteLocalEnd: 58,
-    isCurrent: true,
-    anchor: '#leave-policy',
+    quoteLocalEnd: passage.quote.length,
+    isCurrent: passage.isCurrent,
+    anchor: `mhcite-${passage.versionNumber}.${passage.documentId.slice(-4)}`,
   };
 }
 
+/** `mode: 'compare'`/`'history'` resolve against the one seeded multi-version document, by explicit `versionA`/`versionB`/`documentId` — never inferred, matching the real server's "the caller names the exact versions" contract for these modes. */
+function resolveCompareOrHistoryPassages(body: SearchRequest | AskRequest): {
+  passages: Passage[];
+  warnings: string[];
+} {
+  const all = passageCatalog();
+  const warnings: string[] = [];
+  if (body.mode === 'compare') {
+    if (!body.versionA || !body.versionB) {
+      return {
+        passages: [],
+        warnings: ['Chế độ so sánh cần chọn cả phiên bản A và phiên bản B.'],
+      };
+    }
+    const a = all.find((p) => p.versionId === body.versionA);
+    const b = all.find((p) => p.versionId === body.versionB);
+    if (!a || !b) {
+      return { passages: [], warnings: ['Không tìm thấy một trong hai phiên bản để so sánh.'] };
+    }
+    return { passages: [a, b], warnings };
+  }
+  if (body.mode === 'history') {
+    if (!body.documentId) {
+      return { passages: [], warnings: ['Chế độ lịch sử cần chọn một tài liệu.'] };
+    }
+    const versions = all.filter((p) => p.documentId === body.documentId);
+    if (versions.length === 0) {
+      return {
+        passages: [],
+        warnings: [`Không có phiên bản nào cho tài liệu ${body.documentId}.`],
+      };
+    }
+    return { passages: versions, warnings };
+  }
+  if (body.mode === 'as_of') {
+    if (!body.documentId || !body.asOf) {
+      return { passages: [], warnings: ['Chế độ as-of cần chọn tài liệu và thời điểm (asOf).'] };
+    }
+    const store = getStore();
+    const versions = store.versions.get(body.documentId) ?? [];
+    const asOfMs = Date.parse(body.asOf);
+    const effective = versions
+      .filter((v) => Date.parse(v.effectiveFrom) <= asOfMs)
+      .sort((x, y) => Date.parse(y.effectiveFrom) - Date.parse(x.effectiveFrom))[0];
+    const passage = effective && all.find((p) => p.versionId === effective.id);
+    if (!passage) {
+      return { passages: [], warnings: [`Không có phiên bản nào hiệu lực tại ${body.asOf}.`] };
+    }
+    return { passages: [passage], warnings };
+  }
+  return { passages: [], warnings: [] };
+}
+
+function versionContextFor(
+  body: SearchRequest | AskRequest,
+  passages: Passage[],
+): {
+  mode: string;
+  currentVersionIds: string[];
+  citedVersionIds: string[];
+  changeNote: string | null;
+} {
+  const mode = body.mode ?? 'current';
+  const currentVersionIds = [
+    ...new Set(
+      passageCatalog()
+        .filter((p) => p.isCurrent)
+        .map((p) => p.versionId),
+    ),
+  ];
+  const citedVersionIds = [...new Set(passages.map((p) => p.versionId))];
+  let changeNote: string | null = null;
+  if (mode === 'compare' && passages.length === 2) {
+    const [a, b] = passages;
+    changeNote = `So sánh phiên bản ${a.versionNumber} (${a.versionId}) với phiên bản ${b.versionNumber} (${b.versionId}).`;
+  } else if (mode === 'history' && body.documentId) {
+    changeNote = `Lịch sử phiên bản cho tài liệu ${body.documentId}.`;
+  } else if (mode === 'as_of' && body.asOf) {
+    changeNote = `Truy vấn as-of tại ${body.asOf}.`;
+  }
+  return { mode, currentVersionIds, citedVersionIds, changeNote };
+}
+
+/** Grounded, citation-tagged answer text — every factual sentence carries the `[CITE-n]` label the real grounding validator (`services/qa/grounding.rs`) requires. */
+function buildAnswer(citations: { citeId: string; quote: string }[]): string {
+  if (citations.length === 0) {
+    return 'Không tìm thấy nội dung liên quan trong tài liệu đã lập chỉ mục để trả lời câu hỏi này.';
+  }
+  const clauses = citations.map((c) => `${c.quote} [${c.citeId}]`);
+  return `Dựa trên tài liệu đã lập chỉ mục: ${clauses.join(' ')}`;
+}
+
+function currentModeWarnings(mode: string, citations: CitationPin[]): string[] {
+  if (mode !== 'current') return [];
+  return citations.some((c) => c.isCurrent === false)
+    ? [
+        'Câu trả lời (chế độ hiện hành) đang trích dẫn ít nhất một phiên bản không phải bản mới nhất; kiểm tra lại trước khi sử dụng.',
+      ]
+    : [];
+}
+
+// ---------------------------------------------------------------------------
+// search / ask (synchronous, P2-02 baseline)
+// ---------------------------------------------------------------------------
+
 registerOperation('search', async (ctx) => {
   const body = await ctx.json<SearchRequest>();
-  const documents = [...getStore().documents.values()].flat();
-  const hits = documents.slice(0, body.limit ?? 10).map((doc, i) => ({
-    documentId: doc.id,
-    title: doc.title,
+  const mode = body.mode ?? 'current';
+  const limit = body.limit ?? 10;
+  let passages: Passage[];
+  let warnings: string[];
+  if (mode === 'compare' || mode === 'history' || mode === 'as_of') {
+    const resolved = resolveCompareOrHistoryPassages(body);
+    passages = resolved.passages;
+    warnings = resolved.warnings;
+  } else {
+    passages = matchPassages(body.query, body.collectionIds, limit);
+    warnings = [];
+  }
+  const citations = passages.map((p, i) => passageToCitation(p, citeIdFor(i)));
+  warnings = [...warnings, ...currentModeWarnings(mode, citations)];
+  const hits = passages.map((p, i) => ({
+    citeId: citations[i].citeId,
+    documentId: p.documentId,
+    collectionId: p.collectionId,
+    versionId: p.versionId,
+    title: p.title,
     score: Number((1 - i * 0.1).toFixed(2)),
-    snippet: `Matched "${body.query}" in ${doc.title}.`,
+    snippet: p.quote,
   }));
   return {
     status: 200,
-    body: { hits, citations: hits.map((_, i) => sampleCitation(i)), requestId: nextRequestId() },
+    body: { hits, citations, requestId: nextRequestId(), warnings },
   };
 });
 
 registerOperation('ask', async (ctx) => {
   const body = await ctx.json<AskRequest>();
+  const mode = body.mode ?? 'current';
+  let passages: Passage[];
+  let warnings: string[];
+  if (mode === 'compare' || mode === 'history' || mode === 'as_of') {
+    const resolved = resolveCompareOrHistoryPassages(body);
+    passages = resolved.passages;
+    warnings = resolved.warnings;
+  } else {
+    passages = matchPassages(body.question, body.collectionIds, body.limit ?? 10);
+    warnings = [];
+  }
+  const citations = passages.map((p, i) => passageToCitation(p, citeIdFor(i)));
+  warnings = [...warnings, ...currentModeWarnings(mode, citations)];
+  const versionContext = versionContextFor(body, passages);
   return {
     status: 200,
     body: {
-      answer: `Mock grounded answer for: "${body.question}"`,
-      mode: body.mode ?? 'current',
-      citations: [sampleCitation(0)],
-      warnings: [],
-      embeddingMode: 'mock',
+      answer: buildAnswer(citations),
+      mode,
+      citations,
+      warnings,
+      versionContext,
+      embeddingMode: 'mock_offline',
       requestId: nextRequestId(),
     },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// /ask/stream
+// ---------------------------------------------------------------------------
+
+/** Splits an answer into whitespace-preserving tokens — a stand-in for the real `tokenize_answer` (`services/qa/stream.rs`); good enough to demonstrate a token-growing UI, not a claim about the real tokenizer's boundaries. */
+function tokenizeAnswer(answer: string): string[] {
+  const tokens = answer.match(/\S+\s*/g);
+  return tokens ?? [answer];
+}
+
+interface SseFrame {
+  id?: number;
+  event: string;
+  data: unknown;
+}
+
+function serializeSseFrames(frames: SseFrame[], requestId: string): string {
+  return frames
+    .map((frame) => {
+      const envelope: SseEnvelope = {
+        version: 1,
+        sequence: frame.id ?? 0,
+        event: frame.event,
+        requestId,
+        data: frame.data,
+      };
+      const idLine = frame.id !== undefined ? `id: ${frame.id}\n` : '';
+      return `${idLine}event: ${frame.event}\ndata: ${JSON.stringify(envelope)}\n\n`;
+    })
+    .join('');
+}
+
+registerOperation('askStream', async (ctx) => {
+  const body = await ctx.json<AskRequest>();
+  const rawQuestion = body.question;
+  const revoke = rawQuestion.includes(QA_STREAM_MARKERS.citationRevoked);
+  const fallback = rawQuestion.includes(QA_STREAM_MARKERS.providerFallback);
+  const question = stripMarkers(rawQuestion);
+  const mode = body.mode ?? 'current';
+
+  let passages: Passage[];
+  let scenarioWarnings: string[];
+  if (mode === 'compare' || mode === 'history' || mode === 'as_of') {
+    const resolved = resolveCompareOrHistoryPassages(body);
+    passages = resolved.passages;
+    scenarioWarnings = resolved.warnings;
+  } else {
+    passages = matchPassages(question, body.collectionIds, body.limit ?? 10);
+    scenarioWarnings = [];
+  }
+  const citations = passages.map((p, i) => passageToCitation(p, citeIdFor(i)));
+  const answer = buildAnswer(citations);
+  const tokens = tokenizeAnswer(answer);
+  const versionContext = versionContextFor(body, passages);
+  const warnings = [...scenarioWarnings, ...currentModeWarnings(mode, citations)];
+  if (fallback) {
+    warnings.push(
+      'Nhà cung cấp LLM tạm thời không khả dụng; đã chuyển sang câu trả lời trích xuất.',
+    );
+  }
+
+  const requestId = nextRequestId();
+  const sessionId = nextId();
+  const frames: SseFrame[] = [];
+  let seq = 0;
+  const next = () => {
+    seq += 1;
+    return seq;
+  };
+
+  frames.push({
+    id: next(),
+    event: 'ask.started',
+    data: {
+      streamSessionId: sessionId,
+      mode: 'offline_extractive',
+      embeddingMode: 'mock_offline',
+      citationCount: citations.length,
+    },
+  });
+
+  if (revoke) {
+    // Real behaviour (`ask_stream.rs`'s `append()`/`close()`): the instant a
+    // cited document/version becomes inaccessible mid-stream, the producer
+    // stops appending tokens and closes durably with `citation_revoked` —
+    // citations/version_context/completed never arrive. A couple of tokens
+    // stream first so the UI has visibly started an answer before the close.
+    for (const token of tokens.slice(0, 2)) {
+      frames.push({ id: next(), event: 'ask.token', data: { text: token } });
+    }
+    frames.push({
+      id: next(),
+      event: 'stream.closed',
+      data: { reason: 'citation_revoked' },
+    });
+    return {
+      status: 200,
+      rawBody: { text: serializeSseFrames(frames, requestId), contentType: 'text/event-stream' },
+    };
+  }
+
+  for (const token of tokens) {
+    frames.push({ id: next(), event: 'ask.token', data: { text: token } });
+  }
+  for (const warning of warnings) {
+    frames.push({ id: next(), event: 'ask.warning', data: { message: warning } });
+  }
+  frames.push({ id: next(), event: 'ask.citations', data: { citations } });
+  frames.push({ id: next(), event: 'ask.version_context', data: versionContext });
+  frames.push({
+    id: next(),
+    event: 'ask.completed',
+    data: {
+      mode: fallback ? 'fallback_extractive' : 'offline_extractive',
+      streamSessionId: sessionId,
+    },
+  });
+  frames.push({ id: next(), event: 'stream.closed', data: { reason: 'completed' } });
+
+  return {
+    status: 200,
+    rawBody: { text: serializeSseFrames(frames, requestId), contentType: 'text/event-stream' },
   };
 });

--- a/web/src/mocks/spec/openApiSpec.test.ts
+++ b/web/src/mocks/spec/openApiSpec.test.ts
@@ -4,8 +4,8 @@ import { buildSpecIndex, getOperation } from './openApiSpec';
 const spec = buildSpecIndex();
 
 describe('buildSpecIndex against the real openapi.yaml', () => {
-  it('indexes all 38 component schemas', () => {
-    expect(Object.keys(spec.schemas)).toHaveLength(38);
+  it('indexes all 40 component schemas', () => {
+    expect(Object.keys(spec.schemas)).toHaveLength(40);
     expect(spec.schemas.TokenResponse).toBeDefined();
     expect(spec.schemas.ApiError).toBeDefined();
   });

--- a/web/src/mocks/spec/yaml.test.ts
+++ b/web/src/mocks/spec/yaml.test.ts
@@ -118,9 +118,9 @@ describe('parseYaml against the real openapi.yaml', () => {
     expect(typeof doc.components).toBe('object');
   });
 
-  it('finds all 38 component schemas', () => {
+  it('finds all 40 component schemas', () => {
     const schemas = (doc.components as Record<string, unknown>).schemas as Record<string, unknown>;
-    expect(Object.keys(schemas)).toHaveLength(38);
+    expect(Object.keys(schemas)).toHaveLength(40);
   });
 
   it('parses a representative path item with multiple methods and shared parameters', () => {

--- a/web/src/pages/AdminMembersPage.test.tsx
+++ b/web/src/pages/AdminMembersPage.test.tsx
@@ -19,8 +19,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createApiClient, type ApiClient } from '../api/client';
 import { installMockFetch, mockControl, resetMockState, uninstallMockFetch } from '../mocks';
 import {
+  getOrgMemberships,
   getStore,
   mintTokenPair,
+  ORG_A_ID,
   SECOND_MEMBER_USER_ID,
   THIRD_MEMBER_USER_ID,
 } from '../mocks/fixtures';
@@ -128,7 +130,9 @@ describe('AdminMembersPage', () => {
       fireEvent.click(screen.getByRole('option', { name: 'Biên tập viên' }));
 
       await waitFor(() => {
-        const membership = getStore().memberships.find((m) => m.userId === SECOND_MEMBER_USER_ID);
+        const membership = getOrgMemberships(ORG_A_ID).find(
+          (m) => m.userId === SECOND_MEMBER_USER_ID,
+        );
         expect(membership?.role).toBe('editor');
       });
       // Scoped to this member's own row — see `findRowByUserId`'s doc for why
@@ -148,7 +152,9 @@ describe('AdminMembersPage', () => {
       fireEvent.click(within(row).getByRole('button', { name: 'Kích hoạt lại' }));
 
       await waitFor(() => {
-        const membership = getStore().memberships.find((m) => m.userId === THIRD_MEMBER_USER_ID);
+        const membership = getOrgMemberships(ORG_A_ID).find(
+          (m) => m.userId === THIRD_MEMBER_USER_ID,
+        );
         expect(membership?.state).toBe('active');
       });
     });
@@ -162,7 +168,9 @@ describe('AdminMembersPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Xóa thành viên' }));
 
       await waitFor(() =>
-        expect(getStore().memberships.some((m) => m.userId === SECOND_MEMBER_USER_ID)).toBe(false),
+        expect(getOrgMemberships(ORG_A_ID).some((m) => m.userId === SECOND_MEMBER_USER_ID)).toBe(
+          false,
+        ),
       );
       await waitFor(() =>
         expect(
@@ -187,12 +195,12 @@ describe('AdminMembersPage', () => {
   describe('owner-tier restriction ("admin không quản owner")', () => {
     it('hides owner-granting and locks an owner row for a non-owner caller', async () => {
       const client = loggedInClient();
-      const store = getStore();
-      const callerRow = store.memberships.find((m) => m.role === 'owner');
+      const roster = getOrgMemberships(ORG_A_ID);
+      const callerRow = roster.find((m) => m.role === 'owner');
       expect(callerRow).toBeDefined();
       callerRow!.role = 'admin'; // the signed-in caller is no longer an owner...
       const otherOwnerId = mockUuid(40);
-      store.memberships.push({
+      roster.push({
         userId: otherOwnerId,
         role: 'owner',
         state: 'active',
@@ -226,7 +234,7 @@ describe('AdminMembersPage', () => {
         await within(row).findByText(/tổ chức phải luôn còn ít nhất một chủ sở hữu/),
       ).toBeVisible();
       // Fails closed: the membership itself must not have been mutated.
-      const owner = getStore().memberships.find((m) => m.role === 'owner');
+      const owner = getOrgMemberships(ORG_A_ID).find((m) => m.role === 'owner');
       expect(owner?.state).toBe('active');
     });
   });

--- a/web/src/pages/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage.test.tsx
@@ -87,10 +87,14 @@ describe('LoginPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Đăng nhập' }));
 
     await waitFor(() =>
-      expect(client.login).toHaveBeenCalledWith({
-        email: 'demo@markhand.test',
-        password: 'demo-password',
-      }),
+      // A third `AbortSignal` argument now rides along (`AuthContext.tsx`'s
+      // `login()` passes its own epoch-scoped controller so a superseded
+      // login's request can be cancelled outright) — assert on credentials
+      // only, not on the exact signal instance.
+      expect(client.login).toHaveBeenCalledWith(
+        { email: 'demo@markhand.test', password: 'demo-password' },
+        expect.any(AbortSignal),
+      ),
     );
     await waitFor(() => expect(screen.getByTestId('status')).toHaveTextContent('authenticated'));
   });

--- a/web/src/pages/QaPage.test.tsx
+++ b/web/src/pages/QaPage.test.tsx
@@ -1,0 +1,162 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApiClient, type ApiClient } from '../api/client';
+import { installMockFetch, resetMockState, uninstallMockFetch } from '../mocks';
+import { QA_STREAM_MARKERS } from '../mocks/handlers/qa';
+import { mockUuid } from '../mocks/ids';
+import { RouterProvider } from '../state/RouterProvider';
+import { ScopeProvider } from '../state/ScopeProvider';
+import { QaPage } from './QaPage';
+
+const DEMO_EMAIL = 'demo@markhand.test';
+const DEMO_PASSWORD = 'demo-password';
+const HANDBOOK_COLLECTION_ID = mockUuid(10);
+
+async function loggedInClient(): Promise<ApiClient> {
+  const client = createApiClient({ baseUrl: '' });
+  await client.login({ email: DEMO_EMAIL, password: DEMO_PASSWORD });
+  return client;
+}
+
+function renderQa(client: ApiClient, collectionId?: string) {
+  return render(
+    <RouterProvider>
+      <ScopeProvider>
+        <QaPage collectionId={collectionId} client={client} />
+      </ScopeProvider>
+    </RouterProvider>,
+  );
+}
+
+async function askQuestion(question: string) {
+  fireEvent.change(screen.getByLabelText('Câu hỏi'), { target: { value: question } });
+  fireEvent.click(screen.getByRole('button', { name: 'Hỏi' }));
+}
+
+describe('QaPage', () => {
+  beforeEach(() => {
+    installMockFetch();
+    resetMockState();
+  });
+
+  afterEach(() => {
+    cleanup();
+    uninstallMockFetch();
+  });
+
+  it('searches indexed documents and previews a hit with its version badge', async () => {
+    const client = await loggedInClient();
+    renderQa(client, HANDBOOK_COLLECTION_ID);
+
+    fireEvent.change(screen.getByLabelText('Từ khóa'), { target: { value: 'hội nhập' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Tìm kiếm' }));
+
+    expect(await screen.findByText('Onboarding Guide.pdf')).toBeVisible();
+    expect(screen.getAllByText(/khóa đào tạo hội nhập/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('CITE-0001').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Xem trước' }));
+    expect(await screen.findByTestId('qa-preview-markdown')).toHaveTextContent(
+      'Mock preview content for version 1',
+    );
+    expect(screen.getByText('Phiên bản 1 (bản hiện hành)')).toBeVisible();
+  });
+
+  it('shows "no results" copy for a query that matches nothing indexed', async () => {
+    const client = await loggedInClient();
+    renderQa(client, HANDBOOK_COLLECTION_ID);
+
+    fireEvent.change(screen.getByLabelText('Từ khóa'), {
+      target: { value: 'khong-co-gi-khop-cau-nay' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Tìm kiếm' }));
+
+    expect(
+      await screen.findByText(/Không tìm thấy kết quả phù hợp với "khong-co-gi-khop-cau-nay"/),
+    ).toBeVisible();
+  });
+
+  it('streams a grounded answer token-by-token through to citations (default scenario)', async () => {
+    const client = await loggedInClient();
+    renderQa(client);
+
+    await askQuestion('Lộ trình quý 3 tập trung vào việc gì?');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('qa-answer')).toHaveTextContent(
+        'Lộ trình quý 3 tập trung vào tối ưu hiệu năng lập chỉ mục.',
+      );
+    });
+    expect(await screen.findByText('CITE-0001')).toBeVisible();
+    expect(
+      screen.getByText(
+        /Trích dẫn ở đây chưa kèm định danh tài liệu\/phiên bản theo hợp đồng hiện tại/,
+      ),
+    ).toBeVisible();
+    // Default scenario is not the fallback path.
+    expect(screen.queryByText('Trả lời trích xuất (không qua LLM)')).not.toBeInTheDocument();
+  });
+
+  it('reports "no answer" (zero citations) honestly for a question with no matching passage', async () => {
+    const client = await loggedInClient();
+    renderQa(client);
+
+    await askQuestion('cau-hoi-khong-khop-bat-ky-tai-lieu-nao');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('qa-answer')).toHaveTextContent(
+        'Không tìm thấy nội dung liên quan trong tài liệu đã lập chỉ mục để trả lời câu hỏi này.',
+      );
+    });
+  });
+
+  it('citation_revoked mid-answer: partial answer stays visible with an accessible revoked notice, no crash', async () => {
+    const client = await loggedInClient();
+    renderQa(client);
+
+    await askQuestion(`Lộ trình quý 3 là gì? ${QA_STREAM_MARKERS.citationRevoked}`);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Trích dẫn đã bị thu hồi giữa chừng/)).toBeVisible();
+    });
+    // A partial answer (the tokens that streamed before the revoke) is kept, not blanked.
+    expect(screen.getByTestId('qa-answer')).toHaveTextContent(/\S/);
+    // The revoke happens before ask.citations ever arrives.
+    expect(screen.queryByText('CITE-0001')).not.toBeInTheDocument();
+  });
+
+  it('provider-fallback: still answers via extractive tokens, labelled as extractive, with a warning', async () => {
+    const client = await loggedInClient();
+    renderQa(client);
+
+    await askQuestion(`Lộ trình quý 3 là gì? ${QA_STREAM_MARKERS.providerFallback}`);
+
+    await waitFor(() => {
+      expect(screen.getByText('Trả lời trích xuất (không qua LLM)')).toBeVisible();
+    });
+    expect(screen.getByText(/Nhà cung cấp LLM tạm thời không khả dụng/)).toBeVisible();
+    expect(screen.getByTestId('qa-answer')).toHaveTextContent(
+      'Lộ trình quý 3 tập trung vào tối ưu hiệu năng lập chỉ mục.',
+    );
+  });
+
+  it('"Hủy" aborts an in-flight ask and returns to an inert state', async () => {
+    const client = await loggedInClient();
+    renderQa(client);
+
+    // Deliberately synchronous (no `await` between these) so the assertion
+    // does not race the mock's own near-instant stream resolution (see
+    // `mocks/handlers/qa.ts`'s module doc: the whole response is a
+    // pre-serialized string with nothing to actually await) — clicking
+    // "Hủy" sets `isActive` to `false` synchronously via `useAskStream`'s
+    // `reset()`, which hides the button regardless of whether the stream
+    // had already finished on its own by this point.
+    fireEvent.change(screen.getByLabelText('Câu hỏi'), {
+      target: { value: 'Lộ trình quý 3 là gì?' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Hỏi' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Hủy' }));
+
+    expect(screen.queryByRole('button', { name: 'Hủy' })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/QaPage.tsx
+++ b/web/src/pages/QaPage.tsx
@@ -1,18 +1,50 @@
-import { Notice } from '../components/ui';
+// P2-10: search + streamed ask, built directly on the OpenAPI contract +
+// mock server (owner gate-down, 2026-07-29 — see
+// `plans/markhand-web/backlog/phase-2/issues/README.md`'s P2-10 entry). Was a
+// placeholder before this; every field/endpoint used below is one the
+// contract (`web/src/api/generated/contract.ts`) actually declares — see
+// `components/qa/**`'s own module docs for the one verified gap (citations
+// from `ask`/`ask/stream` carry no document/version id to deep-link with).
+import { useState } from 'react';
+import { apiClient, type ApiClient } from '../api/client';
+import { AskPanel, SearchPanel, type SearchHit } from '../components/qa';
 
-export function QaPage({ collectionId }: { collectionId?: string }) {
+export function QaPage({
+  collectionId,
+  client = apiClient,
+}: {
+  collectionId?: string;
+  /** Injectable for tests; defaults to the app-wide singleton, same convention as `LibraryPage`. */
+  client?: ApiClient;
+}) {
+  const collectionIds = collectionId ? [collectionId] : undefined;
+  // Fed by `SearchPanel` so `AskPanel`'s compare/history document picker has
+  // real documents to choose from instead of a raw UUID field — see
+  // `AskPanel.tsx`'s module doc.
+  const [candidateDocuments, setCandidateDocuments] = useState<SearchHit[]>([]);
+
   return (
-    <section className="page" aria-labelledby="qa-heading">
+    <section className="page" style={{ maxWidth: 'none' }} aria-labelledby="qa-heading">
       <p className="eyebrow">Hỏi đáp</p>
       <h1 id="qa-heading">
-        {collectionId ? `Hỏi đáp trên ${collectionId}` : 'Hỏi đáp trên toàn bộ thư viện'}
+        {collectionId ? `Hỏi đáp trên bộ sưu tập ${collectionId}` : 'Hỏi đáp trên toàn bộ thư viện'}
       </h1>
       <p className="lede">
-        Tìm kiếm, câu trả lời có trích dẫn và trạng thái chỉ mục sẽ hiển thị ở đây khi client
-        API/SSE sẵn sàng.
+        Tìm kiếm tài liệu đã lập chỉ mục hoặc đặt câu hỏi để nhận câu trả lời có trích dẫn, phát dần
+        theo thời gian thực.
       </p>
-      <div aria-live="polite">
-        <Notice tone="info">Chưa kết nối tới API hỏi đáp.</Notice>
+
+      <div style={{ display: 'grid', gap: 'var(--space-4)' }}>
+        <SearchPanel
+          collectionIds={collectionIds}
+          client={client}
+          onHitsChanged={setCandidateDocuments}
+        />
+        <AskPanel
+          collectionIds={collectionIds}
+          client={client}
+          candidateDocuments={candidateDocuments}
+        />
       </div>
     </section>
   );

--- a/web/src/state/askStream.test.ts
+++ b/web/src/state/askStream.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import type { SseMessage } from '../api/sse';
+import {
+  describeAskStreamError,
+  initialAskStreamState,
+  reduceAskStreamMessage,
+  type AskStreamState,
+} from './askStream';
+
+function event(id: number, eventName: string, data: unknown): SseMessage {
+  return {
+    kind: 'event',
+    id: String(id),
+    envelope: { version: 1, sequence: id, event: eventName, requestId: 'req-1', data },
+  };
+}
+
+function fold(
+  messages: SseMessage[],
+  start: AskStreamState = initialAskStreamState(),
+): AskStreamState {
+  return messages.reduce(reduceAskStreamMessage, start);
+}
+
+describe('reduceAskStreamMessage', () => {
+  it('accumulates tokens in order and reaches "completed" on a durable stream.closed', () => {
+    const final = fold([
+      event(1, 'ask.started', {
+        streamSessionId: 'sess-1',
+        mode: 'offline_extractive',
+        citationCount: 1,
+      }),
+      event(2, 'ask.token', { text: 'Xin ' }),
+      event(3, 'ask.token', { text: 'chào ' }),
+      event(4, 'ask.token', { text: 'bạn.' }),
+      event(5, 'ask.citations', {
+        citations: [
+          {
+            citeId: 'CITE-0001',
+            sourceContentSha256: 'a'.repeat(64),
+            canonicalMarkdownSha256: 'b'.repeat(64),
+            quoteSha256: 'c'.repeat(64),
+            chunkIdentitySha256: 'd'.repeat(64),
+            quote: 'Xin chào bạn.',
+            sourceSpanStart: 0,
+            sourceSpanEnd: 10,
+            quoteLocalStart: 0,
+            quoteLocalEnd: 10,
+            isCurrent: true,
+          },
+        ],
+      }),
+      event(6, 'ask.version_context', {
+        mode: 'current',
+        currentVersionIds: ['v1'],
+        citedVersionIds: ['v1'],
+        changeNote: null,
+      }),
+      event(7, 'ask.completed', { mode: 'offline_extractive', streamSessionId: 'sess-1' }),
+      event(8, 'stream.closed', { reason: 'completed' }),
+    ]);
+
+    expect(final.answer).toBe('Xin chào bạn.');
+    expect(final.status).toBe('completed');
+    expect(final.streamSessionId).toBe('sess-1');
+    expect(final.citations).toHaveLength(1);
+    expect(final.citations[0].citeId).toBe('CITE-0001');
+    expect(final.versionContext?.mode).toBe('current');
+    expect(final.errorReason).toBeUndefined();
+  });
+
+  it('ignores a duplicate/out-of-order event id instead of re-applying it (dedupe belt, see module doc)', () => {
+    const afterFirstToken = fold([
+      event(1, 'ask.started', { streamSessionId: 's', mode: 'offline_extractive' }),
+      event(2, 'ask.token', { text: 'A' }),
+    ]);
+    expect(afterFirstToken.answer).toBe('A');
+
+    // A message the real transport would never yield (it already rejects
+    // non-increasing ids as a protocol violation) — feeding it directly to
+    // the reducer proves the second, independent guard this module keeps.
+    const replayed = reduceAskStreamMessage(afterFirstToken, event(2, 'ask.token', { text: 'A' }));
+    expect(replayed.answer).toBe('A'); // not "AA" — the duplicate never re-applied
+
+    const nextReal = reduceAskStreamMessage(replayed, event(3, 'ask.token', { text: 'B' }));
+    expect(nextReal.answer).toBe('AB');
+  });
+
+  it('citation_revoked mid-answer: partial answer kept, status "revoked", no citations ever arrive', () => {
+    const final = fold([
+      event(1, 'ask.started', { streamSessionId: 's', mode: 'offline_extractive' }),
+      event(2, 'ask.token', { text: 'Đang trả lời ' }),
+      event(3, 'ask.token', { text: 'thì bị thu hồi.' }),
+      event(4, 'stream.closed', { reason: 'citation_revoked' }),
+    ]);
+
+    expect(final.status).toBe('revoked');
+    expect(final.errorReason).toBe('citation_revoked');
+    expect(final.answer).toBe('Đang trả lời thì bị thu hồi.');
+    expect(final.citations).toHaveLength(0);
+  });
+
+  it('fallback-extractive: warning arrives before citations, final mode is fallback_extractive', () => {
+    const final = fold([
+      event(1, 'ask.started', { streamSessionId: 's', mode: 'offline_extractive' }),
+      event(2, 'ask.token', { text: 'Trả lời trích xuất.' }),
+      event(3, 'ask.warning', { message: 'Nhà cung cấp LLM tạm thời không khả dụng.' }),
+      event(4, 'ask.citations', { citations: [] }),
+      event(5, 'ask.version_context', {
+        mode: 'current',
+        currentVersionIds: [],
+        citedVersionIds: [],
+        changeNote: null,
+      }),
+      event(6, 'ask.completed', { mode: 'fallback_extractive', streamSessionId: 's' }),
+      event(7, 'stream.closed', { reason: 'completed' }),
+    ]);
+
+    expect(final.status).toBe('completed');
+    expect(final.answerMode).toBe('fallback_extractive');
+    expect(final.warnings).toEqual(['Nhà cung cấp LLM tạm thời không khả dụng.']);
+  });
+
+  it('a network-error close after some progress is a terminal "error", but never downgrades an already-completed/revoked state', () => {
+    const midStream = fold([
+      event(1, 'ask.started', { streamSessionId: 's', mode: 'offline_extractive' }),
+      event(2, 'ask.token', { text: 'A' }),
+    ]);
+    const afterNetworkLoss = reduceAskStreamMessage(midStream, {
+      kind: 'closed',
+      reason: { type: 'network-error' },
+    });
+    expect(afterNetworkLoss.status).toBe('error');
+    expect(afterNetworkLoss.errorReason).toBe('network');
+
+    const completed = fold([
+      event(1, 'ask.started', { streamSessionId: 's', mode: 'offline_extractive' }),
+      event(2, 'stream.closed', { reason: 'completed' }),
+    ]);
+    const stillCompleted = reduceAskStreamMessage(completed, {
+      kind: 'closed',
+      reason: { type: 'network-error' },
+    });
+    expect(stillCompleted.status).toBe('completed');
+  });
+
+  it('a session-lost close (org switch/logout mid-answer) is always terminal, even if already completed', () => {
+    const completed = fold([event(1, 'stream.closed', { reason: 'completed' })]);
+    const afterSessionLost = reduceAskStreamMessage(completed, {
+      kind: 'closed',
+      reason: { type: 'session-lost' },
+    });
+    expect(afterSessionLost.status).toBe('error');
+    expect(afterSessionLost.errorReason).toBe('session-lost');
+  });
+
+  it('gap/parse-error/protocol-violation surface accessible notices without crashing or losing the answer so far', () => {
+    const afterGap = reduceAskStreamMessage(fold([event(1, 'ask.token', { text: 'A' })]), {
+      kind: 'gap',
+      expected: '2',
+      received: '5',
+    });
+    expect(afterGap.answer).toBe('A');
+    expect(afterGap.notices).toHaveLength(1);
+
+    const afterParseError = reduceAskStreamMessage(afterGap, {
+      kind: 'parse-error',
+      raw: 'not json',
+      event: 'ask.token',
+    });
+    expect(afterParseError.notices).toHaveLength(2);
+    expect(afterParseError.status).not.toBe('error');
+
+    const afterProtocolViolation = reduceAskStreamMessage(afterParseError, {
+      kind: 'protocol-violation',
+      message: 'id "1" invalid or not greater than last acked "3"',
+      receivedId: '1',
+    });
+    expect(afterProtocolViolation.status).toBe('error');
+    expect(afterProtocolViolation.errorReason).toBe('protocol_violation');
+  });
+
+  it('heartbeats are a no-op', () => {
+    const before = fold([event(1, 'ask.token', { text: 'A' })]);
+    const after = reduceAskStreamMessage(before, { kind: 'heartbeat' });
+    expect(after).toEqual(before);
+  });
+});
+
+describe('describeAskStreamError', () => {
+  it('has distinct, non-empty Vietnamese copy for every reason the mock/server can actually emit', () => {
+    const reasons = [
+      'cancelled',
+      'session_revoked',
+      'principal_denied',
+      'session_expired',
+      'ops_fence_active',
+      'protocol_violation',
+      'network',
+      'session-lost',
+      'stream_error',
+      'send_timeout',
+      'live_tail_timeout',
+      undefined,
+      'some_future_unrecognized_reason',
+    ];
+    const texts = reasons.map((reason) => describeAskStreamError(reason));
+    for (const text of texts) {
+      expect(text.length).toBeGreaterThan(0);
+    }
+    // An unrecognized reason still gets an honest, distinguishing message
+    // (not silently identical to the generic undefined case).
+    expect(describeAskStreamError('some_future_unrecognized_reason')).toContain(
+      'some_future_unrecognized_reason',
+    );
+  });
+});

--- a/web/src/state/askStream.ts
+++ b/web/src/state/askStream.ts
@@ -1,0 +1,204 @@
+// P2-10 (Q&A). Pure reducer over `api/sse.ts`'s `SseMessage` stream for
+// `POST /ask/stream` — no React/DOM here, same "state/** is plain logic,
+// hooks/components consume it" split as `state/scope.ts`/`scopeCache.ts`.
+//
+// Ordering/dedupe: `SseConnection` itself already refuses to yield a
+// duplicate or out-of-order `id`-bearing event (`advanceCursor` in
+// `api/lastEventId.ts` — a violation there ends the stream as
+// `protocol-violation`, never silently reapplied), so in practice this
+// reducer never sees a real duplicate from a well-behaved connection. The
+// `lastEventSequence` guard below is a second, independent belt for the same
+// invariant — applied at the point the answer/citations state is actually
+// built, not just at the transport's framing layer — kept deliberately
+// redundant with the transport's own guarantee (mirrors
+// `useScopeSafeRequest.ts`'s documented "belt and suspenders" layering) and
+// exercised directly in `askStream.test.ts` by feeding a hand-built duplicate
+// message the transport itself would never actually produce.
+import type { components } from '../api/generated/contract';
+import type { SseCloseReason, SseMessage } from '../api/sse';
+
+export type CitationPin = components['schemas']['CitationPin'];
+
+export interface AskVersionContext {
+  mode: string;
+  currentVersionIds: string[];
+  citedVersionIds: string[];
+  changeNote: string | null;
+}
+
+export type AskStreamStatus = 'idle' | 'streaming' | 'completed' | 'revoked' | 'error';
+
+export interface AskStreamState {
+  readonly status: AskStreamStatus;
+  readonly streamSessionId?: string;
+  /** The server's own `AnswerMode` wire string (`offline_extractive`/`fallback_extractive`/...) — displayed, never re-derived client-side. */
+  readonly answerMode?: string;
+  readonly answer: string;
+  readonly citations: CitationPin[];
+  readonly warnings: string[];
+  readonly versionContext?: AskVersionContext;
+  /** Set once `status` becomes `'error'` (or `'revoked'`, which also carries a reason for the accessible notice) — the `stream.closed` reason code, or a transport-level code (`'network'`, `'session-lost'`, `'protocol_violation'`). */
+  readonly errorReason?: string;
+  /** Non-fatal transport notices (`gap`/`parse-error`) surfaced as accessible status text; never blocks the answer from continuing to render. */
+  readonly notices: string[];
+  readonly lastEventSequence?: number;
+}
+
+export function initialAskStreamState(): AskStreamState {
+  return { status: 'idle', answer: '', citations: [], warnings: [], notices: [] };
+}
+
+function parseSequence(id: string): number | undefined {
+  const n = Number(id);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function applyEnvelope(state: AskStreamState, event: string, data: unknown): AskStreamState {
+  switch (event) {
+    case 'ask.started': {
+      const streamSessionId =
+        isRecord(data) && typeof data.streamSessionId === 'string'
+          ? data.streamSessionId
+          : undefined;
+      const mode = isRecord(data) && typeof data.mode === 'string' ? data.mode : undefined;
+      return { ...state, status: 'streaming', streamSessionId, answerMode: mode };
+    }
+    case 'ask.token': {
+      const text = isRecord(data) && typeof data.text === 'string' ? data.text : '';
+      return { ...state, status: 'streaming', answer: state.answer + text };
+    }
+    case 'ask.warning': {
+      const message = isRecord(data) && typeof data.message === 'string' ? data.message : undefined;
+      return message ? { ...state, warnings: [...state.warnings, message] } : state;
+    }
+    case 'ask.citations': {
+      const citations =
+        isRecord(data) && Array.isArray(data.citations) ? (data.citations as CitationPin[]) : [];
+      return { ...state, citations };
+    }
+    case 'ask.version_context': {
+      if (!isRecord(data)) return state;
+      const versionContext: AskVersionContext = {
+        mode: typeof data.mode === 'string' ? data.mode : 'current',
+        currentVersionIds: Array.isArray(data.currentVersionIds)
+          ? (data.currentVersionIds as string[])
+          : [],
+        citedVersionIds: Array.isArray(data.citedVersionIds)
+          ? (data.citedVersionIds as string[])
+          : [],
+        changeNote: typeof data.changeNote === 'string' ? data.changeNote : null,
+      };
+      return { ...state, versionContext };
+    }
+    case 'ask.completed': {
+      const mode = isRecord(data) && typeof data.mode === 'string' ? data.mode : state.answerMode;
+      return { ...state, answerMode: mode };
+    }
+    case 'stream.closed': {
+      const reason =
+        isRecord(data) && typeof data.reason === 'string' ? data.reason : 'stream_error';
+      return closeWithReason(state, reason);
+    }
+    default:
+      return state; // unknown event name — forward-compatible no-op, not a crash
+  }
+}
+
+function closeWithReason(state: AskStreamState, reason: string): AskStreamState {
+  if (reason === 'completed') {
+    return { ...state, status: 'completed', errorReason: undefined };
+  }
+  if (reason === 'citation_revoked') {
+    return { ...state, status: 'revoked', errorReason: reason };
+  }
+  return { ...state, status: 'error', errorReason: reason };
+}
+
+function applyClose(state: AskStreamState, reason: SseCloseReason): AskStreamState {
+  if (reason.type === 'server') {
+    return closeWithReason(state, reason.code);
+  }
+  if (reason.type === 'network-error') {
+    return state.status === 'completed' || state.status === 'revoked'
+      ? state
+      : { ...state, status: 'error', errorReason: 'network' };
+  }
+  // session-lost: the caller's org/session changed under it (logout, org switch, revoke) —
+  // always terminal regardless of whatever status was current.
+  return { ...state, status: 'error', errorReason: 'session-lost' };
+}
+
+/** Applies one `SseMessage` (from `api/sse.ts`'s `SseConnection`) to `state`. Pure — safe to unit-test directly, and to fold over a canned message array to reconstruct any point in a stream. */
+export function reduceAskStreamMessage(state: AskStreamState, message: SseMessage): AskStreamState {
+  switch (message.kind) {
+    case 'event': {
+      const seq = parseSequence(message.id);
+      if (
+        seq !== undefined &&
+        state.lastEventSequence !== undefined &&
+        seq <= state.lastEventSequence
+      ) {
+        return state; // stale/duplicate id — see module doc's "belt" note
+      }
+      const applied = applyEnvelope(state, message.envelope.event, message.envelope.data);
+      return { ...applied, lastEventSequence: seq ?? state.lastEventSequence };
+    }
+    case 'control':
+      return applyEnvelope(state, message.envelope.event, message.envelope.data);
+    case 'heartbeat':
+      return state;
+    case 'gap':
+      return {
+        ...state,
+        notices: [...state.notices, 'Đã bỏ lỡ một số sự kiện cập nhật; nội dung tiếp tục đồng bộ.'],
+      };
+    case 'protocol-violation':
+      return {
+        ...state,
+        status: 'error',
+        errorReason: 'protocol_violation',
+        notices: [...state.notices, 'Luồng dữ liệu không hợp lệ; đã dừng nhận câu trả lời.'],
+      };
+    case 'parse-error':
+      return {
+        ...state,
+        notices: [...state.notices, 'Không đọc được một phần dữ liệu trả lời từ máy chủ.'],
+      };
+    case 'closed':
+      return applyClose(state, message.reason);
+  }
+}
+
+/** Vietnamese, accessible copy for a terminal `errorReason`. Every reason this mock/server can actually emit (`ask_stream.rs`'s `config_reason` + `api/sse.ts`'s transport-level codes) gets its own line — an unrecognized one still gets an honest generic message instead of silently showing nothing. */
+export function describeAskStreamError(reason: string | undefined): string {
+  switch (reason) {
+    case 'cancelled':
+      return 'Yêu cầu đã được hủy.';
+    case 'session_revoked':
+      return 'Phiên đăng nhập đã bị thu hồi.';
+    case 'principal_denied':
+      return 'Bạn không còn quyền truy cập nội dung này.';
+    case 'session_expired':
+      return 'Phiên hỏi đáp đã hết hạn.';
+    case 'ops_fence_active':
+      return 'Hệ thống đang bảo trì; vui lòng thử lại sau.';
+    case 'protocol_violation':
+      return 'Dữ liệu trả lời không hợp lệ; vui lòng thử lại.';
+    case 'network':
+      return 'Mất kết nối mạng khi đang nhận câu trả lời.';
+    case 'session-lost':
+      return 'Phiên làm việc đã thay đổi (đăng xuất hoặc chuyển tổ chức); đã dừng nhận câu trả lời.';
+    case 'stream_error':
+    case 'send_timeout':
+    case 'live_tail_timeout':
+      return 'Máy chủ tạm thời gặp sự cố khi trả lời; vui lòng thử lại.';
+    case undefined:
+      return 'Đã dừng nhận câu trả lời.';
+    default:
+      return `Đã dừng nhận câu trả lời (${reason}).`;
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -773,7 +773,8 @@ code {
 }
 
 /* — forms — */
-.field > label {
+.field > label,
+.field-label {
   display: block;
   font-size: 12px;
   margin-bottom: 5px;


### PR DESCRIPTION
## Outcome

Vòng tiếp theo sau #323 — 6 commit:

- **Q&A UI (P2-10, `9d4e854`)**: owner hạ gate cho môi trường dev/test — `QaPage` thay placeholder: search + xem trước, hỏi đáp **streaming** qua `POST /ask/stream` (fetch-SSE P2-04, không EventSource); reducer thuần (`state/askStream.ts`) áp đúng thứ tự sự kiện contract (`ask.started → ask.token* → ask.warning* → ask.citations → ask.version_context → ask.completed → stream.closed`) kèm dedupe-guard riêng; `citation_revoked` giữa chừng và fallback trích xuất (`AnswerMode` server, không suy diễn client) đều hiển thị accessible qua `aria-live`. Mock `askStream` deterministic với marker kịch bản; 4 E2E spec mới.
- **Audit-read (1C-11, `e3c5e4b`)**: `GET /api/v1/audit` — bề mặt đọc đầu tiên của `audit_log` append-only: guard `audit.view`, cursor pagination `(created_at,id)` DESC, filter action (enum-validated)/actor/from/to, org isolation (query + RLS); đọc audit cũng được audit (`audit.read`, cả success lẫn deny).
- **Login race fix (`1aae6d3`)**: `client.login()` tự cài token bên trong nên epoch-guard là chưa đủ — truyền `AbortSignal` vào chính `client.login()` để call bị supersede hủy fetch trước khi `setTokens` chạy; kèm test out-of-order login-vs-logout/login-vs-login. Admin mock members/usage org-scoped theo token (trang admin đúng data sau khi switch org).
- **Test hardening 1C-02 (`0e82da7`)**: 4 test DB-gated còn thiếu — 409 last-owner deterministic cho tự-downgrade/remove/suspend, 403 thiếu `member.manage` (audited), 404 member chưa từng tồn tại, audit before/after metadata. Sửa backlog 1C-02 stale (PATCH/DELETE đã landed từ #317).
- **Test hardening R03/R05 (`c22f592`)**: xác minh 3/5 mục "Remaining for Done" đã tồn tại từ trước (không test SSE/ask nào dial Qdrant — vector leg short-circuit khi `embedder: None`); thêm 2 test thật sự thiếu: matrix conflict triage-then-current/history trên real DB, và soak 20 ask đồng thời 2 tenant chứng minh fail-closed không rò giá trị fabricated/cross-tenant khi `STRUCTURED_ENTAILMENT_AVAILABLE=false`.
- **Docs (`66c5a9f` + trong từng commit)**: quyết định hạ gate P2-10 ghi thành văn bản; status 1C-02/1C-11/R03/R05/P2-10/P2-15 đồng bộ với code đã xác minh.

## Scope

`web/src` (QaPage + components/qa, state/askStream, auth login race, mocks qa/members/fixtures), `web/e2e` (qa.spec 4 spec, org-switch mở rộng — tổng 24), `crates/server` (routes/audit mới, db/audit list_page, tests audit_read/members/ask_grounding_matrix), `openapi.yaml` (38→40 schemas: AuditEntry/AuditPage) + contract regenerate, backlog phase-1b/1c/2 README.

Không đổi: production code Q&A/SSE server (R03/R05 chỉ thêm test), RLS, resolver permissions.

## Evidence

- [x] Tests: web **462/462** unit (43 file) + Playwright **24/24**; Rust fast **282/282** lib + toàn bộ integration binary 0 fail; DB-gated trên Postgres 16 local: audit_read 8/8, members 12/12, orgs 12/12, auth 7/7, schema_migrations 8/8, ask_grounding_matrix 3/3 + sse_stream_readiness 11/11 (PG + **MinIO local thật**, binary từ dl.min.io); fmt/clippy `-D warnings`/lint/format:check/build sạch. Mỗi nhóm được chạy độc lập 2 lần (agent thực hiện + coordinator verify lại).
- [x] Manual/benchmark/migration evidence: không migration mới (audit-read dùng schema sẵn có); test mới của R03/R05 được sanity-check bằng cách đảo assertion xác nhận fail được (không tautology); ảnh chụp giao diện mock-mode các flow mới đã gửi kèm phiên làm việc.

## Boundary and security review

- [x] Dependency boundary check passed. (Không dependency mới; web không import Tauri.)
- [x] Tenant/ACL impact reviewed, or N/A. Audit-read: org isolation 2 lớp (query + RLS) + guard `audit.view` + metadata allowlist nguyên trạng, không endpoint cross-org; soak test R05 chứng minh không rò cross-tenant qua ask; mock admin org-scoped.
- [x] Sensitive logging/secret/egress impact reviewed, or N/A. Audit `audit.read` success chỉ ghi `result_count`, không ghi giá trị filter; token không persist/log; fix race login giảm cửa sổ token cũ cài đè sau logout.
- [x] Security review trigger checked. (Đụng auth login path + bề mặt đọc audit — cả hai review theo pattern tiền lệ; không mở surface mutation mới.)

## Follow-up

- [ ] `CitationPin` cần thêm định danh tài liệu/phiên bản để citation từ ask deep-link được preview (gap contract, ghi trong backlog P2-10).
- [ ] GLM entailment (`STRUCTURED_ENTAILMENT_AVAILABLE`) là quyết định sản phẩm — đề xuất tách khỏi R05 thành item riêng; coverage Qdrant thật cần CI có Qdrant.
- [x] Docs, OpenAPI, backlog cập nhật đồng bộ trong PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2AJXqkUkAqRTdCpkwFvwt

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2AJXqkUkAqRTdCpkwFvwt)_