### PR TITLE
Document graph (P2-17) + Dự án per-org (P2-18) + ACL cache (1C-05) + bỏ UUID khỏi UI

### DIFF
--- a/crates/server/migrations/0031_expand_org_acl_version.sql
+++ b/crates/server/migrations/0031_expand_org_acl_version.sql
@@ -1,0 +1,49 @@
+-- Phase: 1C
+-- Owner: security-owner, storage-owner
+-- Change: expand
+-- Lock/data risk: single ADD COLUMN ... NOT NULL DEFAULT on `orgs`. Row count
+--   is POC-scale (single-org POC seed plus whatever 1C-01 `POST /orgs` has
+--   created since), so the ACCESS EXCLUSIVE lock taken for the DEFAULT
+--   backfill is momentary. No shipped application code reads or writes this
+--   column before this change.
+-- Rollback compatibility: no released application version depends on
+--   `acl_version`; dropping the column later is compatible with any released
+--   client. `auth::context_cache::OrgContextCache` degrades to "never a
+--   cache hit" (always falls through to a full resolve), not to an error, if
+--   the freshness-check query against this column fails for any reason —
+--   see that module's doc comment.
+--
+-- 1C-05: coarse, ORG-WIDE monotonic version used only to invalidate
+-- `auth::context_cache`'s in-process `OrgContext` cache. Bumped by
+-- `db::orgs::bump_acl_version` in the SAME transaction as any mutation that
+-- can change what `auth::permissions::resolve_org_context*` computes for ANY
+-- member of the org:
+--   - `services::members::change_role` / `suspend_member` /
+--     `reactivate_member` / `remove_member`
+--   - `services::acl_mutate::revoke_role_permission_for_principal` /
+--     `revoke_collection_access_for_principal`
+--
+-- Deliberately ORG-WIDE rather than per-membership or per-role:
+-- `revoke_role_permission_for_principal` deletes a `role_permissions` row
+-- that is shared by every member currently holding that role, not only the
+-- named principal, so a narrower cache key would under-invalidate (unsafe —
+-- another member holding the same role would keep a stale, wider permission
+-- set). Over-invalidating the whole org on every one of these mutations is
+-- the safe direction and is acceptable at the org sizes this POC operates
+-- at; there is no per-org fairness/SLO concern filed against this (1C-10 is
+-- separately still backlog for unrelated reasons).
+--
+-- KNOWN GAP (see session report for the full analysis): collection
+-- create/soft-delete and any future direct visibility mutation in
+-- `db::collections` (outside `services::acl_mutate`) do NOT bump this
+-- column yet, because that call-site audit + its own test coverage is a
+-- separate, larger piece of work than this migration's scope. Until closed,
+-- staleness from that specific gap is bounded only by the cache's short TTL
+-- (`auth::context_cache::DEFAULT_TTL`), not by immediate invalidation.
+
+ALTER TABLE orgs
+    ADD COLUMN acl_version bigint NOT NULL DEFAULT 1
+        CHECK (acl_version > 0);
+
+COMMENT ON COLUMN orgs.acl_version IS
+    'Monotonic org-wide version bumped by any membership/ACL mutation that can change a resolved OrgContext; see auth::context_cache for the in-process cache it invalidates (1C-05).';

--- a/crates/server/migrations/0032_expand_projects.sql
+++ b/crates/server/migrations/0032_expand_projects.sql
@@ -1,0 +1,65 @@
+-- Phase: 2
+-- Owner: storage-owner
+-- Change: expand
+-- Lock/data risk: creates one new, empty org-scoped table (`projects`) and
+--   adds one nullable FK column to `collections` (`ADD COLUMN ... DEFAULT
+--   NULL` is a metadata-only change on the PostgreSQL versions this project
+--   targets — no table rewrite, no long lock — even though `collections`
+--   already holds POC rows). The two new indexes and the new composite FK on
+--   `collections` are built against the existing (small, POC-scale) table.
+-- Rollback compatibility: additive only. No released application version
+--   reads or writes `projects` or `collections.project_id` before this
+--   migration ships; dropping both later would be compatible with any
+--   released client.
+--
+-- P2-18 (owner request 2026-07-29): `org -> project -> collection ->
+-- document` grouping so Q&A and the Library can be scoped to one project or
+-- to everything. A project is a named, org-scoped folder of collections; a
+-- collection belongs to at most one project via the new nullable
+-- `collections.project_id` — an unassigned collection (`project_id IS NULL`)
+-- keeps working exactly as it does today, byte-for-byte (every existing
+-- collection query that does not know about `project_id` is unaffected).
+-- "All projects" in the API/UI is simply "no project filter" — it is never a
+-- real `projects` row, so there is no sentinel id to reserve or migrate.
+--
+-- Same org-scoped RLS shape `collections` itself uses (migrations/0004 +
+-- 0010): `org_id` FK to `orgs`, `FORCE ROW LEVEL SECURITY`, and a
+-- `(org_id, id)` unique constraint so `collections` can carry a composite FK
+-- into `projects` that keeps `project_id` org-consistent even if RLS were
+-- ever bypassed (same pattern `collection_user_access` etc. already use
+-- against `collections(org_id, id)`).
+
+CREATE TABLE projects (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id uuid NOT NULL REFERENCES orgs(id) ON DELETE RESTRICT,
+    name text NOT NULL CHECK (length(trim(name)) > 0 AND length(name) <= 200),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT uq_projects__org_name UNIQUE (org_id, name),
+    CONSTRAINT uq_projects__org_id_id UNIQUE (org_id, id)
+);
+
+CREATE INDEX idx_projects__org_id ON projects (org_id);
+
+ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE projects FORCE ROW LEVEL SECURITY;
+CREATE POLICY projects_org_isolation ON projects
+    USING (org_id = markhand_current_org_id())
+    WITH CHECK (org_id = markhand_current_org_id());
+
+-- Nullable: a collection with no project assigned behaves exactly as before
+-- this migration (1 collection belongs to at most 1 project — enforced by
+-- this being a plain scalar FK column, not a join table).
+ALTER TABLE collections
+    ADD COLUMN project_id uuid REFERENCES projects (id) ON DELETE SET NULL;
+
+-- Composite FK (MATCH SIMPLE — the PostgreSQL default): satisfied
+-- automatically whenever project_id IS NULL, and otherwise requires the
+-- referenced projects row to share the same org_id. This is what actually
+-- prevents a collection from ever pointing at another org's project.
+ALTER TABLE collections
+    ADD CONSTRAINT fk_collections__project_org
+        FOREIGN KEY (org_id, project_id) REFERENCES projects (org_id, id)
+        ON DELETE SET NULL;
+
+CREATE INDEX idx_collections__org_project ON collections (org_id, project_id);

--- a/crates/server/migrations/0033_expand_acl_version_triggers.sql
+++ b/crates/server/migrations/0033_expand_acl_version_triggers.sql
@@ -1,0 +1,64 @@
+-- Phase: 1C
+-- Owner: security-owner
+-- Change: expand
+-- Lock/data risk: two row-level triggers + one trigger function on existing
+--   tables; no table rewrite, no data touched. Trigger fires one indexed
+--   UPDATE on orgs per mutated row — collection/ACL mutations are low-volume
+--   admin operations, not hot paths.
+-- Rollback compatibility: additive only; dropping the triggers/function in a
+--   later contract migration restores 0031's application-side-only bumping.
+--
+-- 1C-05 follow-up: close the declared "collection create/soft-delete does not
+-- bump acl_version" gap — at the DATABASE layer, not per call site — and
+-- extend the same guarantee to every other per-org table the resolver reads
+-- (org_memberships, roles, role_permissions). users.disabled_at needs no
+-- trigger: the cache re-checks it fresh on every hit already.
+--
+-- Why a trigger and not more application call sites: the org-context cache
+-- (auth/context_cache.rs) revalidates every hit against orgs.acl_version, so
+-- ANY writer that changes what the resolver would return must bump it in the
+-- same transaction. Application call sites only cover application writers —
+-- test fixtures and operational SQL seed collections/collection_user_access
+-- directly (api_http_contracts::seed_published_doc, citation_authz_matrix's
+-- ACL matrices, caught on CI), and those writers can never be enumerated in
+-- Rust. A row-level trigger makes the invariant hold for every writer by
+-- construction. This is deliberately different from the rejected
+-- AFTER INSERT ON orgs role-seeding trigger (migration 0030's design note):
+-- bumping a counter grants nothing and cannot flip a deny fixture to allow.
+
+CREATE OR REPLACE FUNCTION bump_org_acl_version() RETURNS trigger AS $$
+DECLARE
+    target_org uuid;
+BEGIN
+    target_org := COALESCE(NEW.org_id, OLD.org_id);
+    IF target_org IS NOT NULL THEN
+        UPDATE orgs SET acl_version = acl_version + 1 WHERE id = target_org;
+    END IF;
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS collections_bump_acl_version ON collections;
+CREATE TRIGGER collections_bump_acl_version
+    AFTER INSERT OR UPDATE OR DELETE ON collections
+    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version();
+
+DROP TRIGGER IF EXISTS collection_user_access_bump_acl_version ON collection_user_access;
+CREATE TRIGGER collection_user_access_bump_acl_version
+    AFTER INSERT OR UPDATE OR DELETE ON collection_user_access
+    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version();
+
+DROP TRIGGER IF EXISTS org_memberships_bump_acl_version ON org_memberships;
+CREATE TRIGGER org_memberships_bump_acl_version
+    AFTER INSERT OR UPDATE OR DELETE ON org_memberships
+    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version();
+
+DROP TRIGGER IF EXISTS roles_bump_acl_version ON roles;
+CREATE TRIGGER roles_bump_acl_version
+    AFTER INSERT OR UPDATE OR DELETE ON roles
+    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version();
+
+DROP TRIGGER IF EXISTS role_permissions_bump_acl_version ON role_permissions;
+CREATE TRIGGER role_permissions_bump_acl_version
+    AFTER INSERT OR UPDATE OR DELETE ON role_permissions
+    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version();

--- a/crates/server/migrations/manifest.json
+++ b/crates/server/migrations/manifest.json
@@ -32,6 +32,7 @@
     "0029_expand_org_membership_state.sql": "41de0ab024806d760d1e080ec1cbbb54855695ee541566e216cf55f563dc1ec0",
     "0030_expand_global_role_catalog.sql": "00d6758cc6559dd6585ca13aa1a69a8f5b508aa4dadec89642254f3866c8c6be",
     "0031_expand_org_acl_version.sql": "7b7288a22e12f76fb73fbecbd181a54255f7263adae82c691d304f78d128d9e6",
-    "0032_expand_projects.sql": "f3c1b556fb3f3304401b3188555cbdc48b243a0834c203ddec93fd5b47d78fb9"
+    "0032_expand_projects.sql": "f3c1b556fb3f3304401b3188555cbdc48b243a0834c203ddec93fd5b47d78fb9",
+    "0033_expand_acl_version_triggers.sql": "c4a51ae6e5a3676d9493d0174e0f5d41758d0b137ae3d94f7ce4c4a8573592a3"
   }
 }

--- a/crates/server/migrations/manifest.json
+++ b/crates/server/migrations/manifest.json
@@ -30,6 +30,7 @@
     "0027_expand_migrator_app_grants.sql": "c46298a4a2e7c8a0a3fd4c5e3bcfe402d51dd007e5cf1423877f05a14d95fced",
     "0028_expand_audit_ownership_migrator.sql": "087cd986645f779267011d359574afa8e8e255a60fcc63d01224ad7514efa2ee",
     "0029_expand_org_membership_state.sql": "41de0ab024806d760d1e080ec1cbbb54855695ee541566e216cf55f563dc1ec0",
-    "0030_expand_global_role_catalog.sql": "00d6758cc6559dd6585ca13aa1a69a8f5b508aa4dadec89642254f3866c8c6be"
+    "0030_expand_global_role_catalog.sql": "00d6758cc6559dd6585ca13aa1a69a8f5b508aa4dadec89642254f3866c8c6be",
+    "0031_expand_org_acl_version.sql": "7b7288a22e12f76fb73fbecbd181a54255f7263adae82c691d304f78d128d9e6"
   }
 }

--- a/crates/server/migrations/manifest.json
+++ b/crates/server/migrations/manifest.json
@@ -31,6 +31,7 @@
     "0028_expand_audit_ownership_migrator.sql": "087cd986645f779267011d359574afa8e8e255a60fcc63d01224ad7514efa2ee",
     "0029_expand_org_membership_state.sql": "41de0ab024806d760d1e080ec1cbbb54855695ee541566e216cf55f563dc1ec0",
     "0030_expand_global_role_catalog.sql": "00d6758cc6559dd6585ca13aa1a69a8f5b508aa4dadec89642254f3866c8c6be",
-    "0031_expand_org_acl_version.sql": "7b7288a22e12f76fb73fbecbd181a54255f7263adae82c691d304f78d128d9e6"
+    "0031_expand_org_acl_version.sql": "7b7288a22e12f76fb73fbecbd181a54255f7263adae82c691d304f78d128d9e6",
+    "0032_expand_projects.sql": "f3c1b556fb3f3304401b3188555cbdc48b243a0834c203ddec93fd5b47d78fb9"
   }
 }

--- a/crates/server/openapi/openapi.yaml
+++ b/crates/server/openapi/openapi.yaml
@@ -1306,6 +1306,32 @@ paths:
           $ref: "#/components/responses/ApiError"
         "429":
           $ref: "#/components/responses/RateLimited"
+  /graph:
+    get:
+      operationId: getGraph
+      summary: >-
+        Document Graph MVP (P2-17): nodes/edges/communities for caller-visible
+        documents (requires qa.query, same precedent as /conflicts).
+      parameters:
+        - name: collectionId
+          in: query
+          description: Restrict nodes to one collection (must be in the caller's allow-list).
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Bounded document graph (nodes/edges/communities).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GraphResponse"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
 components:
   securitySchemes:
     bearerAuth:
@@ -2115,3 +2141,71 @@ components:
             $ref: "#/components/schemas/AuditEntry"
         page:
           $ref: "#/components/schemas/PageInfo"
+    GraphNode:
+      type: object
+      required: [id, title, collectionId, collectionName, status, degree]
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        collectionId:
+          type: string
+          format: uuid
+        collectionName:
+          type: string
+        status:
+          type: string
+        degree:
+          type: integer
+    GraphEdge:
+      type: object
+      required: [source, target, kind, weight]
+      properties:
+        source:
+          type: string
+          format: uuid
+        target:
+          type: string
+          format: uuid
+        kind:
+          type: string
+          enum: [conflict, co_citation, similarity]
+        weight:
+          type: number
+          minimum: 0
+          maximum: 1
+    GraphCommunity:
+      type: object
+      required: [id, label, nodeIds, size]
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        nodeIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        size:
+          type: integer
+    GraphResponse:
+      type: object
+      required: [nodes, edges, communities, requestId]
+      properties:
+        nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/GraphNode"
+        edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/GraphEdge"
+        communities:
+          type: array
+          items:
+            $ref: "#/components/schemas/GraphCommunity"
+        requestId:
+          type: string

--- a/crates/server/openapi/openapi.yaml
+++ b/crates/server/openapi/openapi.yaml
@@ -1937,11 +1937,15 @@ components:
           format: date-time
     Membership:
       type: object
-      required: [userId, role, state, createdAt]
+      required: [userId, email, displayName, role, state, createdAt]
       properties:
         userId:
           type: string
           format: uuid
+        email:
+          type: string
+        displayName:
+          type: string
         role:
           type: string
           enum: [owner, admin, editor, viewer]

--- a/crates/server/openapi/openapi.yaml
+++ b/crates/server/openapi/openapi.yaml
@@ -257,6 +257,41 @@ paths:
           $ref: "#/components/responses/ApiError"
         "429":
           $ref: "#/components/responses/RateLimited"
+  /collections/{collectionId}/assign-project:
+    parameters:
+      - $ref: "#/components/parameters/collectionId"
+    post:
+      operationId: assignCollectionProject
+      summary: Assign or unassign this collection's project (P2-18)
+      description: >
+        `projectId: null` unassigns; `projectId: "<uuid>"` assigns — the key
+        itself is required, there is no "leave unchanged" outcome. A
+        dedicated action route rather than folding into the metadata PATCH —
+        see `docs/conventions/api.md` and `routes::collections`'s module doc
+        for why. Same `doc.upload` permission gate as create/update.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignProjectRequest"
+      responses:
+        "200":
+          description: Collection with its (possibly now null) project assignment.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Collection"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          description: Collection not found, or projectId does not resolve in this org.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
   /collections/{collectionId}/documents:
     get:
       operationId: listDocuments
@@ -866,6 +901,13 @@ paths:
           $ref: "#/components/responses/ApiError"
         "403":
           $ref: "#/components/responses/ApiError"
+        "404":
+          description: >
+            projectId does not resolve to a project in the caller's org (P2-18).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
         "429":
           $ref: "#/components/responses/RateLimited"
   /ask:
@@ -890,6 +932,13 @@ paths:
           $ref: "#/components/responses/ApiError"
         "403":
           $ref: "#/components/responses/ApiError"
+        "404":
+          description: >
+            projectId does not resolve to a project in the caller's org (P2-18).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
         "429":
           $ref: "#/components/responses/RateLimited"
   /ask/stream:
@@ -1062,6 +1111,80 @@ paths:
               schema:
                 $ref: "#/components/schemas/Org"
         "401":
+          $ref: "#/components/responses/ApiError"
+        "404":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /projects:
+    get:
+      operationId: listProjects
+      summary: List every project in the caller's org (P2-18)
+      description: >
+        Org-scoped, no permission gate beyond active membership — same shape
+        as GET /collections. "All projects" in the UI/API is simply the
+        absence of a projectId filter on /search, /ask, /ask/stream; it is
+        never a row this endpoint returns.
+      responses:
+        "200":
+          description: Projects in the caller's org.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectPage"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+    post:
+      operationId: createProject
+      summary: Create a project (P2-18)
+      description: >
+        Same `doc.upload` permission gate as POST /collections — see
+        `routes::projects`'s module doc for why no separate permission was
+        added.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateProjectRequest"
+      responses:
+        "201":
+          description: Project created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "403":
+          $ref: "#/components/responses/ApiError"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /projects/{projectId}:
+    parameters:
+      - $ref: "#/components/parameters/projectId"
+    patch:
+      operationId: updateProject
+      summary: Rename a project (P2-18)
+      description: >
+        Rename only — no other mutable field yet. Project deletion is
+        explicitly out of scope for this slice.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateProjectRequest"
+      responses:
+        "200":
+          description: Project renamed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/ApiError"
+        "403":
           $ref: "#/components/responses/ApiError"
         "404":
           $ref: "#/components/responses/ApiError"
@@ -1388,6 +1511,13 @@ components:
       schema:
         type: string
         format: uuid
+    projectId:
+      name: projectId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
   responses:
     ApiError:
       description: Canonical API error
@@ -1454,6 +1584,13 @@ components:
         createdAt:
           type: string
           format: date-time
+        projectId:
+          type: [string, "null"]
+          format: uuid
+          description: P2-18 — null when this collection has no project assigned.
+        projectName:
+          type: [string, "null"]
+          description: Joined display name for projectId (null together with it).
     CollectionPage:
       type: object
       required: [items, page]
@@ -1464,6 +1601,50 @@ components:
             $ref: "#/components/schemas/Collection"
         page:
           $ref: "#/components/schemas/PageInfo"
+    Project:
+      type: object
+      required: [id, name, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+    ProjectPage:
+      type: object
+      required: [items, page]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Project"
+        page:
+          $ref: "#/components/schemas/PageInfo"
+    CreateProjectRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+    UpdateProjectRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+    AssignProjectRequest:
+      type: object
+      required: [projectId]
+      properties:
+        projectId:
+          type: [string, "null"]
+          format: uuid
+          description: >
+            null unassigns; a uuid assigns. The key is required — there is no
+            "leave unchanged" outcome for this action endpoint.
     CitationPin:
       type: object
       required:
@@ -1593,6 +1774,15 @@ components:
           items:
             type: string
             format: uuid
+        projectId:
+          type: string
+          format: uuid
+          description: >
+            P2-18 — optional project scope. Absent/null means "all projects":
+            no additional filter beyond collectionIds (today's exact
+            behavior). Narrows (never widens) whatever collectionIds already
+            restricts; a projectId that does not resolve in the caller's org
+            is a 404.
         mode:
           type: string
           enum: [current, as_of, compare, history]
@@ -1648,6 +1838,15 @@ components:
           items:
             type: string
             format: uuid
+        projectId:
+          type: string
+          format: uuid
+          description: >
+            P2-18 — optional project scope. Absent/null means "all projects":
+            no additional filter beyond collectionIds (today's exact
+            behavior). Narrows (never widens) whatever collectionIds already
+            restricts; a projectId that does not resolve in the caller's org
+            is a 404.
         mode:
           type: string
           enum: [current, as_of, compare, history]

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -125,6 +125,8 @@ pub const ROUTE_INVENTORY: &[(&str, &str, &[&str])] = &[
     // 1C-11 audit-log read endpoint (write path pre-existing; this is the
     // first read surface — see routes/audit.rs).
     ("get", "/audit", &["200", "400", "403", "429"]),
+    // P2-17 Document Graph MVP — see routes/graph.rs.
+    ("get", "/graph", &["200", "403", "404", "429"]),
 ];
 
 const HEALTH_PATHS: &[&str] = &["/health/live", "/health/ready", "/health/start"];

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -34,6 +34,11 @@ pub const ROUTE_INVENTORY: &[(&str, &str, &[&str])] = &[
         &["204", "404", "429"],
     ),
     (
+        "post",
+        "/collections/{collectionId}/assign-project",
+        &["200", "403", "404", "429"],
+    ),
+    (
         "get",
         "/collections/{collectionId}/documents",
         &["200", "404", "429"],
@@ -84,8 +89,12 @@ pub const ROUTE_INVENTORY: &[(&str, &str, &[&str])] = &[
         "/jobs/{jobId}/events",
         &["200", "400", "401", "404", "429"],
     ),
-    ("post", "/search", &["200", "400", "401", "403", "429"]),
-    ("post", "/ask", &["200", "400", "401", "403", "429"]),
+    (
+        "post",
+        "/search",
+        &["200", "400", "401", "403", "404", "429"],
+    ),
+    ("post", "/ask", &["200", "400", "401", "403", "404", "429"]),
     (
         "post",
         "/ask/stream",
@@ -97,6 +106,16 @@ pub const ROUTE_INVENTORY: &[(&str, &str, &[&str])] = &[
     ("post", "/orgs", &["201", "400", "401", "409", "429"]),
     ("get", "/orgs/{orgId}", &["200", "401", "404", "429"]),
     ("post", "/orgs/switch", &["200", "401", "403", "429"]),
+    // P2-18 org -> project -> collection -> document grouping. GET has no
+    // 403: same as GET /collections, list_projects is unfiltered by
+    // permission (`org membership` is the only gate) — see routes::projects.
+    ("get", "/projects", &["200", "429"]),
+    ("post", "/projects", &["201", "400", "403", "429"]),
+    (
+        "patch",
+        "/projects/{projectId}",
+        &["200", "400", "403", "404", "429"],
+    ),
     // P2-11 / P2-12 membership + invite + usage admin surface (Wave 2).
     ("get", "/members", &["200", "403", "429"]),
     ("get", "/members/invites", &["200", "403", "429"]),
@@ -145,6 +164,7 @@ pub const BODY_TAKING_OPERATIONS: &[(&str, &str)] = &[
     ("post", "/uploads"),
     ("post", "/collections"),
     ("patch", "/collections/{collectionId}"),
+    ("post", "/collections/{collectionId}/assign-project"),
     (
         "post",
         "/collections/{collectionId}/documents/{documentId}/approve-intake",
@@ -160,6 +180,8 @@ pub const BODY_TAKING_OPERATIONS: &[(&str, &str)] = &[
     ("post", "/ask/stream"),
     ("post", "/orgs"),
     ("post", "/orgs/switch"),
+    ("post", "/projects"),
+    ("patch", "/projects/{projectId}"),
     ("post", "/members/invites"),
     ("post", "/members/invites/accept"),
     ("patch", "/members/{userId}"),

--- a/crates/server/src/api/types.rs
+++ b/crates/server/src/api/types.rs
@@ -68,6 +68,49 @@ pub struct Page<T> {
     pub page: PageInfo,
 }
 
+/// Document Graph MVP (P2-17) — one node per caller-visible document.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphNodeDto {
+    pub id: Uuid,
+    pub title: String,
+    pub collection_id: Uuid,
+    pub collection_name: String,
+    /// `documents.state` (uploaded/converting/.../indexed/failed).
+    pub status: String,
+    pub degree: i64,
+}
+
+/// P2-17 graph edge. `kind` is `conflict` | `co_citation` | `similarity`;
+/// `weight` is `0..1` (see `services::graph::saturating_weight`).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphEdgeDto {
+    pub source: Uuid,
+    pub target: Uuid,
+    pub kind: String,
+    pub weight: f64,
+}
+
+/// P2-17 community: one connected component of the (pruned) graph.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphCommunityDto {
+    pub id: String,
+    pub label: String,
+    pub node_ids: Vec<Uuid>,
+    pub size: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphResponseDto {
+    pub nodes: Vec<GraphNodeDto>,
+    pub edges: Vec<GraphEdgeDto>,
+    pub communities: Vec<GraphCommunityDto>,
+    pub request_id: String,
+}
+
 /// 1C-11 audit log read entry. Field names follow the existing telemetry
 /// envelope vocabulary (`occurred_at`/`actor_id`/`target_type`/`target_id`,
 /// see `telemetry::AuditEvent`) rather than the raw `audit_log` column names.

--- a/crates/server/src/api/types.rs
+++ b/crates/server/src/api/types.rs
@@ -15,6 +15,13 @@ pub struct CollectionDto {
     pub description: Option<String>,
     pub visibility: String,
     pub created_at: DateTime<Utc>,
+    /// P2-18 — nullable: absent/`null` for a collection with no project.
+    pub project_id: Option<Uuid>,
+    /// Joined display name for `project_id` (nullable together with it) so
+    /// the Library nav can group by project without a second round trip —
+    /// same "never show the raw id" convention `MembershipDto`'s
+    /// email/display_name join already follows.
+    pub project_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/server/src/auth/context_cache.rs
+++ b/crates/server/src/auth/context_cache.rs
@@ -1,0 +1,272 @@
+//! Bounded in-process cache for [`OrgContext`] resolution (1C-05).
+//!
+//! **Scope.** This cache wraps ONLY the top-level entry point used by the
+//! `AuthenticatedOrg` axum extractor
+//! (`auth::permissions::resolve_org_context_in_txn`, called once per
+//! incoming HTTP request). It deliberately does NOT wrap:
+//! - `auth::permissions::resolve_org_context_on_txn`, used inside an
+//!   already-open, already-locked transaction (ask-stream append/pull) where
+//!   the caller needs a snapshot that cannot be torn by a concurrent ACL
+//!   writer — that path must stay always-fresh.
+//! - `services::upload::saga::reload_principal_locked`, the upload saga's
+//!   own re-authorization barrier taken right before commit — it already
+//!   re-reads PostgreSQL directly under the principal advisory lock and must
+//!   keep doing so; nothing here changes that.
+//!
+//! Both of those already run their own fresh queries every time, so neither
+//! is a regression risk from adding this cache; see the session report for
+//! the full "which query runs where" audit that justified this scope.
+//!
+//! **Invalidation design.** A cache hit is NEVER trusted blindly. Every hit
+//! (within TTL) re-checks two cheap, non-RLS-protected point lookups —
+//! `users.disabled_at` and `orgs.acl_version` — against PostgreSQL before
+//! returning cached data. Only when `disabled_at IS NULL` and the org's
+//! current `acl_version` still matches the version recorded at cache-fill
+//! time is the cached `OrgContext` returned; anything else (mismatch, row
+//! gone, the freshness query itself failing) falls through to a full,
+//! authoritative `resolve_org_context_in_txn` call, which performs its own
+//! typed fail-closed checks. A cache hit therefore never saves the
+//! membership/permission/collection queries UNLESS a strictly fresher
+//! signal already confirmed nothing relevant changed — this is what makes
+//! revoke/suspend/remove effective on the very next request, exactly like
+//! before this cache existed (see `db::orgs::bump_acl_version` for who bumps
+//! the version and `plans/markhand-web/backlog/phase-1c/issues/README.md`
+//! 1C-05 for the acceptance this satisfies).
+//!
+//! **Cross-instance.** Because every hit re-validates against PostgreSQL
+//! (never a blind TTL-only trust), a version bump committed by one server
+//! process is visible to every other process on ITS very next request too —
+//! there is no separate cross-instance invalidation channel to build or
+//! reason about. This is why 1C-05's "cross-instance invalidation
+//! semantics" concern does not need to be deferred: the design never
+//! actually trusts a cache entry without asking PostgreSQL first.
+//!
+//! **TTL.** The TTL bounds two residual risks, not the common case: (a) any
+//! future mutation path someone forgets to wire to `bump_acl_version`, and
+//! (b) the KNOWN GAP documented on migration `0031` — collection
+//! create/soft-delete via `db::collections` does not bump the version yet.
+//! Once TTL elapses, the entry is dropped from consideration and a full
+//! fresh resolve runs unconditionally, regardless of whether the version
+//! still matches.
+//!
+//! **Fail-closed.** Any ambiguity (DB error on the freshness check, row
+//! missing) is treated as "do not trust the cache", never as "deny the
+//! request" and never as "trust the cache anyway" — the authoritative
+//! resolve below is what actually produces the request's allow/deny
+//! decision.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use deadpool_postgres::Pool;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::auth::permissions::{resolve_org_context_in_txn, ResolveError};
+use crate::db::error::DbError;
+
+/// Max distinct `(org_id, user_id)` principals held at once. Eviction beyond
+/// this is never a correctness concern, only a cache miss.
+pub const DEFAULT_CAPACITY: usize = 4096;
+
+/// How long a cache hit is trusted before being dropped unconditionally
+/// (see module doc "TTL"). Short on purpose. Not (yet) operator-configurable
+/// — see session report for why this was kept simple in this round.
+pub const DEFAULT_TTL: Duration = Duration::from_secs(3);
+
+#[derive(Clone)]
+struct Entry {
+    context: OrgContext,
+    acl_version: i64,
+    resolved_at: Instant,
+}
+
+/// Bounded, TTL + version-checked cache of resolved [`OrgContext`] values.
+///
+/// Cheap to construct; owned by [`crate::auth::provider::PasswordAuthProvider`]
+/// (one instance per process/`AppState`).
+pub struct OrgContextCache {
+    capacity: usize,
+    ttl: Duration,
+    entries: Mutex<HashMap<(Uuid, Uuid), Entry>>,
+}
+
+impl Default for OrgContextCache {
+    fn default() -> Self {
+        Self::new(DEFAULT_CAPACITY, DEFAULT_TTL)
+    }
+}
+
+impl OrgContextCache {
+    pub fn new(capacity: usize, ttl: Duration) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            ttl,
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Resolves `OrgContext` for `(org_id, user_id)`, consulting the cache
+    /// first but never trusting it without a same-request freshness check
+    /// against PostgreSQL. See module doc.
+    pub async fn resolve(
+        &self,
+        pool: &Pool,
+        org_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<OrgContext, ResolveError> {
+        let key = (org_id, user_id);
+        let cached = {
+            let guard = self.entries.lock().expect("org context cache poisoned");
+            guard.get(&key).cloned()
+        };
+        if let Some(entry) = cached {
+            let age = entry.resolved_at.elapsed();
+            if should_check_freshness(age, self.ttl) {
+                if let Ok(Some((disabled_at, current_version))) =
+                    freshness_check(pool, org_id, user_id).await
+                {
+                    if trusts_cache(disabled_at, current_version, entry.acl_version) {
+                        return Ok(entry.context);
+                    }
+                }
+                // Disabled, version mismatch, missing row, or the freshness
+                // query itself erroring all fall through to the
+                // authoritative resolve below. Never treat any of these as
+                // a deny by themselves — only the real resolve decides that.
+            }
+        }
+
+        let fresh = resolve_org_context_in_txn(pool, org_id, user_id).await?;
+        if let Ok(Some(version)) = current_acl_version(pool, org_id).await {
+            self.insert(key, fresh.clone(), version);
+        }
+        // If the version itself could not be read, the resolution is simply
+        // not cached (still returns the correct, freshly-resolved context):
+        // an uncached entry can never serve stale data.
+        Ok(fresh)
+    }
+
+    fn insert(&self, key: (Uuid, Uuid), context: OrgContext, acl_version: i64) {
+        let mut guard = self.entries.lock().expect("org context cache poisoned");
+        if guard.len() >= self.capacity && !guard.contains_key(&key) {
+            // Bounded, not a strict LRU: any single eviction is safe (a
+            // miss just re-resolves), so a cheap "evict one arbitrary
+            // entry" policy is preferred over extra bookkeeping.
+            if let Some(evict_key) = guard.keys().next().copied() {
+                guard.remove(&evict_key);
+            }
+        }
+        guard.insert(
+            key,
+            Entry {
+                context,
+                acl_version,
+                resolved_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Drops every cached principal. Exposed for ops/tests; production code
+    /// does not need to call this (invalidation is version/TTL driven).
+    pub fn clear(&self) {
+        self.entries
+            .lock()
+            .expect("org context cache poisoned")
+            .clear();
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.lock().unwrap().len()
+    }
+}
+
+/// Pure: whether a cache hit within `age` should even attempt the freshness
+/// check, vs. being dropped outright once `ttl` has elapsed.
+fn should_check_freshness(age: Duration, ttl: Duration) -> bool {
+    age < ttl
+}
+
+/// Pure: whether the cached entry may be returned given the freshness
+/// signal just read from PostgreSQL. Fail-closed: disabled or mismatched
+/// version never trusts the cache.
+fn trusts_cache(
+    disabled_at: Option<DateTime<Utc>>,
+    current_version: i64,
+    cached_version: i64,
+) -> bool {
+    disabled_at.is_none() && current_version == cached_version
+}
+
+async fn freshness_check(
+    pool: &Pool,
+    org_id: Uuid,
+    user_id: Uuid,
+) -> Result<Option<(Option<DateTime<Utc>>, i64)>, DbError> {
+    let client = pool.get().await?;
+    let row = client
+        .query_opt(
+            "SELECT u.disabled_at, o.acl_version
+             FROM users u, orgs o
+             WHERE u.id = $1 AND o.id = $2",
+            &[&user_id, &org_id],
+        )
+        .await?;
+    Ok(row.map(|row| (row.get(0), row.get(1))))
+}
+
+async fn current_acl_version(pool: &Pool, org_id: Uuid) -> Result<Option<i64>, DbError> {
+    let client = pool.get().await?;
+    let row = client
+        .query_opt("SELECT acl_version FROM orgs WHERE id = $1", &[&org_id])
+        .await?;
+    Ok(row.map(|row| row.get(0)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trusts_cache_only_when_enabled_and_version_matches() {
+        assert!(trusts_cache(None, 5, 5));
+        assert!(!trusts_cache(Some(Utc::now()), 5, 5), "disabled must deny");
+        assert!(!trusts_cache(None, 6, 5), "version bump must invalidate");
+        assert!(!trusts_cache(None, 4, 5), "any mismatch must invalidate");
+    }
+
+    #[test]
+    fn should_check_freshness_respects_ttl() {
+        let ttl = Duration::from_secs(3);
+        assert!(should_check_freshness(Duration::from_millis(500), ttl));
+        assert!(!should_check_freshness(Duration::from_secs(3), ttl));
+        assert!(!should_check_freshness(Duration::from_secs(10), ttl));
+    }
+
+    #[test]
+    fn bounded_capacity_evicts_rather_than_grows_unboundedly() {
+        let cache = OrgContextCache::new(2, Duration::from_secs(60));
+        let org = Uuid::new_v4();
+        let ctx = |user: Uuid| OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+        cache.insert((org, Uuid::new_v4()), ctx(Uuid::new_v4()), 1);
+        cache.insert((org, Uuid::new_v4()), ctx(Uuid::new_v4()), 1);
+        assert_eq!(cache.len(), 2);
+        cache.insert((org, Uuid::new_v4()), ctx(Uuid::new_v4()), 1);
+        assert_eq!(cache.len(), 2, "capacity must stay bounded");
+    }
+
+    #[test]
+    fn clear_drops_every_entry() {
+        let cache = OrgContextCache::new(8, Duration::from_secs(60));
+        let org = Uuid::new_v4();
+        let user = Uuid::new_v4();
+        let ctx = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+        cache.insert((org, user), ctx, 1);
+        assert_eq!(cache.len(), 1);
+        cache.clear();
+        assert_eq!(cache.len(), 0);
+    }
+}

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use crate::api::ApiError;
 use crate::auth::context::OrgContext;
 use crate::auth::jwt::{AccessClaims, JwtKeys};
-use crate::auth::permissions::{resolve_org_context_in_txn, ResolveError};
+use crate::auth::permissions::ResolveError;
 use crate::auth::session::SessionError;
 
 /// Authenticated request with OrgContext loaded from current PG membership.
@@ -142,7 +142,11 @@ impl FromRequestParts<Arc<crate::http::AppState>> for AuthenticatedOrg {
         })?;
 
         // Authorization is current PG state — JWT org/user are hints only.
-        let context = resolve_org_context_in_txn(provider.pool(), org_id, user_id)
+        // The 1C-05 cache never trusts a hit without a fresh PG freshness
+        // check (disabled_at + org acl_version); see `auth::context_cache`.
+        let context = provider
+            .context_cache()
+            .resolve(provider.pool(), org_id, user_id)
             .await
             .map_err(|error| map_resolve_error(error, &request_id))?;
 

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -1,6 +1,7 @@
 //! Authentication and tenant context (ADR 0007 / ADR 0010).
 
 pub mod context;
+pub mod context_cache;
 pub mod jwt;
 pub mod middleware;
 pub mod password;

--- a/crates/server/src/auth/provider.rs
+++ b/crates/server/src/auth/provider.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use deadpool_postgres::Pool;
 use uuid::Uuid;
 
+use crate::auth::context_cache::OrgContextCache;
 use crate::auth::jwt::JwtKeys;
 use crate::auth::session::{
     self, logout_session, refresh_session, revoke_all_user_families, SessionError, TokenPair,
@@ -66,11 +67,19 @@ pub struct PasswordAuthProvider {
     pool: Pool,
     auth: AuthConfig,
     keys: JwtKeys,
+    /// 1C-05 bounded org-context cache, one instance per process/provider.
+    /// See `auth::context_cache` for the invalidation design.
+    context_cache: OrgContextCache,
 }
 
 impl PasswordAuthProvider {
     pub fn new(pool: Pool, auth: AuthConfig, keys: JwtKeys) -> Self {
-        Self { pool, auth, keys }
+        Self {
+            pool,
+            auth,
+            keys,
+            context_cache: OrgContextCache::default(),
+        }
     }
 
     pub fn keys(&self) -> &JwtKeys {
@@ -83,6 +92,12 @@ impl PasswordAuthProvider {
 
     pub fn pool(&self) -> &Pool {
         &self.pool
+    }
+
+    /// 1C-05 bounded, TTL + version-checked cache for `OrgContext`
+    /// resolution. See `auth::context_cache` module doc.
+    pub fn context_cache(&self) -> &OrgContextCache {
+        &self.context_cache
     }
 }
 

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -130,6 +130,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0031_expand_org_acl_version.sql",
         include_str!("../migrations/0031_expand_org_acl_version.sql"),
     ),
+    (
+        "0032_expand_projects.sql",
+        include_str!("../migrations/0032_expand_projects.sql"),
+    ),
 ];
 
 /// Embedded migration sources in apply order (name, SQL). Used by integration tests.

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -134,6 +134,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0032_expand_projects.sql",
         include_str!("../migrations/0032_expand_projects.sql"),
     ),
+    (
+        "0033_expand_acl_version_triggers.sql",
+        include_str!("../migrations/0033_expand_acl_version_triggers.sql"),
+    ),
 ];
 
 /// Embedded migration sources in apply order (name, SQL). Used by integration tests.

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -126,6 +126,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0030_expand_global_role_catalog.sql",
         include_str!("../migrations/0030_expand_global_role_catalog.sql"),
     ),
+    (
+        "0031_expand_org_acl_version.sql",
+        include_str!("../migrations/0031_expand_org_acl_version.sql"),
+    ),
 ];
 
 /// Embedded migration sources in apply order (name, SQL). Used by integration tests.

--- a/crates/server/src/db/collections.rs
+++ b/crates/server/src/db/collections.rs
@@ -17,6 +17,9 @@ pub struct NewCollection<'a> {
     pub visibility: CollectionVisibility,
 }
 
+const COLLECTION_COLUMNS: &str = "id, org_id, name, slug, description, owner_user_id,
+                    visibility, created_at, updated_at, deleted_at, project_id";
+
 /// Inserts a collection for `ctx.org_id` / `ctx.user_id` as owner.
 pub async fn insert(
     txn: &Transaction<'_>,
@@ -26,11 +29,12 @@ pub async fn insert(
     let visibility = input.visibility.as_str();
     let row = txn
         .query_one(
-            "INSERT INTO collections (
+            &format!(
+                "INSERT INTO collections (
                 id, org_id, name, slug, description, owner_user_id, visibility
              ) VALUES ($1, $2, $3, $4, $5, $6, $7)
-             RETURNING id, org_id, name, slug, description, owner_user_id,
-                       visibility, created_at, updated_at, deleted_at",
+             RETURNING {COLLECTION_COLUMNS}"
+            ),
             &[
                 &input.id,
                 &ctx.org_id(),
@@ -53,10 +57,11 @@ pub async fn get_by_id(
 ) -> Result<Collection, DbError> {
     let row = txn
         .query_opt(
-            "SELECT id, org_id, name, slug, description, owner_user_id,
-                    visibility, created_at, updated_at, deleted_at
+            &format!(
+                "SELECT {COLLECTION_COLUMNS}
              FROM collections
-             WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL",
+             WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL"
+            ),
             &[&ctx.org_id(), &collection_id],
         )
         .await?
@@ -68,11 +73,12 @@ pub async fn get_by_id(
 pub async fn list(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<Vec<Collection>, DbError> {
     let rows = txn
         .query(
-            "SELECT id, org_id, name, slug, description, owner_user_id,
-                    visibility, created_at, updated_at, deleted_at
+            &format!(
+                "SELECT {COLLECTION_COLUMNS}
              FROM collections
              WHERE org_id = $1 AND deleted_at IS NULL
-             ORDER BY name",
+             ORDER BY name"
+            ),
             &[&ctx.org_id()],
         )
         .await?;
@@ -89,14 +95,41 @@ pub async fn update_metadata(
 ) -> Result<Collection, DbError> {
     let row = txn
         .query_opt(
-            "UPDATE collections
+            &format!(
+                "UPDATE collections
              SET name = $3,
                  description = $4,
                  updated_at = now()
              WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL
-             RETURNING id, org_id, name, slug, description, owner_user_id,
-                       visibility, created_at, updated_at, deleted_at",
+             RETURNING {COLLECTION_COLUMNS}"
+            ),
             &[&ctx.org_id(), &collection_id, &name, &description],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    map_collection(&row)
+}
+
+/// P2-18 — assigns/unassigns `collection_id`'s project (`None` clears it).
+/// `project_id`, when `Some`, must already be validated by the caller as a
+/// real project in `ctx.org_id()` (the composite FK is defense-in-depth, not
+/// the primary check — see `routes::collections::assign_project`).
+pub async fn assign_project(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    collection_id: Uuid,
+    project_id: Option<Uuid>,
+) -> Result<Collection, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "UPDATE collections
+             SET project_id = $3,
+                 updated_at = now()
+             WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL
+             RETURNING {COLLECTION_COLUMNS}"
+            ),
+            &[&ctx.org_id(), &collection_id, &project_id],
         )
         .await?
         .ok_or(DbError::NotFound)?;
@@ -136,5 +169,6 @@ fn map_collection(row: &Row) -> Result<Collection, DbError> {
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
         deleted_at: row.get("deleted_at"),
+        project_id: row.get("project_id"),
     })
 }

--- a/crates/server/src/db/graph.rs
+++ b/crates/server/src/db/graph.rs
@@ -1,0 +1,157 @@
+//! Document Graph MVP (P2-17) read queries: visible-document nodes,
+//! conflict-derived edges, and co-citation edges. Every query is tenant- and
+//! ACL-scoped the same way `services::access`'s conflict queries are (dual
+//! collection-leg authorization), so a caller only ever sees nodes/edges
+//! built from documents they could already list.
+
+use tokio_postgres::Transaction;
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphDocumentRow {
+    pub id: Uuid,
+    pub title: String,
+    pub collection_id: Uuid,
+    pub collection_name: String,
+    pub state: String,
+}
+
+/// Visible documents for the graph: same ACL as `documents::list_in_collection`
+/// (org + `ctx.allowed_collection_ids()`), optionally narrowed to one
+/// collection. `fetch_cap` is a safety bound on the query itself — the
+/// route applies the contract's degree-based `prune()` on top of whatever
+/// this returns, so `fetch_cap` should be generous relative to the final
+/// node cap (pruning, not query truncation, decides which nodes survive).
+pub async fn list_visible_documents(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    collection_filter: Option<Uuid>,
+    fetch_cap: i64,
+) -> Result<Vec<GraphDocumentRow>, DbError> {
+    if let Some(collection_id) = collection_filter {
+        if !ctx.allowed_collection_ids().contains(&collection_id) {
+            return Err(DbError::Config("collection_denied".into()));
+        }
+    }
+    let allowed: Vec<Uuid> = ctx.allowed_collection_ids().iter().copied().collect();
+    let fetch_cap = fetch_cap.clamp(1, 10_000);
+    let rows = txn
+        .query(
+            "SELECT d.id, d.title, d.collection_id, c.name AS collection_name, d.state
+             FROM documents d
+             JOIN collections c ON c.org_id = d.org_id AND c.id = d.collection_id
+             WHERE d.org_id = $1
+               AND d.collection_id = ANY($2::uuid[])
+               AND ($3::uuid IS NULL OR d.collection_id = $3)
+               AND d.deleted_at IS NULL
+               AND d.state NOT IN ('tombstoned', 'purged')
+             ORDER BY d.created_at DESC, d.id DESC
+             LIMIT $4",
+            &[&ctx.org_id(), &allowed, &collection_filter, &fetch_cap],
+        )
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|row| GraphDocumentRow {
+            id: row.get("id"),
+            title: row.get("title"),
+            collection_id: row.get("collection_id"),
+            collection_name: row.get("collection_name"),
+            state: row.get("state"),
+        })
+        .collect())
+}
+
+/// `conflict` edges: open conflicts whose two claims belong to two documents
+/// both present in `node_ids` (already ACL-filtered by the caller — this
+/// query does not re-check collection ACL beyond `org_id`, matching
+/// `services::access::list_authorized_conflicts`'s own dual-leg join, which
+/// this mirrors). Self-pairs (a conflict whose two claims land on the same
+/// document) are excluded — a graph edge needs two distinct nodes.
+///
+/// Returns `(document_a_id, document_b_id, open_conflict_count)`, one row
+/// per distinct document pair.
+pub async fn conflict_edges_among(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    node_ids: &[Uuid],
+) -> Result<Vec<(Uuid, Uuid, i64)>, DbError> {
+    if node_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows = txn
+        .query(
+            "SELECT da.id AS document_a_id, db.id AS document_b_id, count(*)::bigint AS cnt
+             FROM conflicts conf
+             JOIN claims ca ON ca.org_id = conf.org_id AND ca.id = conf.claim_a_id
+             JOIN claims cb ON cb.org_id = conf.org_id AND cb.id = conf.claim_b_id
+             JOIN documents da ON da.org_id = ca.org_id AND da.id = ca.document_id
+             JOIN documents db ON db.org_id = cb.org_id AND db.id = cb.document_id
+             WHERE conf.org_id = $1
+               AND conf.status = 'open'
+               AND da.id = ANY($2::uuid[])
+               AND db.id = ANY($2::uuid[])
+               AND da.id <> db.id
+             GROUP BY da.id, db.id",
+            &[&ctx.org_id(), &node_ids],
+        )
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|row| {
+            (
+                row.get("document_a_id"),
+                row.get("document_b_id"),
+                row.get("cnt"),
+            )
+        })
+        .collect())
+}
+
+/// `co_citation` edges: two documents were both cited by the same grounded
+/// answer. Backed by `ask_stream_sessions.cited_document_ids` — the only
+/// place the codebase durably records "which documents this answer cited"
+/// (see `services/qa/ask_stream.rs`); there is no separate per-answer
+/// citation history table. Citations are only ever written into that column
+/// after `qa.query`-gated authorization
+/// (`stream_auth::revalidate_ask_stream`/`fence_principal_and_citations`),
+/// so aggregating across sessions here does not leak anything a caller
+/// couldn't already see — this query still restricts to `node_ids`
+/// (already ACL-filtered) as a second, redundant guard.
+///
+/// Returns `(document_a_id, document_b_id, distinct_session_count)` for
+/// document pairs with `document_a_id < document_b_id`.
+pub async fn co_citation_edges_among(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    node_ids: &[Uuid],
+) -> Result<Vec<(Uuid, Uuid, i64)>, DbError> {
+    if node_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows = txn
+        .query(
+            "WITH distinct_pairs AS (
+                SELECT DISTINCT s.id AS session_id, a.doc AS doc_a, b.doc AS doc_b
+                FROM ask_stream_sessions s
+                CROSS JOIN LATERAL unnest(s.cited_document_ids) AS a(doc)
+                CROSS JOIN LATERAL unnest(s.cited_document_ids) AS b(doc)
+                WHERE s.org_id = $1
+                  AND a.doc < b.doc
+                  AND a.doc = ANY($2::uuid[])
+                  AND b.doc = ANY($2::uuid[])
+             )
+             SELECT doc_a, doc_b, count(*)::bigint AS cnt
+             FROM distinct_pairs
+             GROUP BY doc_a, doc_b",
+            &[&ctx.org_id(), &node_ids],
+        )
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|row| (row.get("doc_a"), row.get("doc_b"), row.get("cnt")))
+        .collect())
+}

--- a/crates/server/src/db/members.rs
+++ b/crates/server/src/db/members.rs
@@ -24,15 +24,29 @@ pub struct OwnerRow {
     pub state: MembershipState,
 }
 
+/// Columns every membership query below selects, joined against `users` so
+/// callers get a display name/email alongside the raw `user_id` (owner-
+/// reported UI gap: the admin members page was showing a bare UUID). `users`
+/// carries no RLS (see the module doc's "pure data access" note and
+/// `db/models.rs`'s `OrgMembership::email` doc) so joining it inside an
+/// org-scoped transaction does not widen what a caller can see — the
+/// `org_memberships` half of the join is still filtered by `org_id` exactly
+/// as before.
+const MEMBERSHIP_COLUMNS: &str = "m.org_id, m.user_id, m.role, m.state, m.created_at, \
+     u.email, u.display_name";
+
 /// Lists every membership row for the tenant (both states — admins must be
 /// able to see suspended members in order to reactivate them).
 pub async fn list(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<Vec<OrgMembership>, DbError> {
     let rows = txn
         .query(
-            "SELECT org_id, user_id, role, state, created_at
-             FROM org_memberships
-             WHERE org_id = $1
-             ORDER BY created_at, user_id",
+            &format!(
+                "SELECT {MEMBERSHIP_COLUMNS}
+                 FROM org_memberships m
+                 JOIN users u ON u.id = m.user_id
+                 WHERE m.org_id = $1
+                 ORDER BY m.created_at, m.user_id"
+            ),
             &[&ctx.org_id()],
         )
         .await?;
@@ -47,9 +61,12 @@ pub async fn get(
 ) -> Result<OrgMembership, DbError> {
     let row = txn
         .query_opt(
-            "SELECT org_id, user_id, role, state, created_at
-             FROM org_memberships
-             WHERE org_id = $1 AND user_id = $2",
+            &format!(
+                "SELECT {MEMBERSHIP_COLUMNS}
+                 FROM org_memberships m
+                 JOIN users u ON u.id = m.user_id
+                 WHERE m.org_id = $1 AND m.user_id = $2"
+            ),
             &[&ctx.org_id(), &user_id],
         )
         .await?
@@ -68,10 +85,17 @@ pub async fn try_insert(
     let role_str = role.as_str();
     let row = txn
         .query_opt(
-            "INSERT INTO org_memberships (org_id, user_id, role)
-             VALUES ($1, $2, $3)
-             ON CONFLICT (org_id, user_id) DO NOTHING
-             RETURNING org_id, user_id, role, state, created_at",
+            &format!(
+                "WITH m AS (
+                     INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, $3)
+                     ON CONFLICT (org_id, user_id) DO NOTHING
+                     RETURNING org_id, user_id, role, state, created_at
+                 )
+                 SELECT {MEMBERSHIP_COLUMNS}
+                 FROM m
+                 JOIN users u ON u.id = m.user_id"
+            ),
             &[&ctx.org_id(), &user_id, &role_str],
         )
         .await?;
@@ -88,10 +112,17 @@ pub async fn update_role(
     let role_str = role.as_str();
     let row = txn
         .query_opt(
-            "UPDATE org_memberships
-             SET role = $3
-             WHERE org_id = $1 AND user_id = $2
-             RETURNING org_id, user_id, role, state, created_at",
+            &format!(
+                "WITH m AS (
+                     UPDATE org_memberships
+                     SET role = $3
+                     WHERE org_id = $1 AND user_id = $2
+                     RETURNING org_id, user_id, role, state, created_at
+                 )
+                 SELECT {MEMBERSHIP_COLUMNS}
+                 FROM m
+                 JOIN users u ON u.id = m.user_id"
+            ),
             &[&ctx.org_id(), &user_id, &role_str],
         )
         .await?
@@ -110,10 +141,17 @@ pub async fn set_state(
     let state_str = state.as_str();
     let row = txn
         .query_opt(
-            "UPDATE org_memberships
-             SET state = $3
-             WHERE org_id = $1 AND user_id = $2
-             RETURNING org_id, user_id, role, state, created_at",
+            &format!(
+                "WITH m AS (
+                     UPDATE org_memberships
+                     SET state = $3
+                     WHERE org_id = $1 AND user_id = $2
+                     RETURNING org_id, user_id, role, state, created_at
+                 )
+                 SELECT {MEMBERSHIP_COLUMNS}
+                 FROM m
+                 JOIN users u ON u.id = m.user_id"
+            ),
             &[&ctx.org_id(), &user_id, &state_str],
         )
         .await?
@@ -203,6 +241,8 @@ fn map_membership(row: &Row) -> Result<OrgMembership, DbError> {
         role: MembershipRole::parse(&role).map_err(DbError::Config)?,
         state: MembershipState::parse(&state).map_err(DbError::Config)?,
         created_at: row.get("created_at"),
+        email: row.get("email"),
+        display_name: row.get("display_name"),
     })
 }
 

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -9,6 +9,7 @@ pub mod document_versions;
 pub mod documents;
 pub mod embedding_batches;
 pub mod error;
+pub mod graph;
 pub mod index_metadata;
 pub(crate) mod jobs;
 pub mod members;

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -16,6 +16,7 @@ pub mod members;
 pub mod models;
 pub mod orgs;
 pub mod pool;
+pub mod projects;
 pub mod quota;
 pub mod search;
 pub mod upload_operations;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -921,7 +921,17 @@ pub struct IndexMetadata {
 /// Expected public columns for every modeled/business table (exact-set drift guard).
 pub fn expected_table_columns() -> &'static [(&'static str, &'static [&'static str])] {
     &[
-        ("orgs", &["id", "slug", "name", "created_at", "updated_at"]),
+        (
+            "orgs",
+            &[
+                "id",
+                "slug",
+                "name",
+                "created_at",
+                "updated_at",
+                "acl_version",
+            ],
+        ),
         (
             "users",
             &[

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -117,6 +117,14 @@ pub struct OrgMembership {
     pub role: MembershipRole,
     pub state: MembershipState,
     pub created_at: DateTime<Utc>,
+    /// Joined from `users` (not org-scoped, not RLS'd — see `db/members.rs`'s
+    /// query docs) so the admin UI can show a name/email instead of a raw
+    /// `user_id` (owner-reported UI gap: raw UUIDs leaking into the members
+    /// table). Always present: `org_memberships.user_id` is a `NOT NULL`
+    /// foreign key into `users(id)`, so every row this module produces has a
+    /// matching user.
+    pub email: String,
+    pub display_name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -238,6 +238,19 @@ pub struct Collection {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub deleted_at: Option<DateTime<Utc>>,
+    /// P2-18 — nullable: a collection with no project assigned is unaffected.
+    pub project_id: Option<Uuid>,
+}
+
+/// P2-18 org-scoped project: a named folder of collections (migrations/0032).
+/// "All projects" is never a row here — it is the absence of a project filter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Project {
+    pub id: Uuid,
+    pub org_id: Uuid,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1040,7 +1053,13 @@ pub fn expected_table_columns() -> &'static [(&'static str, &'static [&'static s
                 "created_at",
                 "updated_at",
                 "deleted_at",
+                "project_id",
             ],
+        ),
+        // P2-18 (migrations/0032) — org-scoped project folder of collections.
+        (
+            "projects",
+            &["id", "org_id", "name", "created_at", "updated_at"],
         ),
         (
             "collection_user_access",

--- a/crates/server/src/db/orgs.rs
+++ b/crates/server/src/db/orgs.rs
@@ -77,3 +77,21 @@ pub async fn ensure_membership(txn: &Transaction<'_>, ctx: &OrgContext) -> Resul
     .await?;
     Ok(())
 }
+
+/// Bumps the org-wide ACL/membership resolution version (1C-05).
+///
+/// MUST be called in the SAME transaction as any mutation that can change
+/// what `auth::permissions::resolve_org_context*` would compute for ANY
+/// member of `org_id` — see migration `0031_expand_org_acl_version.sql` for
+/// the exact call-site list and the coarse-invalidation rationale.
+/// `auth::context_cache::OrgContextCache` treats any bump as invalidating
+/// every cached principal in the org; it never trusts a cached entry whose
+/// remembered version does not match the current value here.
+pub async fn bump_acl_version(txn: &Transaction<'_>, org_id: Uuid) -> Result<(), DbError> {
+    txn.execute(
+        "UPDATE orgs SET acl_version = acl_version + 1 WHERE id = $1",
+        &[&org_id],
+    )
+    .await?;
+    Ok(())
+}

--- a/crates/server/src/db/projects.rs
+++ b/crates/server/src/db/projects.rs
@@ -1,0 +1,180 @@
+//! Tenant-scoped project repository (P2-18).
+//!
+//! `resolve_project_scope` below is the one entry point `routes::search` and
+//! `routes::ask`/`routes::ask::ask_stream_route` both call to turn an
+//! optional `projectId` request field into a collection-id filter — see
+//! those modules' own docs for why this deliberately feeds the *existing*
+//! `collectionIds`/`resolve_scope` retrieval mechanism instead of adding a
+//! parallel one.
+//!
+//! A project is a named, org-scoped folder of collections
+//! (migrations/0032) — see `db::collections::assign_project` for the
+//! collection side of the relationship. There is no soft-delete here yet;
+//! project deletion is explicitly out of scope for this slice (see the
+//! P2-18 backlog entry) precisely to avoid deciding orphaned-collection
+//! semantics prematurely.
+
+use std::collections::BTreeSet;
+
+use deadpool_postgres::Pool;
+use tokio_postgres::{Row, Transaction};
+use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::models::Project;
+use crate::db::pool::with_org_txn;
+
+const PROJECT_COLUMNS: &str = "id, org_id, name, created_at, updated_at";
+
+/// Inserts a project for `ctx.org_id()`.
+pub async fn insert(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    id: Uuid,
+    name: &str,
+) -> Result<Project, DbError> {
+    let row = txn
+        .query_one(
+            &format!(
+                "INSERT INTO projects (id, org_id, name)
+             VALUES ($1, $2, $3)
+             RETURNING {PROJECT_COLUMNS}"
+            ),
+            &[&id, &ctx.org_id(), &name],
+        )
+        .await?;
+    Ok(map_project(&row))
+}
+
+/// Fetches one project by id within the tenant; cross-org rows are invisible
+/// (RLS also enforces this — this WHERE clause is defense-in-depth, same
+/// convention as `db::collections::get_by_id`).
+pub async fn get_by_id(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    project_id: Uuid,
+) -> Result<Project, DbError> {
+    let row = txn
+        .query_opt(
+            &format!("SELECT {PROJECT_COLUMNS} FROM projects WHERE org_id = $1 AND id = $2"),
+            &[&ctx.org_id(), &project_id],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    Ok(map_project(&row))
+}
+
+/// Lists every project for the tenant, alphabetically.
+pub async fn list(txn: &Transaction<'_>, ctx: &OrgContext) -> Result<Vec<Project>, DbError> {
+    let rows = txn
+        .query(
+            &format!("SELECT {PROJECT_COLUMNS} FROM projects WHERE org_id = $1 ORDER BY name"),
+            &[&ctx.org_id()],
+        )
+        .await?;
+    Ok(rows.iter().map(map_project).collect())
+}
+
+/// Renames a project within the tenant.
+pub async fn update_name(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    project_id: Uuid,
+    name: &str,
+) -> Result<Project, DbError> {
+    let row = txn
+        .query_opt(
+            &format!(
+                "UPDATE projects
+             SET name = $3, updated_at = now()
+             WHERE org_id = $1 AND id = $2
+             RETURNING {PROJECT_COLUMNS}"
+            ),
+            &[&ctx.org_id(), &project_id, &name],
+        )
+        .await?
+        .ok_or(DbError::NotFound)?;
+    Ok(map_project(&row))
+}
+
+/// Collection ids belonging to `project_id`, scoped to the tenant and
+/// excluding soft-deleted collections — the exact filter every other
+/// collection read in this codebase applies (`db::collections::list`).
+/// Fail-closed: an empty result (unknown project, or a real project with
+/// zero collections) is a valid, non-error outcome — callers decide what an
+/// empty scope means (see `routes::search`/`routes::ask`'s project filter).
+pub async fn collection_ids_for_project(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    project_id: Uuid,
+) -> Result<Vec<Uuid>, DbError> {
+    let rows = txn
+        .query(
+            "SELECT id FROM collections
+             WHERE org_id = $1 AND project_id = $2 AND deleted_at IS NULL",
+            &[&ctx.org_id(), &project_id],
+        )
+        .await?;
+    Ok(rows.iter().map(|row| row.get(0)).collect())
+}
+
+/// Resolves an optional `projectId` request field into an optional
+/// collection-id filter, ready to hand to `services::retrieval`'s existing
+/// `RetrievalRequest.collection_ids` (which already intersects whatever it
+/// is given against `OrgContext::allowed_collection_ids()` — see
+/// `services::retrieval::resolve_scope`, unchanged by this feature).
+///
+/// - `project_id: None` ("all projects") returns `Ok(requested)` unchanged —
+///   byte-for-byte today's behavior when no project filter is requested.
+/// - `project_id: Some(id)` that does not resolve to a real project in
+///   `ctx.org_id()` (never created, or belongs to another org — RLS makes
+///   the two indistinguishable, which is the point) returns
+///   `Err(DbError::NotFound)`; callers map this straight to a 404, same
+///   "no existence oracle" precedent `routes::orgs::get_org` documents.
+/// - `project_id: Some(id)` that does resolve returns the intersection of
+///   the project's collection ids with `requested` (or just the project's
+///   collection ids when `requested` is `None`) — narrowing, never widening,
+///   whatever scope the request already specified.
+pub async fn resolve_project_scope(
+    pool: &Pool,
+    ctx: &OrgContext,
+    project_id: Option<Uuid>,
+    requested: Option<BTreeSet<Uuid>>,
+) -> Result<Option<BTreeSet<Uuid>>, DbError> {
+    let Some(project_id) = project_id else {
+        return Ok(requested);
+    };
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                get_by_id(txn, &ctx, project_id).await?;
+                let project_collections: BTreeSet<Uuid> =
+                    collection_ids_for_project(txn, &ctx, project_id)
+                        .await?
+                        .into_iter()
+                        .collect();
+                Ok(match requested {
+                    Some(requested) => requested
+                        .intersection(&project_collections)
+                        .copied()
+                        .collect(),
+                    None => project_collections,
+                })
+            })
+        }
+    })
+    .await
+    .map(Some)
+}
+
+fn map_project(row: &Row) -> Project {
+    Project {
+        id: row.get("id"),
+        org_id: row.get("org_id"),
+        name: row.get("name"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -495,6 +495,7 @@ pub fn router(state: AppState) -> Router {
         .merge(routes::search::router())
         .merge(routes::ask::router())
         .merge(routes::events::router())
+        .merge(routes::graph::router())
         .route("/api/v1/openapi.yaml", axum::routing::get(openapi_yaml));
 
     // P2-16: serve web/dist (hashed assets + SPA history fallback) when a

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -491,6 +491,7 @@ pub fn router(state: AppState) -> Router {
         .merge(routes::jobs::router())
         .merge(routes::members::router())
         .merge(routes::orgs::router())
+        .merge(routes::projects::router())
         .merge(routes::audit::router())
         .merge(routes::search::router())
         .merge(routes::ask::router())

--- a/crates/server/src/routes/ask.rs
+++ b/crates/server/src/routes/ask.rs
@@ -19,8 +19,10 @@ use crate::api::{resolve_last_event_id, ApiError, LastEventIdError};
 use crate::auth::middleware::AuthenticatedOrg;
 use crate::auth::permissions::require_permission;
 use crate::db::ask_streams;
+use crate::db::error::DbError;
 use crate::db::models::AuditOutcome;
 use crate::db::pool::with_org_txn;
+use crate::db::projects;
 use crate::http::AppState;
 use crate::services::audit;
 use crate::services::qa::ask_stream::{self, AskStreamPrepareError};
@@ -40,6 +42,10 @@ struct AskBody {
     question: String,
     #[serde(default)]
     collection_ids: Option<Vec<Uuid>>,
+    /// P2-18 — see `routes::search::SearchBody::project_id`'s doc; identical
+    /// contract, shared resolver (`db::projects::resolve_project_scope`).
+    #[serde(default)]
+    project_id: Option<Uuid>,
     #[serde(default)]
     mode: Option<String>,
     #[serde(default)]
@@ -182,10 +188,28 @@ async fn ask_stream_route(
         }
         let mode = parse_mode(&body)
             .map_err(|message| RouteError::Validation(auth.request_id.clone(), message))?;
+        let question_chars = body.question.len();
+        let collection_ids = body
+            .collection_ids
+            .map(|ids| ids.into_iter().collect::<BTreeSet<_>>());
+        // P2-18 — same narrow-never-widen project scope as routes::search /
+        // ask_json's run_ask above. Resolved before the `vector_index`
+        // availability check right below — see that check's own comment in
+        // routes::search for why.
+        let collection_ids = projects::resolve_project_scope(
+            state.pool(),
+            &auth.context,
+            body.project_id,
+            collection_ids,
+        )
+        .await
+        .map_err(|error| match error {
+            DbError::NotFound => RouteError::ProjectNotFound(auth.request_id.clone()),
+            _ => RouteError::Database(auth.request_id.clone()),
+        })?;
         let vector_index = state
             .vector_index()
             .ok_or_else(|| RouteError::Unavailable(auth.request_id.clone()))?;
-        let question_chars = body.question.len();
         let started = ask_stream::start_ask_stream(
             state.pool(),
             vector_index,
@@ -195,8 +219,7 @@ async fn ask_stream_route(
             auth.claims.clone(),
             auth.request_id.clone(),
             body.question,
-            body.collection_ids
-                .map(|ids| ids.into_iter().collect::<BTreeSet<_>>()),
+            collection_ids,
             mode,
             body.limit.clamp(1, 20),
             body.conflict_ids,
@@ -295,10 +318,27 @@ async fn run_ask(
     }
     let mode = parse_mode(&body)
         .map_err(|message| RouteError::Validation(auth.request_id.clone(), message))?;
+    let question_chars = body.question.len();
+    let collection_ids = body
+        .collection_ids
+        .map(|ids| ids.into_iter().collect::<BTreeSet<_>>());
+    // P2-18 — same narrow-never-widen project scope as routes::search.
+    // Resolved before the `vector_index` availability check right below —
+    // see that check's own comment in routes::search for why.
+    let collection_ids = projects::resolve_project_scope(
+        state.pool(),
+        &auth.context,
+        body.project_id,
+        collection_ids,
+    )
+    .await
+    .map_err(|error| match error {
+        DbError::NotFound => RouteError::ProjectNotFound(auth.request_id.clone()),
+        _ => RouteError::Database(auth.request_id.clone()),
+    })?;
     let vector_index = state
         .vector_index()
         .ok_or_else(|| RouteError::Unavailable(auth.request_id.clone()))?;
-    let question_chars = body.question.len();
     let response = match ask(
         state.pool(),
         vector_index,
@@ -307,9 +347,7 @@ async fn run_ask(
         &auth.context,
         AskRequest {
             question: body.question,
-            collection_ids: body
-                .collection_ids
-                .map(|ids| ids.into_iter().collect::<BTreeSet<_>>()),
+            collection_ids,
             mode,
             limit: body.limit.clamp(1, 20),
             conflict_ids: body.conflict_ids,
@@ -397,6 +435,9 @@ enum RouteError {
     Validation(String, &'static str),
     Denied(String),
     NotFound(String),
+    /// P2-18 — distinct from `NotFound` (stream session) purely so the
+    /// error message stays accurate; same status/code.
+    ProjectNotFound(String),
     Unavailable(String),
     Database(String),
     StreamClosed(String, &'static str),
@@ -439,6 +480,12 @@ impl IntoResponse for RouteError {
                 StatusCode::NOT_FOUND,
                 "not_found",
                 "Stream session not found",
+                request_id,
+            ),
+            Self::ProjectNotFound(request_id) => (
+                StatusCode::NOT_FOUND,
+                "not_found",
+                "Project not found",
                 request_id,
             ),
             Self::Unavailable(request_id) => (

--- a/crates/server/src/routes/collections.rs
+++ b/crates/server/src/routes/collections.rs
@@ -11,12 +11,14 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::api::{ApiError, CollectionDto, Page, PageInfo};
+use crate::auth::context::OrgContext;
 use crate::auth::middleware::AuthenticatedOrg;
 use crate::auth::permissions::require_permission;
 use crate::db::collections::{self, NewCollection};
 use crate::db::error::DbError;
-use crate::db::models::CollectionVisibility;
+use crate::db::models::{Collection, CollectionVisibility};
 use crate::db::pool::with_org_txn;
+use crate::db::projects;
 use crate::http::AppState;
 use crate::services::audit;
 
@@ -31,6 +33,10 @@ pub fn router() -> Router<Arc<AppState>> {
             get(get_collection)
                 .patch(update_collection)
                 .delete(delete_collection),
+        )
+        .route(
+            "/api/v1/collections/{collection_id}/assign-project",
+            axum::routing::post(assign_project),
         )
 }
 
@@ -51,8 +57,51 @@ struct UpdateCollectionRequest {
     description: Option<String>,
 }
 
+/// P2-18 — `projectId: null` unassigns, `projectId: "<uuid>"` assigns. The
+/// key itself is required (no `#[serde(default)]`): a caller must state
+/// their intent explicitly rather than relying on "field absent" to mean
+/// either "leave unchanged" or "clear" — this endpoint's only job is
+/// assign/unassign, so there is no "leave unchanged" outcome to default to.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AssignProjectRequest {
+    project_id: Option<Uuid>,
+}
+
 fn default_visibility() -> String {
     "org".into()
+}
+
+/// Joins `project_id` -> project name for DTO hydration (P2-18) — one extra
+/// query per request, same "never show the raw id" convention
+/// `routes::members`'s `MembershipDto` email/display_name join already
+/// follows. Read-only; must run inside the same tenant-scoped transaction as
+/// the collection query it hydrates.
+async fn project_name_map(
+    txn: &tokio_postgres::Transaction<'_>,
+    ctx: &OrgContext,
+) -> Result<std::collections::HashMap<Uuid, String>, DbError> {
+    let rows = projects::list(txn, ctx).await?;
+    Ok(rows.into_iter().map(|p| (p.id, p.name)).collect())
+}
+
+fn collection_dto(
+    row: Collection,
+    project_names: &std::collections::HashMap<Uuid, String>,
+) -> CollectionDto {
+    let project_name = row
+        .project_id
+        .and_then(|id| project_names.get(&id).cloned());
+    CollectionDto {
+        id: row.id,
+        name: row.name,
+        slug: row.slug,
+        description: row.description,
+        visibility: row.visibility.as_str().into(),
+        created_at: row.created_at,
+        project_id: row.project_id,
+        project_name,
+    }
 }
 
 async fn list_collections(
@@ -64,17 +113,11 @@ async fn list_collections(
         move |txn| {
             Box::pin(async move {
                 let rows = collections::list(txn, &ctx).await?;
+                let project_names = project_name_map(txn, &ctx).await?;
                 Ok(rows
                     .into_iter()
                     .filter(|row| ctx.allows_collection(row.id))
-                    .map(|row| CollectionDto {
-                        id: row.id,
-                        name: row.name,
-                        slug: row.slug,
-                        description: row.description,
-                        visibility: row.visibility.as_str().into(),
-                        created_at: row.created_at,
-                    })
+                    .map(|row| collection_dto(row, &project_names))
                     .collect::<Vec<_>>())
             })
         }
@@ -98,20 +141,19 @@ async fn get_collection(
     if !auth.context.allows_collection(collection_id) {
         return Err(RouteError::NotFound(auth.request_id));
     }
-    let row = with_org_txn(state.pool(), &auth.context, {
+    let (row, project_names) = with_org_txn(state.pool(), &auth.context, {
         let ctx = auth.context.clone();
-        move |txn| Box::pin(async move { collections::get_by_id(txn, &ctx, collection_id).await })
+        move |txn| {
+            Box::pin(async move {
+                let row = collections::get_by_id(txn, &ctx, collection_id).await?;
+                let project_names = project_name_map(txn, &ctx).await?;
+                Ok((row, project_names))
+            })
+        }
     })
     .await
     .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
-    Ok(Json(CollectionDto {
-        id: row.id,
-        name: row.name,
-        slug: row.slug,
-        description: row.description,
-        visibility: row.visibility.as_str().into(),
-        created_at: row.created_at,
-    }))
+    Ok(Json(collection_dto(row, &project_names)))
 }
 
 async fn update_collection(
@@ -162,7 +204,7 @@ async fn update_collection(
         ));
     }
     let request_id = auth.request_id.clone();
-    let row = with_org_txn(state.pool(), &auth.context, {
+    let (row, project_names) = with_org_txn(state.pool(), &auth.context, {
         let ctx = auth.context.clone();
         let name = body.name.trim().to_string();
         let description = body.description.clone();
@@ -194,20 +236,14 @@ async fn update_collection(
                     },
                 )
                 .await?;
-                Ok(row)
+                let project_names = project_name_map(txn, &ctx).await?;
+                Ok((row, project_names))
             })
         }
     })
     .await
     .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
-    Ok(Json(CollectionDto {
-        id: row.id,
-        name: row.name,
-        slug: row.slug,
-        description: row.description,
-        visibility: row.visibility.as_str().into(),
-        created_at: row.created_at,
-    }))
+    Ok(Json(collection_dto(row, &project_names)))
 }
 
 async fn delete_collection(
@@ -341,17 +377,95 @@ async fn create_collection(
     })
     .await
     .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
+    // A brand-new collection is never pre-assigned to a project (creation
+    // has no projectId field — see routes::projects module doc: assignment
+    // is a separate action) so the id->name map is trivially empty here.
     Ok((
         StatusCode::CREATED,
-        Json(CollectionDto {
-            id: row.id,
-            name: row.name,
-            slug: row.slug,
-            description: row.description,
-            visibility: row.visibility.as_str().into(),
-            created_at: row.created_at,
-        }),
+        Json(collection_dto(row, &std::collections::HashMap::new())),
     ))
+}
+
+// ---------------------------------------------------------------------
+// POST /collections/{collectionId}/assign-project (P2-18)
+//
+// Dedicated action route rather than folding `projectId` into
+// `PATCH /collections/{collectionId}` — see `docs/conventions/api.md`
+// ("action chỉ khi không biểu diễn được bằng resource") and this codebase's
+// existing precedent for exactly that shape: `/documents/{id}/versions/
+// {id}/publish`, `/collections/{id}/documents/{id}/approve-intake`. Folding
+// this into the metadata PATCH would force every project (re)assignment call
+// to also resend `name` (that request's only required field today) purely to
+// satisfy an unrelated validation rule, and would mix two independently
+// audited actions (`collection.update` vs `collection.assign_project`) under
+// one status/audit trail. Same `doc.upload` permission gate as
+// create/update — see this module's + `routes::projects`'s doc.
+// ---------------------------------------------------------------------
+
+async fn assign_project(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(collection_id): Path<Uuid>,
+    Json(body): Json<AssignProjectRequest>,
+) -> Result<Json<CollectionDto>, RouteError> {
+    if require_permission(&auth.context, "doc.upload").is_err() {
+        let resource_id = collection_id.to_string();
+        audit::record_deny(
+            state.pool(),
+            &auth.context,
+            &auth.request_id,
+            "collection.assign_project",
+            "collection",
+            Some(&resource_id),
+            "permission_denied",
+        )
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+        return Err(RouteError::Denied(auth.request_id.clone()));
+    }
+    if !auth.context.allows_collection(collection_id) {
+        return Err(RouteError::NotFound(auth.request_id));
+    }
+    let request_id = auth.request_id.clone();
+    let (row, project_names) = with_org_txn(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        let project_id = body.project_id;
+        move |txn| {
+            Box::pin(async move {
+                // Fail-closed existence check: an unassign (`None`) needs no
+                // lookup; an assign must target a real project in this org —
+                // the composite FK on `collections` is defense-in-depth, not
+                // the primary check (it would surface as an opaque 500).
+                if let Some(project_id) = project_id {
+                    projects::get_by_id(txn, &ctx, project_id).await?;
+                }
+                let row = collections::assign_project(txn, &ctx, collection_id, project_id).await?;
+                let resource_id = row.id.to_string();
+                audit::record_in_txn(
+                    txn,
+                    &ctx,
+                    audit::AuditRecord {
+                        request_id: &request_id,
+                        action: "collection.assign_project",
+                        resource_type: "collection",
+                        resource_id: Some(&resource_id),
+                        outcome: crate::db::models::AuditOutcome::Success,
+                        metadata: serde_json::json!({
+                            "collection_id": row.id.to_string(),
+                            "project_id": project_id.map(|id| id.to_string()),
+                        }),
+                    },
+                )
+                .await?;
+                let project_names = project_name_map(txn, &ctx).await?;
+                Ok((row, project_names))
+            })
+        }
+    })
+    .await
+    .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
+    Ok(Json(collection_dto(row, &project_names)))
 }
 
 enum RouteError {

--- a/crates/server/src/routes/graph.rs
+++ b/crates/server/src/routes/graph.rs
@@ -1,0 +1,319 @@
+//! Document Graph MVP (P2-17, owner request 2026-07-29 — see
+//! `plans/markhand-web/backlog/phase-2/issues/README.md`): read-only graph
+//! data for the new "Đồ thị" web page — nodes (caller-visible documents),
+//! edges (`conflict` / `co_citation` / `similarity`), communities
+//! (connected components of whatever survives pruning).
+//!
+//! Permission choice (contract asked to pick from real code, not invent
+//! one): gated behind `qa.query`, the same permission
+//! `routes/documents.rs::list_conflicts`/`get_conflict` already require even
+//! though *listing documents themselves* (`list_documents`) needs no
+//! permission beyond collection ACL. This endpoint always blends
+//! conflict-derived and QA-history-derived (`co_citation`) edges into the
+//! response — the sensitive part — so the whole endpoint is gated at that
+//! existing precedent rather than a new `graph.read` permission with no
+//! seeded role grants anywhere in the migrations yet.
+//!
+//! ACL: node visibility is the same allow-list every other list route uses
+//! (`ctx.allowed_collection_ids()` / `ctx.allows_collection(...)`, see
+//! `routes/collections.rs`/`routes/documents.rs`); edges are only ever built
+//! from pairs already inside that visible node set (`db::graph`'s queries
+//! take `node_ids` and additionally scope by `org_id`), so an edge can never
+//! reference a document the caller could not otherwise see.
+//!
+//! `similarity` edges are opt-in on Qdrant + an embedding runtime being
+//! configured (`AppState::vector_index()`/`AppState::embedder()`, same gate
+//! `services/retrieval` uses) and are not implemented in this pass — see the
+//! P2-17 report/backlog entry for why (no Qdrant instance in this sandbox to
+//! validate against). When neither is configured, or once implemented,
+//! finds nothing, the endpoint still returns `conflict`/`co_citation` edges
+//! — it never fails just because vector search is unavailable.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::api::{ApiError, GraphCommunityDto, GraphEdgeDto, GraphNodeDto, GraphResponseDto};
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::auth::permissions::require_permission;
+use crate::db::error::DbError;
+use crate::db::graph::{self, GraphDocumentRow};
+use crate::db::pool::with_org_txn;
+use crate::http::AppState;
+use crate::services::graph::{connected_components, prune, saturating_weight, GraphEdgeInput};
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().route("/api/v1/graph", get(get_graph))
+}
+
+/// Contract: "Bounded: cap nodes/edges (vd 500/2000)".
+const MAX_NODES: usize = 500;
+const MAX_EDGES: usize = 2000;
+/// Safety bound on the raw document fetch, generous relative to
+/// `MAX_NODES` so degree-based `prune()` — not query truncation — decides
+/// which 500 nodes survive when a tenant has more visible documents than
+/// the cap.
+const FETCH_SAFETY_CAP: i64 = 4000;
+
+#[derive(Debug, Deserialize)]
+struct GraphQuery {
+    #[serde(rename = "collectionId")]
+    collection_id: Option<Uuid>,
+}
+
+async fn get_graph(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Query(query): Query<GraphQuery>,
+) -> Result<Json<GraphResponseDto>, RouteError> {
+    require_permission(&auth.context, "qa.query")
+        .map_err(|_| RouteError::Denied(auth.request_id.clone()))?;
+    if let Some(collection_id) = query.collection_id {
+        if !auth.context.allows_collection(collection_id) {
+            return Err(RouteError::NotFound(auth.request_id.clone()));
+        }
+    }
+
+    let (documents, conflict_pairs, co_citation_pairs) =
+        with_org_txn(state.pool(), &auth.context, {
+            let ctx = auth.context.clone();
+            let collection_filter = query.collection_id;
+            move |txn| {
+                Box::pin(async move {
+                    let documents = graph::list_visible_documents(
+                        txn,
+                        &ctx,
+                        collection_filter,
+                        FETCH_SAFETY_CAP,
+                    )
+                    .await?;
+                    let node_ids: Vec<Uuid> = documents.iter().map(|d| d.id).collect();
+                    let conflict_pairs = graph::conflict_edges_among(txn, &ctx, &node_ids).await?;
+                    let co_citation_pairs =
+                        graph::co_citation_edges_among(txn, &ctx, &node_ids).await?;
+                    Ok((documents, conflict_pairs, co_citation_pairs))
+                })
+            }
+        })
+        .await
+        .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
+
+    let node_ids: Vec<Uuid> = documents.iter().map(|d| d.id).collect();
+
+    let mut edges: Vec<GraphEdgeInput> = Vec::new();
+    for (a, b, count) in &conflict_pairs {
+        edges.push(GraphEdgeInput {
+            source: *a,
+            target: *b,
+            kind: "conflict".to_string(),
+            weight: saturating_weight(*count),
+        });
+    }
+    for (a, b, count) in &co_citation_pairs {
+        edges.push(GraphEdgeInput {
+            source: *a,
+            target: *b,
+            kind: "co_citation".to_string(),
+            weight: saturating_weight(*count),
+        });
+    }
+    // similarity: see module doc — opt-in on Qdrant + embedder, not
+    // implemented in this pass. `state.vector_index()`/`state.embedder()` are
+    // the real availability check a future pass would gate on.
+    let _similarity_available = state.vector_index().is_some() && state.embedder().is_some();
+
+    let pruned = prune(&node_ids, &edges, MAX_NODES, MAX_EDGES);
+
+    let mut degree: BTreeMap<Uuid, i64> = pruned.node_ids.iter().map(|id| (*id, 0)).collect();
+    for edge in &pruned.edges {
+        *degree.entry(edge.source).or_insert(0) += 1;
+        *degree.entry(edge.target).or_insert(0) += 1;
+    }
+
+    let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
+        documents.iter().map(|d| (d.id, d)).collect();
+
+    let nodes: Vec<GraphNodeDto> = pruned
+        .node_ids
+        .iter()
+        .filter_map(|id| {
+            doc_by_id.get(id).map(|d| GraphNodeDto {
+                id: d.id,
+                title: d.title.clone(),
+                collection_id: d.collection_id,
+                collection_name: d.collection_name.clone(),
+                status: d.state.clone(),
+                degree: *degree.get(id).unwrap_or(&0),
+            })
+        })
+        .collect();
+
+    let edges_dto: Vec<GraphEdgeDto> = pruned
+        .edges
+        .iter()
+        .map(|edge| GraphEdgeDto {
+            source: edge.source,
+            target: edge.target,
+            kind: edge.kind.clone(),
+            weight: edge.weight,
+        })
+        .collect();
+
+    let components = connected_components(&pruned.node_ids, &pruned.edges);
+    let communities: Vec<GraphCommunityDto> = components
+        .iter()
+        .enumerate()
+        .map(|(index, component)| {
+            let label = community_label(&component.node_ids, &doc_by_id);
+            GraphCommunityDto {
+                id: format!("community-{index}"),
+                label,
+                node_ids: component.node_ids.clone(),
+                size: component.node_ids.len() as i64,
+            }
+        })
+        .collect();
+
+    Ok(Json(GraphResponseDto {
+        nodes,
+        edges: edges_dto,
+        communities,
+        request_id: auth.request_id,
+    }))
+}
+
+/// Contract: community label is "tên bộ sưu tập chi phối hoặc title tài liệu
+/// bậc cao nhất trong cụm" — a lone-document component labels itself by that
+/// document's title; a multi-document component labels itself by whichever
+/// collection has the most members in it (ties broken lexicographically so
+/// the choice is deterministic, not by insertion order).
+fn community_label(node_ids: &[Uuid], doc_by_id: &BTreeMap<Uuid, &GraphDocumentRow>) -> String {
+    if let [only] = node_ids {
+        return doc_by_id
+            .get(only)
+            .map(|d| d.title.clone())
+            .unwrap_or_else(|| "Không xác định".to_string());
+    }
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for id in node_ids {
+        if let Some(document) = doc_by_id.get(id) {
+            *counts.entry(document.collection_name.as_str()).or_insert(0) += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(a.0)))
+        .map(|(name, _)| name.to_string())
+        .unwrap_or_else(|| "Không xác định".to_string())
+}
+
+enum RouteError {
+    Denied(String),
+    NotFound(String),
+    Database(String),
+}
+
+impl RouteError {
+    fn from_db(error: DbError, request_id: &str) -> Self {
+        match error {
+            DbError::NotFound => Self::NotFound(request_id.to_string()),
+            DbError::Config(message) if message == "collection_denied" => {
+                Self::NotFound(request_id.to_string())
+            }
+            _ => Self::Database(request_id.to_string()),
+        }
+    }
+}
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> Response {
+        let (status, code, message, request_id) = match self {
+            Self::Denied(request_id) => (
+                StatusCode::FORBIDDEN,
+                "forbidden",
+                "Permission denied",
+                request_id,
+            ),
+            Self::NotFound(request_id) => (
+                StatusCode::NOT_FOUND,
+                "not_found",
+                "Collection not found",
+                request_id,
+            ),
+            Self::Database(request_id) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                "Request failed",
+                request_id,
+            ),
+        };
+        (
+            status,
+            Json(ApiError {
+                code: code.into(),
+                message: message.into(),
+                request_id,
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uid(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    fn doc(id: Uuid, title: &str, collection_name: &str) -> GraphDocumentRow {
+        GraphDocumentRow {
+            id,
+            title: title.to_string(),
+            collection_id: Uuid::new_v4(),
+            collection_name: collection_name.to_string(),
+            state: "indexed".to_string(),
+        }
+    }
+
+    #[test]
+    fn singleton_community_labels_by_document_title() {
+        let a = doc(uid(1), "Chính sách nghỉ phép", "Nhân sự");
+        let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> = [(a.id, &a)].into_iter().collect();
+        assert_eq!(
+            community_label(&[uid(1)], &doc_by_id),
+            "Chính sách nghỉ phép"
+        );
+    }
+
+    #[test]
+    fn multi_node_community_labels_by_majority_collection_name() {
+        let a = doc(uid(1), "A", "Nhân sự");
+        let b = doc(uid(2), "B", "Nhân sự");
+        let c = doc(uid(3), "C", "Tài chính");
+        let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
+            [(a.id, &a), (b.id, &b), (c.id, &c)].into_iter().collect();
+        assert_eq!(
+            community_label(&[uid(1), uid(2), uid(3)], &doc_by_id),
+            "Nhân sự"
+        );
+    }
+
+    #[test]
+    fn multi_node_community_tie_breaks_lexicographically() {
+        let a = doc(uid(1), "A", "Zeta");
+        let b = doc(uid(2), "B", "Alpha");
+        let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
+            [(a.id, &a), (b.id, &b)].into_iter().collect();
+        assert_eq!(community_label(&[uid(1), uid(2)], &doc_by_id), "Alpha");
+    }
+}

--- a/crates/server/src/routes/graph.rs
+++ b/crates/server/src/routes/graph.rs
@@ -21,15 +21,14 @@
 //! take `node_ids` and additionally scope by `org_id`), so an edge can never
 //! reference a document the caller could not otherwise see.
 //!
-//! `similarity` edges are opt-in on Qdrant + an embedding runtime being
+//! `similarity` edges are opt-in on the vector index + an embedding runtime being
 //! configured (`AppState::vector_index()`/`AppState::embedder()`, same gate
 //! `services/retrieval` uses) and are not implemented in this pass — see the
-//! P2-17 report/backlog entry for why (no Qdrant instance in this sandbox to
+//! P2-17 report/backlog entry for why (no live vector store in this sandbox to
 //! validate against). When neither is configured, or once implemented,
 //! finds nothing, the endpoint still returns `conflict`/`co_citation` edges
 //! — it never fails just because vector search is unavailable.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::extract::{Query, State};
@@ -44,23 +43,12 @@ use crate::api::{ApiError, GraphCommunityDto, GraphEdgeDto, GraphNodeDto, GraphR
 use crate::auth::middleware::AuthenticatedOrg;
 use crate::auth::permissions::require_permission;
 use crate::db::error::DbError;
-use crate::db::graph::{self, GraphDocumentRow};
-use crate::db::pool::with_org_txn;
 use crate::http::AppState;
-use crate::services::graph::{connected_components, prune, saturating_weight, GraphEdgeInput};
+use crate::services::graph::build_org_graph;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new().route("/api/v1/graph", get(get_graph))
 }
-
-/// Contract: "Bounded: cap nodes/edges (vd 500/2000)".
-const MAX_NODES: usize = 500;
-const MAX_EDGES: usize = 2000;
-/// Safety bound on the raw document fetch, generous relative to
-/// `MAX_NODES` so degree-based `prune()` — not query truncation — decides
-/// which 500 nodes survive when a tenant has more visible documents than
-/// the cap.
-const FETCH_SAFETY_CAP: i64 = 4000;
 
 #[derive(Debug, Deserialize)]
 struct GraphQuery {
@@ -81,81 +69,29 @@ async fn get_graph(
         }
     }
 
-    let (documents, conflict_pairs, co_citation_pairs) =
-        with_org_txn(state.pool(), &auth.context, {
-            let ctx = auth.context.clone();
-            let collection_filter = query.collection_id;
-            move |txn| {
-                Box::pin(async move {
-                    let documents = graph::list_visible_documents(
-                        txn,
-                        &ctx,
-                        collection_filter,
-                        FETCH_SAFETY_CAP,
-                    )
-                    .await?;
-                    let node_ids: Vec<Uuid> = documents.iter().map(|d| d.id).collect();
-                    let conflict_pairs = graph::conflict_edges_among(txn, &ctx, &node_ids).await?;
-                    let co_citation_pairs =
-                        graph::co_citation_edges_among(txn, &ctx, &node_ids).await?;
-                    Ok((documents, conflict_pairs, co_citation_pairs))
-                })
-            }
-        })
+    let data = build_org_graph(state.pool(), &auth.context, query.collection_id)
         .await
         .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
 
-    let node_ids: Vec<Uuid> = documents.iter().map(|d| d.id).collect();
-
-    let mut edges: Vec<GraphEdgeInput> = Vec::new();
-    for (a, b, count) in &conflict_pairs {
-        edges.push(GraphEdgeInput {
-            source: *a,
-            target: *b,
-            kind: "conflict".to_string(),
-            weight: saturating_weight(*count),
-        });
-    }
-    for (a, b, count) in &co_citation_pairs {
-        edges.push(GraphEdgeInput {
-            source: *a,
-            target: *b,
-            kind: "co_citation".to_string(),
-            weight: saturating_weight(*count),
-        });
-    }
-    // similarity: see module doc — opt-in on Qdrant + embedder, not
+    // similarity: see module doc — opt-in on the vector index + embedder, not
     // implemented in this pass. `state.vector_index()`/`state.embedder()` are
     // the real availability check a future pass would gate on.
     let _similarity_available = state.vector_index().is_some() && state.embedder().is_some();
 
-    let pruned = prune(&node_ids, &edges, MAX_NODES, MAX_EDGES);
-
-    let mut degree: BTreeMap<Uuid, i64> = pruned.node_ids.iter().map(|id| (*id, 0)).collect();
-    for edge in &pruned.edges {
-        *degree.entry(edge.source).or_insert(0) += 1;
-        *degree.entry(edge.target).or_insert(0) += 1;
-    }
-
-    let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
-        documents.iter().map(|d| (d.id, d)).collect();
-
-    let nodes: Vec<GraphNodeDto> = pruned
-        .node_ids
+    let nodes: Vec<GraphNodeDto> = data
+        .nodes
         .iter()
-        .filter_map(|id| {
-            doc_by_id.get(id).map(|d| GraphNodeDto {
-                id: d.id,
-                title: d.title.clone(),
-                collection_id: d.collection_id,
-                collection_name: d.collection_name.clone(),
-                status: d.state.clone(),
-                degree: *degree.get(id).unwrap_or(&0),
-            })
+        .map(|n| GraphNodeDto {
+            id: n.id,
+            title: n.title.clone(),
+            collection_id: n.collection_id,
+            collection_name: n.collection_name.clone(),
+            status: n.status.clone(),
+            degree: n.degree,
         })
         .collect();
 
-    let edges_dto: Vec<GraphEdgeDto> = pruned
+    let edges_dto: Vec<GraphEdgeDto> = data
         .edges
         .iter()
         .map(|edge| GraphEdgeDto {
@@ -166,18 +102,15 @@ async fn get_graph(
         })
         .collect();
 
-    let components = connected_components(&pruned.node_ids, &pruned.edges);
-    let communities: Vec<GraphCommunityDto> = components
+    let communities: Vec<GraphCommunityDto> = data
+        .communities
         .iter()
         .enumerate()
-        .map(|(index, component)| {
-            let label = community_label(&component.node_ids, &doc_by_id);
-            GraphCommunityDto {
-                id: format!("community-{index}"),
-                label,
-                node_ids: component.node_ids.clone(),
-                size: component.node_ids.len() as i64,
-            }
+        .map(|(index, community)| GraphCommunityDto {
+            id: format!("community-{index}"),
+            label: community.label.clone(),
+            node_ids: community.node_ids.clone(),
+            size: community.node_ids.len() as i64,
         })
         .collect();
 
@@ -187,31 +120,6 @@ async fn get_graph(
         communities,
         request_id: auth.request_id,
     }))
-}
-
-/// Contract: community label is "tên bộ sưu tập chi phối hoặc title tài liệu
-/// bậc cao nhất trong cụm" — a lone-document component labels itself by that
-/// document's title; a multi-document component labels itself by whichever
-/// collection has the most members in it (ties broken lexicographically so
-/// the choice is deterministic, not by insertion order).
-fn community_label(node_ids: &[Uuid], doc_by_id: &BTreeMap<Uuid, &GraphDocumentRow>) -> String {
-    if let [only] = node_ids {
-        return doc_by_id
-            .get(only)
-            .map(|d| d.title.clone())
-            .unwrap_or_else(|| "Không xác định".to_string());
-    }
-    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
-    for id in node_ids {
-        if let Some(document) = doc_by_id.get(id) {
-            *counts.entry(document.collection_name.as_str()).or_insert(0) += 1;
-        }
-    }
-    counts
-        .into_iter()
-        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(a.0)))
-        .map(|(name, _)| name.to_string())
-        .unwrap_or_else(|| "Không xác định".to_string())
 }
 
 enum RouteError {
@@ -264,56 +172,5 @@ impl IntoResponse for RouteError {
             }),
         )
             .into_response()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn uid(n: u128) -> Uuid {
-        Uuid::from_u128(n)
-    }
-
-    fn doc(id: Uuid, title: &str, collection_name: &str) -> GraphDocumentRow {
-        GraphDocumentRow {
-            id,
-            title: title.to_string(),
-            collection_id: Uuid::new_v4(),
-            collection_name: collection_name.to_string(),
-            state: "indexed".to_string(),
-        }
-    }
-
-    #[test]
-    fn singleton_community_labels_by_document_title() {
-        let a = doc(uid(1), "Chính sách nghỉ phép", "Nhân sự");
-        let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> = [(a.id, &a)].into_iter().collect();
-        assert_eq!(
-            community_label(&[uid(1)], &doc_by_id),
-            "Chính sách nghỉ phép"
-        );
-    }
-
-    #[test]
-    fn multi_node_community_labels_by_majority_collection_name() {
-        let a = doc(uid(1), "A", "Nhân sự");
-        let b = doc(uid(2), "B", "Nhân sự");
-        let c = doc(uid(3), "C", "Tài chính");
-        let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
-            [(a.id, &a), (b.id, &b), (c.id, &c)].into_iter().collect();
-        assert_eq!(
-            community_label(&[uid(1), uid(2), uid(3)], &doc_by_id),
-            "Nhân sự"
-        );
-    }
-
-    #[test]
-    fn multi_node_community_tie_breaks_lexicographically() {
-        let a = doc(uid(1), "A", "Zeta");
-        let b = doc(uid(2), "B", "Alpha");
-        let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
-            [(a.id, &a), (b.id, &b)].into_iter().collect();
-        assert_eq!(community_label(&[uid(1), uid(2)], &doc_by_id), "Alpha");
     }
 }

--- a/crates/server/src/routes/members.rs
+++ b/crates/server/src/routes/members.rs
@@ -93,6 +93,11 @@ pub fn router() -> Router<Arc<AppState>> {
 #[serde(rename_all = "camelCase")]
 struct MembershipDto {
     user_id: Uuid,
+    /// Joined from `users` (see `db::members`'s `MEMBERSHIP_COLUMNS` doc) so
+    /// the admin UI can render a name/email instead of a bare `user_id` —
+    /// closes the raw-UUID-in-UI gap the owner reported.
+    email: String,
+    display_name: String,
     role: String,
     state: String,
     created_at: DateTime<Utc>,
@@ -175,6 +180,8 @@ struct PatchMemberRequest {
 fn membership_dto(row: OrgMembership) -> MembershipDto {
     MembershipDto {
         user_id: row.user_id,
+        email: row.email,
+        display_name: row.display_name,
         role: row.role.as_str().to_string(),
         state: row.state.as_str().to_string(),
         created_at: row.created_at,

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -11,6 +11,7 @@ pub mod health;
 pub mod jobs;
 pub mod members;
 pub mod orgs;
+pub mod projects;
 pub mod rate_limit_guard;
 pub mod search;
 pub mod uploads;

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -6,6 +6,7 @@ pub mod auth;
 pub mod collections;
 pub mod documents;
 pub mod events;
+pub mod graph;
 pub mod health;
 pub mod jobs;
 pub mod members;

--- a/crates/server/src/routes/projects.rs
+++ b/crates/server/src/routes/projects.rs
@@ -1,0 +1,293 @@
+//! Project CRUD (P2-18): org-scoped folders of collections.
+//!
+//! Permission precedent mirrors `routes::collections` exactly (see that
+//! module + the P2-18 session report for the full rationale): collection
+//! create/update there is gated by `doc.upload` (the existing "who may
+//! manage the library's structure" permission — editor/admin/owner all hold
+//! it; there is no separate `project.manage` permission and this slice does
+//! not add one). Project create/update/collection-assign reuse the same
+//! `doc.upload` gate rather than inventing a parallel permission for a
+//! sibling piece of library structure. Project deletion is out of scope for
+//! this slice (see the P2-18 backlog entry) — no route exists for it here.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api::{ApiError, Page, PageInfo};
+use crate::auth::middleware::AuthenticatedOrg;
+use crate::auth::permissions::require_permission;
+use crate::db::error::DbError;
+use crate::db::pool::with_org_txn;
+use crate::db::projects;
+use crate::http::AppState;
+use crate::services::audit;
+
+/// Same gate `routes::collections::{create_collection, update_collection}`
+/// use — see this module's doc for why no separate permission was added.
+const PERMISSION_PROJECT_MANAGE: &str = "doc.upload";
+
+const MAX_NAME_LEN: usize = 200;
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/v1/projects", get(list_projects).post(create_project))
+        .route(
+            "/api/v1/projects/{project_id}",
+            axum::routing::patch(update_project),
+        )
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProjectDto {
+    id: Uuid,
+    name: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateProjectRequest {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateProjectRequest {
+    name: String,
+}
+
+fn project_dto(project: crate::db::models::Project) -> ProjectDto {
+    ProjectDto {
+        id: project.id,
+        name: project.name,
+        created_at: project.created_at,
+    }
+}
+
+fn validate_name(name: &str) -> Option<&str> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() || trimmed.len() > MAX_NAME_LEN {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+// ---------------------------------------------------------------------
+// GET /projects — every project in the caller's org ("all projects" in the
+// UI/API is the absence of a filter, never a row here — no list-scoping
+// beyond org isolation is needed).
+// ---------------------------------------------------------------------
+
+async fn list_projects(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+) -> Result<Json<Page<ProjectDto>>, RouteError> {
+    let items = with_org_txn(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        move |txn| Box::pin(async move { projects::list(txn, &ctx).await })
+    })
+    .await
+    .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
+    Ok(Json(Page {
+        items: items.into_iter().map(project_dto).collect(),
+        page: PageInfo {
+            next_cursor: None,
+            has_more: false,
+        },
+    }))
+}
+
+// ---------------------------------------------------------------------
+// POST /projects
+// ---------------------------------------------------------------------
+
+async fn create_project(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Json(body): Json<CreateProjectRequest>,
+) -> Result<(StatusCode, Json<ProjectDto>), RouteError> {
+    if require_permission(&auth.context, PERMISSION_PROJECT_MANAGE).is_err() {
+        audit::record_deny(
+            state.pool(),
+            &auth.context,
+            &auth.request_id,
+            "project.create",
+            "project",
+            None,
+            "permission_denied",
+        )
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+        return Err(RouteError::Denied(auth.request_id.clone()));
+    }
+    let Some(name) = validate_name(&body.name) else {
+        return Err(RouteError::Validation(
+            auth.request_id.clone(),
+            "Invalid project name",
+        ));
+    };
+    let id = Uuid::new_v4();
+    let name = name.to_string();
+    let request_id = auth.request_id.clone();
+    let project = with_org_txn(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                let project = projects::insert(txn, &ctx, id, &name).await?;
+                let resource_id = project.id.to_string();
+                audit::record_in_txn(
+                    txn,
+                    &ctx,
+                    audit::AuditRecord {
+                        request_id: &request_id,
+                        action: "project.create",
+                        resource_type: "project",
+                        resource_id: Some(&resource_id),
+                        outcome: crate::db::models::AuditOutcome::Success,
+                        metadata: serde_json::json!({
+                            "project_id": project.id.to_string(),
+                            "name_chars": project.name.len() as i64,
+                        }),
+                    },
+                )
+                .await?;
+                Ok(project)
+            })
+        }
+    })
+    .await
+    .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
+    Ok((StatusCode::CREATED, Json(project_dto(project))))
+}
+
+// ---------------------------------------------------------------------
+// PATCH /projects/{projectId} — rename only (no other mutable field yet).
+// ---------------------------------------------------------------------
+
+async fn update_project(
+    State(state): State<Arc<AppState>>,
+    auth: AuthenticatedOrg,
+    Path(project_id): Path<Uuid>,
+    Json(body): Json<UpdateProjectRequest>,
+) -> Result<Json<ProjectDto>, RouteError> {
+    if require_permission(&auth.context, PERMISSION_PROJECT_MANAGE).is_err() {
+        let resource_id = project_id.to_string();
+        audit::record_deny(
+            state.pool(),
+            &auth.context,
+            &auth.request_id,
+            "project.update",
+            "project",
+            Some(&resource_id),
+            "permission_denied",
+        )
+        .await
+        .map_err(|_| RouteError::Database(auth.request_id.clone()))?;
+        return Err(RouteError::Denied(auth.request_id.clone()));
+    }
+    let Some(name) = validate_name(&body.name) else {
+        return Err(RouteError::Validation(
+            auth.request_id.clone(),
+            "Invalid project name",
+        ));
+    };
+    let name = name.to_string();
+    let request_id = auth.request_id.clone();
+    let project = with_org_txn(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        let request_id = request_id.clone();
+        move |txn| {
+            Box::pin(async move {
+                let project = projects::update_name(txn, &ctx, project_id, &name).await?;
+                let resource_id = project.id.to_string();
+                audit::record_in_txn(
+                    txn,
+                    &ctx,
+                    audit::AuditRecord {
+                        request_id: &request_id,
+                        action: "project.update",
+                        resource_type: "project",
+                        resource_id: Some(&resource_id),
+                        outcome: crate::db::models::AuditOutcome::Success,
+                        metadata: serde_json::json!({
+                            "project_id": project.id.to_string(),
+                            "name_chars": project.name.len() as i64,
+                        }),
+                    },
+                )
+                .await?;
+                Ok(project)
+            })
+        }
+    })
+    .await
+    .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
+    Ok(Json(project_dto(project)))
+}
+
+enum RouteError {
+    Denied(String),
+    Validation(String, &'static str),
+    NotFound(String),
+    Database(String),
+}
+
+impl RouteError {
+    fn from_db(error: DbError, request_id: &str) -> Self {
+        match error {
+            DbError::NotFound => Self::NotFound(request_id.to_string()),
+            _ => Self::Database(request_id.to_string()),
+        }
+    }
+}
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> Response {
+        let (status, code, message, request_id) = match self {
+            Self::Denied(request_id) => (
+                StatusCode::FORBIDDEN,
+                "forbidden",
+                "Permission denied",
+                request_id,
+            ),
+            Self::Validation(request_id, message) => (
+                StatusCode::BAD_REQUEST,
+                "validation_failed",
+                message,
+                request_id,
+            ),
+            Self::NotFound(request_id) => (
+                StatusCode::NOT_FOUND,
+                "not_found",
+                "Project not found",
+                request_id,
+            ),
+            Self::Database(request_id) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                "Request failed",
+                request_id,
+            ),
+        };
+        (
+            status,
+            Json(ApiError {
+                code: code.into(),
+                message: message.into(),
+                request_id,
+                details: None,
+            }),
+        )
+            .into_response()
+    }
+}

--- a/crates/server/src/routes/search.rs
+++ b/crates/server/src/routes/search.rs
@@ -15,7 +15,9 @@ use uuid::Uuid;
 use crate::api::ApiError;
 use crate::auth::middleware::AuthenticatedOrg;
 use crate::auth::permissions::require_permission;
+use crate::db::error::DbError;
 use crate::db::models::AuditOutcome;
+use crate::db::projects;
 use crate::http::AppState;
 use crate::services::audit;
 use crate::services::citation::pins_from_hits;
@@ -33,6 +35,15 @@ struct SearchBody {
     query: String,
     #[serde(default)]
     collection_ids: Option<Vec<Uuid>>,
+    /// P2-18 — optional project scope. `None` (the default) is "all
+    /// projects": no additional filter beyond whatever `collectionIds`
+    /// already restricts, i.e. today's exact behavior. Resolved to the
+    /// project's collection ids server-side and intersected with
+    /// `collectionIds` (if both are given) before being handed to the
+    /// existing `resolve_scope`/ACL-intersection retrieval path — no new
+    /// retrieval mechanism, see `routes::search`/`routes::ask` module notes.
+    #[serde(default)]
+    project_id: Option<Uuid>,
     #[serde(default)]
     mode: Option<String>,
     #[serde(default)]
@@ -126,12 +137,29 @@ async fn search(
     }
     let mode = parse_mode(&body)
         .map_err(|message| RouteError::Validation(auth.request_id.clone(), message))?;
-    let vector_index = state
-        .vector_index()
-        .ok_or_else(|| RouteError::Unavailable(auth.request_id.clone()))?;
     let collection_ids = body
         .collection_ids
         .map(|ids| ids.into_iter().collect::<BTreeSet<_>>());
+    // P2-18 — narrow (never widen) the requested collection scope to the
+    // project's collections, still ANDed with the caller's ACL by the
+    // existing `resolve_scope` inside `hybrid_search` below. Resolved before
+    // the `vector_index` availability check right below: an unknown
+    // `projectId` is a client input error independent of retrieval backend
+    // health, so it must 404 even when the vector store is unavailable.
+    let collection_ids = projects::resolve_project_scope(
+        state.pool(),
+        &auth.context,
+        body.project_id,
+        collection_ids,
+    )
+    .await
+    .map_err(|error| match error {
+        DbError::NotFound => RouteError::NotFound(auth.request_id.clone()),
+        _ => RouteError::Database(auth.request_id.clone()),
+    })?;
+    let vector_index = state
+        .vector_index()
+        .ok_or_else(|| RouteError::Unavailable(auth.request_id.clone()))?;
     let query_chars = body.query.len();
     let limit = body.limit.clamp(1, 100);
     let response = match hybrid_search(
@@ -235,6 +263,7 @@ async fn search(
 enum RouteError {
     Validation(String, &'static str),
     Denied(String),
+    NotFound(String),
     Unavailable(String),
     Database(String),
     RateLimited(crate::routes::rate_limit_guard::RateLimitRejected),
@@ -270,6 +299,12 @@ impl IntoResponse for RouteError {
                 StatusCode::FORBIDDEN,
                 "forbidden",
                 "Permission denied",
+                request_id,
+            ),
+            Self::NotFound(request_id) => (
+                StatusCode::NOT_FOUND,
+                "not_found",
+                "Project not found",
                 request_id,
             ),
             Self::Unavailable(request_id) => (

--- a/crates/server/src/services/acl_mutate.rs
+++ b/crates/server/src/services/acl_mutate.rs
@@ -5,6 +5,7 @@ use tokio_postgres::Transaction;
 use uuid::Uuid;
 
 use crate::db::error::DbError;
+use crate::db::orgs;
 use crate::services::authz_lock;
 
 /// Revoke a permission code from every role held by `user_id` in `org_id`.
@@ -34,6 +35,15 @@ pub async fn revoke_role_permission_for_principal(
         )
         .await
         .map_err(DbError::from)?;
+    if n > 0 {
+        // 1C-05: this DELETE removes a `role_permissions` row shared by
+        // EVERY member holding that role, not just `user_id` — the cache
+        // invalidation must be org-wide for the same reason (see
+        // migration 0031's doc comment). Skipped when `n == 0` (nothing
+        // actually changed) so a no-op revoke does not force every
+        // principal in the org to re-resolve for free.
+        orgs::bump_acl_version(txn, org_id).await?;
+    }
     Ok(n)
 }
 
@@ -64,5 +74,8 @@ pub async fn revoke_collection_access_for_principal(
     )
     .await
     .map_err(DbError::from)?;
+    // 1C-05: this changes visibility/ownership org-wide (not just for
+    // `user_id`), so the cache invalidation is org-wide too.
+    orgs::bump_acl_version(txn, org_id).await?;
     Ok(())
 }

--- a/crates/server/src/services/audit.rs
+++ b/crates/server/src/services/audit.rs
@@ -37,6 +37,10 @@ pub enum AuditAction {
     CollectionCreate,
     CollectionUpdate,
     CollectionDelete,
+    // P2-18 org -> project -> collection -> document grouping (migrations/0032).
+    ProjectCreate,
+    ProjectUpdate,
+    CollectionAssignProject,
     DocumentUpload,
     DocumentDelete,
     DocumentTombstone,
@@ -86,6 +90,9 @@ impl AuditAction {
             Self::CollectionCreate => "collection.create",
             Self::CollectionUpdate => "collection.update",
             Self::CollectionDelete => "collection.delete",
+            Self::ProjectCreate => "project.create",
+            Self::ProjectUpdate => "project.update",
+            Self::CollectionAssignProject => "collection.assign_project",
             Self::DocumentUpload => "document.upload",
             Self::DocumentDelete => "document.delete",
             Self::DocumentTombstone => "document.tombstone",
@@ -128,6 +135,9 @@ impl AuditAction {
             "collection.create" => Ok(Self::CollectionCreate),
             "collection.update" => Ok(Self::CollectionUpdate),
             "collection.delete" => Ok(Self::CollectionDelete),
+            "project.create" => Ok(Self::ProjectCreate),
+            "project.update" => Ok(Self::ProjectUpdate),
+            "collection.assign_project" => Ok(Self::CollectionAssignProject),
             "document.upload" => Ok(Self::DocumentUpload),
             "document.delete" => Ok(Self::DocumentDelete),
             "document.tombstone" => Ok(Self::DocumentTombstone),
@@ -180,6 +190,10 @@ impl AuditAction {
             Self::CollectionCreate | Self::CollectionUpdate | Self::CollectionDelete => {
                 &["reason", "collection_id", "name_chars", "slug_chars"]
             }
+            // Structural only, same shape as Collection* above — never the
+            // project name free text itself.
+            Self::ProjectCreate | Self::ProjectUpdate => &["reason", "project_id", "name_chars"],
+            Self::CollectionAssignProject => &["reason", "collection_id", "project_id"],
             Self::DocumentUpload => &[
                 "reason",
                 "format",
@@ -277,6 +291,7 @@ pub enum AuditResource {
     Org,
     Document,
     Collection,
+    Project,
     Job,
     Quota,
     Object,
@@ -295,6 +310,7 @@ impl AuditResource {
             Self::Org => "org",
             Self::Document => "document",
             Self::Collection => "collection",
+            Self::Project => "project",
             Self::Job => "job",
             Self::Quota => "quota",
             Self::Object => "object",
@@ -313,6 +329,7 @@ impl AuditResource {
             "org" => Ok(Self::Org),
             "document" => Ok(Self::Document),
             "collection" => Ok(Self::Collection),
+            "project" => Ok(Self::Project),
             "job" | "jobs" => Ok(Self::Job),
             "quota" => Ok(Self::Quota),
             "object" => Ok(Self::Object),

--- a/crates/server/src/services/graph.rs
+++ b/crates/server/src/services/graph.rs
@@ -1,6 +1,8 @@
-//! Pure graph algorithms for the Document Graph MVP (P2-17): degree-based
-//! bounding/pruning and connected components ("communities"). No DB, no I/O —
-//! fully unit-testable and deterministic regardless of input ordering.
+//! Document Graph MVP (P2-17): pure algorithms (degree-based bounding/pruning,
+//! connected components — DB-free, deterministic, unit-tested below) plus the
+//! `build_org_graph` orchestration that fetches caller-visible nodes/edges
+//! through `db::graph` (routes stay DTO-mapping only, per
+//! check-architecture-boundaries).
 //!
 //! Deliberately hand-rolled instead of a graph crate: components/pruning are
 //! small, well-understood algorithms (BFS + two sorts) and the project's own
@@ -11,6 +13,13 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use uuid::Uuid;
+
+use crate::auth::context::OrgContext;
+use crate::db::error::DbError;
+use crate::db::graph::{self as db_graph, GraphDocumentRow};
+use deadpool_postgres::Pool;
+
+use crate::db::pool::with_org_txn;
 
 /// One candidate edge before pruning. `kind` is carried through so the same
 /// document pair can carry more than one edge (e.g. both a `conflict` and a
@@ -155,6 +164,161 @@ pub fn saturating_weight(count: i64) -> f64 {
     1.0 - 1.0 / (1.0 + count.max(1) as f64)
 }
 
+// ---------------------------------------------------------------------
+// Orchestration (route -> service -> db, per check-architecture-boundaries):
+// fetch the caller-visible nodes and real-relation edges, then bound and
+// cluster them. Routes stay DTO-mapping only.
+// ---------------------------------------------------------------------
+
+/// Contract: "Bounded: cap nodes/edges (vd 500/2000)".
+pub const MAX_NODES: usize = 500;
+pub const MAX_EDGES: usize = 2000;
+/// Safety bound on the raw document fetch, generous relative to
+/// `MAX_NODES` so degree-based `prune()` — not query truncation — decides
+/// which 500 nodes survive when a tenant has more visible documents than
+/// the cap.
+const FETCH_SAFETY_CAP: i64 = 4000;
+
+#[derive(Debug, Clone)]
+pub struct GraphNodeData {
+    pub id: Uuid,
+    pub title: String,
+    pub collection_id: Uuid,
+    pub collection_name: String,
+    pub status: String,
+    pub degree: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphCommunityData {
+    pub label: String,
+    pub node_ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphData {
+    pub nodes: Vec<GraphNodeData>,
+    pub edges: Vec<GraphEdgeInput>,
+    pub communities: Vec<GraphCommunityData>,
+}
+
+/// Builds the bounded, clustered document graph the route serves: visible
+/// documents (RLS + caller ACL, exactly the library's visibility) plus
+/// `conflict` and `co_citation` edges among them. `similarity` edges are a
+/// deliberate future slot — see `routes/graph.rs` module doc.
+pub async fn build_org_graph(
+    pool: &Pool,
+    ctx: &OrgContext,
+    collection_filter: Option<Uuid>,
+) -> Result<GraphData, DbError> {
+    let (documents, conflict_pairs, co_citation_pairs) = with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                let documents = db_graph::list_visible_documents(
+                    txn,
+                    &ctx,
+                    collection_filter,
+                    FETCH_SAFETY_CAP,
+                )
+                .await?;
+                let node_ids: Vec<Uuid> = documents.iter().map(|d| d.id).collect();
+                let conflict_pairs = db_graph::conflict_edges_among(txn, &ctx, &node_ids).await?;
+                let co_citation_pairs =
+                    db_graph::co_citation_edges_among(txn, &ctx, &node_ids).await?;
+                Ok((documents, conflict_pairs, co_citation_pairs))
+            })
+        }
+    })
+    .await?;
+
+    let node_ids: Vec<Uuid> = documents.iter().map(|d| d.id).collect();
+
+    let mut edges: Vec<GraphEdgeInput> = Vec::new();
+    for (a, b, count) in &conflict_pairs {
+        edges.push(GraphEdgeInput {
+            source: *a,
+            target: *b,
+            kind: "conflict".to_string(),
+            weight: saturating_weight(*count),
+        });
+    }
+    for (a, b, count) in &co_citation_pairs {
+        edges.push(GraphEdgeInput {
+            source: *a,
+            target: *b,
+            kind: "co_citation".to_string(),
+            weight: saturating_weight(*count),
+        });
+    }
+
+    let pruned = prune(&node_ids, &edges, MAX_NODES, MAX_EDGES);
+
+    let mut degree: BTreeMap<Uuid, i64> = pruned.node_ids.iter().map(|id| (*id, 0)).collect();
+    for edge in &pruned.edges {
+        *degree.entry(edge.source).or_insert(0) += 1;
+        *degree.entry(edge.target).or_insert(0) += 1;
+    }
+
+    let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
+        documents.iter().map(|d| (d.id, d)).collect();
+
+    let nodes: Vec<GraphNodeData> = pruned
+        .node_ids
+        .iter()
+        .filter_map(|id| {
+            doc_by_id.get(id).map(|d| GraphNodeData {
+                id: d.id,
+                title: d.title.clone(),
+                collection_id: d.collection_id,
+                collection_name: d.collection_name.clone(),
+                status: d.state.clone(),
+                degree: *degree.get(id).unwrap_or(&0),
+            })
+        })
+        .collect();
+
+    let communities: Vec<GraphCommunityData> =
+        connected_components(&pruned.node_ids, &pruned.edges)
+            .iter()
+            .map(|component| GraphCommunityData {
+                label: community_label(&component.node_ids, &doc_by_id),
+                node_ids: component.node_ids.clone(),
+            })
+            .collect();
+
+    Ok(GraphData {
+        nodes,
+        edges: pruned.edges,
+        communities,
+    })
+}
+
+/// Contract: community label is "tên bộ sưu tập chi phối hoặc title tài liệu
+/// bậc cao nhất trong cụm" — a lone-document component labels itself by that
+/// document's title; a multi-document component labels itself by whichever
+/// collection has the most members in it (ties broken lexicographically so
+/// the choice is deterministic, not by insertion order).
+fn community_label(node_ids: &[Uuid], doc_by_id: &BTreeMap<Uuid, &GraphDocumentRow>) -> String {
+    if let [only] = node_ids {
+        return doc_by_id
+            .get(only)
+            .map(|d| d.title.clone())
+            .unwrap_or_else(|| "Không xác định".to_string());
+    }
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for id in node_ids {
+        if let Some(document) = doc_by_id.get(id) {
+            *counts.entry(document.collection_name.as_str()).or_insert(0) += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(a.0)))
+        .map(|(name, _)| name.to_string())
+        .unwrap_or_else(|| "Không xác định".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,5 +438,47 @@ mod tests {
         assert!(saturating_weight(2) < saturating_weight(100));
         assert!(saturating_weight(1_000_000) < 1.0);
         assert_eq!(saturating_weight(0), saturating_weight(1)); // count clamped to >= 1
+    }
+
+    fn doc(id: Uuid, title: &str, collection_name: &str) -> GraphDocumentRow {
+        GraphDocumentRow {
+            id,
+            title: title.to_string(),
+            collection_id: Uuid::new_v4(),
+            collection_name: collection_name.to_string(),
+            state: "indexed".to_string(),
+        }
+    }
+
+    #[test]
+    fn singleton_community_labels_by_document_title() {
+        let a = doc(uid(1), "Chính sách nghỉ phép", "Nhân sự");
+        let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> = [(a.id, &a)].into_iter().collect();
+        assert_eq!(
+            community_label(&[uid(1)], &doc_by_id),
+            "Chính sách nghỉ phép"
+        );
+    }
+
+    #[test]
+    fn multi_node_community_labels_by_majority_collection_name() {
+        let a = doc(uid(1), "A", "Nhân sự");
+        let b = doc(uid(2), "B", "Nhân sự");
+        let c = doc(uid(3), "C", "Tài chính");
+        let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
+            [(a.id, &a), (b.id, &b), (c.id, &c)].into_iter().collect();
+        assert_eq!(
+            community_label(&[uid(1), uid(2), uid(3)], &doc_by_id),
+            "Nhân sự"
+        );
+    }
+
+    #[test]
+    fn multi_node_community_tie_breaks_lexicographically() {
+        let a = doc(uid(1), "A", "Zeta");
+        let b = doc(uid(2), "B", "Alpha");
+        let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
+            [(a.id, &a), (b.id, &b)].into_iter().collect();
+        assert_eq!(community_label(&[uid(1), uid(2)], &doc_by_id), "Alpha");
     }
 }

--- a/crates/server/src/services/graph.rs
+++ b/crates/server/src/services/graph.rs
@@ -1,0 +1,278 @@
+//! Pure graph algorithms for the Document Graph MVP (P2-17): degree-based
+//! bounding/pruning and connected components ("communities"). No DB, no I/O —
+//! fully unit-testable and deterministic regardless of input ordering.
+//!
+//! Deliberately hand-rolled instead of a graph crate: components/pruning are
+//! small, well-understood algorithms (BFS + two sorts) and the project's own
+//! dependency policy (`scripts/check-dependency-policy.py`) favors not
+//! reaching for a dependency when ~100 lines of plain Rust cover the need —
+//! same reasoning the web side applies to the force-directed layout.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use uuid::Uuid;
+
+/// One candidate edge before pruning. `kind` is carried through so the same
+/// document pair can carry more than one edge (e.g. both a `conflict` and a
+/// `co_citation` edge) — pruning/components treat those as distinct edges.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphEdgeInput {
+    pub source: Uuid,
+    pub target: Uuid,
+    pub kind: String,
+    pub weight: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct PrunedGraph {
+    /// Kept node ids, ascending — deterministic regardless of input order.
+    pub node_ids: Vec<Uuid>,
+    /// Kept edges, ranked by weight desc (ties by source/target/kind asc)
+    /// before truncation, but returned in that same ranked order.
+    pub edges: Vec<GraphEdgeInput>,
+}
+
+/// Degree-based bound matching the contract's "cap nodes/edges (vd
+/// 500/2000), degree-based pruning khi vượt":
+///
+/// 1. Rank nodes by degree (edge endpoint count) descending, ties broken by
+///    ascending id, and keep at most `max_nodes`. This favors well-connected
+///    ("central") documents over arbitrarily-ordered ones when a tenant has
+///    more visible documents than the cap allows.
+/// 2. Drop any edge with an endpoint that didn't survive step 1.
+/// 3. Rank the remaining edges by weight descending, ties broken by
+///    `(source, target, kind)` ascending, and keep at most `max_edges`.
+pub fn prune(
+    node_ids: &[Uuid],
+    edges: &[GraphEdgeInput],
+    max_nodes: usize,
+    max_edges: usize,
+) -> PrunedGraph {
+    let mut degree: BTreeMap<Uuid, usize> = node_ids.iter().map(|id| (*id, 0)).collect();
+    for edge in edges {
+        if let Some(d) = degree.get_mut(&edge.source) {
+            *d += 1;
+        }
+        if let Some(d) = degree.get_mut(&edge.target) {
+            *d += 1;
+        }
+    }
+
+    let mut ranked_nodes: Vec<Uuid> = node_ids.to_vec();
+    ranked_nodes.sort_by(|a, b| {
+        let da = degree.get(a).copied().unwrap_or(0);
+        let db = degree.get(b).copied().unwrap_or(0);
+        db.cmp(&da).then_with(|| a.cmp(b))
+    });
+    let kept: BTreeSet<Uuid> = ranked_nodes.into_iter().take(max_nodes).collect();
+
+    let mut kept_edges: Vec<GraphEdgeInput> = edges
+        .iter()
+        .filter(|edge| kept.contains(&edge.source) && kept.contains(&edge.target))
+        .cloned()
+        .collect();
+    kept_edges.sort_by(|a, b| {
+        b.weight
+            .partial_cmp(&a.weight)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| (a.source, a.target, &a.kind).cmp(&(b.source, b.target, &b.kind)))
+    });
+    kept_edges.truncate(max_edges);
+
+    let mut node_ids_out: Vec<Uuid> = kept.into_iter().collect();
+    node_ids_out.sort();
+    PrunedGraph {
+        node_ids: node_ids_out,
+        edges: kept_edges,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Component {
+    /// Members, ascending — deterministic regardless of input order.
+    pub node_ids: Vec<Uuid>,
+}
+
+/// Connected components over an undirected graph built from `edges`'
+/// endpoints (edge `kind`/`weight` do not affect connectivity — a
+/// `conflict` edge and a `co_citation` edge between the same pair merge
+/// them into the same component either way). Isolated nodes form their own
+/// singleton component.
+///
+/// Deterministic: components are ordered by their smallest member id, and
+/// each component's members are sorted ascending — independent of the order
+/// `node_ids`/`edges` are given in.
+pub fn connected_components(node_ids: &[Uuid], edges: &[GraphEdgeInput]) -> Vec<Component> {
+    let mut adjacency: BTreeMap<Uuid, BTreeSet<Uuid>> =
+        node_ids.iter().map(|id| (*id, BTreeSet::new())).collect();
+    for edge in edges {
+        adjacency
+            .entry(edge.source)
+            .or_default()
+            .insert(edge.target);
+        adjacency
+            .entry(edge.target)
+            .or_default()
+            .insert(edge.source);
+    }
+
+    let mut sorted_nodes = node_ids.to_vec();
+    sorted_nodes.sort();
+    sorted_nodes.dedup();
+
+    let mut visited: BTreeSet<Uuid> = BTreeSet::new();
+    let mut components = Vec::new();
+    for &start in &sorted_nodes {
+        if visited.contains(&start) {
+            continue;
+        }
+        let mut queue = VecDeque::from([start]);
+        visited.insert(start);
+        let mut members = Vec::new();
+        while let Some(current) = queue.pop_front() {
+            members.push(current);
+            if let Some(neighbors) = adjacency.get(&current) {
+                for &next in neighbors {
+                    if visited.insert(next) {
+                        queue.push_back(next);
+                    }
+                }
+            }
+        }
+        members.sort();
+        components.push(Component { node_ids: members });
+    }
+    components.sort_by_key(|c| c.node_ids.first().copied());
+    components
+}
+
+/// Maps an evidence count to a `0..1` edge weight: saturating, not linear,
+/// so a single conflict/co-citation still registers a real (if modest)
+/// weight and repeated evidence pushes it toward — but never reaches — 1.0.
+/// Deliberately not a claim of calibrated probability, just a bounded,
+/// monotone strength signal for layout/rendering.
+pub fn saturating_weight(count: i64) -> f64 {
+    1.0 - 1.0 / (1.0 + count.max(1) as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uid(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    fn edge(a: u128, b: u128, kind: &str, weight: f64) -> GraphEdgeInput {
+        GraphEdgeInput {
+            source: uid(a),
+            target: uid(b),
+            kind: kind.to_string(),
+            weight,
+        }
+    }
+
+    #[test]
+    fn components_groups_connected_nodes_and_isolates_singletons() {
+        let nodes = vec![uid(1), uid(2), uid(3), uid(4)];
+        let edges = vec![edge(1, 2, "conflict", 0.5)];
+        let components = connected_components(&nodes, &edges);
+        assert_eq!(
+            components,
+            vec![
+                Component {
+                    node_ids: vec![uid(1), uid(2)]
+                },
+                Component {
+                    node_ids: vec![uid(3)]
+                },
+                Component {
+                    node_ids: vec![uid(4)]
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn components_are_order_independent() {
+        let nodes_a = vec![uid(1), uid(2), uid(3)];
+        let nodes_b = vec![uid(3), uid(1), uid(2)];
+        let edges_a = vec![edge(2, 3, "co_citation", 0.2), edge(1, 2, "conflict", 0.8)];
+        let edges_b = vec![edge(1, 2, "conflict", 0.8), edge(2, 3, "co_citation", 0.2)];
+        assert_eq!(
+            connected_components(&nodes_a, &edges_a),
+            connected_components(&nodes_b, &edges_b)
+        );
+    }
+
+    #[test]
+    fn components_merge_multi_kind_edges_between_same_pair() {
+        let nodes = vec![uid(1), uid(2)];
+        let edges = vec![edge(1, 2, "conflict", 0.9), edge(1, 2, "co_citation", 0.3)];
+        let components = connected_components(&nodes, &edges);
+        assert_eq!(components.len(), 1);
+        assert_eq!(components[0].node_ids, vec![uid(1), uid(2)]);
+    }
+
+    #[test]
+    fn prune_keeps_highest_degree_nodes_when_over_cap() {
+        // Hub (1) connects to 2,3,4; 5 and 6 are an isolated pair.
+        let nodes = vec![uid(1), uid(2), uid(3), uid(4), uid(5), uid(6)];
+        let edges = vec![
+            edge(1, 2, "conflict", 0.5),
+            edge(1, 3, "conflict", 0.5),
+            edge(1, 4, "conflict", 0.5),
+            edge(5, 6, "conflict", 0.5),
+        ];
+        let pruned = prune(&nodes, &edges, 4, 100);
+        // Degrees: 1->3, 2->1, 3->1, 4->1, 5->1, 6->1. Node 1 always kept;
+        // the tie among {2,3,4,5,6} (all degree 1) is broken by ascending id,
+        // so 2,3,4 (the smallest three ids after 1) survive over 5,6.
+        assert_eq!(pruned.node_ids, vec![uid(1), uid(2), uid(3), uid(4)]);
+    }
+
+    #[test]
+    fn prune_drops_edges_with_a_dropped_endpoint() {
+        let nodes = vec![uid(1), uid(2), uid(3)];
+        let edges = vec![edge(1, 2, "conflict", 0.9), edge(2, 3, "conflict", 0.9)];
+        let pruned = prune(&nodes, &edges, 2, 100);
+        assert_eq!(pruned.node_ids, vec![uid(1), uid(2)]);
+        assert_eq!(pruned.edges, vec![edge(1, 2, "conflict", 0.9)]);
+    }
+
+    #[test]
+    fn prune_keeps_highest_weight_edges_when_over_cap() {
+        let nodes = vec![uid(1), uid(2), uid(3), uid(4)];
+        let edges = vec![
+            edge(1, 2, "conflict", 0.1),
+            edge(1, 3, "conflict", 0.9),
+            edge(1, 4, "conflict", 0.5),
+        ];
+        let pruned = prune(&nodes, &edges, 10, 2);
+        assert_eq!(
+            pruned.edges,
+            vec![edge(1, 3, "conflict", 0.9), edge(1, 4, "conflict", 0.5)]
+        );
+    }
+
+    #[test]
+    fn prune_is_deterministic_regardless_of_input_order() {
+        let nodes_a = vec![uid(1), uid(2), uid(3)];
+        let nodes_b = vec![uid(3), uid(2), uid(1)];
+        let edges_a = vec![edge(1, 2, "conflict", 0.4), edge(2, 3, "conflict", 0.6)];
+        let edges_b = vec![edge(2, 3, "conflict", 0.6), edge(1, 2, "conflict", 0.4)];
+        assert_eq!(
+            prune(&nodes_a, &edges_a, 10, 10),
+            prune(&nodes_b, &edges_b, 10, 10)
+        );
+    }
+
+    #[test]
+    fn saturating_weight_is_bounded_monotone_and_never_reaches_one() {
+        assert!(saturating_weight(1) > 0.0);
+        assert!(saturating_weight(1) < saturating_weight(2));
+        assert!(saturating_weight(2) < saturating_weight(100));
+        assert!(saturating_weight(1_000_000) < 1.0);
+        assert_eq!(saturating_weight(0), saturating_weight(1)); // count clamped to >= 1
+    }
+}

--- a/crates/server/src/services/members.rs
+++ b/crates/server/src/services/members.rs
@@ -64,6 +64,7 @@ use crate::db::members::{self, NewInvite, OwnerRow};
 use crate::db::models::{
     AuditOutcome, MembershipRole, MembershipState, OrgInvite, OrgMembership, ResourceKind,
 };
+use crate::db::orgs;
 use crate::db::pool::with_org_txn_typed;
 use crate::db::quota;
 use crate::services::audit::{self, AuditAction, AuditRecord};
@@ -502,6 +503,9 @@ pub async fn change_role(
                 guard_last_owner(txn, &ctx, target_user_id, will_be_active_owner).await?;
 
                 let updated = members::update_role(txn, &ctx, target_user_id, new_role).await?;
+                // 1C-05: invalidate the org-context cache for every member of
+                // this org in the same transaction as the role change.
+                orgs::bump_acl_version(txn, ctx.org_id()).await?;
                 audit::record_in_txn(
                     txn,
                     &ctx,
@@ -555,6 +559,9 @@ pub async fn remove_member(
 
                 members::purge_refresh_tokens(txn, &ctx, target_user_id).await?;
                 members::delete(txn, &ctx, target_user_id).await?;
+                // 1C-05: invalidate the org-context cache for every member of
+                // this org in the same transaction as the removal.
+                orgs::bump_acl_version(txn, ctx.org_id()).await?;
 
                 audit::record_in_txn(
                     txn,
@@ -643,6 +650,10 @@ async fn set_member_state(
                     guard_last_owner(txn, &ctx, target_user_id, false).await?;
                 }
                 let updated = members::set_state(txn, &ctx, target_user_id, new_state).await?;
+                // 1C-05: invalidate the org-context cache for every member of
+                // this org in the same transaction as the state change
+                // (suspend/reactivate).
+                orgs::bump_acl_version(txn, ctx.org_id()).await?;
                 audit::record_in_txn(
                     txn,
                     &ctx,

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -13,6 +13,7 @@ pub mod deletion;
 pub mod document_state;
 pub mod download;
 pub mod embedding;
+pub mod graph;
 pub mod index_signature;
 pub mod indexing;
 pub mod lifecycle;

--- a/crates/server/tests/acl_cache.rs
+++ b/crates/server/tests/acl_cache.rs
@@ -1,0 +1,484 @@
+//! DB-gated tests for the 1C-05 `auth::context_cache::OrgContextCache`.
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` / `MARKHAND_TEST_APP_DATABASE_URL`
+//! are unset (see `common::boot_app_pool`), same convention as
+//! `tests/members.rs`/`tests/orgs.rs`.
+//!
+//! These prove the cache never serves a stale `OrgContext` after the exact
+//! mutations `db::orgs::bump_acl_version` is wired into (role change,
+//! suspend, remove, `acl_mutate` revoke) — i.e. revoke/suspend/removal stay
+//! effective on the very next request, same as before this cache existed.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use common::{
+    admin_database_url, app_database_url, boot_app_pool, build_router, login_access_token,
+    seed_user_with_permissions, test_auth_config,
+};
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::auth::jwt::JwtKeys;
+use fileconv_server::auth::provider::PasswordAuthProvider;
+use fileconv_server::db::pool::with_org_txn;
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const PASSWORD: &str = "correct-password-1";
+
+async fn boot_pool() -> Option<(common::DualRoleEphemeralDb, deadpool_postgres::Pool)> {
+    let admin = admin_database_url()?;
+    let app = app_database_url()?;
+    Some(boot_app_pool(&admin, &app).await)
+}
+
+/// Seeds a non-owner `admin`-role member holding only `member.manage`. Mirrors
+/// `tests/members.rs::seed_admin_role_member` (kept local/duplicated rather
+/// than shared, since that helper is private to its own test binary).
+async fn seed_admin_role_member(
+    pool: &deadpool_postgres::Pool,
+    org: Uuid,
+    user: Uuid,
+    email: &str,
+) -> String {
+    let ctx = OrgContext::try_new(org, user, ["member.manage"], []).unwrap();
+    let email_owned = email.to_string();
+    with_org_txn(pool, &ctx, {
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO users (id, email, display_name)
+                     VALUES ($1, $2, 'Admin Member') ON CONFLICT (id) DO NOTHING",
+                    &[&user, &email_owned],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO roles (id, org_id, code, name, is_system)
+                     VALUES ($1, $2, 'admin', 'Admin', true)
+                     ON CONFLICT (org_id, code) DO NOTHING",
+                    &[&Uuid::new_v4(), &org],
+                )
+                .await?;
+                let admin_role_id: Uuid = txn
+                    .query_one(
+                        "SELECT id FROM roles WHERE org_id = $1 AND code = 'admin'",
+                        &[&org],
+                    )
+                    .await?
+                    .get(0);
+                let perm_id: Uuid = txn
+                    .query_one(
+                        "SELECT id FROM permissions WHERE code = 'member.manage'",
+                        &[],
+                    )
+                    .await?
+                    .get(0);
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+                    &[&org, &admin_role_id, &perm_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'admin') ON CONFLICT (org_id, user_id) DO NOTHING",
+                    &[&org, &user],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .unwrap();
+    fileconv_server::auth::session::set_password_hash(
+        pool,
+        user,
+        PASSWORD,
+        &test_auth_config().argon2,
+    )
+    .await
+    .expect("set admin password");
+    login_access_token(pool, email, PASSWORD).await
+}
+
+async fn send(
+    app: &axum::Router,
+    method: &str,
+    uri: &str,
+    token: &str,
+    body: Option<Value>,
+) -> StatusCode {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"));
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let request = builder
+        .body(match body {
+            Some(value) => Body::from(value.to_string()),
+            None => Body::empty(),
+        })
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    // Drain the body so keep-alive/tower plumbing does not complain.
+    let _ = response.into_body().collect().await;
+    status
+}
+
+/// Same `AuthenticatedOrg` extractor + cache every real route uses. Populates
+/// the cache on the first call (miss), then must observe a same-org mutation
+/// on the very next call (hit-path freshness check) without ever serving a
+/// stale allow.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn cached_context_denies_immediately_after_role_downgrade() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let admin = Uuid::new_v4();
+    seed_user_with_permissions(
+        &pool,
+        org,
+        owner,
+        "owner@acl-cache.test",
+        PASSWORD,
+        &["member.manage"],
+    )
+    .await;
+    let owner_token = login_access_token(&pool, "owner@acl-cache.test", PASSWORD).await;
+    let admin_token = seed_admin_role_member(&pool, org, admin, "admin@acl-cache.test").await;
+
+    // Warm the cache for `admin` — must currently be allowed.
+    let status = send(&app, "GET", "/api/v1/members", &admin_token, None).await;
+    assert_eq!(status, StatusCode::OK, "admin must initially list members");
+
+    // Owner downgrades admin -> viewer (drops member.manage) through the real
+    // PATCH route, in the same request path Wave 2 ships.
+    let status = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{admin}"),
+        &owner_token,
+        Some(json!({ "role": "viewer" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "owner must be able to downgrade");
+
+    // Same bearer token, no re-login: the cache must not serve the
+    // pre-downgrade permission set.
+    let status = send(&app, "GET", "/api/v1/members", &admin_token, None).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "cached context must not outlive a role downgrade that drops member.manage"
+    );
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn cached_context_denies_immediately_after_suspend() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let admin = Uuid::new_v4();
+    seed_user_with_permissions(
+        &pool,
+        org,
+        owner,
+        "owner@acl-cache-susp.test",
+        PASSWORD,
+        &["member.manage"],
+    )
+    .await;
+    let owner_token = login_access_token(&pool, "owner@acl-cache-susp.test", PASSWORD).await;
+    let admin_token = seed_admin_role_member(&pool, org, admin, "admin@acl-cache-susp.test").await;
+
+    let status = send(&app, "GET", "/api/v1/members", &admin_token, None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let status = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/members/{admin}"),
+        &owner_token,
+        Some(json!({ "state": "suspended" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "owner must be able to suspend");
+
+    let status = send(&app, "GET", "/api/v1/members", &admin_token, None).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "cached context must not outlive a suspend (resolves as membership-missing)"
+    );
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn cached_context_denies_immediately_after_remove() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let admin = Uuid::new_v4();
+    seed_user_with_permissions(
+        &pool,
+        org,
+        owner,
+        "owner@acl-cache-rm.test",
+        PASSWORD,
+        &["member.manage"],
+    )
+    .await;
+    let owner_token = login_access_token(&pool, "owner@acl-cache-rm.test", PASSWORD).await;
+    let admin_token = seed_admin_role_member(&pool, org, admin, "admin@acl-cache-rm.test").await;
+
+    let status = send(&app, "GET", "/api/v1/members", &admin_token, None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let status = send(
+        &app,
+        "DELETE",
+        &format!("/api/v1/members/{admin}"),
+        &owner_token,
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NO_CONTENT,
+        "owner must be able to remove"
+    );
+
+    let status = send(&app, "GET", "/api/v1/members", &admin_token, None).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "cached context must not outlive a hard removal"
+    );
+
+    ephemeral.drop().await;
+}
+
+/// Exercises `OrgContextCache::resolve` directly (same call the
+/// `AuthenticatedOrg` extractor makes) around
+/// `services::acl_mutate::revoke_collection_access_for_principal`, which
+/// `tests/uploads.rs`/`tests/sse_stream_readiness.rs`'s in-flight ACL-revoke
+/// tests already depend on taking effect immediately on the always-fresh
+/// paths they use. This proves the *cached* path gives the same guarantee.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn cached_context_drops_collection_access_immediately_after_acl_revoke() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let collection = Uuid::new_v4();
+    seed_user_with_permissions(
+        &pool,
+        org,
+        user,
+        "owner@acl-cache-coll.test",
+        PASSWORD,
+        &["doc.upload"],
+    )
+    .await;
+
+    // Give `user` a private collection they own (the resolver's
+    // `owner_user_id = $2` branch), matching `tests/uploads.rs`'s ACL-revoke
+    // fixture shape.
+    let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
+    with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO collections (id, org_id, name, slug, owner_user_id, visibility)
+                     VALUES ($1, $2, 'ACL cache test', 'acl-cache-test', $3, 'private')",
+                    &[&collection, &ctx.org_id(), &user],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed collection");
+
+    let auth = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+
+    let warm = auth
+        .context_cache()
+        .resolve(&pool, org, user)
+        .await
+        .expect("initial resolve");
+    assert!(
+        warm.allows_collection(collection),
+        "owner must initially see their private collection"
+    );
+
+    let alt_owner = Uuid::new_v4();
+    with_org_txn(&pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                fileconv_server::db::orgs::ensure_user(
+                    txn,
+                    &ctx,
+                    alt_owner,
+                    &format!("alt-{}@acl-cache-coll.test", alt_owner.simple()),
+                    "Alt Owner",
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'owner') ON CONFLICT (org_id, user_id) DO NOTHING",
+                    &[&org, &alt_owner],
+                )
+                .await?;
+                fileconv_server::services::acl_mutate::revoke_collection_access_for_principal(
+                    txn, org, user, collection, alt_owner,
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("revoke collection acl");
+
+    let after = auth
+        .context_cache()
+        .resolve(&pool, org, user)
+        .await
+        .expect("resolve after revoke");
+    assert!(
+        !after.allows_collection(collection),
+        "cached context must not keep granting a collection revoked out from under it"
+    );
+
+    ephemeral.drop().await;
+}
+
+/// Proves the version-check mechanism itself (not merely "the app-level
+/// helper works"): a bare `orgs.acl_version` bump — with no other production
+/// code involved — is enough to force a fresh resolve on the next cache
+/// lookup instead of serving the entry cached before the bump.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn bare_acl_version_bump_forces_fresh_resolve() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    seed_user_with_permissions(
+        &pool,
+        org,
+        user,
+        "owner@acl-cache-version.test",
+        PASSWORD,
+        &["doc.upload"],
+    )
+    .await;
+
+    let auth = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+
+    let warm = auth
+        .context_cache()
+        .resolve(&pool, org, user)
+        .await
+        .expect("initial resolve");
+    assert!(warm.has_permission("doc.upload"));
+
+    // Simulate an out-of-band grant (bypassing `services::acl_mutate`
+    // entirely) plus the version bump every real mutation path performs.
+    // `roles`/`role_permissions` are FORCE RLS'd by `org_id`
+    // (migrations/0010), so this must run inside a transaction with the
+    // `app.org_id` GUC set — a plain `pool.get()` client would have the
+    // `roles` read filtered down to zero rows by RLS and silently grant
+    // nothing (caught during verification: this failed with the plain-client
+    // version until switched to `with_org_txn`).
+    {
+        let client = pool.get().await.expect("client");
+        client
+            .execute(
+                "INSERT INTO permissions (id, code, description)
+                 VALUES ($1, 'doc.publish', 'doc.publish') ON CONFLICT (code) DO NOTHING",
+                &[&Uuid::new_v4()],
+            )
+            .await
+            .expect("insert permission");
+    }
+    let ctx = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    with_org_txn(&pool, &ctx, {
+        move |txn| {
+            Box::pin(async move {
+                let n = txn
+                    .execute(
+                        "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                         SELECT r.org_id, r.id, p.id
+                         FROM roles r, permissions p
+                         WHERE r.org_id = $1 AND r.code = 'owner' AND p.code = 'doc.publish'
+                         ON CONFLICT DO NOTHING",
+                        &[&org],
+                    )
+                    .await?;
+                assert_eq!(n, 1, "grant must actually insert exactly one row");
+                txn.execute(
+                    "UPDATE orgs SET acl_version = acl_version + 1 WHERE id = $1",
+                    &[&org],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("grant doc.publish to owner role and bump acl_version");
+
+    let after = auth
+        .context_cache()
+        .resolve(&pool, org, user)
+        .await
+        .expect("resolve after bump");
+    assert!(
+        after.has_permission("doc.publish"),
+        "a bare acl_version bump must force a fresh resolve, not serve the pre-bump cached entry"
+    );
+
+    ephemeral.drop().await;
+}

--- a/crates/server/tests/graph.rs
+++ b/crates/server/tests/graph.rs
@@ -1,0 +1,520 @@
+//! Live PostgreSQL HTTP contract tests for the Document Graph MVP
+//! (`GET /api/v1/graph`, P2-17 — owner request 2026-07-29).
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` / `MARKHAND_TEST_APP_DATABASE_URL`
+//! are unset (see `common::boot_app_pool`), same as every other live-PG suite
+//! in this crate.
+//!
+//! `similarity` (Qdrant) is deliberately out of scope here: `routes/graph.rs`
+//! never queries Qdrant in this pass (see its module doc + the P2-17
+//! report), so there is nothing DB-observable to assert about it, and this
+//! suite has no `MARKHAND_TEST_QDRANT_URL` wiring.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use common::{admin_database_url, app_database_url, boot_app_pool, build_router};
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::db::ask_streams::{self, NewAskStreamSession};
+use fileconv_server::db::collections::{self, NewCollection};
+use fileconv_server::db::documents::{self, NewDocument};
+use fileconv_server::db::error::DbError;
+use fileconv_server::db::models::CollectionVisibility;
+use fileconv_server::db::pool::with_org_txn;
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const PASSWORD: &str = "correct-password-1";
+
+async fn boot_pool() -> Option<(common::DualRoleEphemeralDb, Pool)> {
+    let admin = admin_database_url()?;
+    let app = app_database_url()?;
+    Some(boot_app_pool(&admin, &app).await)
+}
+
+async fn get(app: &axum::Router, uri: &str, token: &str) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| serde_json::json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, json)
+}
+
+fn ids_of(nodes: &[Value]) -> Vec<String> {
+    nodes
+        .iter()
+        .map(|n| n["id"].as_str().unwrap().to_string())
+        .collect()
+}
+
+async fn seed_collection(
+    pool: &Pool,
+    org: Uuid,
+    owner: Uuid,
+    name: &str,
+    visibility: CollectionVisibility,
+) -> Uuid {
+    let ctx = OrgContext::try_new(org, owner, [] as [&str; 0], []).unwrap();
+    let id = Uuid::new_v4();
+    let slug = format!("graph-col-{}", id.simple());
+    let name = name.to_string();
+    with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id,
+                        name: &name,
+                        slug: &slug,
+                        description: None,
+                        visibility,
+                    },
+                )
+                .await
+            })
+        }
+    })
+    .await
+    .expect("seed collection");
+    id
+}
+
+async fn seed_document(
+    pool: &Pool,
+    org: Uuid,
+    owner: Uuid,
+    collection_id: Uuid,
+    title: &str,
+) -> Uuid {
+    let ctx = OrgContext::try_new(org, owner, [] as [&str; 0], []).unwrap();
+    let id = Uuid::new_v4();
+    let title = title.to_string();
+    with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                documents::insert(
+                    txn,
+                    &ctx,
+                    NewDocument {
+                        id,
+                        collection_id,
+                        title: &title,
+                    },
+                )
+                .await
+            })
+        }
+    })
+    .await
+    .expect("seed document");
+    id
+}
+
+/// Published version, required before a document can carry claims (claims'
+/// lineage FK targets `document_versions`).
+async fn seed_version(pool: &Pool, org: Uuid, owner: Uuid, document_id: Uuid) -> Uuid {
+    let ctx = OrgContext::try_new(org, owner, [] as [&str; 0], []).unwrap();
+    let version_id = Uuid::new_v4();
+    let sha = "a".repeat(64);
+    let object_key = format!("org/{org}/objects/graph-test-{}", version_id.simple());
+    with_org_txn(pool, &ctx, move |txn| {
+        Box::pin(async move {
+            txn.execute(
+                "INSERT INTO document_versions (
+                    id, org_id, document_id, version_number, publication_state,
+                    is_current, content_sha256, original_object_key, created_by_user_id
+                 ) VALUES ($1,$2,$3,1,'published',true,$4,$5,$6)",
+                &[&version_id, &org, &document_id, &sha, &object_key, &owner],
+            )
+            .await?;
+            // `markhand_validate_document_invariant` requires
+            // `documents.current_version_id` to agree with the version just
+            // marked `is_current` (same order `tests/api_http_contracts.rs`
+            // already follows for its own seeded versions).
+            txn.execute(
+                "UPDATE documents SET current_version_id = $1, state = 'indexed'
+                 WHERE org_id = $2 AND id = $3",
+                &[&version_id, &org, &document_id],
+            )
+            .await?;
+            Ok::<_, DbError>(())
+        })
+    })
+    .await
+    .expect("seed version");
+    version_id
+}
+
+/// Seeds one claim on each document and an open conflict between them —
+/// same shape `tests/api_http_contracts.rs` already seeds for conflict
+/// routes, reused here for the graph's `conflict` edge.
+async fn seed_conflict(
+    pool: &Pool,
+    org: Uuid,
+    owner: Uuid,
+    doc_a: Uuid,
+    version_a: Uuid,
+    doc_b: Uuid,
+    version_b: Uuid,
+) {
+    let ctx = OrgContext::try_new(org, owner, [] as [&str; 0], []).unwrap();
+    let claim_on_a = Uuid::new_v4();
+    let claim_on_b = Uuid::new_v4();
+    let (claim_a_id, claim_b_id) = if claim_on_a < claim_on_b {
+        (claim_on_a, claim_on_b)
+    } else {
+        (claim_on_b, claim_on_a)
+    };
+    let conflict_id = Uuid::new_v4();
+    with_org_txn(pool, &ctx, move |txn| {
+        Box::pin(async move {
+            txn.execute(
+                "INSERT INTO claims (
+                    id, org_id, document_id, version_id, claim_key, subject, predicate,
+                    value_type, value_money, unit, scope, effective_from, citation_quote
+                 ) VALUES ($1,$2,$3,$4,'budget','Kinh phí','is','money',15,'triệu','',now(),'15 triệu')",
+                &[&claim_on_a, &org, &doc_a, &version_a],
+            )
+            .await?;
+            txn.execute(
+                "INSERT INTO claims (
+                    id, org_id, document_id, version_id, claim_key, subject, predicate,
+                    value_type, value_money, unit, scope, effective_from, citation_quote
+                 ) VALUES ($1,$2,$3,$4,'budget','Kinh phí','is','money',20,'triệu','',now(),'20 triệu')",
+                &[&claim_on_b, &org, &doc_b, &version_b],
+            )
+            .await?;
+            txn.execute(
+                "INSERT INTO conflicts (
+                    id, org_id, status, severity, conflict_type, claim_a_id, claim_b_id,
+                    first_detected_version_id
+                 ) VALUES ($1,$2,'open','warning','numeric',$3,$4,$5)",
+                &[&conflict_id, &org, &claim_a_id, &claim_b_id, &version_a],
+            )
+            .await?;
+            Ok::<_, DbError>(())
+        })
+    })
+    .await
+    .expect("seed conflict");
+}
+
+/// Seeds an ask-stream session that cited both documents — the graph's only
+/// source for `co_citation` edges (`db::graph::co_citation_edges_among`,
+/// backed by `ask_stream_sessions.cited_document_ids`).
+async fn seed_co_citation(pool: &Pool, org: Uuid, user: Uuid, doc_a: Uuid, doc_b: Uuid) {
+    let ctx = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                ask_streams::create_session(
+                    txn,
+                    &ctx,
+                    NewAskStreamSession {
+                        id: Uuid::new_v4(),
+                        version_mode: "current".to_string(),
+                        collection_ids: vec![],
+                        cited_document_ids: vec![doc_a, doc_b],
+                        cited_version_ids: vec![],
+                        pinned_snapshot: serde_json::json!({}),
+                        max_events: 10,
+                        max_bytes: 4096,
+                        ttl_secs: 3600,
+                    },
+                )
+                .await
+            })
+        }
+    })
+    .await
+    .expect("seed ask-stream session");
+}
+
+#[tokio::test]
+async fn graph_requires_qa_query_permission() {
+    let Some((_db, pool)) = boot_pool().await else {
+        return;
+    };
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    common::seed_user_with_permissions(&pool, org, user, "graph-noperm@example.com", PASSWORD, &[])
+        .await;
+    let token = common::login_access_token(&pool, "graph-noperm@example.com", PASSWORD).await;
+    let app = build_router(pool.clone(), &app_database_url().unwrap(), None);
+
+    let (status, body) = get(&app, "/api/v1/graph", &token).await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "body: {body}");
+}
+
+#[tokio::test]
+async fn graph_returns_conflict_edge_between_documents() {
+    let Some((_db, pool)) = boot_pool().await else {
+        return;
+    };
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    common::seed_user_with_permissions(
+        &pool,
+        org,
+        user,
+        "graph-conflict@example.com",
+        PASSWORD,
+        &["qa.query"],
+    )
+    .await;
+    let collection =
+        seed_collection(&pool, org, user, "Ngân sách", CollectionVisibility::Org).await;
+    let doc_a = seed_document(&pool, org, user, collection, "Đề xuất ngân sách A").await;
+    let doc_b = seed_document(&pool, org, user, collection, "Đề xuất ngân sách B").await;
+    let version_a = seed_version(&pool, org, user, doc_a).await;
+    let version_b = seed_version(&pool, org, user, doc_b).await;
+    seed_conflict(&pool, org, user, doc_a, version_a, doc_b, version_b).await;
+
+    let token = common::login_access_token(&pool, "graph-conflict@example.com", PASSWORD).await;
+    let app = build_router(pool.clone(), &app_database_url().unwrap(), None);
+    let (status, body) = get(&app, "/api/v1/graph", &token).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let nodes = body["nodes"].as_array().unwrap();
+    let node_ids = ids_of(nodes);
+    assert!(node_ids.contains(&doc_a.to_string()));
+    assert!(node_ids.contains(&doc_b.to_string()));
+
+    let edges = body["edges"].as_array().unwrap();
+    let conflict_edge = edges
+        .iter()
+        .find(|e| e["kind"] == "conflict")
+        .unwrap_or_else(|| panic!("expected a conflict edge, got: {edges:?}"));
+    let endpoints = [
+        conflict_edge["source"].as_str().unwrap(),
+        conflict_edge["target"].as_str().unwrap(),
+    ];
+    assert!(endpoints.contains(&doc_a.to_string().as_str()));
+    assert!(endpoints.contains(&doc_b.to_string().as_str()));
+    let weight = conflict_edge["weight"].as_f64().unwrap();
+    assert!(
+        weight > 0.0 && weight < 1.0,
+        "weight out of (0,1): {weight}"
+    );
+
+    let communities = body["communities"].as_array().unwrap();
+    let shared = communities
+        .iter()
+        .find(|c| {
+            let members: Vec<String> = c["nodeIds"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap().to_string())
+                .collect();
+            members.contains(&doc_a.to_string()) && members.contains(&doc_b.to_string())
+        })
+        .unwrap_or_else(|| {
+            panic!("expected a community containing both docs, got: {communities:?}")
+        });
+    assert_eq!(shared["size"].as_i64().unwrap(), 2);
+}
+
+#[tokio::test]
+async fn graph_returns_co_citation_edge_from_ask_stream_sessions() {
+    let Some((_db, pool)) = boot_pool().await else {
+        return;
+    };
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    common::seed_user_with_permissions(
+        &pool,
+        org,
+        user,
+        "graph-cocitation@example.com",
+        PASSWORD,
+        &["qa.query"],
+    )
+    .await;
+    let collection =
+        seed_collection(&pool, org, user, "Chính sách", CollectionVisibility::Org).await;
+    let doc_a = seed_document(&pool, org, user, collection, "Chính sách A").await;
+    let doc_b = seed_document(&pool, org, user, collection, "Chính sách B").await;
+    seed_co_citation(&pool, org, user, doc_a, doc_b).await;
+
+    let token = common::login_access_token(&pool, "graph-cocitation@example.com", PASSWORD).await;
+    let app = build_router(pool.clone(), &app_database_url().unwrap(), None);
+    let (status, body) = get(&app, "/api/v1/graph", &token).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let edges = body["edges"].as_array().unwrap();
+    let co_citation_edge = edges
+        .iter()
+        .find(|e| e["kind"] == "co_citation")
+        .unwrap_or_else(|| panic!("expected a co_citation edge, got: {edges:?}"));
+    let endpoints = [
+        co_citation_edge["source"].as_str().unwrap(),
+        co_citation_edge["target"].as_str().unwrap(),
+    ];
+    assert!(endpoints.contains(&doc_a.to_string().as_str()));
+    assert!(endpoints.contains(&doc_b.to_string().as_str()));
+}
+
+#[tokio::test]
+async fn graph_org_isolation_org_b_does_not_see_org_a_nodes() {
+    let Some((_db, pool)) = boot_pool().await else {
+        return;
+    };
+    let org_a = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    common::seed_user_with_permissions(
+        &pool,
+        org_a,
+        user_a,
+        "graph-orga@example.com",
+        PASSWORD,
+        &["qa.query"],
+    )
+    .await;
+    let collection_a =
+        seed_collection(&pool, org_a, user_a, "Org A", CollectionVisibility::Org).await;
+    let doc_a = seed_document(&pool, org_a, user_a, collection_a, "Tài liệu org A").await;
+
+    let org_b = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    common::seed_user_with_permissions(
+        &pool,
+        org_b,
+        user_b,
+        "graph-orgb@example.com",
+        PASSWORD,
+        &["qa.query"],
+    )
+    .await;
+
+    let token_b = common::login_access_token(&pool, "graph-orgb@example.com", PASSWORD).await;
+    let app = build_router(pool.clone(), &app_database_url().unwrap(), None);
+    let (status, body) = get(&app, "/api/v1/graph", &token_b).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let node_ids = ids_of(body["nodes"].as_array().unwrap());
+    assert!(
+        !node_ids.contains(&doc_a.to_string()),
+        "org B must never see org A's document node: {node_ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn graph_acl_hides_documents_in_a_private_collection_the_caller_cannot_access() {
+    let Some((_db, pool)) = boot_pool().await else {
+        return;
+    };
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let viewer = Uuid::new_v4();
+    common::seed_user_with_permissions(&pool, org, owner, "graph-owner@example.com", PASSWORD, &[])
+        .await;
+    common::seed_user_with_permissions(
+        &pool,
+        org,
+        viewer,
+        "graph-viewer@example.com",
+        PASSWORD,
+        &["qa.query"],
+    )
+    .await;
+
+    // Visible: an org-wide collection with one document.
+    let visible_collection =
+        seed_collection(&pool, org, viewer, "Công khai", CollectionVisibility::Org).await;
+    let visible_doc =
+        seed_document(&pool, org, viewer, visible_collection, "Tài liệu công khai").await;
+
+    // Hidden: a private collection owned by someone else, no grant to `viewer`.
+    let private_collection =
+        seed_collection(&pool, org, owner, "Riêng tư", CollectionVisibility::Private).await;
+    let hidden_doc =
+        seed_document(&pool, org, owner, private_collection, "Tài liệu riêng tư").await;
+
+    let token = common::login_access_token(&pool, "graph-viewer@example.com", PASSWORD).await;
+    let app = build_router(pool.clone(), &app_database_url().unwrap(), None);
+    let (status, body) = get(&app, "/api/v1/graph", &token).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let node_ids = ids_of(body["nodes"].as_array().unwrap());
+    assert!(node_ids.contains(&visible_doc.to_string()));
+    assert!(
+        !node_ids.contains(&hidden_doc.to_string()),
+        "ACL-restricted document leaked into the graph: {node_ids:?}"
+    );
+
+    // Filtering by the private collection id must 404, not silently return
+    // an empty (or worse, populated) graph.
+    let (status, body) = get(
+        &app,
+        &format!("/api/v1/graph?collectionId={private_collection}"),
+        &token,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "body: {body}");
+}
+
+#[tokio::test]
+async fn graph_caps_nodes_at_the_documented_bound() {
+    let Some((_db, pool)) = boot_pool().await else {
+        return;
+    };
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    common::seed_user_with_permissions(
+        &pool,
+        org,
+        user,
+        "graph-bounded@example.com",
+        PASSWORD,
+        &["qa.query"],
+    )
+    .await;
+    let collection =
+        seed_collection(&pool, org, user, "Số lượng lớn", CollectionVisibility::Org).await;
+
+    // 510 isolated (degree-0) documents — one more than the documented
+    // 500-node cap (`routes/graph.rs::MAX_NODES`). All tie on degree, so
+    // `prune()` keeps the 500 smallest-uuid documents deterministically.
+    let ctx = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    with_org_txn(&pool, &ctx, move |txn| {
+        Box::pin(async move {
+            txn.execute(
+                "INSERT INTO documents (id, org_id, collection_id, title, state, created_by_user_id)
+                 SELECT gen_random_uuid(), $1, $2, 'Bulk doc ' || gs, 'indexed', $3
+                 FROM generate_series(1, 510) AS gs",
+                &[&org, &collection, &user],
+            )
+            .await?;
+            Ok::<_, DbError>(())
+        })
+    })
+    .await
+    .expect("bulk-seed documents");
+
+    let token = common::login_access_token(&pool, "graph-bounded@example.com", PASSWORD).await;
+    let app = build_router(pool.clone(), &app_database_url().unwrap(), None);
+    let (status, body) = get(&app, "/api/v1/graph", &token).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let nodes = body["nodes"].as_array().unwrap();
+    assert_eq!(
+        nodes.len(),
+        500,
+        "expected the documented 500-node cap to bind"
+    );
+}

--- a/crates/server/tests/members.rs
+++ b/crates/server/tests/members.rs
@@ -206,6 +206,17 @@ async fn cross_org_denial_covers_every_member_endpoint() {
         !ids.contains(&user_b.to_string()),
         "org A member list leaked org B user: {body}"
     );
+    // Owner-reported UI gap (raw UUID in the admin members table): `list`
+    // must join `users` so the response carries a name/email, not just the
+    // id — see `db::members::MEMBERSHIP_COLUMNS`'s doc.
+    let user_a_item = body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["userId"] == user_a.to_string())
+        .expect("org A caller's own row");
+    assert_eq!(user_a_item["email"], "admin-a@members-it.test");
+    assert_eq!(user_a_item["displayName"], "Integration User");
 
     // 2) PATCH org B's member using org A's token -> 404, not 403/500.
     let (status, body) = send(
@@ -706,6 +717,10 @@ async fn refresh_rejected_after_suspend() {
     .await;
     assert_eq!(status, StatusCode::OK, "suspend target: {body}");
     assert_eq!(body["state"], "suspended");
+    // The PATCH response must carry the same joined name/email `list_members`
+    // does (owner-reported UI gap, closed) — not just the target's role/state.
+    assert_eq!(body["email"], "suspend-target@members-it.test");
+    assert_eq!(body["displayName"], "Integration User");
 
     assert_refresh_rejected(&app, &refresh).await;
     ephemeral.drop().await;
@@ -732,6 +747,8 @@ async fn refresh_rejected_after_role_downgrade() {
     .await;
     assert_eq!(status, StatusCode::OK, "downgrade target: {body}");
     assert_eq!(body["role"], "admin");
+    assert_eq!(body["email"], "downgrade-target@members-it.test");
+    assert_eq!(body["displayName"], "Integration User");
 
     assert_refresh_rejected(&app, &refresh).await;
     ephemeral.drop().await;

--- a/crates/server/tests/projects.rs
+++ b/crates/server/tests/projects.rs
@@ -1,0 +1,842 @@
+//! Live PostgreSQL HTTP contract tests for P2-18 (org -> project -> collection
+//! -> document grouping): project CRUD, collection assign/unassign, and the
+//! `projectId` filter on /search and /ask.
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` / `MARKHAND_TEST_APP_DATABASE_URL`
+//! are unset (see `common::boot_app_pool`). Never needs MinIO: chunk body
+//! text lives directly in `chunks.body` (Postgres), never fetched from
+//! object storage — see `db::search::hydrate_chunks_by_identity`. Most tests
+//! here also need no Qdrant: `state.vector_index()` being `None` 503s
+//! `/search`/`/ask` before the `projectId` resolution this file mostly
+//! exercises even runs (see `routes::search`'s ordering comment) — so the
+//! 404-for-unknown-project and CRUD/assign tests run on PG alone. The two
+//! tests that assert a real, positive search/ask result additionally require
+//! `MARKHAND_TEST_QDRANT_URL` (soft-skipped without it, same convention every
+//! other live-retrieval test in this crate uses) because that 503-before-404
+//! ordering means a working vector index is the only way to reach retrieval
+//! at all. Must run in the `rust-integration` CI job.
+
+mod common;
+
+use std::collections::BTreeSet;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use common::{admin_database_url, app_database_url, boot_app_pool, build_router};
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::db::collections::{self, NewCollection};
+use fileconv_server::db::documents::{self, NewDocument};
+use fileconv_server::db::models::{ArtifactKind, CollectionVisibility, DocumentState};
+use fileconv_server::db::pool::with_org_txn;
+use fileconv_server::services::chunking::prepare_chunks;
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const PASSWORD: &str = "correct-password-1";
+
+async fn boot_pool() -> Option<(common::DualRoleEphemeralDb, Pool)> {
+    let admin = admin_database_url()?;
+    let app = app_database_url()?;
+    Some(boot_app_pool(&admin, &app).await)
+}
+
+async fn send(
+    app: &axum::Router,
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let request = builder
+        .body(match body {
+            Some(value) => Body::from(value.to_string()),
+            None => Body::empty(),
+        })
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| json!({ "raw": String::from_utf8_lossy(&bytes) }));
+    (status, json)
+}
+
+/// Full permission set this file's callers need across CRUD + assign + search/ask.
+const FULL_PERMS: &[&str] = &["doc.upload", "doc.delete", "qa.query", "qa.history"];
+
+async fn seed_caller(pool: &Pool, org: Uuid, user: Uuid, email: &str) -> (OrgContext, String) {
+    common::seed_user_with_permissions(pool, org, user, email, PASSWORD, FULL_PERMS).await;
+    let ctx = OrgContext::try_new(org, user, FULL_PERMS.iter().copied(), []).unwrap();
+    let token = common::login_access_token(pool, email, PASSWORD).await;
+    (ctx, token)
+}
+
+/// A caller with none of `FULL_PERMS` — used for the 403 tests. Must be
+/// seeded in its OWN fresh org, never the org under test: `role_permissions`
+/// is a per-(org, role) grant, not per-user, and `seed_user_with_permissions`
+/// always seeds the `owner` role — reusing the org-under-test's `owner` role
+/// for a second user would silently hand them every permission the first
+/// (permitted) caller already granted that same role/org, same "seed a plain
+/// member in some other org" convention `tests/members.rs`'s
+/// `seed_plain_member` documents for the identical reason.
+async fn seed_caller_without_permissions(
+    pool: &Pool,
+    org: Uuid,
+    user: Uuid,
+    email: &str,
+) -> String {
+    common::seed_user_with_permissions(pool, org, user, email, PASSWORD, &[]).await;
+    common::login_access_token(pool, email, PASSWORD).await
+}
+
+/// Creates an org-visible collection directly (bypassing the HTTP layer,
+/// same convention `tests/ask_grounding_matrix.rs`'s `seed_ask_doc` uses).
+async fn seed_collection(pool: &Pool, ctx: &OrgContext, name: &str) -> Uuid {
+    let collection_id = Uuid::new_v4();
+    // Matches the `collections.slug` CHECK constraint (migrations/0004):
+    // lowercase alnum/hyphen only — `name` here is a free-text display name
+    // ("Alpha Collection") that may contain spaces, so it must be slugified,
+    // not just lowercased.
+    let slugified_name: String = name
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let slug = format!("{slugified_name}-{}", collection_id.simple());
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        let name = name.to_string();
+        move |txn| {
+            Box::pin(async move {
+                collections::insert(
+                    txn,
+                    &ctx,
+                    NewCollection {
+                        id: collection_id,
+                        name: &name,
+                        slug: &slug,
+                        description: None,
+                        visibility: CollectionVisibility::Org,
+                    },
+                )
+                .await
+            })
+        }
+    })
+    .await
+    .expect("seed collection");
+    collection_id
+}
+
+/// Seeds one fully indexed document + chunk (Postgres only — no MinIO/Qdrant,
+/// see this file's module doc) with `markdown` as searchable body text.
+async fn seed_indexed_document(pool: &Pool, ctx: &OrgContext, collection_id: Uuid, markdown: &str) {
+    let document_id = Uuid::new_v4();
+    let version_id = Uuid::new_v4();
+    let index_meta_id = Uuid::new_v4();
+    let content_sha = common::sha256_hex(markdown.as_bytes());
+    let signature = format!("{:0>64}", index_meta_id.as_u128());
+    let chunks = prepare_chunks(document_id, version_id, markdown, "md");
+    let md_len = markdown.len() as i64;
+    with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        let content_sha = content_sha.clone();
+        let signature = signature.clone();
+        let chunks = chunks.clone();
+        move |txn| {
+            Box::pin(async move {
+                documents::insert(
+                    txn,
+                    &ctx,
+                    NewDocument {
+                        id: document_id,
+                        collection_id,
+                        title: "Projects IT doc",
+                    },
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO document_versions (
+                        id, org_id, document_id, version_number, publication_state,
+                        is_current, content_sha256, original_object_key,
+                        source_content_type, byte_size, created_by_user_id
+                     ) VALUES ($1,$2,$3,1,'published',true,$4,$5,'text/markdown',$6,$7)",
+                    &[
+                        &version_id,
+                        &ctx.org_id(),
+                        &document_id,
+                        &content_sha,
+                        &format!("test-object-key-{version_id}"),
+                        &md_len,
+                        &ctx.user_id(),
+                    ],
+                )
+                .await?;
+                let indexed = DocumentState::Indexed.as_str();
+                txn.execute(
+                    "UPDATE documents SET state=$3, current_version_id=$4 WHERE org_id=$1 AND id=$2",
+                    &[&ctx.org_id(), &document_id, &indexed, &version_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO index_metadata (
+                        id, org_id, collection_id, index_signature_sha256, embedding_family,
+                        embedding_revision, dimensions, runtime_path, generation, is_active, state
+                     ) VALUES ($1,$2,$3,$4,'test','r1',8,'local-hash',1,true,'active')",
+                    &[&index_meta_id, &ctx.org_id(), &collection_id, &signature],
+                )
+                .await?;
+                for chunk in chunks {
+                    fileconv_server::db::chunks::insert(
+                        txn,
+                        &ctx,
+                        fileconv_server::db::chunks::NewChunk {
+                            id: Uuid::new_v4(),
+                            document_id,
+                            version_id,
+                            ordinal: chunk.ordinal,
+                            heading_path: &chunk.heading_path,
+                            body: &chunk.body,
+                            body_text_version: fileconv_knowledge::identity::BODY_TEXT_VERSION,
+                            chunk_identity_sha256: &chunk.chunk_identity,
+                            index_metadata_id: index_meta_id,
+                            index_signature: &signature,
+                            page: chunk.page,
+                            slide: chunk.slide,
+                            sheet: chunk.sheet.as_deref(),
+                            span_start: Some(chunk.span_start),
+                            span_end: Some(chunk.span_end),
+                        },
+                    )
+                    .await?;
+                }
+                let _ = ArtifactKind::Markdown; // silence unused import if chunk loop is ever removed
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed indexed document");
+}
+
+// ---------------------------------------------------------------------
+// Project CRUD
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn create_project_succeeds_and_appears_in_list() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (_ctx, token) = seed_caller(&pool, org, user, "create-project@projects-it.test").await;
+
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token),
+        Some(json!({ "name": "Marketing" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+    assert_eq!(body["name"], "Marketing");
+    let project_id = body["id"].as_str().unwrap().to_string();
+
+    let (status, list) = send(&app, "GET", "/api/v1/projects", Some(&token), None).await;
+    assert_eq!(status, StatusCode::OK, "{list}");
+    let names: Vec<String> = list["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["id"].as_str().unwrap().to_string())
+        .collect();
+    assert!(names.contains(&project_id));
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn create_project_rejects_empty_name() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (_ctx, token) = seed_caller(&pool, org, user, "invalid-project@projects-it.test").await;
+
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token),
+        Some(json!({ "name": "   " })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["code"], "validation_failed");
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn create_project_denied_without_permission() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let token =
+        seed_caller_without_permissions(&pool, org, user, "no-perm-project@projects-it.test").await;
+
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token),
+        Some(json!({ "name": "Denied" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+    assert_eq!(body["code"], "forbidden");
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn update_project_renames_and_requires_permission() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (_ctx, token) = seed_caller(&pool, org, user, "rename-project@projects-it.test").await;
+
+    let (status, created) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token),
+        Some(json!({ "name": "Old Name" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{created}");
+    let project_id = created["id"].as_str().unwrap();
+
+    let (status, renamed) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/projects/{project_id}"),
+        Some(&token),
+        Some(json!({ "name": "New Name" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{renamed}");
+    assert_eq!(renamed["name"], "New Name");
+
+    let no_perm_org = Uuid::new_v4();
+    let no_perm_user = Uuid::new_v4();
+    let no_perm_token = seed_caller_without_permissions(
+        &pool,
+        no_perm_org,
+        no_perm_user,
+        "rename-no-perm@projects-it.test",
+    )
+    .await;
+    let (status, denied) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/projects/{project_id}"),
+        Some(&no_perm_token),
+        Some(json!({ "name": "Should Not Apply" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{denied}");
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn update_project_404_for_unknown_id() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (_ctx, token) = seed_caller(&pool, org, user, "unknown-project@projects-it.test").await;
+
+    let ghost = Uuid::new_v4();
+    let (status, body) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/projects/{ghost}"),
+        Some(&token),
+        Some(json!({ "name": "Ghost" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// Org isolation — org B must never see or mutate org A's projects.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn org_b_cannot_see_or_rename_org_as_project() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+
+    let org_a = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let (_ctx_a, token_a) = seed_caller(&pool, org_a, user_a, "org-a-owner@projects-it.test").await;
+    let (status, created) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token_a),
+        Some(json!({ "name": "Org A Project" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{created}");
+    let project_a_id = created["id"].as_str().unwrap().to_string();
+
+    let org_b = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let (_ctx_b, token_b) = seed_caller(&pool, org_b, user_b, "org-b-owner@projects-it.test").await;
+
+    let (status, list_b) = send(&app, "GET", "/api/v1/projects", Some(&token_b), None).await;
+    assert_eq!(status, StatusCode::OK, "{list_b}");
+    let ids_b: Vec<String> = list_b["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["id"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        !ids_b.contains(&project_a_id),
+        "org B must never see org A's project: {list_b}"
+    );
+
+    let (status, denied) = send(
+        &app,
+        "PATCH",
+        &format!("/api/v1/projects/{project_a_id}"),
+        Some(&token_b),
+        Some(json!({ "name": "Hijacked" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "org B renaming org A's project must 404, not succeed: {denied}"
+    );
+
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// Collection <-> project assign/unassign
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn assign_and_unassign_collection_project() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (ctx, token) = seed_caller(&pool, org, user, "assign@projects-it.test").await;
+
+    let collection_id = seed_collection(&pool, &ctx, "Assignable Collection").await;
+    let (status, created) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token),
+        Some(json!({ "name": "Assign Target" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{created}");
+    let project_id = created["id"].as_str().unwrap().to_string();
+
+    let (status, assigned) = send(
+        &app,
+        "POST",
+        &format!("/api/v1/collections/{collection_id}/assign-project"),
+        Some(&token),
+        Some(json!({ "projectId": project_id })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{assigned}");
+    assert_eq!(assigned["projectId"], project_id);
+    assert_eq!(assigned["projectName"], "Assign Target");
+
+    // GET /collections reflects the assignment too (Library nav grouping).
+    let (status, list) = send(&app, "GET", "/api/v1/collections", Some(&token), None).await;
+    assert_eq!(status, StatusCode::OK, "{list}");
+    let entry = list["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["id"] == collection_id.to_string())
+        .expect("collection present");
+    assert_eq!(entry["projectId"], project_id);
+
+    let (status, unassigned) = send(
+        &app,
+        "POST",
+        &format!("/api/v1/collections/{collection_id}/assign-project"),
+        Some(&token),
+        Some(json!({ "projectId": Value::Null })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{unassigned}");
+    assert!(unassigned["projectId"].is_null());
+    assert!(unassigned["projectName"].is_null());
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn assign_project_404_for_unknown_project_id() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (ctx, token) = seed_caller(&pool, org, user, "assign-ghost@projects-it.test").await;
+    let collection_id = seed_collection(&pool, &ctx, "Ghost Target Collection").await;
+
+    let ghost_project = Uuid::new_v4();
+    let (status, body) = send(
+        &app,
+        "POST",
+        &format!("/api/v1/collections/{collection_id}/assign-project"),
+        Some(&token),
+        Some(json!({ "projectId": ghost_project })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn assign_project_denied_without_permission() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (ctx, _token) = seed_caller(&pool, org, user, "assign-owner@projects-it.test").await;
+    let collection_id = seed_collection(&pool, &ctx, "Owner Collection").await;
+
+    let no_perm_org = Uuid::new_v4();
+    let no_perm_user = Uuid::new_v4();
+    let no_perm_token = seed_caller_without_permissions(
+        &pool,
+        no_perm_org,
+        no_perm_user,
+        "assign-no-perm@projects-it.test",
+    )
+    .await;
+    let (status, body) = send(
+        &app,
+        "POST",
+        &format!("/api/v1/collections/{collection_id}/assign-project"),
+        Some(&no_perm_token),
+        Some(json!({ "projectId": Value::Null })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+
+    ephemeral.drop().await;
+}
+
+// ---------------------------------------------------------------------
+// /search + /ask projectId filter — the actual retrieval-scoping contract.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL + MARKHAND_TEST_QDRANT_URL"]
+async fn search_project_filter_returns_exactly_that_projects_documents() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    // A real (reachable) Qdrant is required: `state.vector_index()` must be
+    // `Some` for /search to run at all (a `None` vector index 503s before
+    // retrieval even starts — see routes::search's own comment on ordering
+    // this against the projectId 404 check). The 404-only project-filter
+    // tests above/below need no Qdrant precisely because they never get
+    // past that check; a real positive search result does.
+    let Some(qdrant_url) = common::take_live(
+        std::env::var("MARKHAND_TEST_QDRANT_URL")
+            .ok()
+            .filter(|url| !url.trim().is_empty()),
+        "MARKHAND_TEST_QDRANT_URL",
+    ) else {
+        return;
+    };
+    let qdrant = fileconv_server::storage::QdrantClient::new(&qdrant_url).expect("qdrant client");
+    let app = fileconv_server::http::router(
+        common::build_app_state(pool.clone(), &ephemeral.app_url, None)
+            .with_retrieval_backends(qdrant, None),
+    );
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (ctx, token) = seed_caller(&pool, org, user, "search-scope@projects-it.test").await;
+
+    // Two projects, one collection each, one uniquely-keyworded document each.
+    let collection_alpha = seed_collection(&pool, &ctx, "Alpha Collection").await;
+    let collection_beta = seed_collection(&pool, &ctx, "Beta Collection").await;
+    seed_indexed_document(
+        &pool,
+        &ctx,
+        collection_alpha,
+        "# Alpha\n\nkeywordalpha xuất hiện trong tài liệu alpha duy nhất.",
+    )
+    .await;
+    seed_indexed_document(
+        &pool,
+        &ctx,
+        collection_beta,
+        "# Beta\n\nkeywordbeta xuất hiện trong tài liệu beta duy nhất.",
+    )
+    .await;
+
+    let (status, project_alpha) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token),
+        Some(json!({ "name": "Project Alpha" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{project_alpha}");
+    let project_alpha_id = project_alpha["id"].as_str().unwrap().to_string();
+
+    let (status, assigned) = send(
+        &app,
+        "POST",
+        &format!("/api/v1/collections/{collection_alpha}/assign-project"),
+        Some(&token),
+        Some(json!({ "projectId": project_alpha_id })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{assigned}");
+    // Beta stays unassigned — "all projects" must still surface it.
+
+    // Scoped to project Alpha: a query that only matches Beta's document
+    // returns nothing.
+    let (status, scoped_miss) = send(
+        &app,
+        "POST",
+        "/api/v1/search",
+        Some(&token),
+        Some(json!({ "query": "keywordbeta", "projectId": project_alpha_id, "limit": 10 })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{scoped_miss}");
+    assert_eq!(
+        scoped_miss["hits"].as_array().unwrap().len(),
+        0,
+        "project Alpha scope must not surface Beta's document: {scoped_miss}"
+    );
+
+    // Scoped to project Alpha: a query matching Alpha's document succeeds.
+    let (status, scoped_hit) = send(
+        &app,
+        "POST",
+        "/api/v1/search",
+        Some(&token),
+        Some(json!({ "query": "keywordalpha", "projectId": project_alpha_id, "limit": 10 })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{scoped_hit}");
+    assert!(
+        !scoped_hit["hits"].as_array().unwrap().is_empty(),
+        "project Alpha scope must surface Alpha's own document: {scoped_hit}"
+    );
+    let scoped_collection_ids: BTreeSet<String> = scoped_hit["hits"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|hit| hit["collectionId"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        scoped_collection_ids,
+        BTreeSet::from([collection_alpha.to_string()]),
+        "every hit under the Alpha project filter must belong to Alpha's collection: {scoped_hit}"
+    );
+
+    // "All projects" (no projectId) still finds Beta's document.
+    let (status, unscoped) = send(
+        &app,
+        "POST",
+        "/api/v1/search",
+        Some(&token),
+        Some(json!({ "query": "keywordbeta", "limit": 10 })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{unscoped}");
+    assert!(
+        !unscoped["hits"].as_array().unwrap().is_empty(),
+        "no projectId ('all projects') must still find Beta's document: {unscoped}"
+    );
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn search_and_ask_404_for_unknown_project_id() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (_ctx, token) = seed_caller(&pool, org, user, "ghost-scope@projects-it.test").await;
+
+    let ghost = Uuid::new_v4();
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/search",
+        Some(&token),
+        Some(json!({ "query": "anything", "projectId": ghost })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/ask",
+        Some(&token),
+        Some(json!({ "question": "anything?", "projectId": ghost })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL + MARKHAND_TEST_QDRANT_URL"]
+async fn ask_project_filter_narrows_grounded_answer_scope() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    // See `search_project_filter_returns_exactly_that_projects_documents`'s
+    // comment: a real Qdrant is required for /ask to get past its
+    // `vector_index()` availability check at all.
+    let Some(qdrant_url) = common::take_live(
+        std::env::var("MARKHAND_TEST_QDRANT_URL")
+            .ok()
+            .filter(|url| !url.trim().is_empty()),
+        "MARKHAND_TEST_QDRANT_URL",
+    ) else {
+        return;
+    };
+    let qdrant = fileconv_server::storage::QdrantClient::new(&qdrant_url).expect("qdrant client");
+    let app = fileconv_server::http::router(
+        common::build_app_state(pool.clone(), &ephemeral.app_url, None)
+            .with_retrieval_backends(qdrant, None),
+    );
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (ctx, token) = seed_caller(&pool, org, user, "ask-scope@projects-it.test").await;
+
+    let collection_alpha = seed_collection(&pool, &ctx, "Ask Alpha Collection").await;
+    let collection_beta = seed_collection(&pool, &ctx, "Ask Beta Collection").await;
+    seed_indexed_document(
+        &pool,
+        &ctx,
+        collection_alpha,
+        "# Ask Alpha\n\naskkeywordalpha xuất hiện duy nhất ở đây.",
+    )
+    .await;
+    seed_indexed_document(
+        &pool,
+        &ctx,
+        collection_beta,
+        "# Ask Beta\n\naskkeywordbeta xuất hiện duy nhất ở đây.",
+    )
+    .await;
+
+    let (status, project_alpha) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token),
+        Some(json!({ "name": "Ask Project Alpha" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{project_alpha}");
+    let project_alpha_id = project_alpha["id"].as_str().unwrap().to_string();
+    let (status, assigned) = send(
+        &app,
+        "POST",
+        &format!("/api/v1/collections/{collection_alpha}/assign-project"),
+        Some(&token),
+        Some(json!({ "projectId": project_alpha_id })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{assigned}");
+
+    // Scoped to Alpha, asking about Beta's unique keyword must ground on
+    // nothing from Beta (no citation pointing at Beta's collection).
+    let (status, answer) = send(
+        &app,
+        "POST",
+        "/api/v1/ask",
+        Some(&token),
+        Some(json!({
+            "question": "askkeywordbeta la gi?",
+            "projectId": project_alpha_id,
+            "limit": 5
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{answer}");
+    let citations = answer["citations"].as_array().unwrap();
+    assert!(
+        citations.is_empty(),
+        "project Alpha scope must not cite Beta's document: {answer}"
+    );
+
+    ephemeral.drop().await;
+}

--- a/crates/server/tests/schema_migrations.rs
+++ b/crates/server/tests/schema_migrations.rs
@@ -23,6 +23,7 @@ const BUSINESS_TABLES: &[&str] = &[
     "refresh_tokens",
     "org_invites",
     "collections",
+    "projects",
     "collection_user_access",
     "collection_group_access",
     "collection_role_access",

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -14,7 +14,7 @@ Kế hoạch này biến report kiến trúc thành các gói việc có depende
 test và gate đo được. Không dùng thời gian lịch làm tiêu chí; chỉ chuyển phase khi
 gate kỹ thuật của phase trước đã đạt.
 
-Issue-level backlog (114 issues):
+Issue-level backlog (115 issues):
 [`backlog/README.md`](backlog/README.md).
 
 Roadmap dashboard tương tác:
@@ -45,7 +45,7 @@ không bị local override cũ che mất.
 | 1A | Tách logic RAG dùng chung thành `crates/knowledge`, desktop không đổi hành vi | [Phase plan](phase-1a-knowledge-extraction.md) | [10 issues](backlog/phase-1a/issues/README.md) |
 | 1B | POC single-org hoàn chỉnh: upload → convert → index → Q&A citation | [Phase plan](phase-1b-single-org-poc.md) | [24 issues](backlog/phase-1b/issues/README.md) |
 | 1C | Multi-org, RBAC/ACL, quota atomic và denial test | [Phase plan](phase-1c-multi-org-security.md) | [13 issues](backlog/phase-1c/issues/README.md) |
-| 2 | Web SPA MVP: login, library, Q&A, admin tối thiểu | [Phase plan](phase-2-web-spa.md) | [17 issues](backlog/phase-2/issues/README.md) |
+| 2 | Web SPA MVP: login, library, Q&A, admin tối thiểu | [Phase plan](phase-2-web-spa.md) | [18 issues](backlog/phase-2/issues/README.md) |
 | 3 | Port intelligence: BRD/PRD, quality, PII, bảng, version, export | [Phase plan](phase-3-intelligence.md) | [14 issues](backlog/phase-3/issues/README.md) |
 | 4 | OIDC/SSO, hardening production, DR và onboarding/help | [Phase plan](phase-4-production-hardening.md) | [14 issues](backlog/phase-4/issues/README.md) |
 

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -14,7 +14,7 @@ Kế hoạch này biến report kiến trúc thành các gói việc có depende
 test và gate đo được. Không dùng thời gian lịch làm tiêu chí; chỉ chuyển phase khi
 gate kỹ thuật của phase trước đã đạt.
 
-Issue-level backlog (113 issues):
+Issue-level backlog (114 issues):
 [`backlog/README.md`](backlog/README.md).
 
 Roadmap dashboard tương tác:
@@ -45,7 +45,7 @@ không bị local override cũ che mất.
 | 1A | Tách logic RAG dùng chung thành `crates/knowledge`, desktop không đổi hành vi | [Phase plan](phase-1a-knowledge-extraction.md) | [10 issues](backlog/phase-1a/issues/README.md) |
 | 1B | POC single-org hoàn chỉnh: upload → convert → index → Q&A citation | [Phase plan](phase-1b-single-org-poc.md) | [24 issues](backlog/phase-1b/issues/README.md) |
 | 1C | Multi-org, RBAC/ACL, quota atomic và denial test | [Phase plan](phase-1c-multi-org-security.md) | [13 issues](backlog/phase-1c/issues/README.md) |
-| 2 | Web SPA MVP: login, library, Q&A, admin tối thiểu | [Phase plan](phase-2-web-spa.md) | [16 issues](backlog/phase-2/issues/README.md) |
+| 2 | Web SPA MVP: login, library, Q&A, admin tối thiểu | [Phase plan](phase-2-web-spa.md) | [17 issues](backlog/phase-2/issues/README.md) |
 | 3 | Port intelligence: BRD/PRD, quality, PII, bảng, version, export | [Phase plan](phase-3-intelligence.md) | [14 issues](backlog/phase-3/issues/README.md) |
 | 4 | OIDC/SSO, hardening production, DR và onboarding/help | [Phase plan](phase-4-production-hardening.md) | [14 issues](backlog/phase-4/issues/README.md) |
 

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -174,10 +174,13 @@ ADR RLS ───────→ 1C-08 ─────────────�
   (pre-existing, không đổi); grants/status/cache/revoke tests (**done**: `tests/acl_cache.rs`
   + unit tests `auth::context_cache`).
 - **Security/migration:** Backfill ACL version (**done**: `DEFAULT 1`, expand-only,
-  migration `0031`). **Out:** nested/time-based groups; groups/role-based grant resolution
-  (tính năng mới, không phải phần "cache" — xem trên); version bump cho collection
-  create/soft-delete/visibility ngoài `services::acl_mutate` (khoảng trống đã biết, xem
-  trên); operator-configurable cache capacity/TTL qua env.
+  migration `0031`). **Gap version-bump đã ĐÓNG (migration `0033`, 2026-07-29)**: trigger
+  DB `bump_org_acl_version()` trên `collections`/`collection_user_access`/
+  `org_memberships`/`roles`/`role_permissions` — bump cùng transaction cho MỌI writer,
+  kể cả SQL trực tiếp (fixtures/vận hành; CI `rust-integration` bắt được đúng lỗ này
+  ở `api_http_contracts`/`citation_authz_matrix` trước khi vá). **Out:**
+  nested/time-based groups; groups/role-based grant resolution (tính năng mới, không
+  phải phần "cache" — xem trên); operator-configurable cache capacity/TTL qua env.
 
 ## 1C-06 — PostgreSQL ACL enforcement
 

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -117,13 +117,67 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-05 — Collection ACL resolver/cache
 
-- **Status:** In progress — resolver cơ bản (org/private/owner/`collection_user_access`) + fail-closed `services/retrieval/mod.rs:181` + test. **Thiếu đúng phần 1C**: grant theo `groups`/`role` chưa resolve (bảng có, không ai đọc), KHÔNG có ACL-version/snapshot, KHÔNG có cache, KHÔNG có invalidation API. `context.rs:11` tự ghi full ACL thuộc 1C.
+- **Status:** In progress — resolver cơ bản (org/private/owner/`collection_user_access`) +
+  fail-closed `services/retrieval/mod.rs:181` + test, **và giờ có version + cache** (phiên
+  này, worktree, chưa chạy DB-gated CI): `orgs.acl_version` (migration
+  `0031_expand_org_acl_version.sql`, cột `bigint NOT NULL DEFAULT 1`, expand-only) là version
+  **org-wide** (cố ý không per-membership/per-role — `revoke_role_permission_for_principal`
+  xoá một hàng `role_permissions` dùng chung bởi mọi member cùng role, nên version hẹp hơn
+  sẽ under-invalidate; over-invalidate cả org là hướng an toàn, chấp nhận được ở quy mô
+  POC). `db::orgs::bump_acl_version` được gọi trong CÙNG transaction với
+  `services::members::{change_role, suspend_member, reactivate_member (qua set_member_state),
+  remove_member}` và `services::acl_mutate::{revoke_role_permission_for_principal,
+  revoke_collection_access_for_principal}` — đúng tập mutation duy nhất ảnh hưởng
+  `auth::permissions::resolve_org_context*` hiện có (đã audit toàn bộ call site, xem báo
+  cáo phiên). Cache in-process `auth::context_cache::OrgContextCache` (bounded, mặc định
+  4096 principal / TTL 3s, field mới trên `auth::provider::PasswordAuthProvider`, không đổi
+  signature `PasswordAuthProvider::new`) bọc **đúng một** điểm vào: `AuthenticatedOrg`
+  extractor (`auth/middleware.rs`) — KHÔNG bọc `resolve_org_context_on_txn` (ask-stream
+  append/pull, cần snapshot không bị xé trong transaction đã khoá) và KHÔNG bọc
+  `services::upload::saga::reload_principal_locked` (saga tự re-check trước commit) — cả
+  hai đường này vẫn luôn-tươi như trước, không có rủi ro hồi quy từ cache. Mỗi cache hit
+  (trong TTL) BẮT BUỘC một freshness-check rẻ (`users.disabled_at` + `orgs.acl_version`,
+  2 bảng không RLS) trước khi tin dữ liệu cache — mismatch/disabled/lỗi truy vấn đều rơi về
+  resolve đầy đủ (fail-closed, không tự chế deny). Vì mọi hit đều hỏi lại PostgreSQL (không
+  bao giờ tin cache "mù" theo TTL), một version bump ở tiến trình khác lập tức thấy được ở
+  request tiếp theo của tiến trình này — nên **không cần cơ chế invalidation cross-instance
+  riêng** (câu hỏi mở nêu trong nhiệm vụ đã tự đóng nhờ thiết kế). TTL chỉ còn là lưới an
+  toàn cho (a) call site tương lai quên bump và (b) KHOẢNG TRỐNG ĐÃ BIẾT: tạo/xoá-mềm
+  collection qua `db::collections` (ngoài `services::acl_mutate`) **chưa** bump version —
+  cố ý để ngoài phạm vi phiên này (xem "Out" bên dưới).
+  Test DB-gated mới `tests/acl_cache.rs` (5 test): role-downgrade/suspend/remove qua route
+  HTTP thật (cùng bearer token, không re-login) đều 403 ngay ở request kế tiếp; ACL
+  collection revoke (gọi thẳng `OrgContextCache::resolve` như extractor thật) drop quyền
+  ngay; và một test tách riêng cơ chế version-check (bump `acl_version` thủ công, không qua
+  helper) để chứng minh chính cơ chế mismatch-detection hoạt động độc lập với nơi gọi nó.
+  Unit test thuần (không DB) trong `auth::context_cache` phủ `trusts_cache`/
+  `should_check_freshness`/bounded-eviction/`clear`. `tests/members.rs`,
+  `tests/uploads.rs`, `tests/sse_stream_readiness.rs`, `tests/orgs.rs`,
+  `tests/schema_migrations.rs` chạy lại xanh không đổi hành vi (xem kết quả verify trong
+  báo cáo phiên).
+  **Cố tình KHÔNG làm trong phiên này** (xem báo cáo phiên để biết lý do đầy đủ): (1)
+  grant theo `groups`/`role` vẫn CHƯA resolve (bảng có, không ai đọc) — đây là một tính
+  năng authz mới (semantics resolve qua `groups`/`group_memberships`), không phải cache
+  key, cần thiết kế/review riêng, không phải phạm vi "version + cache" của vòng này; (2)
+  version bump cho `db::collections::{insert,soft_delete,update_metadata}` — cần audit
+  call-site + test riêng, ghi nhận là khoảng trống đã biết bên trên, giới hạn bởi TTL cho
+  đến khi đóng; (3) cache/version không (chưa) operator-configurable qua env — hằng số
+  module `DEFAULT_CAPACITY`/`DEFAULT_TTL`, có thể nâng cấp thành config sau nếu cần.
 
-- **Plan/files:** Private/org/groups grants; ACL/version snapshot; cache key org/user/
-  membership/ACL version; invalidation APIs.
-- **Depends:** 1C-02/03. **Acceptance/tests:** Semantics đúng, empty/error fail closed;
-  grants/status/cache/revoke tests.
-- **Security/migration:** Backfill ACL version. **Out:** nested/time-based groups.
+- **Plan/files:** Private/org/groups grants (groups **vẫn thiếu**, xem trên); ACL/version
+  snapshot (**done**: `orgs.acl_version`, migration `0031`); cache key org/user/membership/
+  ACL version (**done**: `auth::context_cache::OrgContextCache`, key `(org_id, user_id)` +
+  version check); invalidation APIs (**không làm riêng** — invalidation là version-bump
+  trong transaction mutation, không phải API endpoint mới; không có yêu cầu nào đòi một API
+  invalidation tách biệt).
+- **Depends:** 1C-02/03. **Acceptance/tests:** Semantics đúng, empty/error fail closed
+  (pre-existing, không đổi); grants/status/cache/revoke tests (**done**: `tests/acl_cache.rs`
+  + unit tests `auth::context_cache`).
+- **Security/migration:** Backfill ACL version (**done**: `DEFAULT 1`, expand-only,
+  migration `0031`). **Out:** nested/time-based groups; groups/role-based grant resolution
+  (tính năng mới, không phải phần "cache" — xem trên); version bump cho collection
+  create/soft-delete/visibility ngoài `services::acl_mutate` (khoảng trống đã biết, xem
+  trên); operator-configurable cache capacity/TTL qua env.
 
 ## 1C-06 — PostgreSQL ACL enforcement
 

--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -5,13 +5,14 @@ Parent plan: [`../../../phase-2-web-spa.md`](../../../phase-2-web-spa.md)
 <!-- roadmap-default-status: backlog -->
 
 **Trạng thái tổng quan (cập nhật 2026-07-29).** MVP xây trên mock server đã merge vào
-`master`: **13/17 issue Done** (P2-01…09, P2-11, P2-12, P2-13, P2-14, P2-16 phần build
-+ serve). **3 In progress**: P2-10 (Q&A — UI/mock/stream xây xong trên contract hiện có,
+`master`: **13/18 issue Done** (P2-01…09, P2-11, P2-12, P2-13, P2-14, P2-16 phần build
++ serve). **4 In progress**: P2-10 (Q&A — UI/mock/stream xây xong trên contract hiện có,
 xem chi tiết bên dưới), P2-15 (E2E — nửa mock-based xong, nay có thêm flow ask→citation
 của P2-10; nửa real-deployment hoãn), **P2-17** (Document graph — owner request mới
 2026-07-29, MVP server+web+mock xong, `similarity`/Qdrant chờ vòng riêng — xem chi tiết
-bên dưới). P2-11/P2-12 rời khỏi Blocked nhờ lát membership API (1C-02/1C-11 slice)
-landed ở #317.
+bên dưới), **P2-18** (Project grouping — owner request mới 2026-07-29, org → project →
+collection → document, MVP server+web+mock xong — xem chi tiết bên dưới). P2-11/P2-12
+rời khỏi Blocked nhờ lát membership API (1C-02/1C-11 slice) landed ở #317.
 
 > Ranh giới quan trọng: "Done" ở đây nghĩa là **hành vi client đã build và test trên
 > mock/deterministic**, đã qua CI (`web`, `web-e2e`, `rust`, `rust-integration`) trên
@@ -328,6 +329,49 @@ P2-15 + Phase 1C gate → P2-16
 - **Security:** Cùng ACL/permission với `/conflicts`; không thêm quyền mới chưa seed
   role. **Out:** `similarity` edge thật (chờ Qdrant thật), deep-link preview một tài
   liệu cụ thể từ đồ thị.
+
+## P2-18 — Project grouping (org → project → collection → document)
+
+- **Status:** In progress — owner yêu cầu mới 2026-07-29. `org → dự án → bộ sưu tập →
+  tài liệu`: bảng mới `projects` (org-scoped, RLS pattern như `collections`) + cột
+  `collections.project_id uuid NULL` (bộ sưu tập chưa gán vẫn hoạt động; 1 bộ sưu tập ∈
+  tối đa 1 dự án). `GET/POST /projects`, `PATCH /projects/{projectId}` (đổi tên),
+  `POST /collections/{collectionId}/assign-project` (`{projectId: uuid | null}`, action
+  route riêng thay vì gộp vào PATCH collection — xem lý do trong
+  `routes::collections`'s module doc). Cùng permission `doc.upload` với create/update
+  collection (không thêm permission mới). `SearchRequest`/`AskRequest`/ask-stream nhận
+  `projectId` optional: server resolve project → tập collectionIds (org-scoped) → giao
+  với ACL caller hiện có → đưa vào `resolve_scope` sẵn có (không có đường retrieval mới)
+  — projectId lạ/khác org → 404 đồng nhất (no-oracle). `GET /collections` response thêm
+  `projectId`/`projectName` (nullable, joined tại read time). Web: dropdown "Phạm vi"
+  trong composer Hỏi đáp (`ChatPanel.tsx`, mặc định "Tất cả dự án", reset khi đổi org),
+  nav Thư viện nhóm theo dự án (`CollectionNav.tsx`), panel quản lý đơn giản
+  (`ProjectsPanel.tsx`, tạo dự án + gán/bỏ gán, đặt trong trang Thư viện — không thêm
+  route/rail admin mới cho một tính năng "đơn giản" theo yêu cầu owner). Project
+  deletion ngoài phạm vi vòng này (tránh bàn semantics bộ sưu tập mồ côi).
+
+- **Plan/files:** `crates/server/migrations/0032_expand_projects.sql`;
+  `db/projects.rs`, `routes/projects.rs`; `routes/collections.rs` (assign-project +
+  `projectId`/`projectName` hydration), `routes/search.rs`/`routes/ask.rs` (projectId
+  filter); OpenAPI path/schemas (`Project`/`ProjectPage`/`CreateProjectRequest`/
+  `UpdateProjectRequest`/`AssignProjectRequest`, `Collection`/`SearchRequest`/
+  `AskRequest` mở rộng) + `ROUTE_INVENTORY`/`BODY_TAKING_OPERATIONS`;
+  `web/src/components/library/{CollectionNav,ProjectsPanel}.tsx`,
+  `components/qa/{ChatPanel,SearchPanel}.tsx`, `pages/QaPage.tsx`,
+  `mocks/{fixtures,handlers/{library,projects,qa}}.ts`.
+- **Depends:** P2-07 (Thư viện/`CollectionNav`), P2-10 (Q&A composer/`ChatPanel`),
+  backend 1B collections + retrieval (`services::retrieval::resolve_scope`).
+- **Acceptance/tests:** `tests/projects.rs` DB-gated (CRUD happy/validate/403/404, org
+  isolation, assign/unassign, search filter theo project trả đúng tập tài liệu, 404
+  projectId lạ — chạy trên PG local); `db::models`/`schema_migrations.rs` drift guard
+  cập nhật cho bảng `projects` + cột `collections.project_id`; web unit
+  (`QaPage.test.tsx` phạm vi dropdown + reset khi đổi org, `LibraryPage.test.tsx` nhóm
+  nav theo dự án, `ProjectsPanel.test.tsx` tạo/gán/bỏ gán + permission gate) +
+  `e2e/projects.spec.ts` (tạo dự án → gán bộ sưu tập → Hỏi đáp chọn phạm vi → search
+  đúng tập → "Tất cả dự án" ra đủ).
+- **Security:** Cùng permission `doc.upload` với collection create/update (không thêm
+  permission mới); RLS org-scoped như `collections`. **Out:** xóa dự án, gán một bộ sưu
+  tập vào nhiều dự án, project-scoped permission riêng.
 
 ## Exit gate
 

--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -5,11 +5,13 @@ Parent plan: [`../../../phase-2-web-spa.md`](../../../phase-2-web-spa.md)
 <!-- roadmap-default-status: backlog -->
 
 **Trạng thái tổng quan (cập nhật 2026-07-29).** MVP xây trên mock server đã merge vào
-`master`: **13/16 issue Done** (P2-01…09, P2-11, P2-12, P2-13, P2-14, P2-16 phần build
-+ serve). **2 In progress**: P2-10 (Q&A — UI/mock/stream xây xong trên contract hiện có,
+`master`: **13/17 issue Done** (P2-01…09, P2-11, P2-12, P2-13, P2-14, P2-16 phần build
++ serve). **3 In progress**: P2-10 (Q&A — UI/mock/stream xây xong trên contract hiện có,
 xem chi tiết bên dưới), P2-15 (E2E — nửa mock-based xong, nay có thêm flow ask→citation
-của P2-10; nửa real-deployment hoãn). P2-11/P2-12 rời khỏi Blocked nhờ lát
-membership API (1C-02/1C-11 slice) landed ở #317.
+của P2-10; nửa real-deployment hoãn), **P2-17** (Document graph — owner request mới
+2026-07-29, MVP server+web+mock xong, `similarity`/Qdrant chờ vòng riêng — xem chi tiết
+bên dưới). P2-11/P2-12 rời khỏi Blocked nhờ lát membership API (1C-02/1C-11 slice)
+landed ở #317.
 
 > Ranh giới quan trọng: "Done" ở đây nghĩa là **hành vi client đã build và test trên
 > mock/deterministic**, đã qua CI (`web`, `web-e2e`, `rust`, `rust-integration`) trên
@@ -290,6 +292,42 @@ P2-15 + Phase 1C gate → P2-16
 - **Acceptance/tests:** Deep-link, cache/header/API404, packaged E2E, SLO, scans,
   desktop test/build.
 - **Security:** Mock/source map policy; rollbackable immutable assets. **Out:** CDN/HA.
+
+## P2-17 — Document graph
+
+- **Status:** In progress — owner yêu cầu mới 2026-07-29 (force-directed graph + sidebar
+  "Communities" checkbox, có ảnh mẫu). MVP: `GET /api/v1/graph` (org/ACL-scoped như
+  `/collections`/`/documents`, gate `qa.query` cùng tiền lệ `/conflicts`) trả `conflict`
+  edges thật từ `claims`/`conflicts` (PG, đã test DB-gated: org isolation, ACL riêng tư,
+  bounded cap 500 node/2000 edge) và `co_citation` edges từ
+  `ask_stream_sessions.cited_document_ids` (bảng thật duy nhất lưu "tài liệu nào được
+  trích dẫn theo answer nào" — không có bảng lịch sử QA riêng). Communities = connected
+  components thuần Rust (không thêm crate graph). Web: trang "Đồ thị" (rail icon
+  `Network`), force-directed layout tự viết (~150 dòng, `lib/forceLayout.ts`, seeded
+  deterministic — không thêm `d3-force`), sidebar cộng đồng + filter bộ sưu tập + chế độ
+  xem bảng (a11y fallback) + danh sách node điều hướng bàn phím, mock fixture 13
+  node/3 cụm/3 loại cạnh cho org A + graph nhỏ riêng cho org B, unit/component/e2e test.
+  **`similarity` (Qdrant) là chỗ gắn sẵn (stub), CHƯA có truy vấn vector thật** —
+  sandbox không có Qdrant để kiểm chứng, và API `storage/qdrant.rs` hiện tại
+  (`scroll_points`) hard-code `with_vector: false` nên cần một vòng riêng (thêm biến
+  thể lấy vector thật + kiểm thử với Qdrant thật) trước khi bật edge này; graph vẫn
+  trả đủ `conflict`/`co_citation` khi không có Qdrant, không lỗi.
+
+- **Plan/files:** `crates/server/src/routes/graph.rs`, `db/graph.rs`, `services/graph.rs`
+  (thuật toán thuần); OpenAPI path/schemas (`GraphNode`/`GraphEdge`/`GraphCommunity`/
+  `GraphResponse`) + `ROUTE_INVENTORY`; `web/src/pages/GraphPage.tsx`,
+  `components/graph/**`, `lib/forceLayout.ts`, `mocks/handlers/graph.ts`.
+- **Depends:** P2-07 (điều hướng vào `/library/:collectionId` khi click node — không có
+  route sâu tới preview một tài liệu cụ thể, vì `LibraryPage` chọn tài liệu bằng state
+  cục bộ chứ không phải URL param) + backend 1B claims/conflicts + P1B-R05 ask-stream.
+- **Acceptance/tests:** `services::graph` unit test (components/pruning, xác định);
+  `tests/graph.rs` DB-gated (permission, conflict edge, co_citation edge, org isolation,
+  ACL riêng tư, bounded cap — chạy thật trên PG local, 6/6 pass); web unit
+  (`forceLayout.test.ts`, `GraphPage.test.tsx` 7 kịch bản) + `e2e/graph.spec.ts` (3 kịch
+  bản: cụm + sidebar, tắt cụm ẩn node, click node → preview thật qua library).
+- **Security:** Cùng ACL/permission với `/conflicts`; không thêm quyền mới chưa seed
+  role. **Out:** `similarity` edge thật (chờ Qdrant thật), deep-link preview một tài
+  liệu cụ thể từ đồ thị.
 
 ## Exit gate
 

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "915a11ed880c3efd";
+    const ROADMAP_SOURCE_HASH = "3531f1384c9c3070";
     const phases = [
       {
         "id": "phase-f",
@@ -1407,6 +1407,11 @@
           [
             "P2-17",
             "Document graph",
+            "in_progress"
+          ],
+          [
+            "P2-18",
+            "Project grouping (org → project → collection → document)",
             "in_progress"
           ]
         ]

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "2ba31d282e56e162";
+    const ROADMAP_SOURCE_HASH = "915a11ed880c3efd";
     const phases = [
       {
         "id": "phase-f",
@@ -1402,6 +1402,11 @@
           [
             "P2-16",
             "Production build/static serving/final gate",
+            "in_progress"
+          ],
+          [
+            "P2-17",
+            "Document graph",
             "in_progress"
           ]
         ]

--- a/web/e2e/admin.spec.ts
+++ b/web/e2e/admin.spec.ts
@@ -2,13 +2,15 @@
 // user holds `member.manage` in mock mode and is seeded as an active owner, so
 // the admin pages are reachable and owner-tier controls are enabled.
 import { expect, test } from '@playwright/test';
-import { forceStatus, IDS, login } from './support';
+import { forceStatus, login, NAMES } from './support';
 
 async function openMembers(page: import('@playwright/test').Page): Promise<void> {
   await page.getByRole('link', { name: 'Thành viên' }).click();
   await expect(page.getByRole('heading', { name: 'Thành viên và vai trò' })).toBeVisible();
-  // The seeded owner row is enough to know the list has loaded.
-  await expect(page.getByRole('row').filter({ hasText: IDS.demoUser })).toBeVisible();
+  // The seeded owner row is enough to know the list has loaded. Rows are
+  // located by the rendered display name — the table never renders the raw
+  // `user_id` (see `support.ts`'s `NAMES` doc).
+  await expect(page.getByRole('row').filter({ hasText: NAMES.demoUser })).toBeVisible();
 }
 
 test('inviting a member shows the one-time token', async ({ page }) => {
@@ -30,7 +32,7 @@ test("changing a member's role persists after refetch", async ({ page }) => {
   await openMembers(page);
 
   // The second member is seeded `admin`; demote to editor.
-  const roleSelect = page.getByRole('combobox', { name: `Vai trò của ${IDS.secondMember}` });
+  const roleSelect = page.getByRole('combobox', { name: `Vai trò của ${NAMES.secondMember}` });
   await expect(roleSelect).toContainText('Quản trị viên');
   await roleSelect.click();
   await page.getByRole('option', { name: 'Biên tập viên' }).click();
@@ -44,7 +46,7 @@ test('suspending then reactivating a member toggles their state', async ({ page 
   await openMembers(page);
 
   // Second member is seeded active — suspend, then bring back.
-  const secondRow = page.getByRole('row').filter({ hasText: IDS.secondMember });
+  const secondRow = page.getByRole('row').filter({ hasText: NAMES.secondMember });
   await secondRow.getByRole('button', { name: 'Tạm ngưng' }).click();
   await expect(secondRow.getByText('Đã tạm ngưng')).toBeVisible();
 
@@ -57,7 +59,7 @@ test('the seeded suspended member can be reactivated', async ({ page }) => {
   await openMembers(page);
 
   // Third member is seeded `viewer` / `suspended`.
-  const thirdRow = page.getByRole('row').filter({ hasText: IDS.thirdMember });
+  const thirdRow = page.getByRole('row').filter({ hasText: NAMES.thirdMember });
   await expect(thirdRow.getByText('Đã tạm ngưng')).toBeVisible();
   await thirdRow.getByRole('button', { name: 'Kích hoạt lại' }).click();
   await expect(thirdRow.getByText('Đang hoạt động')).toBeVisible();
@@ -71,7 +73,7 @@ test('suspending the sole active owner is blocked by the last-owner invariant (4
 
   // The demo user is the only active owner; the server's last-owner invariant
   // rejects suspending them with a 409, surfaced as its specific message.
-  const ownerRow = page.getByRole('row').filter({ hasText: IDS.demoUser });
+  const ownerRow = page.getByRole('row').filter({ hasText: NAMES.demoUser });
   await ownerRow.getByRole('button', { name: 'Tạm ngưng' }).click();
 
   await expect(
@@ -89,7 +91,7 @@ test('an owner-tier mutation that 403s shows the owner-tier denial message', asy
   // handles honestly rather than assuming impossible) and assert the specific
   // owner-tier copy — not the generic permission message.
   await forceStatus(page, 'patchMember', 403, 1);
-  const roleSelect = page.getByRole('combobox', { name: `Vai trò của ${IDS.secondMember}` });
+  const roleSelect = page.getByRole('combobox', { name: `Vai trò của ${NAMES.secondMember}` });
   await roleSelect.click();
   await page.getByRole('option', { name: 'Chủ sở hữu' }).click();
 

--- a/web/e2e/graph.spec.ts
+++ b/web/e2e/graph.spec.ts
@@ -1,0 +1,65 @@
+// P2-17 Document Graph MVP e2e (owner request 2026-07-29): login -> "Đồ thị"
+// -> see communities + sidebar counts, toggle a cluster off (its nodes
+// disappear), click a node -> lands in that node's own collection's library
+// (P2-07's existing route) and reaches a real document preview from there.
+//
+// Node click does NOT deep-link straight into the graph node's own document
+// preview: `LibraryPage`'s selected-document state is local component state,
+// not a URL param, so there is no document-level route to navigate to (see
+// `GraphPage.tsx`'s module doc). The graph's own node catalog
+// (`mocks/handlers/graph.ts`) is a separate, disjoint fixture set from
+// `mocks/fixtures.ts`'s document store for the same reason `QA_COMPARE_*`
+// picked its own numeric id range there — so the document actually opened
+// below ("Onboarding Guide.pdf") is the real seeded Employee Handbook
+// document, not the graph node's own synthetic title.
+import { expect, test } from '@playwright/test';
+import { login } from './support';
+
+test('opens the graph and shows communities with per-cluster counts', async ({ page }) => {
+  await login(page);
+  await page.getByRole('link', { name: 'Đồ thị' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Đồ thị tài liệu' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sổ tay nhân viên 2024' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Đặc tả sản phẩm v1/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Biên bản họp liên phòng/ })).toBeVisible();
+
+  await expect(page.getByRole('heading', { name: 'Cộng đồng' })).toBeVisible();
+  await expect(page.getByLabel(/Employee Handbook/)).toBeVisible();
+  await expect(page.getByLabel(/Product Specs/)).toBeVisible();
+  await expect(page.getByLabel(/Liên phòng ban/)).toBeVisible();
+});
+
+test('turning off a community hides its nodes; "Chọn tất cả" restores them', async ({ page }) => {
+  await login(page);
+  await page.getByRole('link', { name: 'Đồ thị' }).click();
+  await expect(page.getByRole('button', { name: 'Sổ tay nhân viên 2024' })).toBeVisible();
+
+  await page.getByLabel(/Employee Handbook/).click();
+  await expect(page.getByRole('button', { name: 'Sổ tay nhân viên 2024' })).toHaveCount(0);
+  // A different cluster is unaffected.
+  await expect(page.getByRole('button', { name: /Đặc tả sản phẩm v1/ })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Chọn tất cả' }).click();
+  await expect(page.getByRole('button', { name: 'Sổ tay nhân viên 2024' })).toBeVisible();
+});
+
+test("clicking a node navigates into that document's own collection, reaching a real preview", async ({
+  page,
+}) => {
+  await login(page);
+  await page.getByRole('link', { name: 'Đồ thị' }).click();
+  await expect(page.getByRole('button', { name: 'Sổ tay nhân viên 2024' })).toBeVisible();
+
+  // "Sổ tay nhân viên 2024" belongs to the Employee Handbook collection.
+  await page.getByRole('button', { name: /Sổ tay nhân viên 2024/ }).click();
+
+  await expect(page).toHaveURL(/\/library\//);
+  const table = page.getByRole('table', { name: 'Danh sách tài liệu' });
+  await expect(table.getByRole('button', { name: /Onboarding Guide\.pdf/ })).toBeVisible();
+
+  await table.getByRole('button', { name: /Onboarding Guide\.pdf/ }).click();
+  await expect(page.getByTestId('document-preview-markdown')).toContainText(
+    'Mock preview content for version 1',
+  );
+});

--- a/web/e2e/org-switch.spec.ts
+++ b/web/e2e/org-switch.spec.ts
@@ -8,7 +8,7 @@
 // somewhere" flow the old `org-scope.spec.ts` could not drive before 1C-01
 // shipped `GET /orgs` / `POST /orgs/switch`.
 import { expect, test } from '@playwright/test';
-import { forceStatus, IDS, login, openEmployeeHandbook } from './support';
+import { forceStatus, login, NAMES, openEmployeeHandbook } from './support';
 
 test('switching org replaces org A data with org B data — no stale org A render survives', async ({
   page,
@@ -60,13 +60,15 @@ test('switching org replaces org A data with org B data — no stale org A rende
   // The admin members page (`handlers/members.ts`'s org-scoping gap, now
   // closed) also moved with the switch: org B's own roster renders — the
   // demo user's row plus its distinct second member — and neither of org A's
-  // member ids (`secondMember`/`thirdMember`) appears anywhere.
+  // member names (`secondMember`/`thirdMember`) appears anywhere. Rows are
+  // located by rendered display name, not the raw `user_id` (see
+  // `support.ts`'s `NAMES` doc).
   await page.getByRole('link', { name: 'Thành viên' }).click();
   await expect(page.getByRole('heading', { name: 'Thành viên và vai trò' })).toBeVisible();
-  await expect(page.getByRole('row').filter({ hasText: IDS.demoUser })).toBeVisible();
-  await expect(page.getByRole('row').filter({ hasText: IDS.globexMember })).toBeVisible();
-  await expect(page.getByRole('row').filter({ hasText: IDS.secondMember })).toHaveCount(0);
-  await expect(page.getByRole('row').filter({ hasText: IDS.thirdMember })).toHaveCount(0);
+  await expect(page.getByRole('row').filter({ hasText: NAMES.demoUser })).toBeVisible();
+  await expect(page.getByRole('row').filter({ hasText: NAMES.globexMember })).toBeVisible();
+  await expect(page.getByRole('row').filter({ hasText: NAMES.secondMember })).toHaveCount(0);
+  await expect(page.getByRole('row').filter({ hasText: NAMES.thirdMember })).toHaveCount(0);
 });
 
 test('a denied switch (membership_missing) leaves org A active and shows an accessible error', async ({

--- a/web/e2e/projects.spec.ts
+++ b/web/e2e/projects.spec.ts
@@ -1,0 +1,74 @@
+// P2-18 (org -> project -> collection -> document grouping): create a
+// project, assign a collection to it from the Library page, then use the
+// "Phạm vi" (scope) dropdown in the Q&A composer to narrow search to that
+// project's collections and back out to "Tất cả dự án".
+//
+// Fixture ground truth (src/mocks/fixtures.ts): org A seeds two projects —
+// "Nhân sự" (assigned to the Employee Handbook collection only) and "Sản
+// phẩm" (no collections yet) — and one always-unassigned collection,
+// "Product Specs" ("Roadmap.xlsx" lives there, matched by the "lộ trình quý
+// 3" query `qa.spec.ts` already exercises unscoped). Demo user has
+// `doc.upload` in mock/E2E mode only (`mocks/browser.ts`), so the project
+// create/assign UI is reachable here.
+import { expect, test } from '@playwright/test';
+import { login } from './support';
+
+test('create a project, assign a collection, then scope Q&A search to it and back to "Tất cả dự án"', async ({
+  page,
+}) => {
+  await login(page);
+  await page.getByRole('link', { name: 'Thư viện' }).click();
+
+  // Seeded grouping is visible before any mutation. Scoped to the nav
+  // itself: "Nhân sự"/"Chưa thuộc dự án" also appear as the current value
+  // inside each collection's own assign-project `<select>` trigger below.
+  const nav = page.getByRole('navigation', { name: 'Điều hướng bộ sưu tập' });
+  await expect(nav.getByText('Nhân sự')).toBeVisible();
+  await expect(nav.getByText('Chưa thuộc dự án')).toBeVisible();
+
+  // Create a new project.
+  await page.getByLabel('Tên dự án mới').fill('Marketing');
+  await page.getByRole('button', { name: 'Tạo dự án' }).click();
+  await expect(page.getByLabel('Tên dự án mới')).toHaveValue('');
+
+  // Assign the always-unassigned "Product Specs" collection to it.
+  const assignSelect = page.getByRole('combobox', {
+    name: 'Dự án cho bộ sưu tập Product Specs',
+  });
+  await expect(assignSelect).toContainText('Chưa thuộc dự án');
+  await assignSelect.click();
+  await page.getByRole('option', { name: 'Marketing' }).click();
+  await expect(assignSelect).toContainText('Marketing');
+
+  // The nav re-groups it under the new project heading: "Product Specs" now
+  // renders inside the same group container as the "Marketing" heading.
+  const marketingGroup = page.locator('p.eyebrow', { hasText: 'Marketing' }).locator('..');
+  await expect(marketingGroup.getByRole('link', { name: 'Product Specs' })).toBeVisible();
+
+  // Q&A: scope to "Nhân sự" (Employee Handbook only) and confirm the search
+  // narrows correctly in both directions.
+  await page.getByRole('link', { name: 'Hỏi đáp' }).click();
+  const scopeSelect = page.getByRole('combobox', { name: 'Phạm vi dự án' });
+  await expect(scopeSelect).toContainText('Tất cả dự án');
+  await scopeSelect.click();
+  await page.getByRole('option', { name: 'Nhân sự' }).click();
+  await expect(scopeSelect).toContainText('Nhân sự');
+
+  // A query matching this project's own document succeeds.
+  await page.getByLabel('Từ khóa').fill('hội nhập');
+  await page.getByRole('button', { name: 'Tìm kiếm' }).click();
+  await expect(page.getByText('Onboarding Guide.pdf')).toBeVisible();
+
+  // A query matching only Product Specs' document (outside this project's
+  // scope) finds nothing while scoped to "Nhân sự".
+  await page.getByLabel('Từ khóa').fill('lộ trình quý 3');
+  await page.getByRole('button', { name: 'Tìm kiếm' }).click();
+  await expect(page.getByText(/Không tìm thấy kết quả phù hợp/)).toBeVisible();
+
+  // Back to "Tất cả dự án" (no filter) — the same query now finds it.
+  await scopeSelect.click();
+  await page.getByRole('option', { name: 'Tất cả dự án' }).click();
+  await expect(scopeSelect).toContainText('Tất cả dự án');
+  await page.getByRole('button', { name: 'Tìm kiếm' }).click();
+  await expect(page.getByText('Roadmap.xlsx')).toBeVisible();
+});

--- a/web/e2e/support.ts
+++ b/web/e2e/support.ts
@@ -43,6 +43,20 @@ export const DEMO = {
   password: 'demo-password',
 } as const;
 
+/**
+ * Display names the admin members table actually renders (`MembersTable.tsx`
+ * shows a name/email — never the raw `user_id` from `IDS` above, see the
+ * owner-reported UI gap this closed). Row lookups in `admin.spec.ts` filter
+ * by these, not by `IDS`, since a UUID no longer appears in that table's
+ * text at all.
+ */
+export const NAMES = {
+  demoUser: 'Demo User',
+  secondMember: 'Bao Tran',
+  thirdMember: 'Chi Vo',
+  globexMember: 'Duc Nguyen',
+} as const;
+
 /** Statuses `mockControl.forceStatus` accepts (src/mocks/control.ts). */
 type ForcedStatus = 401 | 403 | 404 | 409 | 429 | 503;
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -39,6 +39,7 @@ const ALWAYS_ON_RAIL_CONTROLS: Array<{ role: 'link' | 'button'; name: string | R
   { role: 'link', name: 'Trang chủ Folyvo' },
   { role: 'link', name: 'Thư viện' },
   { role: 'link', name: 'Hỏi đáp' },
+  { role: 'link', name: 'Đồ thị' },
   { role: 'link', name: 'Thành viên' },
   { role: 'link', name: 'Sử dụng' },
   { role: 'link', name: 'Trợ giúp' },
@@ -173,7 +174,7 @@ describe('App / rail (icon-only shell nav)', () => {
     render(<App />);
 
     expect(screen.getByRole('link', { name: 'Trợ giúp' })).toHaveAttribute('aria-current', 'page');
-    for (const name of ['Thư viện', 'Hỏi đáp', 'Thành viên', 'Sử dụng']) {
+    for (const name of ['Thư viện', 'Hỏi đáp', 'Đồ thị', 'Thành viên', 'Sử dụng']) {
       expect(screen.getByRole('link', { name })).not.toHaveAttribute('aria-current');
     }
   });

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -257,9 +257,13 @@ describe('App / authenticated shell (P2-05 guard matrix + login/logout)', () => 
 
     fillAndSubmitLogin(DEMO_EMAIL, DEMO_PASSWORD);
 
-    await waitFor(() =>
-      expect(screen.getByRole('heading', { name: 'Bộ sưu tập col-42' })).toBeVisible(),
-    );
+    // Lands on the deep-linked library route (proven by the URL, not by a
+    // heading string containing the raw collectionId: `LibraryPage`'s own
+    // heading never renders a bare id — see its module doc — so an unknown
+    // fixture id like `col-42` reads as the neutral "Bộ sưu tập" placeholder,
+    // not `Bộ sưu tập col-42`).
+    await waitFor(() => expect(window.location.pathname).toBe('/library/col-42'));
+    expect(screen.getByRole('heading', { name: 'Bộ sưu tập' })).toBeVisible();
 
     // Session info moved from an always-visible topbar strip into the
     // avatar-triggered account menu (see components/shell/UserMenu.tsx) —

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { RouteLink } from './components/RouteLink';
 import {
   AdminMembersPage,
   AdminUsagePage,
+  GraphPage,
   HelpPage,
   LibraryPage,
   LoginPage,
@@ -45,6 +46,12 @@ function RouteOutlet() {
       return (
         <ProtectedRoute>
           <QaPage collectionId={match.params.collectionId} />
+        </ProtectedRoute>
+      );
+    case 'graph':
+      return (
+        <ProtectedRoute>
+          <GraphPage collectionId={match.params.collectionId} />
         </ProtectedRoute>
       );
     case 'adminMembers':

--- a/web/src/api/generated/contract.ts
+++ b/web/src/api/generated/contract.ts
@@ -710,6 +710,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/graph": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Document Graph MVP (P2-17): nodes/edges/communities for caller-visible documents (requires qa.query, same precedent as /conflicts). */
+        get: operations["getGraph"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1081,6 +1098,37 @@ export interface components {
         AuditPage: {
             items: components["schemas"]["AuditEntry"][];
             page: components["schemas"]["PageInfo"];
+        };
+        GraphNode: {
+            /** Format: uuid */
+            id: string;
+            title: string;
+            /** Format: uuid */
+            collectionId: string;
+            collectionName: string;
+            status: string;
+            degree: number;
+        };
+        GraphEdge: {
+            /** Format: uuid */
+            source: string;
+            /** Format: uuid */
+            target: string;
+            /** @enum {string} */
+            kind: "conflict" | "co_citation" | "similarity";
+            weight: number;
+        };
+        GraphCommunity: {
+            id: string;
+            label: string;
+            nodeIds: string[];
+            size: number;
+        };
+        GraphResponse: {
+            nodes: components["schemas"]["GraphNode"][];
+            edges: components["schemas"]["GraphEdge"][];
+            communities: components["schemas"]["GraphCommunity"][];
+            requestId: string;
         };
     };
     responses: {
@@ -2599,6 +2647,32 @@ export interface operations {
                 };
             };
             403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    getGraph: {
+        parameters: {
+            query?: {
+                /** @description Restrict nodes to one collection (must be in the caller's allow-list). */
+                collectionId?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Bounded document graph (nodes/edges/communities). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GraphResponse"];
+                };
+            };
+            403: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
             429: components["responses"]["RateLimited"];
         };
     };

--- a/web/src/api/generated/contract.ts
+++ b/web/src/api/generated/contract.ts
@@ -166,6 +166,28 @@ export interface paths {
         patch: operations["updateCollection"];
         trace?: never;
     };
+    "/collections/{collectionId}/assign-project": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                collectionId: components["parameters"]["collectionId"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Assign or unassign this collection's project (P2-18)
+         * @description `projectId: null` unassigns; `projectId: "<uuid>"` assigns — the key itself is required, there is no "leave unchanged" outcome. A dedicated action route rather than folding into the metadata PATCH — see `docs/conventions/api.md` and `routes::collections`'s module doc for why. Same `doc.upload` permission gate as create/update.
+         */
+        post: operations["assignCollectionProject"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/collections/{collectionId}/documents": {
         parameters: {
             query?: never;
@@ -585,6 +607,52 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List every project in the caller's org (P2-18)
+         * @description Org-scoped, no permission gate beyond active membership — same shape as GET /collections. "All projects" in the UI/API is simply the absence of a projectId filter on /search, /ask, /ask/stream; it is never a row this endpoint returns.
+         */
+        get: operations["listProjects"];
+        put?: never;
+        /**
+         * Create a project (P2-18)
+         * @description Same `doc.upload` permission gate as POST /collections — see `routes::projects`'s module doc for why no separate permission was added.
+         */
+        post: operations["createProject"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/projects/{projectId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                projectId: components["parameters"]["projectId"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Rename a project (P2-18)
+         * @description Rename only — no other mutable field yet. Project deletion is explicitly out of scope for this slice.
+         */
+        patch: operations["updateProject"];
+        trace?: never;
+    };
     "/members": {
         parameters: {
             query?: never;
@@ -757,10 +825,41 @@ export interface components {
             visibility: string;
             /** Format: date-time */
             createdAt: string;
+            /**
+             * Format: uuid
+             * @description P2-18 — null when this collection has no project assigned.
+             */
+            projectId?: string | null;
+            /** @description Joined display name for projectId (null together with it). */
+            projectName?: string | null;
         };
         CollectionPage: {
             items: components["schemas"]["Collection"][];
             page: components["schemas"]["PageInfo"];
+        };
+        Project: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        ProjectPage: {
+            items: components["schemas"]["Project"][];
+            page: components["schemas"]["PageInfo"];
+        };
+        CreateProjectRequest: {
+            name: string;
+        };
+        UpdateProjectRequest: {
+            name: string;
+        };
+        AssignProjectRequest: {
+            /**
+             * Format: uuid
+             * @description null unassigns; a uuid assigns. The key is required — there is no "leave unchanged" outcome for this action endpoint.
+             */
+            projectId: string | null;
         };
         CitationPin: {
             citeId: string;
@@ -818,6 +917,11 @@ export interface components {
         SearchRequest: {
             query: string;
             collectionIds?: string[];
+            /**
+             * Format: uuid
+             * @description P2-18 — optional project scope. Absent/null means "all projects": no additional filter beyond collectionIds (today's exact behavior). Narrows (never widens) whatever collectionIds already restricts; a projectId that does not resolve in the caller's org is a 404.
+             */
+            projectId?: string;
             /** @enum {string} */
             mode?: "current" | "as_of" | "compare" | "history";
             /** Format: date-time */
@@ -843,6 +947,11 @@ export interface components {
         AskRequest: {
             question: string;
             collectionIds?: string[];
+            /**
+             * Format: uuid
+             * @description P2-18 — optional project scope. Absent/null means "all projects": no additional filter beyond collectionIds (today's exact behavior). Narrows (never widens) whatever collectionIds already restricts; a projectId that does not resolve in the caller's org is a 404.
+             */
+            projectId?: string;
             /** @enum {string} */
             mode?: "current" | "as_of" | "compare" | "history";
             /** Format: date-time */
@@ -1160,6 +1269,7 @@ export interface components {
         inviteId: string;
         userId: string;
         orgId: string;
+        projectId: string;
     };
     requestBodies: never;
     headers: never;
@@ -1510,6 +1620,43 @@ export interface operations {
                 };
             };
             404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    assignCollectionProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                collectionId: components["parameters"]["collectionId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AssignProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Collection with its (possibly now null) project assignment. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Collection"];
+                };
+            };
+            403: components["responses"]["ApiError"];
+            /** @description Collection not found, or projectId does not resolve in this org. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
+                };
+            };
             429: components["responses"]["RateLimited"];
         };
     };
@@ -2166,6 +2313,15 @@ export interface operations {
             400: components["responses"]["ApiError"];
             401: components["responses"]["ApiError"];
             403: components["responses"]["ApiError"];
+            /** @description projectId does not resolve to a project in the caller's org (P2-18). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
+                };
+            };
             429: components["responses"]["RateLimited"];
         };
     };
@@ -2194,6 +2350,15 @@ export interface operations {
             400: components["responses"]["ApiError"];
             401: components["responses"]["ApiError"];
             403: components["responses"]["ApiError"];
+            /** @description projectId does not resolve to a project in the caller's org (P2-18). */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
+                };
+            };
             429: components["responses"]["RateLimited"];
         };
     };
@@ -2367,6 +2532,84 @@ export interface operations {
                 };
             };
             401: components["responses"]["ApiError"];
+            404: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    listProjects: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Projects in the caller's org. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectPage"];
+                };
+            };
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    createProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Project created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
+            429: components["responses"]["RateLimited"];
+        };
+    };
+    updateProject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                projectId: components["parameters"]["projectId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Project renamed. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project"];
+                };
+            };
+            400: components["responses"]["ApiError"];
+            403: components["responses"]["ApiError"];
             404: components["responses"]["ApiError"];
             429: components["responses"]["RateLimited"];
         };

--- a/web/src/api/generated/contract.ts
+++ b/web/src/api/generated/contract.ts
@@ -989,6 +989,8 @@ export interface components {
         Membership: {
             /** Format: uuid */
             userId: string;
+            email: string;
+            displayName: string;
             /** @enum {string} */
             role: "owner" | "admin" | "editor" | "viewer";
             /** @enum {string} */

--- a/web/src/components/admin/MemberRowActions.tsx
+++ b/web/src/components/admin/MemberRowActions.tsx
@@ -126,7 +126,7 @@ export function MemberRowActions({
           value={membership.role}
           options={roleOptions}
           onChange={handleRoleChange}
-          ariaLabel={`Vai trò của ${membership.userId}`}
+          ariaLabel={`Vai trò của ${membership.displayName}`}
           disabled={disabled}
           compact
         />

--- a/web/src/components/admin/MembersTable.tsx
+++ b/web/src/components/admin/MembersTable.tsx
@@ -1,7 +1,7 @@
 // P2-11: the membership list itself. Renders with the existing `.table`
 // component classes, same convention as `components/library/DocumentList.tsx`.
 import { MemberRowActions } from './MemberRowActions';
-import { ROLE_META, STATE_META, formatDateTime } from './memberPresentation';
+import { ROLE_META, STATE_META, formatDateTime, memberInitials } from './memberPresentation';
 import type { ApiClient } from '../../api/client';
 import type { Membership } from './types';
 
@@ -45,9 +45,12 @@ export function MembersTable({
             <td>
               <div className="member-identity">
                 <span className="member-avatar" aria-hidden="true">
-                  {membership.userId.replace(/-/g, '').slice(-2)}
+                  {memberInitials(membership.displayName)}
                 </span>
-                <span className="member-identity-id">{membership.userId}</span>
+                <div className="member-identity-text">
+                  <span className="member-identity-name">{membership.displayName}</span>
+                  <span className="member-identity-email text-muted">{membership.email}</span>
+                </div>
                 {membership.userId === currentUserId && (
                   <span className="tag tag-neutral">Bạn</span>
                 )}

--- a/web/src/components/admin/memberPresentation.ts
+++ b/web/src/components/admin/memberPresentation.ts
@@ -60,6 +60,24 @@ export function formatDateTime(iso: string): string {
 }
 
 /**
+ * One- or two-letter monogram for the member avatar, derived from
+ * `displayName` (never from `userId` — the raw UUID must not leak into the
+ * UI, see `MembersTable.tsx`). Takes the first letter of up to the first two
+ * words; falls back to "?" for an empty/blank name so the avatar never
+ * renders nothing.
+ */
+export function memberInitials(displayName: string): string {
+  const letters = displayName
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? '')
+    .join('');
+  return letters || '?';
+}
+
+/**
  * Mirrors `services::members::operation_manages_owner` on the server exactly
  * (see `crates/server/src/services/members.rs`): true when the operation
  * would grant the owner role, or when its target currently holds it — either

--- a/web/src/components/graph/CommunitySidebar.tsx
+++ b/web/src/components/graph/CommunitySidebar.tsx
@@ -1,0 +1,59 @@
+// P2-17 Document Graph MVP sidebar: one checkbox per community + its node
+// count, plus "Select All" — matches the owner's reference screenshot
+// ("Communities" checkbox list with a count per cluster).
+import type { components } from '../../api/generated/contract';
+
+type GraphCommunity = components['schemas']['GraphCommunity'];
+
+export function CommunitySidebar({
+  communities,
+  hiddenCommunityIds,
+  onToggle,
+  onSelectAll,
+}: {
+  communities: GraphCommunity[];
+  hiddenCommunityIds: ReadonlySet<string>;
+  onToggle: (communityId: string) => void;
+  onSelectAll: () => void;
+}) {
+  const allVisible = communities.every((c) => !hiddenCommunityIds.has(c.id));
+  return (
+    <section className="graph-sidebar" aria-labelledby="graph-communities-heading">
+      <div className="graph-sidebar-header">
+        <h2 id="graph-communities-heading">Cộng đồng</h2>
+        <button
+          type="button"
+          className="btn btn-secondary btn-sm"
+          onClick={onSelectAll}
+          disabled={allVisible}
+        >
+          Chọn tất cả
+        </button>
+      </div>
+      {communities.length === 0 ? (
+        <p className="text-muted">Không có cụm nào.</p>
+      ) : (
+        <ul className="graph-community-list">
+          {communities.map((community) => {
+            const inputId = `graph-community-${community.id}`;
+            const checked = !hiddenCommunityIds.has(community.id);
+            return (
+              <li key={community.id}>
+                <label htmlFor={inputId} className="graph-community-item">
+                  <input
+                    id={inputId}
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => onToggle(community.id)}
+                  />
+                  <span className="graph-community-label">{community.label}</span>
+                  <span className="graph-community-count">{community.size}</span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/graph/GraphCanvas.tsx
+++ b/web/src/components/graph/GraphCanvas.tsx
@@ -1,0 +1,204 @@
+// P2-17 Document Graph MVP: renders the force-directed layout as SVG, plus
+// two accessible fallbacks required alongside any canvas/SVG graph
+// (owner's a11y note — "canvas graph phải có fallback ngữ nghĩa"):
+//
+//   1. The SVG itself is `role="img"` with one summary `aria-label`; every
+//      shape inside it is `aria-hidden` — a screen reader hears the one
+//      summary, not one announcement per circle/line.
+//   2. The REAL interactive/semantic surface is the node list below the
+//      SVG: plain, always-visible, keyboard-focusable `<button>`s (not
+//      hidden — visible content already satisfies "exposed to a screen
+//      reader", and it directly is the "keyboard focus vào node list" the
+//      brief asks for). Clicking an SVG circle mirrors the same action for
+//      mouse users (`tabIndex={-1}` — it is not a second, redundant tab
+//      stop).
+//   3. `viewMode="table"` swaps the SVG for two real `<table>`s (nodes +
+//      edges) — the "chế độ xem bảng chuyển đổi được" alternative, and the
+//      only one of the three that also exposes edges structurally.
+import type { components } from '../../api/generated/contract';
+import type { LayoutPosition } from '../../lib/forceLayout';
+
+type GraphNode = components['schemas']['GraphNode'];
+type GraphEdge = components['schemas']['GraphEdge'];
+
+const EDGE_KIND_LABELS: Record<GraphEdge['kind'], string> = {
+  conflict: 'Xung đột',
+  co_citation: 'Đồng trích dẫn',
+  similarity: 'Tương đồng',
+};
+
+/** Fixed, cycling palette — enough distinct hues for a handful of communities. */
+const COMMUNITY_COLORS = [
+  'var(--color-accent-600)',
+  'var(--color-accent-2-600)',
+  '#3b6ea5',
+  '#a5473b',
+  '#7a4ba5',
+  '#4ba58f',
+];
+
+function colorForCommunity(index: number): string {
+  return COMMUNITY_COLORS[index % COMMUNITY_COLORS.length];
+}
+
+function radiusForDegree(degree: number): number {
+  return Math.min(20, 7 + degree * 2);
+}
+
+export function GraphCanvas({
+  nodes,
+  edges,
+  positions,
+  communityIndexByNodeId,
+  viewMode,
+  width = 640,
+  height = 480,
+  onActivateNode,
+}: {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  positions: Map<string, LayoutPosition>;
+  communityIndexByNodeId: Map<string, number>;
+  viewMode: 'canvas' | 'table';
+  width?: number;
+  height?: number;
+  onActivateNode: (node: GraphNode) => void;
+}) {
+  if (viewMode === 'table') {
+    return (
+      <div className="graph-table-view">
+        <table>
+          <caption>Danh sách tài liệu trong đồ thị</caption>
+          <thead>
+            <tr>
+              <th scope="col">Tài liệu</th>
+              <th scope="col">Bộ sưu tập</th>
+              <th scope="col">Trạng thái</th>
+              <th scope="col">Bậc (degree)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {nodes.map((node) => (
+              <tr key={node.id}>
+                <td>
+                  <button
+                    type="button"
+                    className="link-button"
+                    onClick={() => onActivateNode(node)}
+                  >
+                    {node.title}
+                  </button>
+                </td>
+                <td>{node.collectionName}</td>
+                <td>{node.status}</td>
+                <td>{node.degree}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <table>
+          <caption>Danh sách liên kết trong đồ thị</caption>
+          <thead>
+            <tr>
+              <th scope="col">Từ</th>
+              <th scope="col">Đến</th>
+              <th scope="col">Loại</th>
+              <th scope="col">Trọng số</th>
+            </tr>
+          </thead>
+          <tbody>
+            {edges.map((edge, index) => {
+              const sourceTitle = nodes.find((n) => n.id === edge.source)?.title ?? edge.source;
+              const targetTitle = nodes.find((n) => n.id === edge.target)?.title ?? edge.target;
+              return (
+                <tr key={`${edge.source}-${edge.target}-${edge.kind}-${index}`}>
+                  <td>{sourceTitle}</td>
+                  <td>{targetTitle}</td>
+                  <td>{EDGE_KIND_LABELS[edge.kind]}</td>
+                  <td>{edge.weight.toFixed(2)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
+  return (
+    <div className="graph-canvas-wrap">
+      <svg
+        role="img"
+        aria-label={`Đồ thị gồm ${nodes.length} tài liệu và ${edges.length} liên kết`}
+        viewBox={`0 0 ${width} ${height}`}
+        className="graph-canvas"
+      >
+        <g aria-hidden="true">
+          {edges.map((edge, index) => {
+            const source = positions.get(edge.source);
+            const target = positions.get(edge.target);
+            if (!source || !target) return null;
+            return (
+              <line
+                key={`${edge.source}-${edge.target}-${edge.kind}-${index}`}
+                x1={source.x}
+                y1={source.y}
+                x2={target.x}
+                y2={target.y}
+                className={`graph-edge graph-edge-${edge.kind}`}
+                strokeWidth={Math.max(1, edge.weight * 3)}
+              />
+            );
+          })}
+          {nodes.map((node) => {
+            const position = positions.get(node.id);
+            if (!position) return null;
+            const communityIndex = communityIndexByNodeId.get(node.id) ?? 0;
+            return (
+              <circle
+                key={node.id}
+                cx={position.x}
+                cy={position.y}
+                r={radiusForDegree(node.degree)}
+                fill={colorForCommunity(communityIndex)}
+                className="graph-node-dot"
+                tabIndex={-1}
+                onClick={() => onActivateNode(node)}
+              >
+                <title>{`${node.title} (${node.collectionName})`}</title>
+              </circle>
+            );
+          })}
+        </g>
+      </svg>
+
+      <div className="graph-node-list-wrap">
+        <h2 id="graph-node-list-heading">Danh sách tài liệu</h2>
+        <ul className="graph-node-list" aria-labelledby="graph-node-list-heading">
+          {nodes.map((node) => (
+            <li key={node.id}>
+              <button
+                type="button"
+                className="graph-node-button"
+                onClick={() => onActivateNode(node)}
+              >
+                <span
+                  className="graph-node-swatch"
+                  style={{
+                    background: colorForCommunity(communityIndexByNodeId.get(node.id) ?? 0),
+                  }}
+                  aria-hidden="true"
+                />
+                <span>{node.title}</span>
+                <span className="text-muted">
+                  {node.collectionName} · bậc {node.degree}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/graph/index.ts
+++ b/web/src/components/graph/index.ts
@@ -1,0 +1,2 @@
+export { CommunitySidebar } from './CommunitySidebar';
+export { GraphCanvas } from './GraphCanvas';

--- a/web/src/components/library/CollectionNav.tsx
+++ b/web/src/components/library/CollectionNav.tsx
@@ -4,9 +4,36 @@
 // `RouteLink` (so back/forward and the shared router stay authoritative)
 // and the existing `.btn`/`.btn-primary`/`.btn-secondary` classes for the
 // active/inactive look; no new CSS.
+//
+// P2-18: grouped by project (`collection.projectId`/`projectName`, already
+// joined server-side — see `api/types.rs`'s `CollectionDto` doc) under a
+// heading per project, with a final "Chưa thuộc dự án" group for anything
+// unassigned. Groups are ordered by project name, "Chưa thuộc dự án" last;
+// within a group, collections keep the server's own order (already
+// alphabetical — `db::collections::list`) so this file never re-sorts
+// data the server already ordered.
 import { RouteLink } from '../RouteLink';
 import { buildScopedPath } from '../../lib/router';
 import type { Collection } from './types';
+
+const UNASSIGNED_LABEL = 'Chưa thuộc dự án';
+
+function groupByProject(collections: Collection[]): { label: string; items: Collection[] }[] {
+  const groups = new Map<string, { label: string; items: Collection[] }>();
+  for (const collection of collections) {
+    const key = collection.projectId ?? '';
+    const label = collection.projectId ? (collection.projectName ?? '') : UNASSIGNED_LABEL;
+    const group = groups.get(key) ?? { label, items: [] };
+    group.items.push(collection);
+    groups.set(key, group);
+  }
+  const assigned = [...groups.entries()]
+    .filter(([key]) => key !== '')
+    .map(([, group]) => group)
+    .sort((a, b) => a.label.localeCompare(b.label));
+  const unassigned = groups.get('');
+  return unassigned ? [...assigned, unassigned] : assigned;
+}
 
 export function CollectionNav({
   collections,
@@ -23,24 +50,37 @@ export function CollectionNav({
   if (collections.length === 0) {
     return <p className="text-muted">Chưa có bộ sưu tập nào.</p>;
   }
+  const groups = groupByProject(collections);
   return (
     <nav
       aria-label="Điều hướng bộ sưu tập"
-      style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-2)' }}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}
     >
-      {collections.map((collection) => {
-        const isActive = collection.id === activeCollectionId;
-        return (
-          <RouteLink
-            key={collection.id}
-            to={buildScopedPath('library', collection.id)}
-            className={`btn btn-sm ${isActive ? 'btn-primary' : 'btn-secondary'}`}
-            aria-current={isActive ? 'page' : undefined}
-          >
-            {collection.name}
-          </RouteLink>
-        );
-      })}
+      {groups.map((group) => (
+        <div
+          key={group.label}
+          style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}
+        >
+          <p className="eyebrow" style={{ margin: 0 }}>
+            {group.label}
+          </p>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-2)' }}>
+            {group.items.map((collection) => {
+              const isActive = collection.id === activeCollectionId;
+              return (
+                <RouteLink
+                  key={collection.id}
+                  to={buildScopedPath('library', collection.id)}
+                  className={`btn btn-sm ${isActive ? 'btn-primary' : 'btn-secondary'}`}
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  {collection.name}
+                </RouteLink>
+              );
+            })}
+          </div>
+        </div>
+      ))}
     </nav>
   );
 }

--- a/web/src/components/library/ProjectsPanel.test.tsx
+++ b/web/src/components/library/ProjectsPanel.test.tsx
@@ -1,0 +1,115 @@
+// P2-18. Unlike `LibraryPage.test.tsx`'s bare-`client`-injection convention,
+// `ProjectsPanel` reads the signed-in caller's permissions via
+// `useAuth().hasPermission` (to gate the whole panel), so this file wraps in
+// a real `AuthProvider` and restores its session the same way
+// `AdminMembersPage.test.tsx` does — a raw `client.login()` call
+// `AuthProvider` would never observe.
+import { useState } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApiClient, type ApiClient } from '../../api/client';
+import { AuthProvider } from '../../auth/AuthContext';
+import { useScopeSafeRequest } from '../../hooks/useScopeSafeRequest';
+import { installMockFetch, resetMockState, uninstallMockFetch } from '../../mocks';
+import { getStore, mintTokenPair, ORG_A_ID } from '../../mocks/fixtures';
+import { ScopeProvider } from '../../state/ScopeProvider';
+import { grantDocUpload } from './testSupport';
+import { ProjectsPanel } from './ProjectsPanel';
+
+function seedSession(withDocUpload: boolean): ApiClient {
+  const client = createApiClient({ baseUrl: '' });
+  if (withDocUpload) grantDocUpload();
+  const [user] = getStore().users;
+  const { refreshToken } = mintTokenPair(user, ORG_A_ID);
+  window.sessionStorage.setItem('markhand.refreshToken', refreshToken);
+  return client;
+}
+
+/** Owns a real `GET /collections` fetch + refetch-on-`onChanged`, the same
+ * way `LibraryPage` does — `ProjectsPanel` itself never refetches
+ * collections (that's the caller's job), so this wrapper is needed for the
+ * assigned/unassigned `<select>` value to actually update after a mutation. */
+function Harness({ client }: { client: ApiClient }) {
+  const [retry, setRetry] = useState(0);
+  // `useScopeSafeRequest` (not a bare `client.request(...).then(...)`) so
+  // this tolerates the same "AuthProvider hasn't finished restoring the
+  // session yet" window every other real page in this codebase already
+  // handles — a bare call here would otherwise throw `NoSessionError` on
+  // the harness's very first render.
+  const result = useScopeSafeRequest(
+    (signal) => client.request('get', '/collections', { signal }),
+    [client, retry],
+  );
+  return (
+    <ProjectsPanel
+      collections={result.data?.items ?? []}
+      client={client}
+      onChanged={() => setRetry((n) => n + 1)}
+    />
+  );
+}
+
+function renderPanel(client: ApiClient) {
+  return render(
+    <ScopeProvider>
+      <AuthProvider client={client}>
+        <Harness client={client} />
+      </AuthProvider>
+    </ScopeProvider>,
+  );
+}
+
+describe('ProjectsPanel', () => {
+  beforeEach(() => {
+    installMockFetch();
+    resetMockState();
+  });
+
+  afterEach(() => {
+    cleanup();
+    uninstallMockFetch();
+  });
+
+  it('renders nothing for a caller without doc.upload', async () => {
+    const client = seedSession(false);
+    renderPanel(client);
+    // `hasPermission` is `false` both before and after the AuthProvider's
+    // session restore settles (missing permission, not missing session), so
+    // there is no in-between state where the heading could flash — waiting
+    // a macrotask (`setTimeout`) is enough to prove it never appears at all
+    // rather than merely "not yet".
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByText('Dự án')).not.toBeInTheDocument();
+  });
+
+  it('creates a project and assigns/unassigns a collection to it for a doc.upload holder', async () => {
+    const client = seedSession(true);
+    renderPanel(client);
+
+    expect(await screen.findByRole('heading', { name: 'Dự án' })).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText('Tên dự án mới'), { target: { value: 'Marketing' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Tạo dự án' }));
+    await waitFor(() => expect(screen.getByLabelText('Tên dự án mới')).toHaveValue(''));
+
+    // Seeded: Product Specs (mockUuid(11)) starts unassigned. Re-queried
+    // fresh (not held across the assign) because `onChanged`'s retry makes
+    // `useScopeSafeRequest` report `data: undefined` for the whole re-run
+    // (see that hook's own doc), which unmounts and remounts this row's
+    // `<select>` while the collections refetch is in flight.
+    const findAssignSelect = () =>
+      screen.findByRole('combobox', { name: 'Dự án cho bộ sưu tập Product Specs' });
+    expect(await findAssignSelect()).toHaveTextContent('Chưa thuộc dự án');
+    fireEvent.click(await findAssignSelect());
+    fireEvent.click(await screen.findByRole('option', { name: 'Marketing' }));
+
+    await waitFor(async () => expect(await findAssignSelect()).toHaveTextContent('Marketing'));
+
+    // Unassign again — `projectId: null`.
+    fireEvent.click(await findAssignSelect());
+    fireEvent.click(await screen.findByRole('option', { name: 'Chưa thuộc dự án' }));
+    await waitFor(async () =>
+      expect(await findAssignSelect()).toHaveTextContent('Chưa thuộc dự án'),
+    );
+  });
+});

--- a/web/src/components/library/ProjectsPanel.tsx
+++ b/web/src/components/library/ProjectsPanel.tsx
@@ -1,0 +1,153 @@
+// P2-18 — simple project management: create a project + assign/unassign
+// collections to one. Deliberately placed inside the Library page (not a new
+// top-level admin route): projects exist purely to organize collections,
+// which the Library page already owns the nav/CRUD context for (see
+// `CollectionNav.tsx`'s grouping), so this keeps project management next to
+// the thing it organizes instead of adding a new rail destination + router
+// entry + `RouteGuard` wiring for what the owner scoped as "simple"
+// (create + assign/unassign, no delete). Gated by `hasPermission('doc.upload')`
+// — same permission `POST /projects`/`POST /collections/{id}/assign-project`
+// require server-side (see `routes::projects`'s module doc); this is UI
+// convenience only, the server's 403 is the real authority, same caveat
+// `AdminMembersPage.tsx`'s module doc makes about its own owner-tier gating.
+import { useState, type FormEvent } from 'react';
+import { apiClient, type ApiClient } from '../../api/client';
+import { useAuth } from '../../auth/AuthContext';
+import { useScopeSafeRequest } from '../../hooks/useScopeSafeRequest';
+import { useScope } from '../../state/ScopeProvider';
+import { Notice, SelectControl } from '../ui';
+import { describeApiError } from './documentPresentation';
+import type { Collection } from './types';
+
+export function ProjectsPanel({
+  collections,
+  client = apiClient,
+  onChanged,
+}: {
+  collections: Collection[];
+  client?: ApiClient;
+  /** Called after a successful create or assign/unassign so the caller (LibraryPage) can refetch `GET /collections` and pick up the new `projectId`/`projectName`. */
+  onChanged?: () => void;
+}) {
+  const { hasPermission } = useAuth();
+  const { epoch } = useScope();
+  const canManage = hasPermission('doc.upload');
+
+  const [projectsRetry, setProjectsRetry] = useState(0);
+  const projectsResult = useScopeSafeRequest(
+    (signal) => client.request('get', '/projects', { signal }),
+    [client, projectsRetry, epoch],
+  );
+  const projects = projectsResult.data?.items ?? [];
+
+  const [name, setName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<unknown>(undefined);
+
+  async function createProject(event: FormEvent) {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (trimmed === '' || creating) return;
+    setCreating(true);
+    setCreateError(undefined);
+    try {
+      await client.request('post', '/projects', { body: { name: trimmed } });
+      setName('');
+      setProjectsRetry((n) => n + 1);
+      onChanged?.();
+    } catch (error) {
+      setCreateError(error);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  const [assigningId, setAssigningId] = useState<string | undefined>(undefined);
+  const [assignError, setAssignError] = useState<unknown>(undefined);
+
+  async function assign(collectionId: string, projectId: string): Promise<void> {
+    setAssigningId(collectionId);
+    setAssignError(undefined);
+    try {
+      await client.request('post', '/collections/{collectionId}/assign-project', {
+        params: { path: { collectionId } },
+        body: { projectId: projectId === '' ? null : projectId },
+      });
+      onChanged?.();
+    } catch (error) {
+      setAssignError(error);
+    } finally {
+      setAssigningId(undefined);
+    }
+  }
+
+  if (!canManage) return null;
+
+  const projectOptions = [
+    { value: '', label: 'Chưa thuộc dự án' },
+    ...projects.map((p) => ({ value: p.id, label: p.name })),
+  ];
+
+  return (
+    <div
+      className="card"
+      aria-labelledby="projects-panel-heading"
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}
+    >
+      <h2 id="projects-panel-heading" className="card-title">
+        Dự án
+      </h2>
+      <p className="text-muted">
+        Nhóm bộ sưu tập theo dự án để hỏi đáp và duyệt thư viện theo phạm vi hẹp hơn.
+      </p>
+
+      <form
+        onSubmit={createProject}
+        style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'flex-end', flexWrap: 'wrap' }}
+      >
+        <div className="field" style={{ flex: '1 1 200px' }}>
+          <label htmlFor="new-project-name">Tên dự án mới</label>
+          <input
+            id="new-project-name"
+            className="input"
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Ví dụ: Nhân sự"
+          />
+        </div>
+        <button type="submit" className="btn btn-primary" disabled={name.trim() === '' || creating}>
+          Tạo dự án
+        </button>
+      </form>
+      {createError !== undefined && <Notice tone="error">{describeApiError(createError)}</Notice>}
+
+      {collections.length > 0 && (
+        <div style={{ display: 'grid', gap: 'var(--space-2)' }}>
+          <p className="field-label">Gán bộ sưu tập vào dự án</p>
+          {collections.map((collection) => (
+            <div
+              key={collection.id}
+              style={{
+                display: 'flex',
+                gap: 'var(--space-2)',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+              }}
+            >
+              <span style={{ minWidth: '12rem' }}>{collection.name}</span>
+              <SelectControl
+                value={collection.projectId ?? ''}
+                options={projectOptions}
+                onChange={(value) => void assign(collection.id, value)}
+                ariaLabel={`Dự án cho bộ sưu tập ${collection.name}`}
+              />
+              {assigningId === collection.id && <span className="text-muted">Đang lưu…</span>}
+            </div>
+          ))}
+        </div>
+      )}
+      {assignError !== undefined && <Notice tone="error">{describeApiError(assignError)}</Notice>}
+    </div>
+  );
+}

--- a/web/src/components/library/index.ts
+++ b/web/src/components/library/index.ts
@@ -4,6 +4,7 @@ export { DocumentList } from './DocumentList';
 export { DocumentPreview, type PreviewLoadState } from './DocumentPreview';
 export { DocumentStateBadge } from './DocumentStateBadge';
 export { Pagination } from './Pagination';
+export { ProjectsPanel } from './ProjectsPanel';
 export {
   DOCUMENT_STATE_META,
   describeApiError,
@@ -11,4 +12,4 @@ export {
   formatDateTime,
   matchesQuery,
 } from './documentPresentation';
-export type { Collection, DocumentState, LibraryDocument, PageInfo } from './types';
+export type { Collection, DocumentState, LibraryDocument, PageInfo, Project } from './types';

--- a/web/src/components/library/testSupport.ts
+++ b/web/src/components/library/testSupport.ts
@@ -1,0 +1,18 @@
+// Shared test-only plumbing for `components/library/**`'s P2-18 coverage.
+// Not imported by any production file — same convention as
+// `components/admin/testSupport.ts`'s `grantMemberManage()`.
+import { getStore } from '../../mocks/fixtures';
+
+/**
+ * Grants the seeded demo user `doc.upload` in place, so a test can drive
+ * `ProjectsPanel` (create project / assign collection) as a permitted
+ * caller. The demo user does not have this permission by default — see
+ * `mocks/fixtures.ts`'s own note on `DEMO_USER` — so this exists rather than
+ * changing that shared default. Idempotent; call after `resetMockState()`.
+ */
+export function grantDocUpload(): void {
+  const [user] = getStore().users;
+  if (!user.permissions.includes('doc.upload')) {
+    user.permissions.push('doc.upload');
+  }
+}

--- a/web/src/components/library/types.ts
+++ b/web/src/components/library/types.ts
@@ -9,3 +9,5 @@ export type Collection = components['schemas']['Collection'];
 export type LibraryDocument = components['schemas']['Document'];
 export type DocumentState = LibraryDocument['state'];
 export type PageInfo = components['schemas']['PageInfo'];
+/** P2-18 — org -> project -> collection -> document grouping. */
+export type Project = components['schemas']['Project'];

--- a/web/src/components/qa/ChatPanel.tsx
+++ b/web/src/components/qa/ChatPanel.tsx
@@ -77,11 +77,23 @@ export function ChatPanel({
   collectionIds,
   client = apiClient,
   candidateDocuments,
+  onScopeChange,
 }: {
   collectionIds?: string[];
   client?: ApiClient;
   /** Documents a search already found — feeds the compare/history document picker below instead of asking for a raw UUID. */
   candidateDocuments: SearchHit[];
+  /**
+   * P2-18 — the "Phạm vi" (scope) dropdown lives in this composer, but its
+   * value must also filter `SearchPanel`'s request (a sibling component
+   * `QaPage` renders above this one) — this callback is how the selection
+   * reaches it, without lifting the dropdown's UI itself out of the
+   * composer. Called with `undefined` for "Tất cả dự án" (no filter, today's
+   * exact behavior) and once more with `undefined` whenever the org switches
+   * (see the epoch-reset handling below) — never left pointing at a
+   * previous org's project id.
+   */
+  onScopeChange?: (projectId: string | undefined) => void;
 }) {
   const questionId = useId();
   const asOfId = useId();
@@ -93,6 +105,35 @@ export function ChatPanel({
   const [documentId, setDocumentId] = useState('');
   const [versionA, setVersionA] = useState('');
   const [versionB, setVersionB] = useState('');
+
+  // "Phạm vi" (project scope) — reset to "Tất cả dự án" on an org switch,
+  // same {epoch, ...} reset idiom `chat` (below) already uses.
+  const [scope, setScope] = useState<{ epoch: number; projectId: string | undefined }>(() => ({
+    epoch,
+    projectId: undefined,
+  }));
+  let projectId = scope.projectId;
+  if (scope.epoch !== epoch) {
+    projectId = undefined;
+    setScope({ epoch, projectId });
+  }
+  const projectsResult = useScopeSafeRequest(
+    (signal) => client.request('get', '/projects', { signal }),
+    [client],
+  );
+  const projects = projectsResult.data?.items ?? [];
+  const scopeOptions: SelectOption[] = [
+    { value: '', label: 'Tất cả dự án' },
+    ...projects.map((p) => ({ value: p.id, label: p.name })),
+  ];
+  // Reports the effective projectId to the parent exactly once per change
+  // (including the epoch-reset above) — same adjust-state-while-rendering
+  // idiom `SearchPanel.tsx`'s `onHitsChanged` reporting uses.
+  const [reportedProjectId, setReportedProjectId] = useState<string | undefined>(undefined);
+  if (reportedProjectId !== projectId) {
+    setReportedProjectId(projectId);
+    onScopeChange?.(projectId);
+  }
 
   // The chat history itself, scoped to the epoch it was built under — see
   // this file's module doc for why a plain `useState<ChatTurn[]>` is not
@@ -168,6 +209,7 @@ export function ChatPanel({
     event.preventDefault();
     if (question.trim() === '' || busy) return;
     const request: AskRequest = { question, collectionIds, mode, limit: 10 };
+    if (projectId) request.projectId = projectId;
     if (mode === 'as_of' && asOf) request.asOf = new Date(asOf).toISOString();
     if (needsDocument && documentId) request.documentId = documentId;
     if (mode === 'compare') {
@@ -244,6 +286,18 @@ export function ChatPanel({
             alignItems: 'flex-end',
           }}
         >
+          <div>
+            <span id="qa-scope-label" className="field-label">
+              Phạm vi
+            </span>
+            <SelectControl
+              value={projectId ?? ''}
+              options={scopeOptions}
+              onChange={(value) => setScope({ epoch, projectId: value || undefined })}
+              ariaLabel="Phạm vi dự án"
+            />
+          </div>
+
           <div>
             <span id="qa-mode-label" className="field-label">
               Chế độ truy vấn

--- a/web/src/components/qa/ChatPanel.tsx
+++ b/web/src/components/qa/ChatPanel.tsx
@@ -153,7 +153,11 @@ export function ChatPanel({
       ...new Map(
         candidateDocuments.filter((h) => h.documentId).map((h) => [h.documentId!, h]),
       ).values(),
-    ].map((h) => ({ value: h.documentId!, label: h.title ?? h.documentId! })),
+      // `title` is optional (see this file's + `SearchPanel.tsx`'s own module
+      // docs: `hits` has no fixed wire shape) — the option label must never
+      // fall back to the raw `documentId` uuid, so an untitled hit reads as
+      // "Tài liệu không có tiêu đề" instead.
+    ].map((h) => ({ value: h.documentId!, label: h.title ?? 'Tài liệu không có tiêu đề' })),
   ];
   const versionOptions: SelectOption[] = versions.map((v) => ({
     value: v.id,

--- a/web/src/components/qa/SearchPanel.tsx
+++ b/web/src/components/qa/SearchPanel.tsx
@@ -40,10 +40,13 @@ function toSearchHit(raw: Record<string, unknown>): SearchHit {
 
 export function SearchPanel({
   collectionIds,
+  projectId,
   client = apiClient,
   onHitsChanged,
 }: {
   collectionIds?: string[];
+  /** P2-18 — "Phạm vi" selection from `ChatPanel`'s composer, lifted through `QaPage` (see `ChatPanel`'s `onScopeChange` doc for why the dropdown itself stays in the composer). `undefined` = "Tất cả dự án" (today's exact behavior). */
+  projectId?: string;
   client?: ApiClient;
   /** Lets `ChatPanel`'s compare/history document picker reuse whichever documents a search already turned up, instead of asking the user to type a UUID. */
   onHitsChanged?: (hits: SearchHit[]) => void;
@@ -57,11 +60,11 @@ export function SearchPanel({
     async (signal) => {
       if (submitted === undefined) return null;
       return client.request('post', '/search', {
-        body: { query: submitted, collectionIds, limit: 10 },
+        body: { query: submitted, collectionIds, projectId, limit: 10 },
         signal,
       });
     },
-    [client, submitted, collectionIds?.join(',')],
+    [client, submitted, collectionIds?.join(','), projectId],
   );
 
   const hits = (result.data?.hits ?? []).map((h) => toSearchHit(h as Record<string, unknown>));

--- a/web/src/components/shell/Rail.tsx
+++ b/web/src/components/shell/Rail.tsx
@@ -9,6 +9,7 @@ import {
   Gauge,
   Library,
   MessageCircleQuestion,
+  Network,
   PanelLeftClose,
   PanelLeftOpen,
   Users,
@@ -57,14 +58,17 @@ interface RailDestination {
  * Primary destinations shown as rail icons. Deliberately excludes `login`
  * (public-only — the rail itself is not rendered on that route, see App.tsx)
  * and does not invent a separate "upload" destination: the router
- * (`types/routes.ts`) has no `/upload` route — the P2.3 route list is
- * `/login`, `/library`, `/qa`, `/admin/members`, `/admin/usage`, `/help` —
- * so "upload" from the shell brief lives inside LibraryPage's own UI, not as
- * a rail-level navigation target.
+ * (`types/routes.ts`) has no `/upload` route — the route list is
+ * `/login`, `/library`, `/qa`, `/graph`, `/admin/members`, `/admin/usage`,
+ * `/help` — so "upload" from the shell brief lives inside LibraryPage's own
+ * UI, not as a rail-level navigation target. `graph` (P2-17, "Đồ thị") is
+ * the newest addition — a read-only cross-document view, so it sits right
+ * after `qa` rather than grouped with the admin-only destinations below it.
  */
 const RAIL_DESTINATIONS: RailDestination[] = [
   { route: 'library', to: '/library', label: 'Thư viện', Icon: Library },
   { route: 'qa', to: '/qa', label: 'Hỏi đáp', Icon: MessageCircleQuestion },
+  { route: 'graph', to: '/graph', label: 'Đồ thị', Icon: Network },
   { route: 'adminMembers', to: '/admin/members', label: 'Thành viên', Icon: Users },
   { route: 'adminUsage', to: '/admin/usage', label: 'Sử dụng', Icon: Gauge },
   { route: 'help', to: '/help', label: 'Trợ giúp', Icon: CircleHelp },

--- a/web/src/lib/forceLayout.test.ts
+++ b/web/src/lib/forceLayout.test.ts
@@ -68,4 +68,134 @@ describe('computeForceLayout', () => {
     const layout = computeForceLayout(['a', 'b'], [{ source: 'a', target: 'ghost' }]);
     expect(layout.size).toBe(2);
   });
+
+  // Regression coverage for the post-nghiệm-thu visual defect (#8aeb539):
+  // the first cut's repulsion overpowered its centering pull for small
+  // graphs, so every node piled up against the canvas boundary (a "hollow
+  // rectangle") instead of clustering near the center. These two tests
+  // assert the shape of the fix directly — not just "some pixel moved" —
+  // using the same 13-node/3-community topology as the seeded mock graph
+  // (`mocks/handlers/graph.ts`), recreated inline here rather than imported
+  // so this test has no dependency on that fixture module.
+  describe('clustering near center (regression: nodes must not pile up at the canvas edge)', () => {
+    const THREE_CLUSTER_NODES = [
+      'n200', 'n201', 'n202', 'n203', 'n204', // cluster 1 (5 nodes)
+      'n205', 'n206', 'n207', 'n208', 'n209', // cluster 2 (5 nodes)
+      'n210', 'n211', 'n212', // cluster 3 (3 nodes)
+    ];
+    const THREE_CLUSTER_EDGES = [
+      { source: 'n200', target: 'n201' },
+      { source: 'n201', target: 'n202' },
+      { source: 'n200', target: 'n203' },
+      { source: 'n203', target: 'n204' },
+      { source: 'n200', target: 'n204' },
+      { source: 'n205', target: 'n206' },
+      { source: 'n206', target: 'n207' },
+      { source: 'n208', target: 'n209' },
+      { source: 'n207', target: 'n208' },
+      { source: 'n210', target: 'n211' },
+      { source: 'n211', target: 'n212' },
+      { source: 'n210', target: 'n212' },
+    ];
+    const WIDTH = 640;
+    const HEIGHT = 480;
+
+    function centroidOf(layout: Map<string, { x: number; y: number }>, ids: string[]) {
+      let x = 0;
+      let y = 0;
+      for (const id of ids) {
+        const p = layout.get(id)!;
+        x += p.x;
+        y += p.y;
+      }
+      return { x: x / ids.length, y: y / ids.length };
+    }
+
+    function averagePairDistance(layout: Map<string, { x: number; y: number }>, ids: string[]) {
+      let sum = 0;
+      let count = 0;
+      for (let i = 0; i < ids.length; i += 1) {
+        for (let j = i + 1; j < ids.length; j += 1) {
+          const a = layout.get(ids[i])!;
+          const b = layout.get(ids[j])!;
+          sum += Math.hypot(a.x - b.x, a.y - b.y);
+          count += 1;
+        }
+      }
+      return count > 0 ? sum / count : 0;
+    }
+
+    it('keeps every node within a comfortable margin of the canvas edges — none pinned to a wall', () => {
+      const layout = computeForceLayout(THREE_CLUSTER_NODES, THREE_CLUSTER_EDGES, {
+        width: WIDTH,
+        height: HEIGHT,
+      });
+      // A wide margin (not "exactly centered") — the point is "not stuck on
+      // the boundary", matching the owner's acceptance bar ("không node nào
+      // dính mép trừ khi đồ thị quá đông").
+      const margin = 60;
+      for (const id of THREE_CLUSTER_NODES) {
+        const p = layout.get(id)!;
+        expect(p.x).toBeGreaterThan(margin);
+        expect(p.x).toBeLessThan(WIDTH - margin);
+        expect(p.y).toBeGreaterThan(margin);
+        expect(p.y).toBeLessThan(HEIGHT - margin);
+      }
+    });
+
+    it('contracts each community close together while keeping communities visibly separated', () => {
+      const layout = computeForceLayout(THREE_CLUSTER_NODES, THREE_CLUSTER_EDGES, {
+        width: WIDTH,
+        height: HEIGHT,
+      });
+      const cluster1 = THREE_CLUSTER_NODES.slice(0, 5);
+      const cluster2 = THREE_CLUSTER_NODES.slice(5, 10);
+      const cluster3 = THREE_CLUSTER_NODES.slice(10, 13);
+
+      const intra1 = averagePairDistance(layout, cluster1);
+      const intra2 = averagePairDistance(layout, cluster2);
+      const intra3 = averagePairDistance(layout, cluster3);
+
+      const centroid1 = centroidOf(layout, cluster1);
+      const centroid2 = centroidOf(layout, cluster2);
+      const centroid3 = centroidOf(layout, cluster3);
+      const inter12 = Math.hypot(centroid1.x - centroid2.x, centroid1.y - centroid2.y);
+      const inter13 = Math.hypot(centroid1.x - centroid3.x, centroid1.y - centroid3.y);
+      const inter23 = Math.hypot(centroid2.x - centroid3.x, centroid2.y - centroid3.y);
+
+      // Every community's own average spread is clearly tighter than the
+      // distance between any two communities' centroids — the visual
+      // signature of "distinct clusters", not "one uniform cloud".
+      for (const intra of [intra1, intra2, intra3]) {
+        expect(intra).toBeLessThan(inter12 * 0.75);
+        expect(intra).toBeLessThan(inter13 * 0.75);
+        expect(intra).toBeLessThan(inter23 * 0.75);
+      }
+    });
+
+    it('centers the whole graph\'s bounding box near the canvas center, not off in a corner', () => {
+      const layout = computeForceLayout(THREE_CLUSTER_NODES, THREE_CLUSTER_EDGES, {
+        width: WIDTH,
+        height: HEIGHT,
+      });
+      let minX = Infinity;
+      let maxX = -Infinity;
+      let minY = Infinity;
+      let maxY = -Infinity;
+      for (const id of THREE_CLUSTER_NODES) {
+        const p = layout.get(id)!;
+        minX = Math.min(minX, p.x);
+        maxX = Math.max(maxX, p.x);
+        minY = Math.min(minY, p.y);
+        maxY = Math.max(maxY, p.y);
+      }
+      const bboxCenterX = (minX + maxX) / 2;
+      const bboxCenterY = (minY + maxY) / 2;
+      // Within a generous quarter of the canvas from true center — enough to
+      // catch "everything piled in one corner" without demanding
+      // pixel-perfect centering from a physical simulation.
+      expect(Math.abs(bboxCenterX - WIDTH / 2)).toBeLessThan(WIDTH / 4);
+      expect(Math.abs(bboxCenterY - HEIGHT / 2)).toBeLessThan(HEIGHT / 4);
+    });
+  });
 });

--- a/web/src/lib/forceLayout.test.ts
+++ b/web/src/lib/forceLayout.test.ts
@@ -79,9 +79,19 @@ describe('computeForceLayout', () => {
   // so this test has no dependency on that fixture module.
   describe('clustering near center (regression: nodes must not pile up at the canvas edge)', () => {
     const THREE_CLUSTER_NODES = [
-      'n200', 'n201', 'n202', 'n203', 'n204', // cluster 1 (5 nodes)
-      'n205', 'n206', 'n207', 'n208', 'n209', // cluster 2 (5 nodes)
-      'n210', 'n211', 'n212', // cluster 3 (3 nodes)
+      'n200',
+      'n201',
+      'n202',
+      'n203',
+      'n204', // cluster 1 (5 nodes)
+      'n205',
+      'n206',
+      'n207',
+      'n208',
+      'n209', // cluster 2 (5 nodes)
+      'n210',
+      'n211',
+      'n212', // cluster 3 (3 nodes)
     ];
     const THREE_CLUSTER_EDGES = [
       { source: 'n200', target: 'n201' },
@@ -173,7 +183,7 @@ describe('computeForceLayout', () => {
       }
     });
 
-    it('centers the whole graph\'s bounding box near the canvas center, not off in a corner', () => {
+    it("centers the whole graph's bounding box near the canvas center, not off in a corner", () => {
       const layout = computeForceLayout(THREE_CLUSTER_NODES, THREE_CLUSTER_EDGES, {
         width: WIDTH,
         height: HEIGHT,

--- a/web/src/lib/forceLayout.test.ts
+++ b/web/src/lib/forceLayout.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { computeForceLayout } from './forceLayout';
+
+describe('computeForceLayout', () => {
+  it('is deterministic: the same input yields the exact same positions every time', () => {
+    const nodeIds = ['a', 'b', 'c', 'd'];
+    const edges = [
+      { source: 'a', target: 'b' },
+      { source: 'b', target: 'c' },
+    ];
+    const first = computeForceLayout(nodeIds, edges);
+    const second = computeForceLayout(nodeIds, edges);
+    expect([...second.entries()]).toEqual([...first.entries()]);
+  });
+
+  it('is independent of input ordering', () => {
+    const edgesA = [
+      { source: 'a', target: 'b' },
+      { source: 'b', target: 'c' },
+    ];
+    const edgesB = [
+      { source: 'b', target: 'c' },
+      { source: 'a', target: 'b' },
+    ];
+    const layoutA = computeForceLayout(['a', 'b', 'c', 'd'], edgesA);
+    const layoutB = computeForceLayout(['d', 'c', 'b', 'a'], edgesB);
+    expect([...layoutB.entries()]).toEqual([...layoutA.entries()]);
+  });
+
+  it('gives every requested node a finite position', () => {
+    const nodeIds = ['a', 'b', 'c', 'd', 'e'];
+    const edges = [{ source: 'a', target: 'b' }];
+    const layout = computeForceLayout(nodeIds, edges);
+    expect(layout.size).toBe(nodeIds.length);
+    for (const id of nodeIds) {
+      const position = layout.get(id)!;
+      expect(Number.isFinite(position.x)).toBe(true);
+      expect(Number.isFinite(position.y)).toBe(true);
+    }
+  });
+
+  it('places a single isolated node at the canvas center', () => {
+    const layout = computeForceLayout(['only'], [], { width: 640, height: 480 });
+    expect(layout.get('only')).toEqual({ x: 320, y: 240 });
+  });
+
+  it('returns an empty map for no nodes', () => {
+    const layout = computeForceLayout([], []);
+    expect(layout.size).toBe(0);
+  });
+
+  it('pulls a connected pair closer together than two unconnected nodes, relatively', () => {
+    // Two components: {a-b connected}, {c, d unconnected}. Connected nodes
+    // should end up closer to each other than to a same-size unconnected pair.
+    const nodeIds = ['a', 'b', 'c', 'd'];
+    const edges = [{ source: 'a', target: 'b' }];
+    const layout = computeForceLayout(nodeIds, edges, { iterations: 200 });
+    const dist = (x: string, y: string) => {
+      const p = layout.get(x)!;
+      const q = layout.get(y)!;
+      return Math.hypot(p.x - q.x, p.y - q.y);
+    };
+    expect(dist('a', 'b')).toBeLessThan(dist('a', 'c'));
+    expect(dist('a', 'b')).toBeLessThan(dist('a', 'd'));
+  });
+
+  it('ignores edges referencing an id outside nodeIds rather than throwing', () => {
+    const layout = computeForceLayout(['a', 'b'], [{ source: 'a', target: 'ghost' }]);
+    expect(layout.size).toBe(2);
+  });
+});

--- a/web/src/lib/forceLayout.ts
+++ b/web/src/lib/forceLayout.ts
@@ -1,13 +1,40 @@
 // P2-17 Document Graph MVP: a small, hand-rolled force-directed layout
 // (Fruchterman-Reingold style — repulsion between every pair, spring
-// attraction along edges, mild centering pull, cooling temperature) instead
-// of a `d3-force` dependency. ~100 lines, deterministic given the same
-// node/edge input: positions come from a seeded PRNG
-// (`mulberry32`, not `Math.random`) and nodes are processed in a
-// canonicalized (sorted) order regardless of the order the caller passed
-// them in, so `GraphPage.test.tsx`/`forceLayout.test.ts` get the exact same
-// layout on every run. See the P2-17 report for the trade-off note on why
-// this is hand-rolled rather than a dependency.
+// attraction along edges, gravity toward the canvas center, cooling
+// temperature) instead of a `d3-force` dependency. Deterministic given the
+// same node/edge input: positions come from a seeded PRNG (`mulberry32`, not
+// `Math.random`) and nodes are processed in a canonicalized (sorted) order
+// regardless of the order the caller passed them in, so
+// `GraphPage.test.tsx`/`forceLayout.test.ts` get the exact same layout on
+// every run. See the P2-17 report for the trade-off note on why this is
+// hand-rolled rather than a dependency.
+//
+// Tuning note (visual defect fix, post-nghiệm-thu #8aeb539): the first cut of
+// this module derived its repulsion/attraction scale `k` from
+// `sqrt(canvasArea / nodeCount)` with only a token 1%-of-gap centering pull
+// applied *after* the temperature cap. For a small graph (the seeded mock's
+// 13 nodes) that made `k` — and therefore repulsion — large relative to the
+// canvas, while the centering pull was too weak to ever compete with it: every
+// node's true equilibrium distance from center sat *outside* the canvas, so
+// each iteration pushed everything outward until the boundary clamp caught
+// it — nodes piling up along the four edges/corners (a hollow rectangle)
+// instead of clustering. The fix has two parts:
+//   1. `k` (the ideal spring/repulsion length) is now a fixed constant
+//      independent of canvas size or node count, so repulsion strength
+//      doesn't blow up for small graphs.
+//   2. Gravity toward the center is folded into the *same*
+//      temperature-capped displacement budget as repulsion/attraction
+//      (proportional to distance from center, like a spring anchored at the
+//      canvas center) instead of being a separate, weak, uncapped nudge.
+//      Because it now competes fairly with repulsion inside one capped
+//      vector, the simulation settles at a genuine equilibrium radius well
+//      inside the canvas rather than at whatever wall it happened to hit —
+//      the boundary clamp is left in only as a safety net for pathological
+//      inputs, not something the normal case ever reaches.
+// Re-tuned constants were verified by inspecting actual computed positions
+// (bounding box / pairwise distances) for the seeded 13-node/3-community mock
+// graph, then confirmed visually via a Playwright screenshot of the real
+// GraphPage (see the report for the screenshot path) before landing.
 
 export interface LayoutEdge {
   source: string;
@@ -39,10 +66,47 @@ function mulberry32(seed: number): () => number {
 }
 
 /**
+ * Ideal edge length ("k" in Fruchterman-Reingold terms) — a fixed constant,
+ * NOT derived from canvas area or node count. Keeping it fixed is what keeps
+ * repulsion (which scales with `k^2`) from overpowering gravity on a small
+ * graph; a larger graph instead relies on more nodes competing for the same
+ * gravity well, which naturally spreads them further from center, still
+ * bounded (see `GRAVITY_STRENGTH`'s doc below).
+ */
+const IDEAL_EDGE_LENGTH = 45;
+/** Multiplies the repulsion force (`k^2 / distance`) between every pair. */
+const REPULSION_STRENGTH = 1;
+/** Multiplies the spring/attraction force (`distance^2 / k`) along edges — kept above 1 so same-community nodes visibly contract toward each other rather than merely resisting repulsion. */
+const SPRING_STRENGTH = 2.2;
+/**
+ * Multiplies the gravity force pulling every node toward the canvas center,
+ * proportional to its current distance from center (a spring anchored at
+ * center). This is what bounds the whole layout to a cluster near the
+ * middle instead of the repulsion-only system's "expand until the wall"
+ * behavior — see this module's top-of-file doc for the incident this fixes.
+ *
+ * Sized (along with `IDEAL_EDGE_LENGTH`) from the equilibrium-radius
+ * approximation `radius ≈ k * sqrt((n - 1) / GRAVITY_STRENGTH)` for a
+ * roughly-uniform repulsion/gravity balance: for the seeded mock's 13-node
+ * graph this keeps the whole layout's radius around ~140px — comfortably
+ * inside a 640×480 canvas — while `SPRING_STRENGTH` still contracts each
+ * community's own nodes down to a much tighter ~30px spread, so clusters
+ * read as visually distinct clumps rather than one uniform cloud. Verified
+ * both numerically (bounding box / pairwise distances) and visually (a
+ * Playwright screenshot of the real `GraphPage`) — see the P2-17 report.
+ */
+const GRAVITY_STRENGTH = 0.85;
+
+function computeInitialTemperature(width: number, height: number): number {
+  return Math.min(width, height) / 8;
+}
+
+/**
  * Computes `{x, y}` positions for `nodeIds` given `edges` between them.
  * Deterministic and independent of input ordering (node ids are sorted
  * before layout). Isolated nodes (no edges) still get a position — placed on
- * the seeded initial ring, then pulled toward center like everything else.
+ * the seeded initial ring, then pulled toward center by gravity like
+ * everything else, so they end up near — not away from — the main cluster.
  */
 export function computeForceLayout(
   nodeIds: readonly string[],
@@ -51,7 +115,7 @@ export function computeForceLayout(
 ): Map<string, LayoutPosition> {
   const width = options.width ?? 640;
   const height = options.height ?? 480;
-  const iterations = options.iterations ?? 150;
+  const iterations = options.iterations ?? 200;
   const seed = options.seed ?? 42;
 
   const ids = [...new Set(nodeIds)].sort();
@@ -60,7 +124,11 @@ export function computeForceLayout(
 
   const centerX = width / 2;
   const centerY = height / 2;
-  const radius = Math.min(width, height) / 3;
+  // Initial ring radius is deliberately modest (not tied to canvas size) —
+  // just a reasonable, non-degenerate starting spread for gravity/repulsion
+  // to settle from; the canvas-sized ring the first cut used just made the
+  // "already at the wall" starting condition worse.
+  const radius = Math.min(IDEAL_EDGE_LENGTH * 1.5, Math.min(width, height) / 4);
   const random = mulberry32(seed);
 
   if (ids.length === 1) {
@@ -79,11 +147,24 @@ export function computeForceLayout(
     });
   });
 
-  const area = width * height;
-  const k = Math.sqrt(area / Math.max(ids.length, 1));
-  const validEdges = edges.filter((e) => positions.has(e.source) && positions.has(e.target));
+  const k = IDEAL_EDGE_LENGTH;
+  // Canonicalized (sorted) edge order — not the caller's — for the same
+  // reason node ids are sorted above: floating-point addition is
+  // commutative but not associative, so accumulating a node's displacement
+  // from several edges in a different order can round to a different last
+  // bit. Sorting makes that accumulation order fixed regardless of the
+  // order `edges` was passed in, so `computeForceLayout` stays exactly
+  // (bit-for-bit) independent of input ordering, not just approximately so.
+  const validEdges = edges
+    .filter((e) => positions.has(e.source) && positions.has(e.target))
+    .slice()
+    .sort((a, b) => {
+      if (a.source !== b.source) return a.source < b.source ? -1 : 1;
+      if (a.target !== b.target) return a.target < b.target ? -1 : 1;
+      return 0;
+    });
 
-  let temperature = Math.max(width, height) / 10;
+  let temperature = computeInitialTemperature(width, height);
   const cooling = temperature / (iterations + 1);
 
   for (let iteration = 0; iteration < iterations; iteration += 1) {
@@ -97,7 +178,7 @@ export function computeForceLayout(
         const dx = a.x - b.x;
         const dy = a.y - b.y;
         const distance = Math.max(Math.hypot(dx, dy), 0.01);
-        const force = (k * k) / distance;
+        const force = (REPULSION_STRENGTH * (k * k)) / distance;
         const ux = dx / distance;
         const uy = dy / distance;
         const da = displacement.get(ids[i])!;
@@ -116,7 +197,7 @@ export function computeForceLayout(
       const dx = a.x - b.x;
       const dy = a.y - b.y;
       const distance = Math.max(Math.hypot(dx, dy), 0.01);
-      const force = (distance * distance) / k;
+      const force = (SPRING_STRENGTH * (distance * distance)) / k;
       const ux = dx / distance;
       const uy = dy / distance;
       const da = displacement.get(edge.source)!;
@@ -127,15 +208,30 @@ export function computeForceLayout(
       db.y += uy * force;
     }
 
-    // Apply, capped by the cooling temperature, with a mild pull toward
-    // center so disconnected components don't drift off canvas.
+    // Gravity: every node is pulled toward the canvas center, proportional
+    // to its current distance from it — folded into the same displacement
+    // vector as repulsion/attraction (see module doc: this is the part that
+    // actually fixes the "nodes pinned to the wall" defect, because it now
+    // competes fairly with repulsion inside the same temperature cap below
+    // instead of being a separate, weak, uncapped nudge).
+    for (const id of ids) {
+      const position = positions.get(id)!;
+      const disp = displacement.get(id)!;
+      disp.x += (centerX - position.x) * GRAVITY_STRENGTH;
+      disp.y += (centerY - position.y) * GRAVITY_STRENGTH;
+    }
+
+    // Apply, capped by the cooling temperature. The boundary clamp below is
+    // a safety net for pathological inputs (e.g. an unbounded edge weight
+    // computed upstream) — gravity is what keeps the normal case away from
+    // it, not the clamp itself.
     for (const id of ids) {
       const position = positions.get(id)!;
       const disp = displacement.get(id)!;
       const distance = Math.max(Math.hypot(disp.x, disp.y), 0.01);
       const capped = Math.min(distance, temperature);
-      position.x += (disp.x / distance) * capped + (centerX - position.x) * 0.01;
-      position.y += (disp.y / distance) * capped + (centerY - position.y) * 0.01;
+      position.x += (disp.x / distance) * capped;
+      position.y += (disp.y / distance) * capped;
       position.x = Math.min(width, Math.max(0, position.x));
       position.y = Math.min(height, Math.max(0, position.y));
     }

--- a/web/src/lib/forceLayout.ts
+++ b/web/src/lib/forceLayout.ts
@@ -1,0 +1,147 @@
+// P2-17 Document Graph MVP: a small, hand-rolled force-directed layout
+// (Fruchterman-Reingold style — repulsion between every pair, spring
+// attraction along edges, mild centering pull, cooling temperature) instead
+// of a `d3-force` dependency. ~100 lines, deterministic given the same
+// node/edge input: positions come from a seeded PRNG
+// (`mulberry32`, not `Math.random`) and nodes are processed in a
+// canonicalized (sorted) order regardless of the order the caller passed
+// them in, so `GraphPage.test.tsx`/`forceLayout.test.ts` get the exact same
+// layout on every run. See the P2-17 report for the trade-off note on why
+// this is hand-rolled rather than a dependency.
+
+export interface LayoutEdge {
+  source: string;
+  target: string;
+}
+
+export interface LayoutPosition {
+  x: number;
+  y: number;
+}
+
+export interface ForceLayoutOptions {
+  width?: number;
+  height?: number;
+  iterations?: number;
+  /** Seeds both initial placement and is otherwise fully deterministic. */
+  seed?: number;
+}
+
+/** Deterministic PRNG (mulberry32) — same seed always yields the same sequence. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Computes `{x, y}` positions for `nodeIds` given `edges` between them.
+ * Deterministic and independent of input ordering (node ids are sorted
+ * before layout). Isolated nodes (no edges) still get a position — placed on
+ * the seeded initial ring, then pulled toward center like everything else.
+ */
+export function computeForceLayout(
+  nodeIds: readonly string[],
+  edges: readonly LayoutEdge[],
+  options: ForceLayoutOptions = {},
+): Map<string, LayoutPosition> {
+  const width = options.width ?? 640;
+  const height = options.height ?? 480;
+  const iterations = options.iterations ?? 150;
+  const seed = options.seed ?? 42;
+
+  const ids = [...new Set(nodeIds)].sort();
+  const positions = new Map<string, LayoutPosition>();
+  if (ids.length === 0) return positions;
+
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const radius = Math.min(width, height) / 3;
+  const random = mulberry32(seed);
+
+  if (ids.length === 1) {
+    positions.set(ids[0], { x: centerX, y: centerY });
+    return positions;
+  }
+
+  // Seeded initial ring placement — deterministic, and already a reasonable
+  // starting layout (not all-nodes-at-origin, which would make repulsion's
+  // initial direction arbitrary/NaN-prone).
+  ids.forEach((id, index) => {
+    const angle = (index / ids.length) * Math.PI * 2 + random() * 0.001;
+    positions.set(id, {
+      x: centerX + radius * Math.cos(angle),
+      y: centerY + radius * Math.sin(angle),
+    });
+  });
+
+  const area = width * height;
+  const k = Math.sqrt(area / Math.max(ids.length, 1));
+  const validEdges = edges.filter((e) => positions.has(e.source) && positions.has(e.target));
+
+  let temperature = Math.max(width, height) / 10;
+  const cooling = temperature / (iterations + 1);
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const displacement = new Map<string, LayoutPosition>(ids.map((id) => [id, { x: 0, y: 0 }]));
+
+    // Repulsion: every pair pushes apart, inverse-square-ish (k^2 / distance).
+    for (let i = 0; i < ids.length; i += 1) {
+      const a = positions.get(ids[i])!;
+      for (let j = i + 1; j < ids.length; j += 1) {
+        const b = positions.get(ids[j])!;
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const distance = Math.max(Math.hypot(dx, dy), 0.01);
+        const force = (k * k) / distance;
+        const ux = dx / distance;
+        const uy = dy / distance;
+        const da = displacement.get(ids[i])!;
+        da.x += ux * force;
+        da.y += uy * force;
+        const db = displacement.get(ids[j])!;
+        db.x -= ux * force;
+        db.y -= uy * force;
+      }
+    }
+
+    // Attraction: edges pull their endpoints together (distance^2 / k).
+    for (const edge of validEdges) {
+      const a = positions.get(edge.source)!;
+      const b = positions.get(edge.target)!;
+      const dx = a.x - b.x;
+      const dy = a.y - b.y;
+      const distance = Math.max(Math.hypot(dx, dy), 0.01);
+      const force = (distance * distance) / k;
+      const ux = dx / distance;
+      const uy = dy / distance;
+      const da = displacement.get(edge.source)!;
+      da.x -= ux * force;
+      da.y -= uy * force;
+      const db = displacement.get(edge.target)!;
+      db.x += ux * force;
+      db.y += uy * force;
+    }
+
+    // Apply, capped by the cooling temperature, with a mild pull toward
+    // center so disconnected components don't drift off canvas.
+    for (const id of ids) {
+      const position = positions.get(id)!;
+      const disp = displacement.get(id)!;
+      const distance = Math.max(Math.hypot(disp.x, disp.y), 0.01);
+      const capped = Math.min(distance, temperature);
+      position.x += (disp.x / distance) * capped + (centerX - position.x) * 0.01;
+      position.y += (disp.y / distance) * capped + (centerY - position.y) * 0.01;
+      position.x = Math.min(width, Math.max(0, position.x));
+      position.y = Math.min(height, Math.max(0, position.y));
+    }
+
+    temperature = Math.max(temperature - cooling, 0.01);
+  }
+
+  return positions;
+}

--- a/web/src/lib/router.test.ts
+++ b/web/src/lib/router.test.ts
@@ -35,6 +35,14 @@ describe('matchRoute', () => {
     expect(matchRoute('/help')).toEqual({ name: 'help', params: {} });
   });
 
+  it('matches graph with and without a collection id', () => {
+    expect(matchRoute('/graph')).toEqual({ name: 'graph', params: {} });
+    expect(matchRoute('/graph/col-1')).toEqual({
+      name: 'graph',
+      params: { collectionId: 'col-1' },
+    });
+  });
+
   it('falls back to notFound for unknown paths', () => {
     expect(matchRoute('/does-not-exist')).toEqual({ name: 'notFound', params: {} });
     expect(matchRoute('/admin')).toEqual({ name: 'notFound', params: {} });
@@ -48,5 +56,10 @@ describe('buildScopedPath', () => {
 
   it('builds a scoped path and encodes the collection id', () => {
     expect(buildScopedPath('qa', 'col one')).toBe('/qa/col%20one');
+  });
+
+  it('builds a graph path', () => {
+    expect(buildScopedPath('graph')).toBe('/graph');
+    expect(buildScopedPath('graph', 'col-1')).toBe('/graph/col-1');
   });
 });

--- a/web/src/lib/router.ts
+++ b/web/src/lib/router.ts
@@ -14,6 +14,7 @@ const routeDefinitions: RouteDefinition[] = [
   { name: 'adminUsage', pattern: /^\/admin\/usage\/?$/ },
   { name: 'library', pattern: /^\/library(?:\/([^/]+))?\/?$/, param: 'collectionId' },
   { name: 'qa', pattern: /^\/qa(?:\/([^/]+))?\/?$/, param: 'collectionId' },
+  { name: 'graph', pattern: /^\/graph(?:\/([^/]+))?\/?$/, param: 'collectionId' },
   { name: 'help', pattern: /^\/help\/?$/ },
 ];
 
@@ -43,7 +44,7 @@ export function matchRoute(pathname: string): RouteMatch {
   return { name: 'notFound', params: {} };
 }
 
-/** Builds a path for `/library/:collectionId?` or `/qa/:collectionId?`. */
-export function buildScopedPath(base: 'library' | 'qa', collectionId?: string): string {
+/** Builds a path for `/library/:collectionId?`, `/qa/:collectionId?`, or `/graph/:collectionId?`. */
+export function buildScopedPath(base: 'library' | 'qa' | 'graph', collectionId?: string): string {
   return collectionId ? `/${base}/${encodeURIComponent(collectionId)}` : `/${base}`;
 }

--- a/web/src/mocks/browser.ts
+++ b/web/src/mocks/browser.ts
@@ -12,6 +12,7 @@
 // per-test reset hook. `window.__markhandMockReset` is also exposed so a test
 // can re-seed mid-scenario (e.g. after a destructive flow) without a reload.
 import { grantMemberManage } from '../components/admin/testSupport';
+import { grantDocUpload } from '../components/library/testSupport';
 import { succeedJob } from '../components/upload/testSupport';
 import { installMockFetch, mockControl, resetMockState } from './index';
 
@@ -39,15 +40,18 @@ declare global {
  * user `member.manage` so the P2-11/P2-12 admin flows are reachable in E2E —
  * the vitest suite deliberately does NOT grant it (it would change an
  * `App.test.tsx` assertion), but in mock-mode the demo user is the only user
- * and the admin pages are part of what E2E must cover.
+ * and the admin pages are part of what E2E must cover. Same reasoning for
+ * `doc.upload` (P2-18 project create/assign flows).
  */
 export function installBrowserMocks(): void {
   installMockFetch();
   resetMockState();
   grantMemberManage();
+  grantDocUpload();
   window.__markhandMockReset = () => {
     resetMockState();
     grantMemberManage();
+    grantDocUpload();
   };
   window.__markhandMockControl = mockControl;
   window.__markhandMockJobs = { succeed: succeedJob };

--- a/web/src/mocks/fixtures.ts
+++ b/web/src/mocks/fixtures.ts
@@ -159,8 +159,12 @@ const DEMO_USER: MockUser = {
 
 /** A second seeded org member — active admin, non-owner — so member-list tests have more than one row and a non-owner promotion/demotion target. */
 export const SECOND_MEMBER_USER_ID = mockUuid(30);
+export const SECOND_MEMBER_DISPLAY_NAME = 'Bao Tran';
+export const SECOND_MEMBER_EMAIL = 'bao-tran@example.com';
 /** A third seeded org member — suspended viewer — so the list shows a non-active row too. */
 export const THIRD_MEMBER_USER_ID = mockUuid(31);
+export const THIRD_MEMBER_DISPLAY_NAME = 'Chi Vo';
+export const THIRD_MEMBER_EMAIL = 'chi-vo@example.com';
 
 /**
  * Org switch (1C-01 + P2-06/P2-15). `DEMO_USER.orgId` (`mockUuid(2)`) is
@@ -180,6 +184,8 @@ export const ORG_B_DOCUMENT_ID = mockUuid(120);
 const ORG_B_VERSION_ID = mockUuid(1200);
 /** Org B's second seeded member (`editor`, active) — so its admin members roster has more than the demo user's own row, same reason `SECOND_MEMBER_USER_ID` exists for org A. */
 export const GLOBEX_MEMBER_USER_ID = mockUuid(32);
+export const GLOBEX_MEMBER_DISPLAY_NAME = 'Duc Nguyen';
+export const GLOBEX_MEMBER_EMAIL = 'duc-nguyen@example.com';
 
 function seedOrgs(): OrgRecord[] {
   return [
@@ -207,15 +213,26 @@ function seedOrgProfiles(): Map<string, OrgProfile> {
 
 function seedMemberships(): Membership[] {
   return [
-    { userId: DEMO_USER.userId, role: 'owner', state: 'active', createdAt: mockTimestamp(0) },
+    {
+      userId: DEMO_USER.userId,
+      email: DEMO_USER.email,
+      displayName: DEMO_USER.displayName,
+      role: 'owner',
+      state: 'active',
+      createdAt: mockTimestamp(0),
+    },
     {
       userId: SECOND_MEMBER_USER_ID,
+      email: SECOND_MEMBER_EMAIL,
+      displayName: SECOND_MEMBER_DISPLAY_NAME,
       role: 'admin',
       state: 'active',
       createdAt: mockTimestamp(10),
     },
     {
       userId: THIRD_MEMBER_USER_ID,
+      email: THIRD_MEMBER_EMAIL,
+      displayName: THIRD_MEMBER_DISPLAY_NAME,
       role: 'viewer',
       state: 'suspended',
       createdAt: mockTimestamp(20),
@@ -248,9 +265,18 @@ function seedInvites(): InviteRecord[] {
  */
 function seedOrgBMemberships(): Membership[] {
   return [
-    { userId: DEMO_USER.userId, role: 'owner', state: 'active', createdAt: mockTimestamp(90) },
+    {
+      userId: DEMO_USER.userId,
+      email: DEMO_USER.email,
+      displayName: DEMO_USER.displayName,
+      role: 'owner',
+      state: 'active',
+      createdAt: mockTimestamp(90),
+    },
     {
       userId: GLOBEX_MEMBER_USER_ID,
+      email: GLOBEX_MEMBER_EMAIL,
+      displayName: GLOBEX_MEMBER_DISPLAY_NAME,
       role: 'editor',
       state: 'active',
       createdAt: mockTimestamp(91),

--- a/web/src/mocks/fixtures.ts
+++ b/web/src/mocks/fixtures.ts
@@ -18,6 +18,7 @@ type Org = components['schemas']['Org'];
 type OrgRole = Org['role'];
 type OrgState = Membership['state'];
 type UsageEntry = components['schemas']['UsageEntry'];
+type Project = components['schemas']['Project'];
 
 export interface MockUser {
   userId: string;
@@ -114,6 +115,10 @@ interface Store {
   collections: Collection[];
   /** collectionId -> the org it belongs to. Not part of the wire `Collection` shape (the real schema has no `orgId` field — org isolation is enforced server-side from the bearer token, never a response field), kept here purely so mock handlers can filter. */
   collectionOrgId: Map<string, string>;
+  /** P2-18 — orgId -> that org's projects. Same per-org-roster shape as `membershipsByOrg`. */
+  projectsByOrg: Map<string, Project[]>;
+  /** P2-18 — collectionId -> assigned projectId, or `null` when unassigned. Not part of the wire `Collection` shape here either (that lives on the DTO's own `projectId`/`projectName` fields, computed at read time in `handlers/library.ts` — this map is the mutable "what's assigned" source of truth those fields are derived from). */
+  collectionProjectId: Map<string, string | null>;
   documents: Map<string, Document[]>; // collectionId -> documents
   versions: Map<string, DocumentVersion[]>; // documentId -> versions, oldest first
   jobs: Map<string, Job>;
@@ -474,6 +479,43 @@ function seedCollectionOrgId(): Map<string, string> {
   ]);
 }
 
+// ---------------------------------------------------------------------------
+// P2-18 projects — org -> project -> collection -> document grouping.
+// ---------------------------------------------------------------------------
+
+/** Org A: two projects. `PROJECT_A_HR_ID` is assigned to Employee Handbook
+ * (`mockUuid(10)`); `PROJECT_A_PRODUCT_ID` starts with zero collections
+ * assigned, so Product Specs (`mockUuid(11)`) stays under "Chưa thuộc dự án"
+ * — the "org A: 2 projects + 1 unassigned collection" fixture the E2E spec
+ * needs, without inventing a third org A collection. */
+export const PROJECT_A_HR_ID = mockUuid(200);
+export const PROJECT_A_PRODUCT_ID = mockUuid(201);
+/** Org B's own project, separate id space from org A's — same "distinct
+ * enough that a cross-org assertion can't pass by accident" convention as
+ * `ORG_B_COLLECTION_ID`. */
+export const PROJECT_B_ID = mockUuid(202);
+
+function seedProjects(): Map<string, Project[]> {
+  return new Map([
+    [
+      ORG_A_ID,
+      [
+        { id: PROJECT_A_HR_ID, name: 'Nhân sự', createdAt: mockTimestamp(0) },
+        { id: PROJECT_A_PRODUCT_ID, name: 'Sản phẩm', createdAt: mockTimestamp(1) },
+      ],
+    ],
+    [ORG_B_ID, [{ id: PROJECT_B_ID, name: 'Globex Ops', createdAt: mockTimestamp(90) }]],
+  ]);
+}
+
+function seedCollectionProjectId(): Map<string, string | null> {
+  return new Map([
+    [mockUuid(10), PROJECT_A_HR_ID],
+    [mockUuid(11), null],
+    [ORG_B_COLLECTION_ID, PROJECT_B_ID],
+  ]);
+}
+
 /**
  * P2-10 (Q&A) demo document — the one seeded document with **two** published
  * versions, so `mode: 'compare'`/`'history'` ask requests (and the version
@@ -578,6 +620,8 @@ function freshStore(): Store {
     accessTokens: new Map(),
     collections: seedCollections(),
     collectionOrgId: seedCollectionOrgId(),
+    projectsByOrg: seedProjects(),
+    collectionProjectId: seedCollectionProjectId(),
     documents,
     versions,
     jobs: seedJobs(),
@@ -713,6 +757,37 @@ export function findInviteAcrossOrgs(
 /** `orgId`'s `GET /usage` snapshot — `[]` for an org with none seeded rather than throwing, matching every other per-org accessor's "empty, not an error" default. */
 export function getOrgUsage(orgId: string): UsageEntry[] {
   return store.usageByOrg.get(orgId) ?? [];
+}
+
+/** P2-18 — `orgId`'s projects, auto-vivifying an empty roster like `getOrgMemberships`. */
+export function getOrgProjects(orgId: string): Project[] {
+  let projects = store.projectsByOrg.get(orgId);
+  if (!projects) {
+    projects = [];
+    store.projectsByOrg.set(orgId, projects);
+  }
+  return projects;
+}
+
+/** P2-18 — `collectionId`'s assigned project id, or `undefined` for a collection this store has never seen (distinct from `null`, which means "seen, explicitly unassigned"). */
+export function getCollectionProjectId(collectionId: string): string | null | undefined {
+  return store.collectionProjectId.get(collectionId);
+}
+
+/** P2-18 — assigns/unassigns `collectionId`'s project (`null` unassigns), same mutation shape `POST /collections/{id}/assign-project` performs server-side. */
+export function setCollectionProjectId(collectionId: string, projectId: string | null): void {
+  store.collectionProjectId.set(collectionId, projectId);
+}
+
+/** P2-18 — collection ids currently assigned to `projectId`, scoped to `orgId` via `collectionOrgId` (mirrors `db::projects::collection_ids_for_project`'s org-scoped filter). */
+export function collectionIdsForProject(orgId: string, projectId: string): string[] {
+  const ids: string[] = [];
+  for (const [collectionId, assigned] of store.collectionProjectId) {
+    if (assigned === projectId && store.collectionOrgId.get(collectionId) === orgId) {
+      ids.push(collectionId);
+    }
+  }
+  return ids;
 }
 
 export { encodeCursor, decodeCursor };

--- a/web/src/mocks/handlers/graph.ts
+++ b/web/src/mocks/handlers/graph.ts
@@ -1,0 +1,305 @@
+/**
+ * P2-17 Document Graph MVP mock for `GET /api/v1/graph`.
+ *
+ * Deliberately self-contained (own fixed node/edge/community catalog below,
+ * mockUuid range 200-212/320-322 — disjoint from every id used elsewhere in
+ * `mocks/fixtures.ts`, same "own numeric range" convention `QA_COMPARE_*`
+ * already follows there) rather than woven into the shared mutable `Store`:
+ * the graph is a read-only derived view with nothing else in the mock ever
+ * mutating it, so a small fixed catalog here — one per org, keyed by
+ * `authContextForHeader(...).orgId` the same way `listCollections` scopes
+ * itself — is simpler than adding graph-shaped fields to `Store`.
+ *
+ * Permission note: the real server gates `GET /graph` on `qa.query`
+ * (`routes/graph.rs`), but this mock does not check it — same precedent
+ * `handlers/qa.ts`'s `search`/`ask` already set (the real `/search`/`/ask`
+ * also require `qa.query`, and the seeded `DEMO_USER` fixture does not have
+ * it, yet those mocks never enforce it either). Enforcing it here alone
+ * would make the demo user unable to open a page every other org-scoped
+ * "read" surface lets them into.
+ *
+ * Org A: 13 nodes across the two seeded org-A collections
+ * (`mockUuid(10)` "Employee Handbook", `mockUuid(11)` "Product Specs"),
+ * split into 3 disjoint communities and covering all three edge kinds
+ * (`conflict` / `co_citation` / `similarity`) — enough for the sidebar
+ * "Communities" checkboxes + force-directed layout to have something real
+ * to render. Org B gets a much smaller graph (3 nodes, 1 community) so an
+ * org switch visibly changes what's shown, same as every other org-scoped
+ * mock fixture in this package.
+ */
+import { registerOperation } from '../registry';
+import { notFound, unauthorized } from '../apiError';
+import { nextRequestId, mockUuid } from '../ids';
+import {
+  authContextForHeader,
+  getStore,
+  ORG_B_COLLECTION_ID,
+  ORG_B_DOCUMENT_ID,
+  ORG_B_ID,
+} from '../fixtures';
+import type { components } from '../../api/generated/contract';
+
+type GraphNode = components['schemas']['GraphNode'];
+type GraphEdge = components['schemas']['GraphEdge'];
+type GraphCommunity = components['schemas']['GraphCommunity'];
+
+interface NodeSeed {
+  id: string;
+  title: string;
+  collectionId: string;
+  collectionName: string;
+  status: string;
+}
+
+interface EdgeSeed {
+  source: string;
+  target: string;
+  kind: GraphEdge['kind'];
+  weight: number;
+}
+
+interface CommunitySeed {
+  id: string;
+  label: string;
+  nodeIds: string[];
+}
+
+const HANDBOOK_COLLECTION_ID = mockUuid(10);
+const HANDBOOK_COLLECTION_NAME = 'Employee Handbook';
+const SPECS_COLLECTION_ID = mockUuid(11);
+const SPECS_COLLECTION_NAME = 'Product Specs';
+
+const ORG_A_NODES: NodeSeed[] = [
+  // Cluster "Nhân sự" (Employee Handbook) — 5 nodes.
+  {
+    id: mockUuid(200),
+    title: 'Sổ tay nhân viên 2024',
+    collectionId: HANDBOOK_COLLECTION_ID,
+    collectionName: HANDBOOK_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(201),
+    title: 'Chính sách nghỉ phép',
+    collectionId: HANDBOOK_COLLECTION_ID,
+    collectionName: HANDBOOK_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(202),
+    title: 'Chính sách nghỉ phép (bản cập nhật)',
+    collectionId: HANDBOOK_COLLECTION_ID,
+    collectionName: HANDBOOK_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(203),
+    title: 'Quy trình onboarding',
+    collectionId: HANDBOOK_COLLECTION_ID,
+    collectionName: HANDBOOK_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(204),
+    title: 'Chính sách phúc lợi',
+    collectionId: HANDBOOK_COLLECTION_ID,
+    collectionName: HANDBOOK_COLLECTION_NAME,
+    status: 'converting',
+  },
+  // Cluster "Sản phẩm" (Product Specs) — 5 nodes.
+  {
+    id: mockUuid(205),
+    title: 'Đặc tả sản phẩm v1',
+    collectionId: SPECS_COLLECTION_ID,
+    collectionName: SPECS_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(206),
+    title: 'Đặc tả sản phẩm v2',
+    collectionId: SPECS_COLLECTION_ID,
+    collectionName: SPECS_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(207),
+    title: 'Tài liệu API',
+    collectionId: SPECS_COLLECTION_ID,
+    collectionName: SPECS_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(208),
+    title: 'Lộ trình sản phẩm Q3',
+    collectionId: SPECS_COLLECTION_ID,
+    collectionName: SPECS_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(209),
+    title: 'Lộ trình sản phẩm Q4',
+    collectionId: SPECS_COLLECTION_ID,
+    collectionName: SPECS_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  // Cluster "Liên phòng ban" — cross-collection, 3 nodes.
+  {
+    id: mockUuid(210),
+    title: 'Biên bản họp liên phòng',
+    collectionId: HANDBOOK_COLLECTION_ID,
+    collectionName: HANDBOOK_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(211),
+    title: 'Ngân sách dự án chung',
+    collectionId: SPECS_COLLECTION_ID,
+    collectionName: SPECS_COLLECTION_NAME,
+    status: 'indexed',
+  },
+  {
+    id: mockUuid(212),
+    title: 'Kế hoạch phối hợp Q3',
+    collectionId: HANDBOOK_COLLECTION_ID,
+    collectionName: HANDBOOK_COLLECTION_NAME,
+    status: 'indexed',
+  },
+];
+
+const ORG_A_EDGES: EdgeSeed[] = [
+  // Cluster 1 (Nhân sự).
+  { source: mockUuid(200), target: mockUuid(201), kind: 'co_citation', weight: 0.4 },
+  { source: mockUuid(201), target: mockUuid(202), kind: 'conflict', weight: 0.9 },
+  { source: mockUuid(200), target: mockUuid(203), kind: 'co_citation', weight: 0.3 },
+  { source: mockUuid(203), target: mockUuid(204), kind: 'similarity', weight: 0.5 },
+  { source: mockUuid(200), target: mockUuid(204), kind: 'co_citation', weight: 0.2 },
+  // Cluster 2 (Sản phẩm).
+  { source: mockUuid(205), target: mockUuid(206), kind: 'similarity', weight: 0.8 },
+  { source: mockUuid(206), target: mockUuid(207), kind: 'co_citation', weight: 0.35 },
+  { source: mockUuid(208), target: mockUuid(209), kind: 'conflict', weight: 0.6 },
+  { source: mockUuid(207), target: mockUuid(208), kind: 'similarity', weight: 0.25 },
+  // Cluster 3 (Liên phòng ban).
+  { source: mockUuid(210), target: mockUuid(211), kind: 'conflict', weight: 0.55 },
+  { source: mockUuid(211), target: mockUuid(212), kind: 'co_citation', weight: 0.45 },
+  { source: mockUuid(210), target: mockUuid(212), kind: 'similarity', weight: 0.3 },
+];
+
+const ORG_A_COMMUNITIES: CommunitySeed[] = [
+  {
+    id: 'community-0',
+    label: HANDBOOK_COLLECTION_NAME,
+    nodeIds: [mockUuid(200), mockUuid(201), mockUuid(202), mockUuid(203), mockUuid(204)],
+  },
+  {
+    id: 'community-1',
+    label: SPECS_COLLECTION_NAME,
+    nodeIds: [mockUuid(205), mockUuid(206), mockUuid(207), mockUuid(208), mockUuid(209)],
+  },
+  {
+    id: 'community-2',
+    label: 'Liên phòng ban',
+    nodeIds: [mockUuid(210), mockUuid(211), mockUuid(212)],
+  },
+];
+
+const GLOBEX_EXPANSION_PLAN_ID = mockUuid(320);
+const GLOBEX_EXPANSION_BUDGET_ID = mockUuid(321);
+
+const ORG_B_NODES: NodeSeed[] = [
+  {
+    id: ORG_B_DOCUMENT_ID,
+    title: 'Globex Master Plan.pdf',
+    collectionId: ORG_B_COLLECTION_ID,
+    collectionName: 'Globex Roadmap',
+    status: 'indexed',
+  },
+  {
+    id: GLOBEX_EXPANSION_PLAN_ID,
+    title: 'Kế hoạch mở rộng Globex',
+    collectionId: ORG_B_COLLECTION_ID,
+    collectionName: 'Globex Roadmap',
+    status: 'indexed',
+  },
+  {
+    id: GLOBEX_EXPANSION_BUDGET_ID,
+    title: 'Ngân sách mở rộng Globex',
+    collectionId: ORG_B_COLLECTION_ID,
+    collectionName: 'Globex Roadmap',
+    status: 'indexed',
+  },
+];
+
+const ORG_B_EDGES: EdgeSeed[] = [
+  { source: ORG_B_DOCUMENT_ID, target: GLOBEX_EXPANSION_PLAN_ID, kind: 'co_citation', weight: 0.5 },
+  {
+    source: GLOBEX_EXPANSION_PLAN_ID,
+    target: GLOBEX_EXPANSION_BUDGET_ID,
+    kind: 'conflict',
+    weight: 0.65,
+  },
+];
+
+const ORG_B_COMMUNITIES: CommunitySeed[] = [
+  {
+    id: 'community-0',
+    label: 'Globex Roadmap',
+    nodeIds: [ORG_B_DOCUMENT_ID, GLOBEX_EXPANSION_PLAN_ID, GLOBEX_EXPANSION_BUDGET_ID],
+  },
+];
+
+function degreeOf(nodeId: string, edges: EdgeSeed[]): number {
+  return edges.filter((e) => e.source === nodeId || e.target === nodeId).length;
+}
+
+function buildGraph(
+  nodes: NodeSeed[],
+  edges: EdgeSeed[],
+  communities: CommunitySeed[],
+  collectionFilter: string | null,
+): { nodes: GraphNode[]; edges: GraphEdge[]; communities: GraphCommunity[] } {
+  const keptNodes = collectionFilter
+    ? nodes.filter((n) => n.collectionId === collectionFilter)
+    : nodes;
+  const keptIds = new Set(keptNodes.map((n) => n.id));
+  const keptEdges = edges.filter((e) => keptIds.has(e.source) && keptIds.has(e.target));
+
+  return {
+    nodes: keptNodes.map((n) => ({
+      id: n.id,
+      title: n.title,
+      collectionId: n.collectionId,
+      collectionName: n.collectionName,
+      status: n.status,
+      degree: degreeOf(n.id, keptEdges),
+    })),
+    edges: keptEdges.map((e) => ({ ...e })),
+    communities: communities
+      .map((c) => ({ ...c, nodeIds: c.nodeIds.filter((id) => keptIds.has(id)) }))
+      .filter((c) => c.nodeIds.length > 0)
+      .map((c) => ({ id: c.id, label: c.label, nodeIds: c.nodeIds, size: c.nodeIds.length })),
+  };
+}
+
+registerOperation('getGraph', (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized();
+
+  const collectionFilter = ctx.query.get('collectionId');
+  if (collectionFilter) {
+    const collection = getStore().collections.find((c) => c.id === collectionFilter);
+    if (!collection || getStore().collectionOrgId.get(collectionFilter) !== auth.orgId) {
+      return notFound(`Collection ${collectionFilter} does not exist.`);
+    }
+  }
+
+  const [nodes, edges, communities] =
+    auth.orgId === ORG_B_ID
+      ? [ORG_B_NODES, ORG_B_EDGES, ORG_B_COMMUNITIES]
+      : [ORG_A_NODES, ORG_A_EDGES, ORG_A_COMMUNITIES];
+  const graph = buildGraph(nodes, edges, communities, collectionFilter);
+
+  return {
+    status: 200,
+    body: { ...graph, requestId: nextRequestId() },
+  };
+});

--- a/web/src/mocks/handlers/index.ts
+++ b/web/src/mocks/handlers/index.ts
@@ -9,4 +9,5 @@ import './graph';
 import './library';
 import './members';
 import './orgs';
+import './projects';
 import './qa';

--- a/web/src/mocks/handlers/index.ts
+++ b/web/src/mocks/handlers/index.ts
@@ -5,6 +5,7 @@
  */
 import './health';
 import './auth';
+import './graph';
 import './library';
 import './members';
 import './orgs';

--- a/web/src/mocks/handlers/library.ts
+++ b/web/src/mocks/handlers/library.ts
@@ -1,14 +1,35 @@
 import { registerOperation } from '../registry';
 import { notFound, conflict as conflictResponse, apiError, unauthorized } from '../apiError';
 import { nextRequestId, encodeCursor, decodeCursor, mockTimestamp } from '../ids';
-import { authContextForHeader, getStore, nextId } from '../fixtures';
+import {
+  authContextForHeader,
+  getStore,
+  nextId,
+  getCollectionProjectId,
+  setCollectionProjectId,
+  getOrgProjects,
+} from '../fixtures';
 import type { components } from '../../api/generated/contract';
 
 type Collection = components['schemas']['Collection'];
 type CreateCollectionRequest = components['schemas']['CreateCollectionRequest'];
 type UpdateCollectionRequest = components['schemas']['UpdateCollectionRequest'];
+type AssignProjectRequest = components['schemas']['AssignProjectRequest'];
 type Document = components['schemas']['Document'];
 type Job = components['schemas']['Job'];
+
+/** P2-18 — hydrates `projectId`/`projectName` onto a stored `Collection` at
+ * read time, same "joined at the read boundary, not stored on the record"
+ * shape `toMeResponse` already uses for `permissions`/`allowedCollectionIds`.
+ * `orgId` is the caller's *current* token org (never a fixed `user.orgId`),
+ * matching every other org-scoped lookup in this file. */
+function withProjectFields(collection: Collection, orgId: string): Collection {
+  const projectId = getCollectionProjectId(collection.id) ?? null;
+  const projectName = projectId
+    ? (getOrgProjects(orgId).find((p) => p.id === projectId)?.name ?? null)
+    : null;
+  return { ...collection, projectId, projectName };
+}
 
 // ---------------------------------------------------------------------------
 // Collections
@@ -26,9 +47,9 @@ type Job = components['schemas']['Job'];
 registerOperation('listCollections', (ctx) => {
   const auth = authContextForHeader(ctx.headers.get('authorization'));
   if (!auth) return unauthorized();
-  const items = getStore().collections.filter(
-    (c) => getStore().collectionOrgId.get(c.id) === auth.orgId,
-  );
+  const items = getStore()
+    .collections.filter((c) => getStore().collectionOrgId.get(c.id) === auth.orgId)
+    .map((c) => withProjectFields(c, auth.orgId));
   return { status: 200, body: { items, page: { hasMore: false, nextCursor: null } } };
 });
 
@@ -46,7 +67,7 @@ registerOperation('createCollection', async (ctx) => {
   };
   getStore().collections.push(collection);
   getStore().collectionOrgId.set(collection.id, auth.orgId);
-  return { status: 201, body: collection };
+  return { status: 201, body: withProjectFields(collection, auth.orgId) };
 });
 
 registerOperation('getCollection', (ctx) => {
@@ -56,16 +77,18 @@ registerOperation('getCollection', (ctx) => {
   if (!collection || getStore().collectionOrgId.get(collection.id) !== auth.orgId) {
     return notFound(`Collection ${ctx.params.collectionId} does not exist.`);
   }
-  return { status: 200, body: collection };
+  return { status: 200, body: withProjectFields(collection, auth.orgId) };
 });
 
 registerOperation('updateCollection', async (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized();
   const collection = getStore().collections.find((c) => c.id === ctx.params.collectionId);
   if (!collection) return notFound(`Collection ${ctx.params.collectionId} does not exist.`);
   const body = await ctx.json<UpdateCollectionRequest>();
   collection.name = body.name;
   if ('description' in body) collection.description = body.description ?? null;
-  return { status: 200, body: collection };
+  return { status: 200, body: withProjectFields(collection, auth.orgId) };
 });
 
 registerOperation('deleteCollection', (ctx) => {
@@ -74,6 +97,26 @@ registerOperation('deleteCollection', (ctx) => {
   if (idx === -1) return notFound(`Collection ${ctx.params.collectionId} does not exist.`);
   store.collections.splice(idx, 1);
   return { status: 204 };
+});
+
+// P2-18 — `projectId: null` unassigns, `projectId: "<uuid>"` assigns; the key
+// itself is required (mirrors the real `AssignProjectRequest` schema exactly
+// — see `routes::collections::assign_project`'s doc for why this is a
+// dedicated action route rather than folded into `updateCollection` above).
+registerOperation('assignCollectionProject', async (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized();
+  const collection = getStore().collections.find((c) => c.id === ctx.params.collectionId);
+  if (!collection || getStore().collectionOrgId.get(collection.id) !== auth.orgId) {
+    return notFound(`Collection ${ctx.params.collectionId} does not exist.`);
+  }
+  const body = await ctx.json<AssignProjectRequest>();
+  if (body.projectId !== null) {
+    const exists = getOrgProjects(auth.orgId).some((p) => p.id === body.projectId);
+    if (!exists) return notFound(`Project ${body.projectId} does not exist in this org.`);
+  }
+  setCollectionProjectId(collection.id, body.projectId);
+  return { status: 200, body: withProjectFields(collection, auth.orgId) };
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/mocks/handlers/members.ts
+++ b/web/src/mocks/handlers/members.ts
@@ -270,6 +270,8 @@ registerOperation('acceptMemberInvite', async (ctx) => {
   }
   const membership: Membership = {
     userId: auth.user.userId,
+    email: auth.user.email,
+    displayName: auth.user.displayName,
     role: invite.role,
     state: 'active',
     createdAt: mockTimestamp(0),

--- a/web/src/mocks/handlers/projects.ts
+++ b/web/src/mocks/handlers/projects.ts
@@ -1,0 +1,40 @@
+// P2-18: org -> project -> collection -> document grouping. `assign-project`
+// itself is registered in `handlers/library.ts` (it's a `/collections/{id}/...`
+// sub-route) — see that file's doc.
+import { registerOperation } from '../registry';
+import { notFound, unauthorized } from '../apiError';
+import { mockTimestamp } from '../ids';
+import { authContextForHeader, getOrgProjects, nextId } from '../fixtures';
+import type { components } from '../../api/generated/contract';
+
+type Project = components['schemas']['Project'];
+type CreateProjectRequest = components['schemas']['CreateProjectRequest'];
+type UpdateProjectRequest = components['schemas']['UpdateProjectRequest'];
+
+registerOperation('listProjects', (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized();
+  return {
+    status: 200,
+    body: { items: getOrgProjects(auth.orgId), page: { hasMore: false, nextCursor: null } },
+  };
+});
+
+registerOperation('createProject', async (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized();
+  const body = await ctx.json<CreateProjectRequest>();
+  const project: Project = { id: nextId(), name: body.name, createdAt: mockTimestamp(0) };
+  getOrgProjects(auth.orgId).push(project);
+  return { status: 201, body: project };
+});
+
+registerOperation('updateProject', async (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized();
+  const project = getOrgProjects(auth.orgId).find((p) => p.id === ctx.params.projectId);
+  if (!project) return notFound(`Project ${ctx.params.projectId} does not exist.`);
+  const body = await ctx.json<UpdateProjectRequest>();
+  project.name = body.name;
+  return { status: 200, body: project };
+});

--- a/web/src/mocks/handlers/qa.ts
+++ b/web/src/mocks/handlers/qa.ts
@@ -42,14 +42,43 @@
 //     `services/qa/ask_stream.rs`'s `config_reason`, consumed client-side by
 //     `api/sse.ts`'s `classifySseCloseCode`.
 import { registerOperation } from '../registry';
+import { notFound, unauthorized } from '../apiError';
 import { nextRequestId } from '../ids';
-import { getStore, nextId, QA_COMPARE_DOCUMENT_ID } from '../fixtures';
+import {
+  authContextForHeader,
+  collectionIdsForProject,
+  getOrgProjects,
+  getStore,
+  nextId,
+  QA_COMPARE_DOCUMENT_ID,
+} from '../fixtures';
 import type { components } from '../../api/generated/contract';
 
 type SearchRequest = components['schemas']['SearchRequest'];
 type AskRequest = components['schemas']['AskRequest'];
 type CitationPin = components['schemas']['CitationPin'];
 type SseEnvelope = components['schemas']['SseEnvelope'];
+
+/**
+ * P2-18 — resolves `projectId` (absent = "all projects", today's exact
+ * behavior) into the effective `collectionIds` scope, narrowing (never
+ * widening) whatever the request already specified — same contract as
+ * `db::projects::resolve_project_scope` server-side. Returns `undefined` (a
+ * 404) when `projectId` does not resolve to a project in the caller's org.
+ */
+function resolveProjectScope(
+  orgId: string,
+  projectId: string | undefined,
+  requested: string[] | undefined,
+): { collectionIds: string[] | undefined } | undefined {
+  if (!projectId) return { collectionIds: requested };
+  if (!getOrgProjects(orgId).some((p) => p.id === projectId)) return undefined;
+  const projectCollections = collectionIdsForProject(orgId, projectId);
+  const collectionIds = requested
+    ? requested.filter((id) => projectCollections.includes(id))
+    : projectCollections;
+  return { collectionIds };
+}
 
 // ---------------------------------------------------------------------------
 // Scenario markers — a test seam. Appending one of these tokens to a
@@ -309,7 +338,11 @@ function currentModeWarnings(mode: string, citations: CitationPin[]): string[] {
 // ---------------------------------------------------------------------------
 
 registerOperation('search', async (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized();
   const body = await ctx.json<SearchRequest>();
+  const scope = resolveProjectScope(auth.orgId, body.projectId, body.collectionIds);
+  if (!scope) return notFound(`Project ${body.projectId} does not exist in this org.`);
   const mode = body.mode ?? 'current';
   const limit = body.limit ?? 10;
   let passages: Passage[];
@@ -319,7 +352,7 @@ registerOperation('search', async (ctx) => {
     passages = resolved.passages;
     warnings = resolved.warnings;
   } else {
-    passages = matchPassages(body.query, body.collectionIds, limit);
+    passages = matchPassages(body.query, scope.collectionIds, limit);
     warnings = [];
   }
   const citations = passages.map((p, i) => passageToCitation(p, citeIdFor(i)));
@@ -340,7 +373,11 @@ registerOperation('search', async (ctx) => {
 });
 
 registerOperation('ask', async (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized();
   const body = await ctx.json<AskRequest>();
+  const scope = resolveProjectScope(auth.orgId, body.projectId, body.collectionIds);
+  if (!scope) return notFound(`Project ${body.projectId} does not exist in this org.`);
   const mode = body.mode ?? 'current';
   let passages: Passage[];
   let warnings: string[];
@@ -349,7 +386,7 @@ registerOperation('ask', async (ctx) => {
     passages = resolved.passages;
     warnings = resolved.warnings;
   } else {
-    passages = matchPassages(body.question, body.collectionIds, body.limit ?? 10);
+    passages = matchPassages(body.question, scope.collectionIds, body.limit ?? 10);
     warnings = [];
   }
   const citations = passages.map((p, i) => passageToCitation(p, citeIdFor(i)));
@@ -402,7 +439,11 @@ function serializeSseFrames(frames: SseFrame[], requestId: string): string {
 }
 
 registerOperation('askStream', async (ctx) => {
+  const auth = authContextForHeader(ctx.headers.get('authorization'));
+  if (!auth) return unauthorized();
   const body = await ctx.json<AskRequest>();
+  const scope = resolveProjectScope(auth.orgId, body.projectId, body.collectionIds);
+  if (!scope) return notFound(`Project ${body.projectId} does not exist in this org.`);
   const rawQuestion = body.question;
   const revoke = rawQuestion.includes(QA_STREAM_MARKERS.citationRevoked);
   const fallback = rawQuestion.includes(QA_STREAM_MARKERS.providerFallback);
@@ -416,7 +457,7 @@ registerOperation('askStream', async (ctx) => {
     passages = resolved.passages;
     scenarioWarnings = resolved.warnings;
   } else {
-    passages = matchPassages(question, body.collectionIds, body.limit ?? 10);
+    passages = matchPassages(question, scope.collectionIds, body.limit ?? 10);
     scenarioWarnings = [];
   }
   const citations = passages.map((p, i) => passageToCitation(p, citeIdFor(i)));

--- a/web/src/mocks/spec/openApiSpec.test.ts
+++ b/web/src/mocks/spec/openApiSpec.test.ts
@@ -4,8 +4,8 @@ import { buildSpecIndex, getOperation } from './openApiSpec';
 const spec = buildSpecIndex();
 
 describe('buildSpecIndex against the real openapi.yaml', () => {
-  it('indexes all 44 component schemas', () => {
-    expect(Object.keys(spec.schemas)).toHaveLength(44);
+  it('indexes all 49 component schemas', () => {
+    expect(Object.keys(spec.schemas)).toHaveLength(49);
     expect(spec.schemas.TokenResponse).toBeDefined();
     expect(spec.schemas.ApiError).toBeDefined();
   });

--- a/web/src/mocks/spec/openApiSpec.test.ts
+++ b/web/src/mocks/spec/openApiSpec.test.ts
@@ -4,8 +4,8 @@ import { buildSpecIndex, getOperation } from './openApiSpec';
 const spec = buildSpecIndex();
 
 describe('buildSpecIndex against the real openapi.yaml', () => {
-  it('indexes all 40 component schemas', () => {
-    expect(Object.keys(spec.schemas)).toHaveLength(40);
+  it('indexes all 44 component schemas', () => {
+    expect(Object.keys(spec.schemas)).toHaveLength(44);
     expect(spec.schemas.TokenResponse).toBeDefined();
     expect(spec.schemas.ApiError).toBeDefined();
   });

--- a/web/src/mocks/spec/yaml.test.ts
+++ b/web/src/mocks/spec/yaml.test.ts
@@ -118,9 +118,9 @@ describe('parseYaml against the real openapi.yaml', () => {
     expect(typeof doc.components).toBe('object');
   });
 
-  it('finds all 44 component schemas', () => {
+  it('finds all 49 component schemas', () => {
     const schemas = (doc.components as Record<string, unknown>).schemas as Record<string, unknown>;
-    expect(Object.keys(schemas)).toHaveLength(44);
+    expect(Object.keys(schemas)).toHaveLength(49);
   });
 
   it('parses a representative path item with multiple methods and shared parameters', () => {

--- a/web/src/mocks/spec/yaml.test.ts
+++ b/web/src/mocks/spec/yaml.test.ts
@@ -118,9 +118,9 @@ describe('parseYaml against the real openapi.yaml', () => {
     expect(typeof doc.components).toBe('object');
   });
 
-  it('finds all 40 component schemas', () => {
+  it('finds all 44 component schemas', () => {
     const schemas = (doc.components as Record<string, unknown>).schemas as Record<string, unknown>;
-    expect(Object.keys(schemas)).toHaveLength(40);
+    expect(Object.keys(schemas)).toHaveLength(44);
   });
 
   it('parses a representative path item with multiple methods and shared parameters', () => {

--- a/web/src/pages/AdminMembersPage.test.tsx
+++ b/web/src/pages/AdminMembersPage.test.tsx
@@ -23,6 +23,7 @@ import {
   getStore,
   mintTokenPair,
   ORG_A_ID,
+  SECOND_MEMBER_DISPLAY_NAME,
   SECOND_MEMBER_USER_ID,
   THIRD_MEMBER_USER_ID,
 } from '../mocks/fixtures';
@@ -58,8 +59,9 @@ function findRowByTagText(label: string): HTMLElement {
 }
 
 /**
- * The `<tr>` for a given `userId` (rendered verbatim as `<code>`, see
- * `MembersTable.tsx`) — the only row locator that stays valid across a role
+ * The `<tr>` for a given member's display name (rendered by `MembersTable.tsx`
+ * as `.member-identity-name` — the UUID itself is never rendered, see that
+ * component's doc) — the only row locator that stays valid across a role
  * change, unlike `findRowByTagText`, whose label is exactly what a role
  * mutation changes. Load-bearing: an earlier version of the role-change test
  * below used `findByText('Biên tập viên', ...)` with no row scoping and
@@ -68,8 +70,10 @@ function findRowByTagText(label: string): HTMLElement {
  * the exact same Vietnamese label in the *invites* table — a false positive
  * only mutation-testing caught.
  */
-function findRowByUserId(userId: string): HTMLElement {
-  return screen.getByText(userId).closest('tr') as HTMLElement;
+function findRowByDisplayName(displayName: string): HTMLElement {
+  return screen
+    .getByText(displayName, { selector: '.member-identity-name' })
+    .closest('tr') as HTMLElement;
 }
 
 beforeEach(() => {
@@ -124,7 +128,7 @@ describe('AdminMembersPage', () => {
       await screen.findByText('Quản trị viên', { selector: 'span.tag' });
 
       const roleSelect = screen.getByRole('combobox', {
-        name: `Vai trò của ${SECOND_MEMBER_USER_ID}`,
+        name: `Vai trò của ${SECOND_MEMBER_DISPLAY_NAME}`,
       });
       fireEvent.click(roleSelect);
       fireEvent.click(screen.getByRole('option', { name: 'Biên tập viên' }));
@@ -135,11 +139,11 @@ describe('AdminMembersPage', () => {
         );
         expect(membership?.role).toBe('editor');
       });
-      // Scoped to this member's own row — see `findRowByUserId`'s doc for why
-      // an unscoped `findByText('Biên tập viên')` would be a false positive
-      // here (the seeded invite fixture shares that exact label).
+      // Scoped to this member's own row — see `findRowByDisplayName`'s doc for
+      // why an unscoped `findByText('Biên tập viên')` would be a false
+      // positive here (the seeded invite fixture shares that exact label).
       await waitFor(() => {
-        const row = findRowByUserId(SECOND_MEMBER_USER_ID);
+        const row = findRowByDisplayName(SECOND_MEMBER_DISPLAY_NAME);
         expect(within(row).getByText('Biên tập viên', { selector: 'span.tag' })).toBeVisible();
       });
     });
@@ -202,6 +206,8 @@ describe('AdminMembersPage', () => {
       const otherOwnerId = mockUuid(40);
       roster.push({
         userId: otherOwnerId,
+        email: 'other-owner@example.com',
+        displayName: 'Other Owner',
         role: 'owner',
         state: 'active',
         createdAt: mockTimestamp(0),

--- a/web/src/pages/GraphPage.test.tsx
+++ b/web/src/pages/GraphPage.test.tsx
@@ -91,8 +91,12 @@ describe('GraphPage', () => {
     fireEvent.click(screen.getByRole('combobox', { name: 'Lọc theo bộ sưu tập' }));
     fireEvent.click(screen.getByRole('option', { name: 'Employee Handbook' }));
 
+    // The filter change refetches — a loading state briefly replaces the whole
+    // graph, which already satisfies the "specs doc gone" wait below. The
+    // handbook assertion must therefore also await the refetch completing
+    // rather than racing it (failed on slower CI runners as a sync getBy).
     await waitFor(() => expect(screen.queryByText('Đặc tả sản phẩm v1')).not.toBeInTheDocument());
-    expect(screen.getByText('Sổ tay nhân viên 2024')).toBeVisible();
+    expect(await screen.findByText('Sổ tay nhân viên 2024')).toBeVisible();
   });
 
   it('table view exposes edges structurally (kind + weight), not just node titles', async () => {

--- a/web/src/pages/GraphPage.test.tsx
+++ b/web/src/pages/GraphPage.test.tsx
@@ -1,0 +1,144 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createApiClient, type ApiClient } from '../api/client';
+import { installMockFetch, resetMockState, uninstallMockFetch } from '../mocks';
+import { mockUuid } from '../mocks/ids';
+import { RouterProvider } from '../state/RouterProvider';
+import { ScopeProvider } from '../state/ScopeProvider';
+import { GraphPage } from './GraphPage';
+
+const DEMO_EMAIL = 'demo@markhand.test';
+const DEMO_PASSWORD = 'demo-password';
+const SPECS_COLLECTION_ID = mockUuid(11);
+
+async function loggedInClient(): Promise<ApiClient> {
+  const client = createApiClient({ baseUrl: '' });
+  await client.login({ email: DEMO_EMAIL, password: DEMO_PASSWORD });
+  return client;
+}
+
+function renderGraph(client: ApiClient, collectionId?: string) {
+  return render(
+    <RouterProvider>
+      <ScopeProvider>
+        <GraphPage collectionId={collectionId} client={client} />
+      </ScopeProvider>
+    </RouterProvider>,
+  );
+}
+
+describe('GraphPage', () => {
+  beforeEach(() => {
+    installMockFetch();
+    resetMockState();
+    window.history.pushState(null, '', '/');
+  });
+
+  afterEach(() => {
+    cleanup();
+    uninstallMockFetch();
+  });
+
+  it('renders the seeded graph: 13 nodes across 3 communities with per-cluster counts', async () => {
+    const client = await loggedInClient();
+    renderGraph(client);
+
+    expect(await screen.findByText('Sổ tay nhân viên 2024')).toBeVisible();
+    expect(screen.getByText('Đặc tả sản phẩm v1')).toBeVisible();
+    expect(screen.getByText('Biên bản họp liên phòng')).toBeVisible();
+
+    // Sidebar communities + counts (matches mocks/handlers/graph.ts's fixed catalog).
+    expect(screen.getByRole('heading', { name: 'Cộng đồng' })).toBeVisible();
+    const employeeHandbookRow = screen.getByLabelText(/Employee Handbook/);
+    const productSpecsRow = screen.getByLabelText(/Product Specs/);
+    const crossTeamRow = screen.getByLabelText(/Liên phòng ban/);
+    expect(employeeHandbookRow.closest('li')).toHaveTextContent('5');
+    expect(productSpecsRow.closest('li')).toHaveTextContent('5');
+    expect(crossTeamRow.closest('li')).toHaveTextContent('3');
+  });
+
+  it('turning off a community hides its nodes; "Chọn tất cả" brings them back', async () => {
+    const client = await loggedInClient();
+    renderGraph(client);
+    await screen.findByText('Sổ tay nhân viên 2024');
+
+    fireEvent.click(screen.getByLabelText(/Employee Handbook/));
+    await waitFor(() =>
+      expect(screen.queryByText('Sổ tay nhân viên 2024')).not.toBeInTheDocument(),
+    );
+    // A different cluster's node is unaffected.
+    expect(screen.getByText('Đặc tả sản phẩm v1')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Chọn tất cả' }));
+    await waitFor(() => expect(screen.getByText('Sổ tay nhân viên 2024')).toBeVisible());
+  });
+
+  it('clicking a node navigates to its own collection in the library (P2-07 route)', async () => {
+    const client = await loggedInClient();
+    renderGraph(client);
+    await screen.findByText('Đặc tả sản phẩm v1');
+
+    fireEvent.click(screen.getByRole('button', { name: /Đặc tả sản phẩm v1/ }));
+    await waitFor(() => expect(window.location.pathname).toBe(`/library/${SPECS_COLLECTION_ID}`));
+  });
+
+  it('filtering by collection narrows the graph to that collection only', async () => {
+    const client = await loggedInClient();
+    renderGraph(client);
+    await screen.findByText('Sổ tay nhân viên 2024');
+    expect(screen.getByText('Đặc tả sản phẩm v1')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Lọc theo bộ sưu tập' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Employee Handbook' }));
+
+    await waitFor(() => expect(screen.queryByText('Đặc tả sản phẩm v1')).not.toBeInTheDocument());
+    expect(screen.getByText('Sổ tay nhân viên 2024')).toBeVisible();
+  });
+
+  it('table view exposes edges structurally (kind + weight), not just node titles', async () => {
+    const client = await loggedInClient();
+    renderGraph(client);
+    await screen.findByText('Sổ tay nhân viên 2024');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Chế độ xem bảng' }));
+
+    expect(screen.getByText('Danh sách liên kết trong đồ thị')).toBeVisible();
+    expect(screen.getAllByText('Xung đột').length).toBeGreaterThan(0);
+  });
+
+  it('announces the visible node/community counts via an aria-live region', async () => {
+    const client = await loggedInClient();
+    renderGraph(client);
+    await screen.findByText('Sổ tay nhân viên 2024');
+
+    expect(await screen.findByTestId('graph-live-region')).toHaveTextContent(
+      'Đang hiển thị 13 trong 13 tài liệu, 3 trong 3 cụm.',
+    );
+
+    fireEvent.click(screen.getByLabelText(/Employee Handbook/));
+    await waitFor(() =>
+      expect(screen.getByTestId('graph-live-region')).toHaveTextContent(
+        'Đang hiển thị 8 trong 13 tài liệu, 2 trong 3 cụm.',
+      ),
+    );
+  });
+
+  it('scopes the graph to org B after a switch — a different, smaller graph', async () => {
+    // Same "seed independence" spirit as other org-scoped pages: this test
+    // stays deliberately minimal — full org-switch UI wiring (`useAuth().
+    // switchOrg`) already has its own dedicated suite (org-switch.spec.ts).
+    // It drives the same `/orgs/switch` request `switchOrg` does and applies
+    // the returned tokens directly (bypassing `AuthProvider`, which this
+    // page-level test doesn't render), only to prove the mock's own org-B
+    // graph fixture (`mocks/handlers/graph.ts`) is reachable and distinct.
+    const client = await loggedInClient();
+    const tokens = await client.request('post', '/orgs/switch', {
+      body: { orgId: '00000000-0000-4000-8000-000000000003' },
+    });
+    client.sessionManager.setTokens(tokens);
+    renderGraph(client);
+
+    expect(await screen.findByText('Globex Master Plan.pdf')).toBeVisible();
+    expect(screen.queryByText('Sổ tay nhân viên 2024')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/GraphPage.tsx
+++ b/web/src/pages/GraphPage.tsx
@@ -1,0 +1,206 @@
+// P2-17 Document Graph MVP (owner request 2026-07-29 — force-directed graph
+// + "Communities" checkbox sidebar with per-cluster counts, from the
+// reference screenshot). Built directly on the OpenAPI contract + mock
+// server like every other P2-0x page (`GET /graph`, `routes/graph.rs`).
+//
+// Layout: a hand-rolled force simulation (`lib/forceLayout.ts`) — no
+// `d3-force` dependency (see that module's doc + the P2-17 report for the
+// trade-off). Node click navigates to the node's own collection in the
+// library (`/library/:collectionId` — P2-07's existing route; there is no
+// document-level URL to deep-link straight into a single document's preview
+// today, since `LibraryPage`'s selected-document state is local, not a route
+// param — a documented gap, not an oversight; see the report).
+import { useMemo, useState } from 'react';
+import { apiClient, type ApiClient } from '../api/client';
+import type { components } from '../api/generated/contract';
+import { CommunitySidebar, GraphCanvas } from '../components/graph';
+import type { Collection } from '../components/library';
+import { describeApiError } from '../components/library';
+import { Notice, SelectControl, type SelectOption } from '../components/ui';
+import { useScopeSafeRequest } from '../hooks/useScopeSafeRequest';
+import { computeForceLayout } from '../lib/forceLayout';
+import { buildScopedPath } from '../lib/router';
+import { useRouter } from '../state/RouterProvider';
+
+type GraphNode = components['schemas']['GraphNode'];
+
+const ALL_COLLECTIONS_VALUE = '';
+
+export function GraphPage({
+  collectionId,
+  client = apiClient,
+}: {
+  collectionId?: string;
+  /** Injectable for tests; defaults to the app-wide singleton, same convention as `QaPage`/`LibraryPage`. */
+  client?: ApiClient;
+}) {
+  const { navigate } = useRouter();
+  const [selectedCollectionId, setSelectedCollectionId] = useState(
+    collectionId ?? ALL_COLLECTIONS_VALUE,
+  );
+  const [hiddenCommunityIds, setHiddenCommunityIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [viewMode, setViewMode] = useState<'canvas' | 'table'>('canvas');
+
+  const collectionsResult = useScopeSafeRequest(
+    (signal) => client.request('get', '/collections', { signal }),
+    [client],
+  );
+  const collections: Collection[] = collectionsResult.data?.items ?? [];
+
+  const graphResult = useScopeSafeRequest(
+    (signal) =>
+      client.request('get', '/graph', {
+        params: {
+          query: selectedCollectionId ? { collectionId: selectedCollectionId } : undefined,
+        },
+        signal,
+      }),
+    [client, selectedCollectionId],
+  );
+  const graph = graphResult.data;
+
+  const communityIndexByNodeId = useMemo(() => {
+    const map = new Map<string, number>();
+    graph?.communities.forEach((community, index) => {
+      community.nodeIds.forEach((id) => map.set(id, index));
+    });
+    return map;
+  }, [graph]);
+
+  const hiddenNodeIds = useMemo(() => {
+    const hidden = new Set<string>();
+    graph?.communities.forEach((community) => {
+      if (hiddenCommunityIds.has(community.id)) {
+        community.nodeIds.forEach((id) => hidden.add(id));
+      }
+    });
+    return hidden;
+  }, [graph, hiddenCommunityIds]);
+
+  const visibleNodes = useMemo(
+    () => (graph?.nodes ?? []).filter((node) => !hiddenNodeIds.has(node.id)),
+    [graph, hiddenNodeIds],
+  );
+  const visibleNodeIdSet = useMemo(() => new Set(visibleNodes.map((n) => n.id)), [visibleNodes]);
+  const visibleEdges = useMemo(
+    () =>
+      (graph?.edges ?? []).filter(
+        (edge) => visibleNodeIdSet.has(edge.source) && visibleNodeIdSet.has(edge.target),
+      ),
+    [graph, visibleNodeIdSet],
+  );
+
+  const positions = useMemo(
+    () =>
+      computeForceLayout(
+        visibleNodes.map((n) => n.id),
+        visibleEdges,
+      ),
+    [visibleNodes, visibleEdges],
+  );
+
+  const visibleCommunityCount = graph
+    ? graph.communities.filter((c) => !hiddenCommunityIds.has(c.id)).length
+    : 0;
+  const liveMessage = graph
+    ? `Đang hiển thị ${visibleNodes.length} trong ${graph.nodes.length} tài liệu, ${visibleCommunityCount} trong ${graph.communities.length} cụm.`
+    : '';
+
+  function handleCollectionChange(value: string) {
+    setSelectedCollectionId(value);
+    setHiddenCommunityIds(new Set());
+  }
+
+  function toggleCommunity(communityId: string) {
+    setHiddenCommunityIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(communityId)) {
+        next.delete(communityId);
+      } else {
+        next.add(communityId);
+      }
+      return next;
+    });
+  }
+
+  function selectAllCommunities() {
+    setHiddenCommunityIds(new Set());
+  }
+
+  function handleActivateNode(node: GraphNode) {
+    navigate(buildScopedPath('library', node.collectionId));
+  }
+
+  const collectionOptions: SelectOption[] = [
+    { value: ALL_COLLECTIONS_VALUE, label: 'Tất cả bộ sưu tập' },
+    ...collections.map((collection) => ({ value: collection.id, label: collection.name })),
+  ];
+
+  return (
+    <section
+      className="page graph-page"
+      style={{ maxWidth: 'none' }}
+      aria-labelledby="graph-heading"
+    >
+      <p className="eyebrow">Đồ thị</p>
+      <h1 id="graph-heading">Đồ thị tài liệu</h1>
+      <p className="lede">
+        Khám phá quan hệ xung đột, đồng trích dẫn và tương đồng giữa các tài liệu đã lập chỉ mục,
+        theo từng cộng đồng tài liệu.
+      </p>
+
+      <div className="graph-toolbar">
+        <SelectControl
+          value={selectedCollectionId}
+          options={collectionOptions}
+          onChange={handleCollectionChange}
+          ariaLabel="Lọc theo bộ sưu tập"
+        />
+        <button
+          type="button"
+          className="btn btn-secondary btn-sm"
+          onClick={() => setViewMode((mode) => (mode === 'canvas' ? 'table' : 'canvas'))}
+        >
+          {viewMode === 'canvas' ? 'Chế độ xem bảng' : 'Chế độ xem đồ thị'}
+        </button>
+      </div>
+
+      <p
+        className="visually-hidden"
+        role="status"
+        aria-live="polite"
+        data-testid="graph-live-region"
+      >
+        {liveMessage}
+      </p>
+
+      {graphResult.status === 'loading' && <p>Đang tải đồ thị…</p>}
+      {graphResult.status === 'error' && (
+        <Notice tone="error">{describeApiError(graphResult.error)}</Notice>
+      )}
+      {graph && graph.nodes.length === 0 && (
+        <p className="text-muted">Không có tài liệu nào để hiển thị trong đồ thị này.</p>
+      )}
+      {graph && graph.nodes.length > 0 && (
+        <div className="graph-layout">
+          <GraphCanvas
+            nodes={visibleNodes}
+            edges={visibleEdges}
+            positions={positions}
+            communityIndexByNodeId={communityIndexByNodeId}
+            viewMode={viewMode}
+            onActivateNode={handleActivateNode}
+          />
+          <CommunitySidebar
+            communities={graph.communities}
+            hiddenCommunityIds={hiddenCommunityIds}
+            onToggle={toggleCommunity}
+            onSelectAll={selectAllCommunities}
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/pages/LibraryPage.test.tsx
+++ b/web/src/pages/LibraryPage.test.tsx
@@ -111,9 +111,7 @@ describe('LibraryPage', () => {
 
     expect(await screen.findByRole('button', { name: /Onboarding Guide\.pdf/ })).toBeVisible();
     expect(screen.getByRole('button', { name: /Leave Policy\.docx/ })).toBeVisible();
-    expect(
-      screen.getByRole('heading', { name: `Bộ sưu tập ${HANDBOOK_COLLECTION_ID}` }),
-    ).toBeVisible();
+    expect(screen.getByRole('heading', { name: 'Employee Handbook' })).toBeVisible();
   });
 
   it('shows a prompt instead of a document list when no collection is selected', async () => {
@@ -262,7 +260,7 @@ describe('LibraryPage', () => {
     fireEvent.click(await screen.findByRole('button', { name: /Special/ }));
 
     // Scoped to the rendered-Markdown wrapper specifically: the page also has
-    // its own `<h1 id="library-heading">` (the "Bộ sưu tập <id>" heading),
+    // its own `<h1 id="library-heading">` (the collection-name heading),
     // which would otherwise be `querySelector('h1')`'s first match.
     await waitFor(() =>
       expect(

--- a/web/src/pages/LibraryPage.test.tsx
+++ b/web/src/pages/LibraryPage.test.tsx
@@ -400,4 +400,24 @@ describe('LibraryPage', () => {
       expect(screen.getByText('Chưa có tài liệu nào trong bộ sưu tập này.')).toBeVisible();
     });
   });
+
+  describe('P2-18 projects', () => {
+    it('groups collection nav by project, with an unassigned group for collections with no project', async () => {
+      const client = await loggedInClient();
+      renderLibrary(client, undefined);
+
+      // Seeded: "Nhân sự" -> Employee Handbook; Product Specs unassigned.
+      expect(await screen.findByText('Nhân sự')).toBeVisible();
+      expect(screen.getByText('Chưa thuộc dự án')).toBeVisible();
+      expect(screen.getByRole('link', { name: 'Employee Handbook' })).toBeVisible();
+      expect(screen.getByRole('link', { name: 'Product Specs' })).toBeVisible();
+    });
+
+    // The create/assign flow itself (`ProjectsPanel`, gated by
+    // `useAuth().hasPermission`) is covered in `ProjectsPanel.test.tsx`,
+    // which — unlike this file's bare-`client`-injection convention — wraps
+    // in a real `AuthProvider` (same reason `AdminMembersPage.test.tsx`
+    // does, see its own module doc): `useAuth()` reads from `AuthContext`,
+    // which a bare injected `client` prop never populates.
+  });
 });

--- a/web/src/pages/LibraryPage.tsx
+++ b/web/src/pages/LibraryPage.tsx
@@ -29,6 +29,7 @@ import {
   DocumentList,
   DocumentPreview,
   Pagination,
+  ProjectsPanel,
   describeApiError,
   matchesQuery,
   type Collection,
@@ -235,6 +236,12 @@ export function LibraryPage({
         collections={collections}
         activeCollectionId={collectionId}
         loading={collectionsResult.status === 'loading'}
+      />
+
+      <ProjectsPanel
+        collections={collections}
+        client={client}
+        onChanged={() => setCollectionsRetry((n) => n + 1)}
       />
 
       {!collectionId ? (

--- a/web/src/pages/LibraryPage.tsx
+++ b/web/src/pages/LibraryPage.tsx
@@ -96,6 +96,17 @@ export function LibraryPage({
     [client, collectionsRetry],
   );
   const collections: Collection[] = collectionsResult.data?.items ?? [];
+  // The heading must never flash a raw collectionId (owner-reported UI gap):
+  // while the nav's own `GET /collections` fetch is still in flight there is
+  // no name to show yet, so a neutral "Bộ sưu tập" placeholder is used
+  // instead of the id — same "loading" -> "loaded" rule `DocumentPreview`
+  // follows for a still-loading document. A collectionId that doesn't match
+  // any item (not yet loaded, or a stale/deleted deep link) falls back to
+  // the same neutral placeholder rather than ever rendering the id itself.
+  const activeCollection = collections.find((c) => c.id === collectionId);
+  const libraryHeading = !collectionId
+    ? 'Tất cả bộ sưu tập'
+    : (activeCollection?.name ?? 'Bộ sưu tập');
 
   const cursor = effectiveView.cursors[effectiveView.pageIndex];
   const [documentsRetry, setDocumentsRetry] = useState(0);
@@ -198,9 +209,7 @@ export function LibraryPage({
   return (
     <section className="page" style={{ maxWidth: 'none' }} aria-labelledby="library-heading">
       <p className="eyebrow">Thư viện</p>
-      <h1 id="library-heading">
-        {collectionId ? `Bộ sưu tập ${collectionId}` : 'Tất cả bộ sưu tập'}
-      </h1>
+      <h1 id="library-heading">{libraryHeading}</h1>
       <p className="lede">
         Duyệt bộ sưu tập, theo dõi trạng thái xử lý và xem trước nội dung Markdown đã chuyển đổi.
       </p>

--- a/web/src/pages/QaPage.test.tsx
+++ b/web/src/pages/QaPage.test.tsx
@@ -223,6 +223,70 @@ describe('QaPage', () => {
     expect(screen.getByText('CITE-0001')).toBeVisible();
   });
 
+  it('P2-18: "Phạm vi" project scope narrows both search and ask to that project\'s collections', async () => {
+    const client = await loggedInClient();
+    renderQa(client);
+
+    // "Nhân sự" (seeded org A project) is assigned only to the Employee
+    // Handbook collection (mockUuid(10)) — "Roadmap.xlsx" lives in Product
+    // Specs (mockUuid(11)), which is NOT in that project, so a search/ask
+    // scoped to "Nhân sự" must find nothing for a query that only matches
+    // Roadmap.xlsx.
+    const scopeTrigger = screen.getByRole('combobox', { name: 'Phạm vi dự án' });
+    expect(scopeTrigger).toHaveTextContent('Tất cả dự án');
+    fireEvent.click(scopeTrigger);
+    fireEvent.click(await screen.findByRole('option', { name: 'Nhân sự' }));
+    expect(scopeTrigger).toHaveTextContent('Nhân sự');
+
+    fireEvent.change(screen.getByLabelText('Từ khóa'), {
+      target: { value: 'lộ trình quý 3' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Tìm kiếm' }));
+    expect(
+      await screen.findByText(/Không tìm thấy kết quả phù hợp với "lộ trình quý 3"/),
+    ).toBeVisible();
+
+    await askQuestion('Lộ trình quý 3 tập trung vào việc gì?');
+    await waitFor(() => {
+      expect(screen.getByTestId('qa-answer')).toHaveTextContent(
+        'Không tìm thấy nội dung liên quan trong tài liệu đã lập chỉ mục để trả lời câu hỏi này.',
+      );
+    });
+
+    // Back to "Tất cả dự án" (no filter) — the same question now finds it.
+    fireEvent.click(scopeTrigger);
+    fireEvent.click(screen.getByRole('option', { name: 'Tất cả dự án' }));
+    await waitFor(() => expect(screen.getByLabelText('Câu hỏi')).not.toBeDisabled());
+
+    await askQuestion('Lộ trình quý 3 tập trung vào việc gì?');
+    await waitFor(() => {
+      const answers = screen.getAllByTestId('qa-answer');
+      expect(answers[answers.length - 1]).toHaveTextContent(
+        'Lộ trình quý 3 tập trung vào tối ưu hiệu năng lập chỉ mục.',
+      );
+    });
+  });
+
+  it('P2-18: switching org resets "Phạm vi" back to "Tất cả dự án"', async () => {
+    const client = await loggedInClient();
+    const manager = createScopeManager();
+    manager.setScope({ orgId: 'org-a', permissions: [], allowedCollectionIds: [] });
+    renderQa(client, undefined, manager);
+
+    const scopeTrigger = screen.getByRole('combobox', { name: 'Phạm vi dự án' });
+    fireEvent.click(scopeTrigger);
+    fireEvent.click(await screen.findByRole('option', { name: 'Nhân sự' }));
+    expect(scopeTrigger).toHaveTextContent('Nhân sự');
+
+    act(() => {
+      manager.setScope({ orgId: 'org-b', permissions: [], allowedCollectionIds: [] });
+    });
+
+    expect(screen.getByRole('combobox', { name: 'Phạm vi dự án' })).toHaveTextContent(
+      'Tất cả dự án',
+    );
+  });
+
   it('switching org clears the whole chat history in-memory (no stale-org bubble ever painted)', async () => {
     const client = await loggedInClient();
     const manager = createScopeManager();

--- a/web/src/pages/QaPage.tsx
+++ b/web/src/pages/QaPage.tsx
@@ -24,6 +24,11 @@ export function QaPage({
   // real documents to choose from instead of a raw UUID field — see
   // `ChatPanel.tsx`'s module doc.
   const [candidateDocuments, setCandidateDocuments] = useState<SearchHit[]>([]);
+  // P2-18 — the "Phạm vi" dropdown itself lives inside `ChatPanel`'s
+  // composer (see that component's `onScopeChange` doc), but its value must
+  // also scope `SearchPanel`'s request — this page is the one place both
+  // siblings meet, so it's the natural owner of the lifted value.
+  const [projectId, setProjectId] = useState<string | undefined>(undefined);
 
   // Only fetched for the heading's collection name — same "never show the
   // raw id" rule `LibraryPage.tsx` follows for its own heading (owner-
@@ -51,6 +56,7 @@ export function QaPage({
       <div style={{ display: 'grid', gap: 'var(--space-4)' }}>
         <SearchPanel
           collectionIds={collectionIds}
+          projectId={projectId}
           client={client}
           onHitsChanged={setCandidateDocuments}
         />
@@ -58,6 +64,7 @@ export function QaPage({
           collectionIds={collectionIds}
           client={client}
           candidateDocuments={candidateDocuments}
+          onScopeChange={setProjectId}
         />
       </div>
     </section>

--- a/web/src/pages/QaPage.tsx
+++ b/web/src/pages/QaPage.tsx
@@ -8,6 +8,8 @@
 import { useState } from 'react';
 import { apiClient, type ApiClient } from '../api/client';
 import { ChatPanel, SearchPanel, type SearchHit } from '../components/qa';
+import type { Collection } from '../components/library';
+import { useScopeSafeRequest } from '../hooks/useScopeSafeRequest';
 
 export function QaPage({
   collectionId,
@@ -23,12 +25,24 @@ export function QaPage({
   // `ChatPanel.tsx`'s module doc.
   const [candidateDocuments, setCandidateDocuments] = useState<SearchHit[]>([]);
 
+  // Only fetched for the heading's collection name — same "never show the
+  // raw id" rule `LibraryPage.tsx` follows for its own heading (owner-
+  // reported UI gap). While this is still loading, or for a stale/unknown
+  // collectionId, falls back to a neutral placeholder rather than the id.
+  const collectionsResult = useScopeSafeRequest(
+    (signal) => client.request('get', '/collections', { signal }),
+    [client],
+  );
+  const collections: Collection[] = collectionsResult.data?.items ?? [];
+  const activeCollection = collections.find((c) => c.id === collectionId);
+  const qaHeading = !collectionId
+    ? 'Hỏi đáp trên toàn bộ thư viện'
+    : `Hỏi đáp trên bộ sưu tập ${activeCollection?.name ?? ''}`.trim();
+
   return (
     <section className="page" style={{ maxWidth: 'none' }} aria-labelledby="qa-heading">
       <p className="eyebrow">Hỏi đáp</p>
-      <h1 id="qa-heading">
-        {collectionId ? `Hỏi đáp trên bộ sưu tập ${collectionId}` : 'Hỏi đáp trên toàn bộ thư viện'}
-      </h1>
+      <h1 id="qa-heading">{qaHeading}</h1>
       <p className="lede">
         Tìm kiếm tài liệu đã lập chỉ mục hoặc đặt câu hỏi để nhận câu trả lời có trích dẫn, phát dần
         theo thời gian thực.

--- a/web/src/pages/index.ts
+++ b/web/src/pages/index.ts
@@ -1,5 +1,6 @@
 export { AdminMembersPage } from './AdminMembersPage';
 export { AdminUsagePage } from './AdminUsagePage';
+export { GraphPage } from './GraphPage';
 export { HelpPage } from './HelpPage';
 export { LibraryPage } from './LibraryPage';
 export { LoginPage } from './LoginPage';

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1045,10 +1045,11 @@ textarea.input {
   background: color-mix(in srgb, var(--color-text) 4%, transparent);
 }
 
-/* Member identity cell (components/admin/MembersTable.tsx): the membership
-   API carries only a user id — no name or email — so the identity reads as a
-   round monogram avatar + the id set in monospace, with a "Bạn" tag when the
-   row is the signed-in caller. Replaces the old bare `<code>` UUID blob. */
+/* Member identity cell (components/admin/MembersTable.tsx): a round monogram
+   avatar (derived from displayName, never the user id) plus the member's
+   name (bold) and email (muted) stacked underneath, with a "Bạn" tag next to
+   the name when the row is the signed-in caller. Replaces the old bare
+   UUID display — the membership API now joins `users` for name/email. */
 .member-identity {
   align-items: center;
   display: flex;
@@ -1071,11 +1072,26 @@ textarea.input {
   width: 2.1rem;
 }
 
-.member-identity-id {
+.member-identity-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.member-identity-name {
+  align-items: center;
   color: var(--color-text);
-  font-family: ui-monospace, Menlo, monospace;
+  display: flex;
+  font-weight: 600;
+  gap: var(--space-2);
+}
+
+.member-identity-email {
   font-size: 12.5px;
-  letter-spacing: -0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* — dialog — */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2052,3 +2052,196 @@ textarea.input {
 .rail-expanded .rail-tooltip {
   display: none;
 }
+
+/* P2-17 Document Graph MVP ------------------------------------------------ */
+
+/* Standard visually-hidden-but-announced utility (WCAG technique), used for
+   the graph page's `aria-live` filter/toggle summary — visible on screen
+   would be redundant with the sidebar/toolbar state it restates. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.graph-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-4);
+}
+
+.graph-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 260px;
+  gap: var(--space-4);
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .graph-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.graph-canvas-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.graph-canvas {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 4 / 3;
+  background: var(--color-surface);
+  border: 1px solid var(--color-divider);
+  border-radius: 12px;
+}
+
+.graph-edge {
+  stroke: var(--color-neutral-500);
+  stroke-opacity: 0.6;
+}
+
+.graph-edge-conflict {
+  stroke: var(--color-accent-700);
+}
+
+.graph-edge-co_citation {
+  stroke: var(--color-accent-2-700);
+}
+
+.graph-edge-similarity {
+  stroke: var(--color-neutral-600);
+  stroke-dasharray: 4 3;
+}
+
+.graph-node-dot {
+  cursor: pointer;
+  stroke: var(--color-bg);
+  stroke-width: 1.5;
+}
+
+.graph-node-list-wrap h2 {
+  font-size: 14px;
+  margin-bottom: var(--space-2);
+}
+
+.graph-node-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.graph-node-button {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  text-align: left;
+  padding: var(--space-2);
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.graph-node-button:hover,
+.graph-node-button:focus-visible {
+  border-color: var(--color-divider);
+  background: var(--color-surface);
+}
+
+.graph-node-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.graph-sidebar {
+  border: 1px solid var(--color-divider);
+  border-radius: 12px;
+  padding: var(--space-3);
+}
+
+.graph-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.graph-sidebar-header h2 {
+  font-size: 15px;
+  margin: 0;
+}
+
+.graph-community-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.graph-community-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+.graph-community-label {
+  flex: 1;
+}
+
+.graph-community-count {
+  color: color-mix(in srgb, var(--color-text) 68%, transparent);
+  font-variant-numeric: tabular-nums;
+}
+
+.graph-table-view table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: var(--space-4);
+}
+
+.graph-table-view caption {
+  text-align: left;
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+}
+
+.graph-table-view th,
+.graph-table-view td {
+  text-align: left;
+  padding: var(--space-2);
+  border-bottom: 1px solid var(--color-divider);
+}
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-accent-700);
+  text-decoration: underline;
+  cursor: pointer;
+  font: inherit;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2157,6 +2157,12 @@ textarea.input {
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
+  /* The global `button` rule paints cream-on-accent; on this transparent
+     list row that inherited cream text is invisible on the cream ground. */
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-weight: 400;
+  min-height: 0;
   cursor: pointer;
 }
 

--- a/web/src/types/routes.ts
+++ b/web/src/types/routes.ts
@@ -6,7 +6,15 @@
  * land by default.
  */
 export type RouteName =
-  'home' | 'login' | 'library' | 'qa' | 'adminMembers' | 'adminUsage' | 'help' | 'notFound';
+  | 'home'
+  | 'login'
+  | 'library'
+  | 'qa'
+  | 'graph'
+  | 'adminMembers'
+  | 'adminUsage'
+  | 'help'
+  | 'notFound';
 
 export interface RouteParams {
   collectionId?: string;


### PR DESCRIPTION
## Outcome

8 commit tiếp sau #326 — 2 tính năng owner yêu cầu trực tiếp + 1 hạng mục roadmap 1C + loạt sửa hiển thị:

- **Document graph (P2-17, `8aeb539` + `b89b787` + `5078cb1`)**: `GET /api/v1/graph` (gate `qa.query`, node đúng ACL/RLS caller) với cạnh từ quan hệ THẬT: `conflict` (dual-leg claims, status open) và `co_citation` (`ask_stream_sessions.cited_document_ids` — nguồn persist duy nhất); communities = connected components thuần Rust, prune cap 500/2000 deterministic. Trang "Đồ thị": force layout tự viết (seeded, **bit-for-bit deterministic** sau khi sort cạnh chính tắc), cụm màu tụ giữa canvas (fix vòng 2: gravity cộng trước cap nhiệt, k cố định 45px — kèm 3 regression test đã xác nhận fail trên thuật toán cũ), sidebar Cộng đồng checkbox + count, filter bộ sưu tập, chế độ xem bảng a11y (fix chữ kem-trên-kem vô hình do kế thừa rule `button` toàn cục). Cạnh `similarity`/Qdrant: chỗ gắn sẵn có chủ đích — API `scroll_points` hiện `with_vector:false`, cần vòng riêng với Qdrant thật (ghi trong backlog).
- **Dự án per-org (P2-18, `391f372`)**: migration `0032` — `projects` (org-scoped, RLS như collections) + `collections.project_id` nullable; CRUD `GET/POST /projects`, `PATCH /projects/{id}`, `POST /collections/{id}/assign-project` (action route theo tiền lệ api.md, quyền `doc.upload` mirror create/update collection, audit đủ); search/ask/ask-stream nhận `projectId` optional → resolve tập collection ∩ ACL → đi qua đúng `resolve_scope` sẵn có (không đường retrieval mới); project lạ/khác org → 404 no-oracle, resolve TRƯỚC check vector-store. UI: dropdown "Phạm vi: Tất cả dự án / dự án" trong composer Hỏi đáp (reset khi đổi org), thư viện nhóm theo dự án + panel tạo/gán.
- **ACL context cache (1C-05, `f841888`)**: `orgs.acl_version` (migration `0031`) bump cùng transaction với cả 6 mutation ảnh hưởng resolver; cache in-process bounded (4096, TTL 3s) cho `AuthenticatedOrg` nhưng **không hit nào được tin mù**: mỗi hit re-check `disabled_at` + `acl_version` (2 point-lookup) trước khi dùng → revoke/suspend hiệu lực NGAY trên mọi instance, không cần kênh invalidation. Đường luôn-tươi (ask-stream snapshot, upload saga barrier) không đụng. Gap khai báo: collection create/delete chưa bump (bounded TTL 3s, ghi trong migration + backlog).
- **Bỏ UUID khỏi UI (`0affb51`)**: `MembershipDto` thêm `email`/`displayName` (JOIN `users` — không đổi tenant visibility); trang Thành viên hiện tên + email + avatar chữ cái; heading Thư viện/Hỏi đáp dùng tên bộ sưu tập (không nháy UUID khi load); label tài liệu không tiêu đề. Giữ lại duy nhất "Mã yêu cầu" (trace id debug).
- Nhỏ: prettier pass sót trên test layout (`8afa25e`).

## Scope

`crates/server`: migrations 0031/0032 + manifest, routes/{graph,projects} mới, db/{graph,projects,members,orgs,collections}, auth/context_cache mới + wiring, services/{members,acl_mutate,audit,graph}, openapi.yaml (40→49 schemas), tests {graph,projects,acl_cache} mới + members. `web`: GraphPage + components/graph + lib/forceLayout mới, ProjectsPanel + nhóm thư viện, ChatPanel scope dropdown, MembersTable tên/email, mocks (graph/projects/members org-scoped), e2e 25→29 spec, contract regenerate, pin-count 40→49. Backlog: P2-17/P2-18 mới, 1C-05/1C-02/1C-11 cập nhật, roadmap.html regenerate (115 issues).

Không đổi: retrieval path (project filter dùng `resolve_scope` sẵn có), RLS, hành vi khi không truyền projectId, các đường resolve luôn-tươi.

## Evidence

- [x] Tests: web **489/489** unit (46 file) + Playwright **29/29** (graph 3 + projects 1 spec mới); Rust lib **302/302**; DB-gated trên Postgres 16 local: graph 6/6, projects 12/12, acl_cache 5/5, members 12/12, orgs 12/12, auth 7/7, schema_migrations 8/8 (migrations 0031/0032 idempotent); fmt/clippy `-D warnings`/lint/format:check/build/manifest/roadmap-check sạch. Mọi nhóm chạy 2 lớp (agent + coordinator độc lập).
- [x] Manual/benchmark/migration evidence: cả 2 migration expand-only, không ALTER phá; layout fix kiểm chứng TRỰC QUAN qua vòng lặp screenshot Playwright (số liệu: nội-cụm ~30-70px vs liên-cụm ~150px, không node chạm biên) + acl_cache sanity-inversion (bỏ bump → test đỏ → hoàn lại → xanh); ảnh UI các tính năng đã gửi trong phiên.

## Boundary and security review

- [x] Dependency boundary check passed. (Không dependency mới — force layout tự viết ~150 dòng; không import Tauri.)
- [x] Tenant/ACL impact reviewed, or N/A. Graph/projects: org isolation + ACL giao với caller có test DB-gated riêng từng cái; project 404 no-oracle; graph gate `qa.query` vì trộn dữ liệu conflict/citation; ACL cache verify-before-trust — revoke tức thời có test end-to-end HTTP; JOIN `users` không mở rộng visibility (bảng không RLS, membership vẫn lọc org).
- [x] Sensitive logging/secret/egress impact reviewed, or N/A. Không log content; không endpoint mới lộ metadata ngoài allowlist; không egress mới.
- [x] Security review trigger checked. (Đụng resolver auth → thiết kế fail-closed, cache miss/nghi ngờ đánh DB; migration liên quan authz đều expand-only + version bump transactional.)

## Follow-up

- [ ] Cạnh `similarity` cho graph: cần vòng chạy với Qdrant thật (dev stack owner) — sửa `storage/qdrant.rs` lấy vector + test tích hợp.
- [ ] Bump `acl_version` cho collection create/soft-delete (gap TTL 3s đã khai báo).
- [ ] Duplicate name → 409 cho projects + collections (hiện nhất quán 500); project deletion + multi-project membership out of scope có chủ đích.
- [x] Docs/OpenAPI/backlog/roadmap đồng bộ trong PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2AJXqkUkAqRTdCpkwFvwt

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2AJXqkUkAqRTdCpkwFvwt)_