### PR TITLE
feat(deploy): add make dev-server and make dev-web

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,16 @@
-SHELL := /bin/bash
+# Linux/macOS/CI use /bin/bash. Windows Make cannot resolve that path; prefer
+# Git for Windows (not System32\bash.exe, which is the WSL launcher).
+ifeq ($(OS),Windows_NT)
+  ifneq ($(wildcard C:/Program Files/Git/bin/bash.exe),)
+    SHELL := C:/Program Files/Git/bin/bash.exe
+  else ifneq ($(wildcard C:/Program Files (x86)/Git/bin/bash.exe),)
+    SHELL := C:/Program Files (x86)/Git/bin/bash.exe
+  else
+    SHELL := bash
+  endif
+else
+  SHELL := /bin/bash
+endif
 
 .PHONY: install check-toolchain check-static check-ci check-boundaries check-migrations \
 	check-fixtures check-markhand-gates check-roadmap check-dependencies check-rust check-rust-tests \
@@ -6,7 +18,8 @@ SHELL := /bin/bash
 	check-corpus check-corpus-pending check-web check-desktop check-foundation \
 	check-spike spike-up spike-health spike-down spike-reset spike-lifecycle \
 	check-desktop-baseline p0-desktop-baseline bundle-linux dev-up dev-health dev-down dev-reset \
-	dev-server-smoke dev-init dev-seed-all dev-seed-password dev-print-defaults dev-download-embedding
+	dev-server dev-web dev-server-smoke dev-init dev-seed-all dev-seed-password \
+	dev-print-defaults dev-download-embedding
 
 install:
 	pnpm install --frozen-lockfile
@@ -134,6 +147,12 @@ dev-up:
 
 dev-health:
 	deploy/scripts/health.sh
+
+dev-server:
+	bash deploy/scripts/dev-server.sh
+
+dev-web:
+	pnpm --dir web dev
 
 dev-server-smoke:
 	deploy/scripts/server-smoke.sh

--- a/deploy/scripts/dev-server.sh
+++ b/deploy/scripts/dev-server.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Load deploy/dev/.env and run fileconv-server (foreground).
+# Prerequisite: Compose stack up (`make dev-up`), migrations applied.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ENV_FILE="$ROOT/deploy/dev/.env"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "missing deploy/dev/.env — run: make dev-init" >&2
+  exit 1
+fi
+
+# Preserve caller/CI COMPOSE_PROFILES over values in .env.
+incoming_profiles="${COMPOSE_PROFILES:-}"
+
+set -a
+# shellcheck disable=SC1090
+source <(sed 's/\r$//' "$ENV_FILE")
+set +a
+
+if [[ -n "$incoming_profiles" ]]; then
+  export COMPOSE_PROFILES="$incoming_profiles"
+fi
+
+# Windows Make → Git Bash often omits ~/.cargo/bin even when PowerShell has it.
+export PATH="${CARGO_HOME:+${CARGO_HOME}/bin:}${HOME}/.cargo/bin:${USERPROFILE:+${USERPROFILE}/.cargo/bin:}${PATH}"
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo not found — install Rust 1.88 and ensure ~/.cargo/bin is on PATH" >&2
+  exit 127
+fi
+
+cd "$ROOT"
+exec cargo run -p fileconv-server "$@"


### PR DESCRIPTION
## Summary
- Add `make dev-server` (load `deploy/dev/.env`, ensure `~/.cargo/bin`, run `fileconv-server`).
- Add `make dev-web` for `pnpm --dir web dev`.
- On Windows, point Make `SHELL` at Git for Windows bash (not WSL's `System32\bash.exe`).

## Test plan
- [ ] Windows PowerShell: `make dev-server` starts API after Compose is up
- [ ] Windows: `make dev-web` starts Vite
- [ ] Linux/CI: `make -n dev-server` / `make -n dev-web` still resolve under `/bin/bash`