### PR TITLE
Citation deep-link tới preview + similarity edges cho document graph + 409 duplicate name

### DIFF
--- a/crates/server/openapi/openapi.yaml
+++ b/crates/server/openapi/openapi.yaml
@@ -211,6 +211,14 @@ paths:
                 $ref: "#/components/schemas/Collection"
         "403":
           $ref: "#/components/responses/ApiError"
+        "409":
+          description: >
+            Collection name already used in this org (`uq_collections__org_name`).
+            Same `name_taken` mapping precedent as POST /orgs's `slug_taken`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
         "429":
           $ref: "#/components/responses/RateLimited"
   /collections/{collectionId}:
@@ -1158,6 +1166,14 @@ paths:
           $ref: "#/components/responses/ApiError"
         "403":
           $ref: "#/components/responses/ApiError"
+        "409":
+          description: >
+            Project name already used in this org (`uq_projects__org_name`).
+            Same `name_taken` mapping precedent as POST /orgs's `slug_taken`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
         "429":
           $ref: "#/components/responses/RateLimited"
   /projects/{projectId}:
@@ -1661,6 +1677,28 @@ components:
       properties:
         citeId:
           type: string
+        # P2-10/P2-07 gap close: the server (`services::citation::CitationPin`)
+        # has always serialized these three fields — this schema simply did
+        # not declare them, so `openapi-typescript`'s generated `CitationPin`
+        # type dropped them and the UI (`CitationCard.tsx`) could not build a
+        # "go to this document" deep-link even though the wire JSON already
+        # carried the id. Optional/nullable (not added to `required`) so this
+        # is a additive, non-breaking widen — no schema version bump. Field
+        # names match the existing `logicalDocumentId`/`versionId` convention
+        # `ResolveCitationRequest` and `/citations/resolve`'s response already
+        # use for the same identifiers, rather than inventing new names.
+        logicalDocumentId:
+          type: string
+          format: uuid
+          nullable: true
+        versionId:
+          type: string
+          format: uuid
+          nullable: true
+        collectionId:
+          type: string
+          format: uuid
+          nullable: true
         sourceContentSha256:
           type: string
           description: Original uploaded/source object SHA-256

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -21,7 +21,7 @@ pub const ROUTE_INVENTORY: &[(&str, &str, &[&str])] = &[
     ("get", "/auth/me", &["200", "401", "429"]),
     ("post", "/uploads", &["201", "400", "403", "413", "429"]),
     ("get", "/collections", &["200", "429"]),
-    ("post", "/collections", &["201", "403", "429"]),
+    ("post", "/collections", &["201", "403", "409", "429"]),
     ("get", "/collections/{collectionId}", &["200", "404", "429"]),
     (
         "patch",
@@ -110,7 +110,7 @@ pub const ROUTE_INVENTORY: &[(&str, &str, &[&str])] = &[
     // 403: same as GET /collections, list_projects is unfiltered by
     // permission (`org membership` is the only gate) — see routes::projects.
     ("get", "/projects", &["200", "429"]),
-    ("post", "/projects", &["201", "400", "403", "429"]),
+    ("post", "/projects", &["201", "400", "403", "409", "429"]),
     (
         "patch",
         "/projects/{projectId}",

--- a/crates/server/src/api/types.rs
+++ b/crates/server/src/api/types.rs
@@ -89,7 +89,10 @@ pub struct GraphNodeDto {
 }
 
 /// P2-17 graph edge. `kind` is `conflict` | `co_citation` | `similarity`;
-/// `weight` is `0..1` (see `services::graph::saturating_weight`).
+/// `weight` is `0..1` (`conflict`/`co_citation` via
+/// `services::graph::saturating_weight`, `similarity` — opt-in on a
+/// configured vector index + embedder — via
+/// `services::graph::normalize_similarity_weight`).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GraphEdgeDto {

--- a/crates/server/src/routes/collections.rs
+++ b/crates/server/src/routes/collections.rs
@@ -8,6 +8,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::Deserialize;
+use tokio_postgres::error::SqlState;
 use uuid::Uuid;
 
 use crate::api::{ApiError, CollectionDto, Page, PageInfo};
@@ -472,6 +473,10 @@ enum RouteError {
     Denied(String),
     Validation(String, &'static str),
     NotFound(String),
+    /// Duplicate `(org_id, name)` — `uq_collections__org_name` unique-violation.
+    /// Same mapping precedent as `services::orgs::CreateOrgError::SlugTaken`
+    /// and `routes::projects`'s own `NameTaken`.
+    NameTaken(String),
     Database(String),
 }
 
@@ -481,6 +486,9 @@ impl RouteError {
             DbError::NotFound => Self::NotFound(request_id.to_string()),
             DbError::Config(message) if message == "collection_denied" => {
                 Self::NotFound(request_id.to_string())
+            }
+            DbError::Query(pg_error) if pg_error.code() == Some(&SqlState::UNIQUE_VIOLATION) => {
+                Self::NameTaken(request_id.to_string())
             }
             _ => Self::Database(request_id.to_string()),
         }
@@ -506,6 +514,12 @@ impl IntoResponse for RouteError {
                 StatusCode::NOT_FOUND,
                 "not_found",
                 "Collection not found",
+                request_id,
+            ),
+            Self::NameTaken(request_id) => (
+                StatusCode::CONFLICT,
+                "name_taken",
+                "Collection name is already taken in this org",
                 request_id,
             ),
             Self::Database(request_id) => (

--- a/crates/server/src/routes/graph.rs
+++ b/crates/server/src/routes/graph.rs
@@ -21,13 +21,17 @@
 //! take `node_ids` and additionally scope by `org_id`), so an edge can never
 //! reference a document the caller could not otherwise see.
 //!
-//! `similarity` edges are opt-in on the vector index + an embedding runtime being
-//! configured (`AppState::vector_index()`/`AppState::embedder()`, same gate
-//! `services/retrieval` uses) and are not implemented in this pass — see the
-//! P2-17 report/backlog entry for why (no live vector store in this sandbox to
-//! validate against). When neither is configured, or once implemented,
-//! finds nothing, the endpoint still returns `conflict`/`co_citation` edges
-//! — it never fails just because vector search is unavailable.
+//! `similarity` edges are opt-in on the vector index + an embedding runtime
+//! being configured (`AppState::vector_index()`/`AppState::embedder()`, same
+//! gate `services/retrieval` uses) — computed by
+//! `services::graph::compute_similarity_edges` via the vector index's
+//! recommend-by-id API (P2-17 follow-up; see that function's doc for the
+//! pipeline). This route stays DTO-mapping only: it just checks both are
+//! configured and passes a `services::graph::SimilarityDeps` through, never
+//! reading the vector store itself. When neither is configured, or the
+//! vector store errors, the endpoint still returns `conflict`/`co_citation`
+//! edges — it never fails just because vector search is unavailable (see
+//! `build_org_graph`'s doc).
 
 use std::sync::Arc;
 
@@ -44,7 +48,7 @@ use crate::auth::middleware::AuthenticatedOrg;
 use crate::auth::permissions::require_permission;
 use crate::db::error::DbError;
 use crate::http::AppState;
-use crate::services::graph::build_org_graph;
+use crate::services::graph::{build_org_graph, SimilarityDeps};
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new().route("/api/v1/graph", get(get_graph))
@@ -69,14 +73,20 @@ async fn get_graph(
         }
     }
 
-    let data = build_org_graph(state.pool(), &auth.context, query.collection_id)
+    // similarity: see module doc — opt-in on both the vector index and an
+    // embedder being configured; `None` when either is missing, which keeps
+    // `build_org_graph`'s response identical to before this pass.
+    let similarity = match (state.vector_index(), state.embedder()) {
+        (Some(vector_index), Some(embedder)) => Some(SimilarityDeps {
+            vector_index,
+            embedder,
+        }),
+        _ => None,
+    };
+
+    let data = build_org_graph(state.pool(), &auth.context, query.collection_id, similarity)
         .await
         .map_err(|error| RouteError::from_db(error, &auth.request_id))?;
-
-    // similarity: see module doc — opt-in on the vector index + embedder, not
-    // implemented in this pass. `state.vector_index()`/`state.embedder()` are
-    // the real availability check a future pass would gate on.
-    let _similarity_available = state.vector_index().is_some() && state.embedder().is_some();
 
     let nodes: Vec<GraphNodeDto> = data
         .nodes

--- a/crates/server/src/routes/projects.rs
+++ b/crates/server/src/routes/projects.rs
@@ -18,6 +18,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
+use tokio_postgres::error::SqlState;
 use uuid::Uuid;
 
 use crate::api::{ApiError, Page, PageInfo};
@@ -239,6 +240,9 @@ enum RouteError {
     Denied(String),
     Validation(String, &'static str),
     NotFound(String),
+    /// Duplicate `(org_id, name)` — `uq_projects__org_name` unique-violation.
+    /// Same mapping precedent as `services::orgs::CreateOrgError::SlugTaken`.
+    NameTaken(String),
     Database(String),
 }
 
@@ -246,6 +250,9 @@ impl RouteError {
     fn from_db(error: DbError, request_id: &str) -> Self {
         match error {
             DbError::NotFound => Self::NotFound(request_id.to_string()),
+            DbError::Query(pg_error) if pg_error.code() == Some(&SqlState::UNIQUE_VIOLATION) => {
+                Self::NameTaken(request_id.to_string())
+            }
             _ => Self::Database(request_id.to_string()),
         }
     }
@@ -270,6 +277,12 @@ impl IntoResponse for RouteError {
                 StatusCode::NOT_FOUND,
                 "not_found",
                 "Project not found",
+                request_id,
+            ),
+            Self::NameTaken(request_id) => (
+                StatusCode::CONFLICT,
+                "name_taken",
+                "Project name is already taken in this org",
                 request_id,
             ),
             Self::Database(request_id) => (

--- a/crates/server/src/services/graph.rs
+++ b/crates/server/src/services/graph.rs
@@ -12,14 +12,21 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
 use crate::db::error::DbError;
 use crate::db::graph::{self as db_graph, GraphDocumentRow};
+use crate::db::index_metadata;
 use deadpool_postgres::Pool;
 
 use crate::db::pool::with_org_txn;
+use crate::services::embedding::ApprovedEmbeddingRuntime;
+use crate::services::index_signature::{collection_name_for_digest, CollectionName};
+use crate::services::retrieval::generation_compatible_with_runtime;
+use crate::storage::error::StorageError;
+use crate::storage::qdrant::{QdrantClient, VectorScope};
 
 /// One candidate edge before pruning. `kind` is carried through so the same
 /// document pair can carry more than one edge (e.g. both a `conflict` and a
@@ -179,6 +186,59 @@ pub const MAX_EDGES: usize = 2000;
 /// the cap.
 const FETCH_SAFETY_CAP: i64 = 4000;
 
+// ---------------------------------------------------------------------
+// `similarity` edges (P2-17 follow-up): opt-in on a configured vector index
+// + embedder, computed via Qdrant's recommend-by-id API — never by scrolling
+// whole vectors back into the app. See `compute_similarity_edges` below for
+// the full pipeline; the constants here are its tunable knobs.
+// ---------------------------------------------------------------------
+
+/// Cross-document neighbors requested per document from Qdrant's recommend API.
+const SIMILARITY_TOP_K: usize = 5;
+/// Minimum Qdrant Cosine score (`[-1, 1]`) to keep a similarity edge at all.
+/// A fresh constant for the graph — not reused from retrieval's hybrid
+/// rerank score, which blends lexical + vector signals and lives on a
+/// different scale entirely.
+pub const SIMILARITY_SCORE_THRESHOLD: f32 = 0.5;
+/// How many of a document's own current chunks are sent as Qdrant `positive`
+/// ids. Small and fixed so the recommend request body stays cheap regardless
+/// of document size.
+const SIMILARITY_POSITIVE_CHUNKS_PER_DOC: usize = 3;
+/// Page size used while scrolling for representative chunk point ids.
+const SIMILARITY_SCROLL_PAGE_LIMIT: usize = 512;
+/// Bounds how many scroll pages we fetch while looking for representative
+/// chunk ids across the whole node set — caps total scanned points at
+/// `SIMILARITY_SCROLL_PAGE_LIMIT * SIMILARITY_SCROLL_MAX_PAGES` regardless of
+/// how many chunks any single document has.
+const SIMILARITY_SCROLL_MAX_PAGES: usize = 8;
+/// Bounds the number of Qdrant recommend round-trips this endpoint makes —
+/// one per document that has at least one representative chunk. Documents
+/// beyond this cap simply get no similarity edges (conflict/co_citation
+/// edges are unaffected, and which documents are affected is deterministic:
+/// `list_visible_documents`' `ORDER BY created_at DESC, id DESC` decides
+/// iteration order). A single batched call (Qdrant's `points/recommend/batch`)
+/// would remove this cap entirely — left for a follow-up, see the P2-17
+/// report.
+const SIMILARITY_NODE_CAP: usize = 200;
+/// Cap applied to the raw similarity edge set before it is merged with
+/// conflict/co_citation edges and hits the shared `prune()` — keeps one
+/// signal from crowding out the others ahead of the overall `MAX_EDGES`.
+const MAX_SIMILARITY_EDGES: usize = 500;
+
+/// Similarity dependencies, injected by the route from
+/// `AppState::vector_index()` / `AppState::embedder()` — `services::graph`
+/// deliberately does not read `AppState` itself (no precedent for services
+/// doing so; see how `services::retrieval::hybrid_search` instead takes
+/// `&QdrantClient` + `Option<&ApprovedEmbeddingRuntime>` as plain
+/// parameters). Keeping the service AppState-free is also what lets
+/// `tests/graph.rs`'s Qdrant-gated integration test call `build_org_graph`
+/// directly against a real `QdrantClient` without booting the whole app.
+#[derive(Clone, Copy)]
+pub struct SimilarityDeps<'a> {
+    pub vector_index: &'a QdrantClient,
+    pub embedder: &'a ApprovedEmbeddingRuntime,
+}
+
 #[derive(Debug, Clone)]
 pub struct GraphNodeData {
     pub id: Uuid,
@@ -204,12 +264,20 @@ pub struct GraphData {
 
 /// Builds the bounded, clustered document graph the route serves: visible
 /// documents (RLS + caller ACL, exactly the library's visibility) plus
-/// `conflict` and `co_citation` edges among them. `similarity` edges are a
-/// deliberate future slot — see `routes/graph.rs` module doc.
+/// `conflict`, `co_citation`, and (when `similarity` is configured)
+/// `similarity` edges among them.
+///
+/// `similarity` is `None` when the vector index and/or embedder is not
+/// configured — the response is unaffected (same as before this pass). When
+/// it is configured, a Qdrant error during similarity computation is
+/// swallowed (no edges added) rather than failing the whole graph — the
+/// endpoint must keep returning `conflict`/`co_citation` edges even if the
+/// vector store is unavailable.
 pub async fn build_org_graph(
     pool: &Pool,
     ctx: &OrgContext,
     collection_filter: Option<Uuid>,
+    similarity: Option<SimilarityDeps<'_>>,
 ) -> Result<GraphData, DbError> {
     let (documents, conflict_pairs, co_citation_pairs) = with_org_txn(pool, ctx, {
         let ctx = ctx.clone();
@@ -250,6 +318,16 @@ pub async fn build_org_graph(
             kind: "co_citation".to_string(),
             weight: saturating_weight(*count),
         });
+    }
+
+    if let Some(deps) = similarity {
+        match compute_similarity_edges(pool, ctx, deps, &documents).await {
+            Ok(similarity_edges) => edges.extend(similarity_edges),
+            Err(_) => {
+                // Fail-soft: see this function's doc comment — a vector
+                // store hiccup must not fail the whole graph.
+            }
+        }
     }
 
     let pruned = prune(&node_ids, &edges, MAX_NODES, MAX_EDGES);
@@ -317,6 +395,234 @@ fn community_label(node_ids: &[Uuid], doc_by_id: &BTreeMap<Uuid, &GraphDocumentR
         .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(a.0)))
         .map(|(name, _)| name.to_string())
         .unwrap_or_else(|| "Không xác định".to_string())
+}
+
+// ---------------------------------------------------------------------
+// `similarity` edges: Qdrant recommend-by-id, aggregate, threshold, cap.
+// ---------------------------------------------------------------------
+
+/// Computes `similarity` edges among `documents` (the same visible node set
+/// `conflict`/`co_citation` edges are built from). For each document with at
+/// least one representative current chunk point, asks Qdrant to recommend
+/// its top-`SIMILARITY_TOP_K` cross-document neighbors from vectors already
+/// indexed by `services::indexing` — no vector ever leaves Qdrant into this
+/// process. Only generations whose signature matches `deps.embedder`'s plan
+/// are queried (mirrors `services::retrieval::generation_compatible_with_runtime`,
+/// so this never sends a query into a Qdrant collection built for a
+/// different embedding family/dimensionality).
+async fn compute_similarity_edges(
+    pool: &Pool,
+    ctx: &OrgContext,
+    deps: SimilarityDeps<'_>,
+    documents: &[GraphDocumentRow],
+) -> Result<Vec<GraphEdgeInput>, StorageError> {
+    if documents.is_empty() {
+        return Ok(Vec::new());
+    }
+    let plan = deps.embedder.plan();
+    let Some(query_dimensions) = plan.expected_dimensions() else {
+        return Ok(Vec::new());
+    };
+
+    let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
+        documents.iter().map(|d| (d.id, d)).collect();
+    let collection_ids: Vec<Uuid> = documents.iter().map(|d| d.collection_id).collect();
+    let active = with_org_txn(pool, ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                index_metadata::list_active_for_collections(txn, &ctx, &collection_ids).await
+            })
+        }
+    })
+    .await
+    .map_err(|_| StorageError::Backend)?;
+
+    let mut by_signature: BTreeMap<String, BTreeSet<Uuid>> = BTreeMap::new();
+    for meta in active {
+        if !generation_compatible_with_runtime(&meta, plan, query_dimensions) {
+            continue;
+        }
+        if let Some(collection_id) = meta.collection_id {
+            by_signature
+                .entry(meta.index_signature_sha256)
+                .or_default()
+                .insert(collection_id);
+        }
+    }
+    if by_signature.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut raw_pairs: Vec<(Uuid, Uuid, f32)> = Vec::new();
+    let mut processed = 0usize;
+
+    'groups: for (digest, group_collections) in by_signature {
+        if processed >= SIMILARITY_NODE_CAP {
+            break;
+        }
+        let collection_name = collection_name_for_digest(&digest)?;
+        let scope = VectorScope::new(ctx.org_id(), group_collections.iter().copied());
+
+        let target_docs: BTreeSet<Uuid> = documents
+            .iter()
+            .filter(|d| group_collections.contains(&d.collection_id))
+            .map(|d| d.id)
+            .collect();
+        if target_docs.is_empty() {
+            continue;
+        }
+
+        let representatives =
+            representative_chunk_points(deps.vector_index, &collection_name, &scope, &target_docs)
+                .await?;
+        let current_only = [json!({ "key": "is_current", "match": { "value": true } })];
+
+        for (document_id, positive_ids) in &representatives {
+            if positive_ids.is_empty() {
+                continue;
+            }
+            if processed >= SIMILARITY_NODE_CAP {
+                break 'groups;
+            }
+            processed += 1;
+
+            let hits = deps
+                .vector_index
+                .recommend(
+                    &collection_name,
+                    &scope,
+                    positive_ids,
+                    &current_only,
+                    SIMILARITY_TOP_K,
+                )
+                .await?;
+            for hit in hits {
+                // A document's other chunks are not a cross-document
+                // neighbor; a neighbor outside the caller-visible node set
+                // must never surface as an edge (same invariant
+                // `routes/graph.rs` documents for conflict/co_citation).
+                if hit.payload.document_id == *document_id
+                    || !doc_by_id.contains_key(&hit.payload.document_id)
+                {
+                    continue;
+                }
+                raw_pairs.push((*document_id, hit.payload.document_id, hit.score));
+            }
+        }
+    }
+
+    let edges = aggregate_similarity_pairs(raw_pairs, SIMILARITY_SCORE_THRESHOLD)
+        .into_iter()
+        .map(|(a, b, score)| GraphEdgeInput {
+            source: a,
+            target: b,
+            kind: "similarity".to_string(),
+            weight: normalize_similarity_weight(score),
+        })
+        .collect();
+    Ok(cap_similarity_edges(edges, MAX_SIMILARITY_EDGES))
+}
+
+/// Gathers up to `SIMILARITY_POSITIVE_CHUNKS_PER_DOC` current chunk point
+/// ids per document in `target_document_ids`, by scrolling Qdrant (payload +
+/// point id only — never vectors, see `QdrantClient::scroll_points_page`'s
+/// `with_vector: false`). Bounded by `SIMILARITY_SCROLL_MAX_PAGES`: a
+/// document with no current chunk indexed yet (or one this scan didn't
+/// reach) simply gets no entry and is skipped by the caller, exactly like a
+/// missing vector index is already handled elsewhere in this pipeline.
+async fn representative_chunk_points(
+    qdrant: &QdrantClient,
+    collection_name: &CollectionName,
+    scope: &VectorScope,
+    target_document_ids: &BTreeSet<Uuid>,
+) -> Result<BTreeMap<Uuid, Vec<Uuid>>, StorageError> {
+    let mut representatives: BTreeMap<Uuid, Vec<Uuid>> = BTreeMap::new();
+    let document_ids: Vec<Value> = target_document_ids
+        .iter()
+        .map(|id| Value::String(id.to_string()))
+        .collect();
+    let extra_must = [
+        json!({ "key": "document_id", "match": { "any": document_ids } }),
+        json!({ "key": "is_current", "match": { "value": true } }),
+    ];
+
+    let mut offset: Option<Value> = None;
+    for _ in 0..SIMILARITY_SCROLL_MAX_PAGES {
+        let page = qdrant
+            .scroll_points_page(
+                collection_name,
+                scope,
+                &extra_must,
+                SIMILARITY_SCROLL_PAGE_LIMIT,
+                offset.clone(),
+            )
+            .await?;
+        for (point_id, payload) in page.points {
+            let bucket = representatives.entry(payload.document_id).or_default();
+            if bucket.len() < SIMILARITY_POSITIVE_CHUNKS_PER_DOC {
+                bucket.push(point_id);
+            }
+        }
+        match page.next_page_offset {
+            Some(next) if representatives.len() < target_document_ids.len() => offset = Some(next),
+            _ => break,
+        }
+    }
+    Ok(representatives)
+}
+
+/// Canonicalizes each unordered document pair (`(min, max)` by id) and keeps
+/// the max score seen for it, dropping anything below `threshold`. Max (not
+/// mean) is deliberate: a single very close chunk pair between two documents
+/// is a meaningful signal even when their other chunks are unrelated — mean
+/// would dilute it toward the documents' average content, the same
+/// "any evidence counts" reasoning `conflict`/`co_citation` edges already
+/// use (see `db::graph::conflict_edges_among`/`co_citation_edges_among`).
+pub fn aggregate_similarity_pairs(
+    raw: Vec<(Uuid, Uuid, f32)>,
+    threshold: f32,
+) -> Vec<(Uuid, Uuid, f32)> {
+    let mut best: BTreeMap<(Uuid, Uuid), f32> = BTreeMap::new();
+    for (a, b, score) in raw {
+        if a == b || score < threshold {
+            continue;
+        }
+        let key = if a < b { (a, b) } else { (b, a) };
+        best.entry(key)
+            .and_modify(|existing| {
+                if score > *existing {
+                    *existing = score;
+                }
+            })
+            .or_insert(score);
+    }
+    best.into_iter()
+        .map(|((a, b), score)| (a, b, score))
+        .collect()
+}
+
+/// Maps a Qdrant Cosine score (range `[-1, 1]`) onto the contract's `0..1`
+/// edge weight. Approved embedding runtimes are expected to score mostly
+/// non-negative for genuinely related chunks in practice, but the map covers
+/// the full Cosine range so a pathological negative score still lands
+/// in-bounds instead of silently clamping to an uninformative 0.
+pub fn normalize_similarity_weight(score: f32) -> f64 {
+    (((score as f64) + 1.0) / 2.0).clamp(0.0, 1.0)
+}
+
+/// Caps the similarity edge set before it is merged with conflict/co_citation
+/// edges, ranked the same way `prune()` ranks edges (weight desc, ties by
+/// `(source, target)` asc) so truncation is deterministic.
+pub fn cap_similarity_edges(mut edges: Vec<GraphEdgeInput>, cap: usize) -> Vec<GraphEdgeInput> {
+    edges.sort_by(|a, b| {
+        b.weight
+            .partial_cmp(&a.weight)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| (a.source, a.target).cmp(&(b.source, b.target)))
+    });
+    edges.truncate(cap);
+    edges
 }
 
 #[cfg(test)]
@@ -480,5 +786,75 @@ mod tests {
         let doc_by_id: BTreeMap<Uuid, &GraphDocumentRow> =
             [(a.id, &a), (b.id, &b)].into_iter().collect();
         assert_eq!(community_label(&[uid(1), uid(2)], &doc_by_id), "Alpha");
+    }
+
+    // -------------------------------------------------------------
+    // `similarity` edges: pure aggregate/threshold/cap unit tests
+    // (no Qdrant — the Qdrant-gated path is covered by the `#[ignore]`d
+    // integration test in `tests/graph.rs`, run only with
+    // `MARKHAND_TEST_QDRANT_URL`).
+    // -------------------------------------------------------------
+
+    #[test]
+    fn aggregate_drops_scores_below_threshold() {
+        let raw = vec![(uid(1), uid(2), 0.49), (uid(3), uid(4), 0.5)];
+        let kept = aggregate_similarity_pairs(raw, 0.5);
+        assert_eq!(kept, vec![(uid(3), uid(4), 0.5)]);
+    }
+
+    #[test]
+    fn aggregate_canonicalizes_pair_order_regardless_of_direction() {
+        // Same pair discovered from both directions (doc 2's recommend call
+        // found doc 1, and vice versa) must collapse into one edge.
+        let raw = vec![(uid(2), uid(1), 0.6), (uid(1), uid(2), 0.7)];
+        let kept = aggregate_similarity_pairs(raw, 0.0);
+        assert_eq!(kept, vec![(uid(1), uid(2), 0.7)]);
+    }
+
+    #[test]
+    fn aggregate_keeps_max_not_mean_across_duplicate_chunk_pairs() {
+        let raw = vec![
+            (uid(1), uid(2), 0.55),
+            (uid(1), uid(2), 0.9),
+            (uid(1), uid(2), 0.6),
+        ];
+        let kept = aggregate_similarity_pairs(raw, 0.0);
+        assert_eq!(kept, vec![(uid(1), uid(2), 0.9)]);
+    }
+
+    #[test]
+    fn aggregate_drops_self_pairs() {
+        let raw = vec![(uid(1), uid(1), 0.99)];
+        assert!(aggregate_similarity_pairs(raw, 0.0).is_empty());
+    }
+
+    #[test]
+    fn normalize_weight_maps_cosine_range_into_zero_one() {
+        assert_eq!(normalize_similarity_weight(1.0), 1.0);
+        assert_eq!(normalize_similarity_weight(-1.0), 0.0);
+        assert_eq!(normalize_similarity_weight(0.0), 0.5);
+        // Pathological out-of-range score still clamps in-bounds.
+        assert_eq!(normalize_similarity_weight(5.0), 1.0);
+        assert_eq!(normalize_similarity_weight(-5.0), 0.0);
+    }
+
+    #[test]
+    fn cap_similarity_edges_keeps_highest_weight_ties_broken_by_endpoints() {
+        let edges = vec![
+            edge(1, 2, "similarity", 0.4),
+            edge(3, 4, "similarity", 0.9),
+            edge(5, 6, "similarity", 0.9),
+        ];
+        let capped = cap_similarity_edges(edges, 2);
+        assert_eq!(
+            capped,
+            vec![edge(3, 4, "similarity", 0.9), edge(5, 6, "similarity", 0.9)]
+        );
+    }
+
+    #[test]
+    fn cap_similarity_edges_is_a_noop_under_the_cap() {
+        let edges = vec![edge(1, 2, "similarity", 0.6)];
+        assert_eq!(cap_similarity_edges(edges.clone(), 500), edges);
     }
 }

--- a/crates/server/src/storage/qdrant.rs
+++ b/crates/server/src/storage/qdrant.rs
@@ -464,6 +464,103 @@ impl QdrantClient {
         Ok(hits)
     }
 
+    /// Recommend cross-document neighbors from vectors Qdrant already holds —
+    /// no vector is ever transferred to the app. `positive_ids` are point ids
+    /// (e.g. a document's own current chunk points); Qdrant resolves them
+    /// against its stored vectors server-side and returns near neighbors,
+    /// excluding the positive ids themselves. Mandatory org + authorized
+    /// collection filter, same as [`Self::search_filtered`]. Used by
+    /// `services::graph`'s `similarity` edges (P2-17 follow-up) instead of
+    /// scrolling whole vectors back into the app.
+    pub async fn recommend(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        positive_ids: &[Uuid],
+        extra_must: &[Value],
+        limit: usize,
+    ) -> Result<Vec<SearchHit>, StorageError> {
+        scope.validate()?;
+        if limit == 0 || positive_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut must = mandatory_filter_must(scope);
+        must.extend(extra_must.iter().cloned());
+        let positive: Vec<Value> = positive_ids
+            .iter()
+            .map(|id| Value::String(id.to_string()))
+            .collect();
+        let url = format!(
+            "{}/collections/{}/points/query",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let body = json!({
+            "query": { "recommend": { "positive": positive, "negative": [] } },
+            "filter": { "must": must },
+            "limit": limit,
+            "with_payload": true,
+        });
+        let response = self
+            .authed(self.http.post(&url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if response.status().as_u16() == 404 || !response.status().is_success() {
+            return self
+                .recommend_legacy(collection_name, scope, positive_ids, extra_must, limit)
+                .await;
+        }
+        let payload: Value = response.json().await.map_err(|_| StorageError::Backend)?;
+        let hits = parse_search_hits(&payload)?;
+        enforce_hits_in_scope(scope, &hits)?;
+        Ok(hits)
+    }
+
+    /// Pre-1.7 Qdrant fallback for [`Self::recommend`] (older `/points/recommend`
+    /// endpoint, same request/response shape as the legacy search fallback).
+    async fn recommend_legacy(
+        &self,
+        collection_name: &CollectionName,
+        scope: &VectorScope,
+        positive_ids: &[Uuid],
+        extra_must: &[Value],
+        limit: usize,
+    ) -> Result<Vec<SearchHit>, StorageError> {
+        let mut must = mandatory_filter_must(scope);
+        must.extend(extra_must.iter().cloned());
+        let positive: Vec<Value> = positive_ids
+            .iter()
+            .map(|id| Value::String(id.to_string()))
+            .collect();
+        let url = format!(
+            "{}/collections/{}/points/recommend",
+            self.base_url,
+            collection_name.as_str()
+        );
+        let body = json!({
+            "positive": positive,
+            "negative": [],
+            "filter": { "must": must },
+            "limit": limit,
+            "with_payload": true,
+        });
+        let response = self
+            .authed(self.http.post(&url))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|_| StorageError::Transport)?;
+        if !response.status().is_success() {
+            return Err(StorageError::Backend);
+        }
+        let payload: Value = response.json().await.map_err(|_| StorageError::Backend)?;
+        let hits = parse_search_hits(&payload)?;
+        enforce_hits_in_scope(scope, &hits)?;
+        Ok(hits)
+    }
+
     /// Overwrite selected payload fields via filter only (no body `points`).
     ///
     /// The filter always includes mandatory org/collection scope, `has_id` for

--- a/crates/server/tests/ask_grounding_matrix.rs
+++ b/crates/server/tests/ask_grounding_matrix.rs
@@ -249,7 +249,7 @@ async fn live_ask_is_extractive_and_delete_during_stream_closes() {
     assert_markhand_app_role(&pool).await;
 
     let markdown = "# BA\n\nKinh phí được phê duyệt là 15 triệu đồng.\n";
-    let (ctx, document_id, _version_id, token) = seed_ask_doc(&pool, &store, markdown).await;
+    let (ctx, document_id, version_id, token) = seed_ask_doc(&pool, &store, markdown).await;
 
     let qdrant = fileconv_server::storage::QdrantClient::new(&qdrant_url).expect("qdrant");
     let response = ask(
@@ -279,6 +279,23 @@ async fn live_ask_is_extractive_and_delete_during_stream_closes() {
         .answer
         .to_ascii_lowercase()
         .contains("glm grounded"));
+
+    // P2-10 gap close: `CitationPin` (`services::citation`) must carry the
+    // exact seeded document/version/collection identity end-to-end through
+    // `ask()` — this is what `CitationCard.tsx`'s `/library/:collectionId?
+    // doc=:documentId` deep-link (web) relies on; the field has always been
+    // on the struct, this asserts the live `ask()` path actually returns it
+    // populated with the *correct* value rather than merely present.
+    assert!(
+        !response.citations.is_empty(),
+        "expected at least one citation pin"
+    );
+    let expected_collection_id = *ctx.allowed_collection_ids().iter().next().unwrap();
+    for citation in &response.citations {
+        assert_eq!(citation.logical_document_id, document_id);
+        assert_eq!(citation.version_id, version_id);
+        assert_eq!(citation.collection_id, expected_collection_id);
+    }
 
     // Stream auth closes when cited document is deleted mid-stream.
     let keys = JwtKeys::from_auth(&test_auth_config()).unwrap();

--- a/crates/server/tests/graph.rs
+++ b/crates/server/tests/graph.rs
@@ -5,10 +5,17 @@
 //! are unset (see `common::boot_app_pool`), same as every other live-PG suite
 //! in this crate.
 //!
-//! `similarity` (Qdrant) is deliberately out of scope here: `routes/graph.rs`
-//! never queries Qdrant in this pass (see its module doc + the P2-17
-//! report), so there is nothing DB-observable to assert about it, and this
-//! suite has no `MARKHAND_TEST_QDRANT_URL` wiring.
+//! `similarity` (Qdrant) HTTP-route coverage is still out of scope here:
+//! `common::build_app_state` never configures `MARKHAND_EMBEDDING_*`, so
+//! `AppState::embedder()` is always `None` in this binary's router and the
+//! route never takes the similarity path. What *is* covered, gated behind
+//! `MARKHAND_TEST_QDRANT_URL` (unset in this sandbox — see the report for why
+//! it could not be run here), is `services::graph::build_org_graph` called
+//! directly with a real `QdrantClient` + a directly-constructed
+//! `ApprovedEmbeddingRuntime` (never calls `.embed()`, so no live embedding
+//! provider is needed) — the same "service takes plain dependencies, not
+//! AppState" shape the route uses, exercised the way `tests/storage.rs`
+//! already exercises `QdrantClient` against a live instance.
 
 mod common;
 
@@ -16,13 +23,24 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use common::{admin_database_url, app_database_url, boot_app_pool, build_router};
 use deadpool_postgres::Pool;
+use fileconv_knowledge::identity::{
+    chunk_identity, IndexSignature, BODY_TEXT_VERSION, RUNTIME_VLLM_LOCAL,
+};
 use fileconv_server::auth::context::OrgContext;
+use fileconv_server::config::{Profile, SecretString};
 use fileconv_server::db::ask_streams::{self, NewAskStreamSession};
 use fileconv_server::db::collections::{self, NewCollection};
 use fileconv_server::db::documents::{self, NewDocument};
 use fileconv_server::db::error::DbError;
-use fileconv_server::db::models::CollectionVisibility;
+use fileconv_server::db::index_metadata::{self, EnsureGeneration};
+use fileconv_server::db::models::{CollectionVisibility, EmbeddingRuntimePath};
 use fileconv_server::db::pool::with_org_txn;
+use fileconv_server::services::embedding::ApprovedEmbeddingRuntime;
+use fileconv_server::services::graph::{build_org_graph, SimilarityDeps};
+use fileconv_server::services::index_signature::CollectionName;
+use fileconv_server::storage::qdrant::{
+    ChunkPointPayload, QdrantAdminApiKey, QdrantAdminClient, QdrantClient, UpsertPoint, VectorScope,
+};
 use http_body_util::BodyExt;
 use serde_json::Value;
 use tower::ServiceExt;
@@ -517,4 +535,345 @@ async fn graph_caps_nodes_at_the_documented_bound() {
         500,
         "expected the documented 500-node cap to bind"
     );
+}
+
+// ---------------------------------------------------------------------
+// `similarity` edges: Qdrant-gated integration test.
+//
+// NOT RUN in this sandbox — there is no live Qdrant instance here, so
+// `MARKHAND_TEST_QDRANT_URL` is unset and this test skips via the early
+// `return` below (see `#[ignore]` + this crate's convention in
+// `tests/storage.rs`). It is written to run for real on CI's
+// `rust-integration` job, which does provide a Qdrant service.
+// ---------------------------------------------------------------------
+
+fn test_qdrant_url() -> Option<String> {
+    match std::env::var("MARKHAND_TEST_QDRANT_URL") {
+        Ok(url) if !url.trim().is_empty() => Some(url),
+        _ => {
+            eprintln!(
+                "skipped: MARKHAND_TEST_QDRANT_URL unset — graph similarity integration test requires a live Qdrant instance"
+            );
+            None
+        }
+    }
+}
+
+fn test_qdrant_admin_client(url: &str) -> QdrantAdminClient {
+    // Local Qdrant ignores api-key when auth is disabled; construction still
+    // requires a distinct non-empty operator credential (same convention as
+    // `tests/storage.rs::test_admin_client`).
+    let key = std::env::var("MARKHAND_TEST_QDRANT_ADMIN_API_KEY")
+        .unwrap_or_else(|_| "test-operator-admin-key".into());
+    QdrantAdminClient::new(url, QdrantAdminApiKey::new(SecretString::new(key)).unwrap())
+        .expect("admin client")
+}
+
+/// Seeds an active index generation for `collection_id` matching `signature`
+/// — the durable row `services::graph::compute_similarity_edges` looks up
+/// via `db::index_metadata::list_active_for_collections` to decide which
+/// Qdrant collection/scope to query. Mirrors what
+/// `services::indexing::ensure_generation` writes for a real index job.
+async fn seed_active_generation(
+    pool: &Pool,
+    org: Uuid,
+    owner: Uuid,
+    collection_id: Uuid,
+    signature: &IndexSignature<'_>,
+) {
+    let ctx = OrgContext::try_new(org, owner, [] as [&str; 0], []).unwrap();
+    let runtime_path = EmbeddingRuntimePath::parse(signature.runtime_path).expect("runtime path");
+    let dimensions = i32::try_from(signature.dimensions).expect("dimensions fit i32");
+    let digest = signature.digest();
+    let chunking_version = signature.chunking_version.to_string();
+    let body_text_version = signature.body_text_version.to_string();
+    let query_normalization_version = signature.query_normalization_version.to_string();
+    let embedding_family = signature.embedding_family.to_string();
+    let embedding_revision = signature.embedding_revision.to_string();
+    let normalized = signature.normalized;
+    with_org_txn(pool, &ctx, {
+        let ctx = ctx.clone();
+        move |txn| {
+            Box::pin(async move {
+                index_metadata::ensure_active_generation(
+                    txn,
+                    &ctx,
+                    EnsureGeneration {
+                        collection_id: Some(collection_id),
+                        signature_sha256: &digest,
+                        chunking_version: &chunking_version,
+                        body_text_version: &body_text_version,
+                        query_normalization_version: &query_normalization_version,
+                        embedding_family: &embedding_family,
+                        embedding_revision: &embedding_revision,
+                        dimensions,
+                        normalized,
+                        runtime_path,
+                    },
+                )
+                .await
+            })
+        }
+    })
+    .await
+    .expect("seed active generation");
+}
+
+/// Upserts one current chunk point for `document_id`, using the index
+/// worker's own write path (`QdrantClient::upsert_points` — the same call
+/// `services::indexing::persist_chunk_batch` makes) rather than any
+/// test-only shortcut.
+#[allow(clippy::too_many_arguments)]
+async fn seed_similarity_point(
+    qdrant: &QdrantClient,
+    collection_name: &CollectionName,
+    org: Uuid,
+    collection_id: Uuid,
+    document_id: Uuid,
+    version_id: Uuid,
+    vector: Vec<f32>,
+) {
+    let chunk = chunk_identity(
+        &document_id.to_string(),
+        &version_id.to_string(),
+        0,
+        "H",
+        &format!("similarity-fixture-{}", document_id.simple()),
+        BODY_TEXT_VERSION,
+    );
+    let scope = VectorScope::new(org, [collection_id]);
+    let point = UpsertPoint {
+        chunk_identity: chunk.clone(),
+        vector,
+        payload: ChunkPointPayload {
+            org_id: org,
+            collection_id,
+            document_id,
+            version_id,
+            chunk_id: chunk,
+            ordinal: 0,
+            is_current: true,
+            is_effective: true,
+            index_generation: 1,
+        },
+    };
+    qdrant
+        .upsert_points(collection_name, &scope, &[point])
+        .await
+        .expect("upsert similarity fixture point");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_QDRANT_URL — not run in this sandbox, see module doc"]
+async fn graph_similarity_edges_from_qdrant_recommend() {
+    let Some((_db, pool)) = boot_pool().await else {
+        return;
+    };
+    let Some(qdrant_url) = test_qdrant_url() else {
+        return;
+    };
+    let qdrant = QdrantClient::new(&qdrant_url).expect("qdrant client");
+    let admin = test_qdrant_admin_client(&qdrant_url);
+
+    // A directly-constructed embedder — `.embed()` is never called on this
+    // path (recommend is by point id, not by query vector), so no live
+    // embedding provider is required. `unique_family` keeps this run's
+    // digest/collection from colliding with any other test's.
+    let unique_family = format!("graph-similarity-itest-{}", Uuid::new_v4().simple());
+    let embedder = ApprovedEmbeddingRuntime::new(
+        "http://embedding.invalid/v1".into(),
+        "test-key".into(),
+        "mock".into(),
+        unique_family,
+        "r1".into(),
+        8,
+        RUNTIME_VLLM_LOCAL.into(),
+        Profile::Test,
+        false,
+        None,
+    )
+    .expect("embedder");
+    let signature = embedder.plan().index_signature(8).expect("signature");
+    let digest = signature.digest();
+    let collection_name = qdrant
+        .ensure_collection_for_digest(&digest, 8, true)
+        .await
+        .expect("ensure collection");
+
+    let org_a = Uuid::new_v4();
+    let owner_a = Uuid::new_v4();
+    let collection_a = seed_collection(
+        &pool,
+        org_a,
+        owner_a,
+        "Tương đồng A",
+        CollectionVisibility::Org,
+    )
+    .await;
+    let doc_near_1 = seed_document(
+        &pool,
+        org_a,
+        owner_a,
+        collection_a,
+        "Chính sách nghỉ phép 2024",
+    )
+    .await;
+    let doc_near_2 = seed_document(
+        &pool,
+        org_a,
+        owner_a,
+        collection_a,
+        "Chính sách nghỉ phép 2025",
+    )
+    .await;
+    let doc_far = seed_document(
+        &pool,
+        org_a,
+        owner_a,
+        collection_a,
+        "Báo cáo tài chính quý 3",
+    )
+    .await;
+    seed_active_generation(&pool, org_a, owner_a, collection_a, &signature).await;
+
+    let org_b = Uuid::new_v4();
+    let owner_b = Uuid::new_v4();
+    let collection_b = seed_collection(
+        &pool,
+        org_b,
+        owner_b,
+        "Tương đồng B",
+        CollectionVisibility::Org,
+    )
+    .await;
+    let doc_cross_org = seed_document(
+        &pool,
+        org_b,
+        owner_b,
+        collection_b,
+        "Chính sách nghỉ phép org khác",
+    )
+    .await;
+    seed_active_generation(&pool, org_b, owner_b, collection_b, &signature).await;
+
+    // Cosine-scored fixture vectors: near_1/near_2 point in (almost) the same
+    // direction (cosine ~1.0, well above `SIMILARITY_SCORE_THRESHOLD`); far
+    // is orthogonal to both (cosine ~0.0, filtered by the threshold); the
+    // cross-org document reuses near_1's exact vector — if org isolation
+    // ever regressed, it would otherwise be near_1's single closest neighbor.
+    let near_vector_1 = vec![1.0, 0.05, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    let near_vector_2 = vec![0.98, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    let far_vector = vec![0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+
+    seed_similarity_point(
+        &qdrant,
+        &collection_name,
+        org_a,
+        collection_a,
+        doc_near_1,
+        Uuid::new_v4(),
+        near_vector_1.clone(),
+    )
+    .await;
+    seed_similarity_point(
+        &qdrant,
+        &collection_name,
+        org_a,
+        collection_a,
+        doc_near_2,
+        Uuid::new_v4(),
+        near_vector_2,
+    )
+    .await;
+    seed_similarity_point(
+        &qdrant,
+        &collection_name,
+        org_a,
+        collection_a,
+        doc_far,
+        Uuid::new_v4(),
+        far_vector,
+    )
+    .await;
+    seed_similarity_point(
+        &qdrant,
+        &collection_name,
+        org_b,
+        collection_b,
+        doc_cross_org,
+        Uuid::new_v4(),
+        near_vector_1,
+    )
+    .await;
+
+    let ctx_a = OrgContext::try_new(org_a, owner_a, [] as [&str; 0], [collection_a]).unwrap();
+    let graph = build_org_graph(
+        &pool,
+        &ctx_a,
+        None,
+        Some(SimilarityDeps {
+            vector_index: &qdrant,
+            embedder: &embedder,
+        }),
+    )
+    .await
+    .expect("build org graph for org a");
+
+    let similarity_edges: Vec<_> = graph
+        .edges
+        .iter()
+        .filter(|e| e.kind == "similarity")
+        .collect();
+    assert!(
+        similarity_edges.iter().any(|e| {
+            let endpoints = [e.source, e.target];
+            endpoints.contains(&doc_near_1) && endpoints.contains(&doc_near_2)
+        }),
+        "expected a similarity edge between the two near documents, got: {similarity_edges:?}"
+    );
+    assert!(
+        similarity_edges
+            .iter()
+            .all(|e| e.source != doc_far && e.target != doc_far),
+        "far document must be filtered out by the score threshold, got: {similarity_edges:?}"
+    );
+    assert!(
+        similarity_edges
+            .iter()
+            .all(|e| e.source != doc_cross_org && e.target != doc_cross_org),
+        "org B's document must never appear in org A's similarity edges, got: {similarity_edges:?}"
+    );
+
+    let near_1_node = graph
+        .nodes
+        .iter()
+        .find(|n| n.id == doc_near_1)
+        .expect("near_1 node present");
+    assert!(
+        near_1_node.degree >= 1,
+        "expected near_1's degree to reflect its similarity edge (prune/degree wiring)"
+    );
+
+    // Org isolation, other direction: org B's own graph must never surface
+    // a similarity edge (it has one visible document — no cross-document
+    // neighbor exists within its own node set, and it must not see org A's).
+    let ctx_b = OrgContext::try_new(org_b, owner_b, [] as [&str; 0], [collection_b]).unwrap();
+    let graph_b = build_org_graph(
+        &pool,
+        &ctx_b,
+        None,
+        Some(SimilarityDeps {
+            vector_index: &qdrant,
+            embedder: &embedder,
+        }),
+    )
+    .await
+    .expect("build org graph for org b");
+    assert!(
+        graph_b.edges.iter().all(|e| e.kind != "similarity"),
+        "org B must not see any similarity edge, got: {:?}",
+        graph_b.edges
+    );
+
+    admin.delete_collection(&collection_name).await.ok();
 }

--- a/crates/server/tests/graph.rs
+++ b/crates/server/tests/graph.rs
@@ -702,6 +702,18 @@ async fn graph_similarity_edges_from_qdrant_recommend() {
 
     let org_a = Uuid::new_v4();
     let owner_a = Uuid::new_v4();
+    // Creates the org/user/membership rows first — collections.org_id is a
+    // real FK; seeding a collection into a nonexistent org fails E23503
+    // (caught on this test's first live CI run).
+    common::seed_user_with_permissions(
+        &pool,
+        org_a,
+        owner_a,
+        "graph-similarity-a@example.com",
+        PASSWORD,
+        &["qa.query"],
+    )
+    .await;
     let collection_a = seed_collection(
         &pool,
         org_a,
@@ -738,6 +750,15 @@ async fn graph_similarity_edges_from_qdrant_recommend() {
 
     let org_b = Uuid::new_v4();
     let owner_b = Uuid::new_v4();
+    common::seed_user_with_permissions(
+        &pool,
+        org_b,
+        owner_b,
+        "graph-similarity-b@example.com",
+        PASSWORD,
+        &["qa.query"],
+    )
+    .await;
     let collection_b = seed_collection(
         &pool,
         org_b,

--- a/crates/server/tests/projects.rs
+++ b/crates/server/tests/projects.rs
@@ -320,6 +320,90 @@ async fn create_project_denied_without_permission() {
     ephemeral.drop().await;
 }
 
+/// UX-3(b): duplicate `(org_id, name)` on `POST /projects` maps to `409
+/// name_taken`, the same precedent `services::orgs::CreateOrgError::SlugTaken`
+/// set for `POST /orgs` — a unique-violation on `uq_projects__org_name`
+/// (migrations/0032) must never surface as an opaque 500.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn create_project_rejects_a_duplicate_name_with_409() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (_ctx, token) = seed_caller(&pool, org, user, "dup-project@projects-it.test").await;
+
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token),
+        Some(json!({ "name": "Marketing" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+
+    let (status_dup, body_dup) = send(
+        &app,
+        "POST",
+        "/api/v1/projects",
+        Some(&token),
+        Some(json!({ "name": "Marketing" })),
+    )
+    .await;
+    assert_eq!(status_dup, StatusCode::CONFLICT, "{body_dup}");
+    assert_eq!(body_dup["code"], "name_taken");
+
+    ephemeral.drop().await;
+}
+
+/// Same 409 mapping precedent as `create_project_rejects_a_duplicate_name_with_409`,
+/// for `POST /collections`'s own `uq_collections__org_name` (migrations/0004).
+/// HTTP-level (not a direct DB insert) so this exercises the actual route's
+/// `RouteError::from_db` mapping, not just the constraint itself.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
+async fn create_collection_rejects_a_duplicate_name_with_409() {
+    let Some((ephemeral, pool)) = boot_pool().await else {
+        return;
+    };
+    let app = build_router(pool.clone(), &ephemeral.app_url, None);
+    let org = Uuid::new_v4();
+    let user = Uuid::new_v4();
+    let (_ctx, token) = seed_caller(&pool, org, user, "dup-collection@projects-it.test").await;
+
+    let (status, body) = send(
+        &app,
+        "POST",
+        "/api/v1/collections",
+        Some(&token),
+        Some(json!({
+            "name": "Support Docs",
+            "slug": format!("support-docs-{}", Uuid::new_v4().simple()),
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+
+    let (status_dup, body_dup) = send(
+        &app,
+        "POST",
+        "/api/v1/collections",
+        Some(&token),
+        Some(json!({
+            "name": "Support Docs",
+            "slug": format!("support-docs-{}", Uuid::new_v4().simple()),
+        })),
+    )
+    .await;
+    assert_eq!(status_dup, StatusCode::CONFLICT, "{body_dup}");
+    assert_eq!(body_dup["code"], "name_taken");
+
+    ephemeral.drop().await;
+}
+
 #[tokio::test]
 #[ignore = "requires MARKHAND_TEST_DATABASE_URL + MARKHAND_TEST_APP_DATABASE_URL"]
 async fn update_project_renames_and_requires_permission() {

--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -9,7 +9,7 @@ Parent plan: [`../../../phase-2-web-spa.md`](../../../phase-2-web-spa.md)
 + serve). **4 In progress**: P2-10 (Q&A — UI/mock/stream xây xong trên contract hiện có,
 xem chi tiết bên dưới), P2-15 (E2E — nửa mock-based xong, nay có thêm flow ask→citation
 của P2-10; nửa real-deployment hoãn), **P2-17** (Document graph — owner request mới
-2026-07-29, MVP server+web+mock xong, `similarity`/Qdrant chờ vòng riêng — xem chi tiết
+2026-07-29, MVP server+web+mock xong, `similarity` đã landed 2026-07-29 (recommend-by-id, org-filter bắt buộc, threshold 0.5 const, cap 500 cạnh/200 node — test tích hợp `graph_similarity_edges_from_qdrant_recommend` gated `MARKHAND_TEST_QDRANT_URL`, evidence đầu tiên trên CI `rust-integration`; follow-up: batch recommend + tune threshold trên corpus thật) — xem chi tiết
 bên dưới), **P2-18** (Project grouping — owner request mới 2026-07-29, org → project →
 collection → document, MVP server+web+mock xong — xem chi tiết bên dưới). P2-11/P2-12
 rời khỏi Blocked nhờ lát membership API (1C-02/1C-11 slice) landed ở #317.
@@ -107,11 +107,30 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #312. Collection nav, filter + cursor pagination thật, preview qua SafeMarkdown. Không có endpoint cross-collection nên "tất cả bộ sưu tập" chỉ điều hướng.
 
+  **Cập nhật (URL param cho tài liệu đang mở, 2026-07-29):** tài liệu đang chọn chuyển từ
+  state cục bộ (`ViewState.selectedDocumentId`) sang query param thật trên URL
+  (`/library/:collectionId?doc=<documentId>` — `RouterProvider`'s `searchParams`, mới
+  thêm cạnh `pathname`/`match`). Reload giữ nguyên tài liệu đang mở (route param được
+  parse lại từ URL, không phải từ state đã mất); back/forward hoạt động qua
+  `popstate` có sẵn của `RouterProvider`, không cần code riêng. `?doc=` có thể trỏ tới
+  một tài liệu không nằm trên trang hiện tại (deep-link từ citation hoặc reload không
+  giữ vị trí phân trang) — rơi vào trường hợp đó thì `LibraryPage` gọi thẳng
+  `GET /documents/{documentId}` để lấy tài liệu, thay vì chỉ tìm trong `items` của trang
+  đang tải. Đổi trang (`goToPrevPage`/`goToNextPage`) xoá `?doc=` (điều hướng, không chỉ
+  set state) vì tài liệu đã chọn thuộc trang cũ. Đây cũng là điều kiện để đóng gap
+  citation deep-link của P2-10 (xem mục đó): `CitationCard` dựng đúng path này.
+  Thêm hướng dẫn/nút mở nhanh bộ sưu tập đầu tiên trên màn "Tất cả bộ sưu tập" (điều
+  hướng thôi, không phải panel upload cross-collection — giữ đúng giới hạn ghi ở dòng
+  Status phía trên).
+
 - **Plan/files:** Adapt browser-safe LibraryView; collection navigation, filter/page,
   status, preview states + SafeMarkdown; unresolved conflict badge/count, side-by-side
   cited BA/design/dev claims và resolved-history link.
 - **Depends:** P2-02/03/05/06. **Acceptance/tests:** Stable URL/pagination; API-only
-  preview; unsafe markdown, 403/404, switch-race tests.
+  preview; unsafe markdown, 403/404, switch-race tests. **+ ?doc= param**: select
+  pushes URL; deep-link preselects + previews; reload (fresh mount, same URL) keeps
+  selection; back/forward moves selection (`LibraryPage.test.tsx`'s "P2-07 URL param"
+  suite); E2E citation→preview (`qa.spec.ts`).
 - **Security:** No local path/public key. **Out:** desktop editor/compare.
 
 ## P2-08 — Upload progress và job lifecycle
@@ -192,6 +211,24 @@ P2-15 + Phase 1C gate → P2-16
   được giữ kèm epoch nó được tạo ra, và bị xoá sạch (adjust-state-while-rendering) ngay
   khi epoch đổi (đổi org/logout) — đóng luôn gap "chưa có test org-switch riêng cho
   AskPanel" đã ghi nhận trước đó (xem Acceptance/tests bên dưới).
+
+  **Cập nhật (citation deep-link gap đóng, 2026-07-29):** gap ở trên (`CitationPin`
+  không có `logicalDocumentId`/`versionId`) là gap **contract/spec**, không phải gap dữ
+  liệu — server (`services::citation::CitationPin`) đã luôn serialize
+  `logicalDocumentId`/`versionId`/`collectionId`; `openapi.yaml`'s `CitationPin` schema
+  chỉ đơn giản chưa khai báo chúng, nên `openapi-typescript` sinh type thiếu 3 field đó
+  dù JSON thật đã có sẵn. Đã đóng bằng cách nới schema (field mới optional/nullable,
+  không đổi required, không bump version — additive) + regenerate `contract.ts`.
+  `CitationCard` giờ dựng link thật `/library/:collectionId?doc=:documentId`
+  (`buildLibraryDocPath`, cùng route `LibraryPage` đọc — xem P2-07) khi pin mang đủ định
+  danh; `ChatTurnBubble` vẫn giữ ghi chú cũ (đổi câu chữ: "một số trích dẫn") cho trường
+  hợp hiếm một pin không mang định danh. `LibraryPage` chuyển từ state cục bộ sang
+  `?doc=` trên URL (xem P2-07) nên deep-link này giữ được cả reload lẫn back/forward.
+  Mock (`mocks/handlers/qa.ts`'s `passageToCitation`) cập nhật theo cùng shape. Còn lại:
+  `/citations/resolve`'s response object (inline, không `$ref` tới `CitationPin`) chưa có
+  `collectionId` — không nằm trong scope lần này (caller resolve đã biết
+  `logicalDocumentId`/`versionId` trước khi gọi, theo đúng thiết kế request của endpoint
+  đó).
 
 - **Plan/files:** Search/ask panel, current/as-of/compare/history selector, index
   readiness, stream reducer, fallback + version-change notes, citation deep-link with
@@ -318,9 +355,12 @@ P2-15 + Phase 1C gate → P2-16
   (thuật toán thuần); OpenAPI path/schemas (`GraphNode`/`GraphEdge`/`GraphCommunity`/
   `GraphResponse`) + `ROUTE_INVENTORY`; `web/src/pages/GraphPage.tsx`,
   `components/graph/**`, `lib/forceLayout.ts`, `mocks/handlers/graph.ts`.
-- **Depends:** P2-07 (điều hướng vào `/library/:collectionId` khi click node — không có
-  route sâu tới preview một tài liệu cụ thể, vì `LibraryPage` chọn tài liệu bằng state
-  cục bộ chứ không phải URL param) + backend 1B claims/conflicts + P1B-R05 ask-stream.
+- **Depends:** P2-07 (điều hướng vào `/library/:collectionId` khi click node — vẫn chưa
+  sâu tới preview một tài liệu cụ thể *từ đồ thị*: `GraphPage` truyền `collectionId`,
+  không truyền `documentId`, dù `LibraryPage` giờ đã đọc tài liệu đang mở từ URL param
+  `?doc=` — xem P2-07 — nên việc "click node → mở đúng tài liệu đó" chỉ cần
+  `GraphPage` build `?doc=` vào cùng link, chưa làm ở đây) + backend 1B
+  claims/conflicts + P1B-R05 ask-stream.
 - **Acceptance/tests:** `services::graph` unit test (components/pruning, xác định);
   `tests/graph.rs` DB-gated (permission, conflict edge, co_citation edge, org isolation,
   ACL riêng tư, bounded cap — chạy thật trên PG local, 6/6 pass); web unit
@@ -350,6 +390,15 @@ P2-15 + Phase 1C gate → P2-16
   route/rail admin mới cho một tính năng "đơn giản" theo yêu cầu owner). Project
   deletion ngoài phạm vi vòng này (tránh bàn semantics bộ sưu tập mồ côi).
 
+  **Cập nhật (409 cho trùng tên, 2026-07-29):** `POST /projects` và `POST /collections`
+  đều đã có unique constraint `(org_id, name)` trong DB từ trước (`uq_projects__org_name`
+  migrations/0032, `uq_collections__org_name` migrations/0004) nhưng route trước đó map
+  MỌI lỗi DB không phải `NotFound` thành 500 `internal_error` — trùng tên rơi vào đó
+  thay vì 409. Đóng theo đúng tiền lệ `services::orgs::CreateOrgError::SlugTaken`
+  (`routes::orgs`): thêm `RouteError::NameTaken` map từ `SqlState::UNIQUE_VIOLATION`
+  → `409 name_taken` ở cả hai route. `ROUTE_INVENTORY` + `openapi.yaml` (`createProject`/
+  `createCollection` responses) thêm `409`.
+
 - **Plan/files:** `crates/server/migrations/0032_expand_projects.sql`;
   `db/projects.rs`, `routes/projects.rs`; `routes/collections.rs` (assign-project +
   `projectId`/`projectName` hydration), `routes/search.rs`/`routes/ask.rs` (projectId
@@ -363,7 +412,8 @@ P2-15 + Phase 1C gate → P2-16
   backend 1B collections + retrieval (`services::retrieval::resolve_scope`).
 - **Acceptance/tests:** `tests/projects.rs` DB-gated (CRUD happy/validate/403/404, org
   isolation, assign/unassign, search filter theo project trả đúng tập tài liệu, 404
-  projectId lạ — chạy trên PG local); `db::models`/`schema_migrations.rs` drift guard
+  projectId lạ, **409 trùng tên cho cả `POST /projects` và `POST /collections`** —
+  chạy trên PG local); `db::models`/`schema_migrations.rs` drift guard
   cập nhật cho bảng `projects` + cột `collections.project_id`; web unit
   (`QaPage.test.tsx` phạm vi dropdown + reset khi đổi org, `LibraryPage.test.tsx` nhóm
   nav theo dự án, `ProjectsPanel.test.tsx` tạo/gán/bỏ gán + permission gate) +

--- a/web/e2e/qa.spec.ts
+++ b/web/e2e/qa.spec.ts
@@ -59,13 +59,28 @@ test('ask streams a grounded answer token-by-token, then citations', async ({ pa
     'Lộ trình quý 3 tập trung vào tối ưu hiệu năng lập chỉ mục.',
   );
   await expect(page.getByText('CITE-0001', { exact: true })).toBeVisible();
-  // No preview deep-link here on purpose: `CitationPin` (contract.ts) carries
-  // no document/version id, so `ChatPanel` cannot resolve one — it says so
-  // instead of a silently-dead "Xem trước" button (see `CitationCard.tsx`'s
-  // module doc for the verified contract gap this documents).
-  await expect(
-    page.getByText(/Trích dẫn ở đây chưa kèm định danh tài liệu\/phiên bản/),
-  ).toBeVisible();
+
+  // P2-10 gap close: `CitationPin` (contract.ts) now carries
+  // `logicalDocumentId`/`versionId`/`collectionId` (`mocks/handlers/qa.ts`'s
+  // `passageToCitation`), so the citation for "Roadmap.xlsx" deep-links
+  // straight to its Library preview instead of the old dead-link note (see
+  // `CitationCard.tsx`'s module doc for the contract gap this closes).
+  // This question's tokens ("quý") also match the unrelated compare-doc
+  // fixture, so a second citation/link can render here too — scope to the
+  // CITE-0001 card specifically rather than assuming there is only one link.
+  await page
+    .locator('li.card', { hasText: 'CITE-0001' })
+    .getByRole('link', { name: 'Xem trước tài liệu' })
+    .click();
+  await expect(page).toHaveURL(/\/library\/[^/]+\?doc=[^/]+$/);
+  // `#library-preview-heading`, not a bare role query: the mock preview
+  // markdown re-embeds the title as its own `<h1># Roadmap.xlsx`, so the
+  // title text renders twice on this page (this panel's own heading, and
+  // that one) — same ambiguity `LibraryPage.test.tsx` documents.
+  await expect(page.locator('#library-preview-heading')).toHaveText('Roadmap.xlsx');
+  await expect(page.getByTestId('document-preview-markdown')).toContainText(
+    'Mock preview content for version',
+  );
 });
 
 test('citation_revoked mid-answer surfaces an accessible revoked notice without losing the partial answer', async ({

--- a/web/src/api/generated/contract.ts
+++ b/web/src/api/generated/contract.ts
@@ -863,6 +863,12 @@ export interface components {
         };
         CitationPin: {
             citeId: string;
+            /** Format: uuid */
+            logicalDocumentId?: string | null;
+            /** Format: uuid */
+            versionId?: string | null;
+            /** Format: uuid */
+            collectionId?: string | null;
             /** @description Original uploaded/source object SHA-256 */
             sourceContentSha256: string;
             /** @description Trusted canonical Markdown artifact SHA-256 */
@@ -1546,6 +1552,15 @@ export interface operations {
                 };
             };
             403: components["responses"]["ApiError"];
+            /** @description Collection name already used in this org (`uq_collections__org_name`). Same `name_taken` mapping precedent as POST /orgs's `slug_taken`. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
+                };
+            };
             429: components["responses"]["RateLimited"];
         };
     };
@@ -2581,6 +2596,15 @@ export interface operations {
             };
             400: components["responses"]["ApiError"];
             403: components["responses"]["ApiError"];
+            /** @description Project name already used in this org (`uq_projects__org_name`). Same `name_taken` mapping precedent as POST /orgs's `slug_taken`. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiError"];
+                };
+            };
             429: components["responses"]["RateLimited"];
         };
     };

--- a/web/src/components/qa/ChatPanel.tsx
+++ b/web/src/components/qa/ChatPanel.tsx
@@ -32,10 +32,12 @@
 // the real `GET /documents/{documentId}/versions` endpoint — no invented
 // picker data.
 //
-// Citation deep-link gap (see `CitationCard.tsx`'s own doc for the full
+// Citation deep-link (see `CitationCard.tsx`'s own doc for the full
 // reasoning): the `CitationPin` the contract returns from `ask`/`ask/stream`
-// carries no document/version id, so citations here render content only —
-// `ChatTurnBubble` says so below the list instead of a silently-dead link.
+// now carries `logicalDocumentId`/`versionId`/`collectionId` (P2-10 gap
+// close), so a citation with that identity renders a real
+// `/library/:collectionId?doc=` link; `ChatTurnBubble` still says so below
+// the list for the rarer pin that doesn't carry it.
 import { useEffect, useId, useRef, useState, type FormEvent } from 'react';
 import { apiClient, type ApiClient } from '../../api/client';
 import type { components } from '../../api/generated/contract';

--- a/web/src/components/qa/ChatTurnBubble.tsx
+++ b/web/src/components/qa/ChatTurnBubble.tsx
@@ -169,10 +169,21 @@ export function ChatTurnBubble({
               <CitationCard key={citation.citeId} citation={citation} />
             ))}
           </ul>
-          <p className="text-muted">
-            Trích dẫn ở đây chưa kèm định danh tài liệu/phiên bản theo hợp đồng hiện tại — dùng ô
-            Tìm kiếm phía trên để mở bản xem trước theo tài liệu.
-          </p>
+          {/* P2-10 gap close: `CitationPin` now carries `logicalDocumentId`/
+              `collectionId` (see `CitationCard.tsx`'s module doc), so most
+              citations render their own "Xem trước tài liệu" deep-link
+              directly. This note only still applies to a pin that, for
+              whatever reason, doesn't carry that identity — kept rather than
+              removed outright so that case still points at a working
+              alternative instead of just going quiet. */}
+          {display.citations.some(
+            (citation) => !citation.collectionId || !citation.logicalDocumentId,
+          ) && (
+            <p className="text-muted">
+              Một số trích dẫn ở đây chưa kèm định danh tài liệu/phiên bản — dùng ô Tìm kiếm phía
+              trên để mở bản xem trước theo tài liệu.
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/web/src/components/qa/CitationCard.test.tsx
+++ b/web/src/components/qa/CitationCard.test.tsx
@@ -1,0 +1,67 @@
+// P2-10 gap close: `CitationCard` renders a real Library preview deep-link
+// once a `CitationPin` carries `logicalDocumentId`/`collectionId`
+// (`hasDeepLink`), and falls back to plain content (no link) when it
+// doesn't — see the component's own module doc for the contract history.
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RouterProvider } from '../../state/RouterProvider';
+import { CitationCard, type CitationPin } from './CitationCard';
+
+function basePin(overrides: Partial<CitationPin> = {}): CitationPin {
+  return {
+    citeId: 'CITE-0001',
+    sourceContentSha256: 'a'.repeat(64),
+    canonicalMarkdownSha256: 'b'.repeat(64),
+    quoteSha256: 'c'.repeat(64),
+    chunkIdentitySha256: 'd'.repeat(64),
+    quote: 'Lộ trình quý 3 tập trung vào tối ưu hiệu năng lập chỉ mục.',
+    sourceSpanStart: 0,
+    sourceSpanEnd: 10,
+    quoteLocalStart: 0,
+    quoteLocalEnd: 10,
+    isCurrent: true,
+    anchor: 'mhcite1.test',
+    ...overrides,
+  };
+}
+
+function renderCard(citation: CitationPin) {
+  return render(
+    <RouterProvider>
+      <ul>
+        <CitationCard citation={citation} />
+      </ul>
+    </RouterProvider>,
+  );
+}
+
+describe('CitationCard', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('links to the exact document/version when the pin carries identity', () => {
+    const documentId = '11111111-1111-1111-1111-111111111111';
+    const collectionId = '22222222-2222-2222-2222-222222222222';
+    renderCard(basePin({ logicalDocumentId: documentId, collectionId }));
+
+    const link = screen.getByRole('link', { name: 'Xem trước tài liệu' });
+    expect(link).toHaveAttribute('href', `/library/${collectionId}?doc=${documentId}`);
+  });
+
+  it('falls back to no link when the pin has no document/collection identity', () => {
+    renderCard(basePin());
+
+    expect(screen.queryByRole('link', { name: 'Xem trước tài liệu' })).not.toBeInTheDocument();
+  });
+
+  it('still renders quote/citeId/current badge regardless of deep-link availability', () => {
+    renderCard(basePin({ isCurrent: false }));
+
+    expect(screen.getByText('CITE-0001')).toBeVisible();
+    expect(screen.getByText('Không phải bản hiện hành')).toBeVisible();
+    expect(
+      screen.getByText('“Lộ trình quý 3 tập trung vào tối ưu hiệu năng lập chỉ mục.”'),
+    ).toBeVisible();
+  });
+});

--- a/web/src/components/qa/CitationCard.tsx
+++ b/web/src/components/qa/CitationCard.tsx
@@ -1,15 +1,19 @@
-// Renders one `CitationPin` (contract.ts) exactly as the wire shape carries
-// it. Deliberately does NOT attempt a "go to this document" link: the
-// `CitationPin` schema (`crates/server/openapi/openapi.yaml`) has no
-// `logicalDocumentId`/`versionId` field — only `resolveCitation`'s *request*
-// shape (`ResolveCitationRequest`) requires those, which the caller would
-// already need to know before calling it, so there is no contract-given path
-// from a bare ask/search citation back to "which document/version". This is
-// a verified gap (see the P2-10 report), not a client oversight — search
-// *hits* carry a `documentId` (that shape is mock-convention/generic per the
-// spec, not the citation itself) and get a working deep-link via
-// `DocumentPreviewPanel`; ask's `citations` do not.
+// Renders one `CitationPin` (contract.ts). P2-10 gap close: the server
+// (`services::citation::CitationPin`) has always carried
+// `logicalDocumentId`/`versionId`/`collectionId` — the OpenAPI schema simply
+// didn't declare them (see `openapi.yaml`'s `CitationPin` doc comment), so
+// the generated contract type dropped them and this card had no way to link
+// back to "which document/version". Now that the schema declares them
+// (nullable — a resolved-but-un-hydrated pin, or a future producer that still
+// omits them, must keep degrading gracefully rather than throwing), a
+// citation that carries a `collectionId` gets a real
+// `/library/:collectionId?doc=:documentId` deep-link (`buildLibraryDocPath`,
+// same path `LibraryPage` itself reads); one that doesn't (the previous,
+// verified contract gap) still falls back to the old explanatory note rather
+// than a silently-dead link.
 import type { components } from '../../api/generated/contract';
+import { buildLibraryDocPath } from '../../lib/router';
+import { RouteLink } from '../RouteLink';
 
 export type CitationPin = components['schemas']['CitationPin'];
 
@@ -20,8 +24,16 @@ function locationLabel(citation: CitationPin): string | null {
   return null;
 }
 
+/** Whether this pin carries enough identity to build a working preview deep-link. */
+export function hasDeepLink(
+  citation: CitationPin,
+): citation is CitationPin & { collectionId: string; logicalDocumentId: string } {
+  return Boolean(citation.collectionId && citation.logicalDocumentId);
+}
+
 export function CitationCard({ citation }: { citation: CitationPin }) {
   const location = locationLabel(citation);
+  const deepLinkable = hasDeepLink(citation);
   return (
     <li className="card" style={{ padding: 'var(--space-3)' }}>
       <div
@@ -35,6 +47,14 @@ export function CitationCard({ citation }: { citation: CitationPin }) {
         )}
         {citation.isCurrent === true && <span className="tag tag-accent-2">Bản hiện hành</span>}
         {location && <span className="text-muted">{location}</span>}
+        {deepLinkable && (
+          <RouteLink
+            className="btn btn-secondary btn-sm"
+            to={buildLibraryDocPath(citation.collectionId, citation.logicalDocumentId)}
+          >
+            Xem trước tài liệu
+          </RouteLink>
+        )}
       </div>
       <blockquote style={{ margin: 'var(--space-2) 0 0', fontStyle: 'italic' }}>
         “{citation.quote}”

--- a/web/src/lib/router.ts
+++ b/web/src/lib/router.ts
@@ -48,3 +48,14 @@ export function matchRoute(pathname: string): RouteMatch {
 export function buildScopedPath(base: 'library' | 'qa' | 'graph', collectionId?: string): string {
   return collectionId ? `/${base}/${encodeURIComponent(collectionId)}` : `/${base}`;
 }
+
+/**
+ * Builds `/library/:collectionId?doc=:documentId` (P2-07 citation deep-link).
+ * `collectionId` is required here — unlike `buildScopedPath`, there is no
+ * "all collections" variant that also opens one specific document, since
+ * `LibraryPage` only ever fetches a document list (and can only preselect a
+ * row from it) once a `collectionId` is in scope.
+ */
+export function buildLibraryDocPath(collectionId: string, documentId: string): string {
+  return `/library/${encodeURIComponent(collectionId)}?doc=${encodeURIComponent(documentId)}`;
+}

--- a/web/src/mocks/handlers/qa.ts
+++ b/web/src/mocks/handlers/qa.ts
@@ -218,6 +218,15 @@ function citeIdFor(index: number): string {
 function passageToCitation(passage: Passage, citeId: string): CitationPin {
   return {
     citeId,
+    // P2-10 gap close — these three now mirror the real
+    // `services::citation::CitationPin` shape (see `openapi.yaml`'s
+    // `CitationPin` doc comment), matching the same `documentId`/
+    // `collectionId`/`versionId` this mock's `passageCatalog()` already
+    // carries for the corresponding `search` hit, so a citation and its
+    // matching search hit deep-link to the exact same document/version.
+    logicalDocumentId: passage.documentId,
+    versionId: passage.versionId,
+    collectionId: passage.collectionId,
     sourceContentSha256: `src-${passage.versionId}`,
     canonicalMarkdownSha256: `md-${passage.versionId}`,
     quoteSha256: `quote-${passage.versionId}`,

--- a/web/src/pages/LibraryPage.test.tsx
+++ b/web/src/pages/LibraryPage.test.tsx
@@ -96,6 +96,13 @@ function renderLibrary(client: ApiClient, collectionId?: string) {
 
 describe('LibraryPage', () => {
   beforeEach(() => {
+    // P2-07: `?doc=` now lives on `window.location.search`
+    // (`RouterProvider`'s `searchParams`), which — unlike the `collectionId`
+    // prop `renderLibrary` injects directly — is real browser state that
+    // persists across tests unless reset. Without this, a test that
+    // navigates to `?doc=...` would leak that query string into whichever
+    // test runs next.
+    window.history.pushState(null, '', '/');
     installMockFetch();
     resetMockState();
   });
@@ -398,6 +405,88 @@ describe('LibraryPage', () => {
         expect(screen.queryByRole('button', { name: /Sẽ bị xóa\.pdf/ })).not.toBeInTheDocument(),
       );
       expect(screen.getByText('Chưa có tài liệu nào trong bộ sưu tập này.')).toBeVisible();
+    });
+  });
+
+  describe('P2-07 URL param (?doc=)', () => {
+    it('selecting a document pushes ?doc= onto the URL', async () => {
+      const collection = seedCollection();
+      const doc = seedDocumentWithVersion(collection.id, { title: 'Selected.pdf' });
+      const client = await loggedInClient();
+      renderLibrary(client, collection.id);
+
+      fireEvent.click(await screen.findByRole('button', { name: /Selected\.pdf/ }));
+
+      await waitFor(() =>
+        expect(window.location.search).toBe(`?doc=${encodeURIComponent(doc.id)}`),
+      );
+    });
+
+    it('opening the page with ?doc= already on the URL preselects and previews that document (deep-link)', async () => {
+      const collection = seedCollection();
+      const doc = seedDocumentWithVersion(collection.id, { title: 'DeepLinked.pdf' });
+      seedDocumentWithVersion(collection.id, { title: 'Other.pdf' });
+      window.history.pushState(null, '', `/library/${collection.id}?doc=${doc.id}`);
+      const client = await loggedInClient();
+      renderLibrary(client, collection.id);
+
+      // Preselected without any click: the row shows selected and its own
+      // preview loads straight away. `getByText` (not `getByRole('heading',
+      // …)`) because the mock's preview markdown re-embeds the title as its
+      // own `# DeepLinked.pdf` heading — same title text appears twice
+      // (this panel's own `<h2 id="library-preview-heading">` and that `<h1>`
+      // inside the rendered Markdown), so only the id-scoped one is unambiguous.
+      expect(await screen.findByTestId('document-preview-markdown')).toHaveTextContent(
+        'Mock preview content for version 1',
+      );
+      expect(document.getElementById('library-preview-heading')).toHaveTextContent(
+        'DeepLinked.pdf',
+      );
+    });
+
+    it('reload (fresh mount at the same URL) keeps the same document open', async () => {
+      const collection = seedCollection();
+      const doc = seedDocumentWithVersion(collection.id, { title: 'Reloaded.pdf' });
+      const client = await loggedInClient();
+      const first = renderLibrary(client, collection.id);
+
+      fireEvent.click(await screen.findByRole('button', { name: /Reloaded\.pdf/ }));
+      await waitFor(() => expect(window.location.search).toContain(doc.id));
+
+      // Simulate a reload: unmount without touching `window.location` (a
+      // real reload keeps the URL, tears down all component state, and
+      // re-parses it from scratch), then mount a brand-new instance.
+      first.unmount();
+      renderLibrary(client, collection.id);
+
+      expect(await screen.findByTestId('document-preview-markdown')).toHaveTextContent(
+        'Mock preview content for version 1',
+      );
+      expect(document.getElementById('library-preview-heading')).toHaveTextContent('Reloaded.pdf');
+    });
+
+    it('back/forward (popstate) moves the selection without a click', async () => {
+      const collection = seedCollection();
+      const docA = seedDocumentWithVersion(collection.id, { title: 'A.pdf' });
+      const docB = seedDocumentWithVersion(collection.id, { title: 'B.pdf' });
+      const client = await loggedInClient();
+      renderLibrary(client, collection.id);
+
+      fireEvent.click(await screen.findByRole('button', { name: /A\.pdf/ }));
+      await waitFor(() => expect(window.location.search).toContain(docA.id));
+      fireEvent.click(await screen.findByRole('button', { name: /B\.pdf/ }));
+      await waitFor(() => expect(window.location.search).toContain(docB.id));
+
+      // Back: the browser itself moves history; `popstate` is what
+      // `RouterProvider` listens for (it never intercepts real back/forward).
+      // jsdom dispatches `popstate` asynchronously, so this is a `waitFor`,
+      // not an immediate assertion.
+      window.history.back();
+
+      await waitFor(() => expect(window.location.search).toContain(docA.id));
+      await waitFor(() =>
+        expect(document.getElementById('library-preview-heading')).toHaveTextContent('A.pdf'),
+      );
     });
   });
 

--- a/web/src/pages/LibraryPage.tsx
+++ b/web/src/pages/LibraryPage.tsx
@@ -21,6 +21,17 @@
 // only source of truth for state (`converting` -> `indexed`, tombstoning),
 // which also means a delete's own row disappears on the next page load
 // rather than being optimistically hidden while the server may still reject.
+//
+// P2-07 gap close: which document is open lives in the URL's `?doc=`
+// query param (`useRouter().searchParams`), not local component state — a
+// reload re-parses the same URL and reopens the same document, and
+// back/forward through browser history moves the selection because it moves
+// through `RouterProvider`'s own `popstate` listener, both for free. This is
+// also what makes `CitationCard`'s deep-link (`/library/:collectionId?doc=`)
+// work: navigating there is indistinguishable from a user clicking the same
+// row themselves. Selecting a document (`selectDocument` below) calls
+// `navigate()` so each selection is its own history entry, same as any other
+// in-app navigation this router already treats that way (`RouteLink`).
 import { useState } from 'react';
 import { apiClient, type ApiClient } from '../api/client';
 import {
@@ -38,9 +49,12 @@ import {
   type StatusFilterValue,
 } from '../components/library';
 import { DocumentRowActions } from '../components/actions';
+import { RouteLink } from '../components/RouteLink';
 import { Notice } from '../components/ui';
 import { UploadPanel } from '../components/upload';
 import { useScopeSafeRequest } from '../hooks/useScopeSafeRequest';
+import { buildLibraryDocPath, buildScopedPath } from '../lib/router';
+import { useRouter } from '../state/RouterProvider';
 import { useScope } from '../state/ScopeProvider';
 
 /** Server default is 50 (clamped [1,100]); 20 keeps a page comfortably scannable. */
@@ -54,7 +68,6 @@ interface ViewState {
   cursors: Array<string | undefined>;
   searchText: string;
   statusFilter: StatusFilterValue;
-  selectedDocumentId: string | null;
 }
 
 function initialView(collectionId: string | undefined): ViewState {
@@ -64,7 +77,6 @@ function initialView(collectionId: string | undefined): ViewState {
     cursors: [undefined],
     searchText: '',
     statusFilter: 'all',
-    selectedDocumentId: null,
   };
 }
 
@@ -77,6 +89,7 @@ export function LibraryPage({
   client?: ApiClient;
 }) {
   const { epoch } = useScope();
+  const { searchParams, navigate } = useRouter();
   const [view, setView] = useState<ViewState>(() => initialView(collectionId));
   // A `collectionId` prop change (collection switch/deep link) re-scopes the
   // whole page — pagination, filters, and selection all belonged to the
@@ -157,7 +170,35 @@ export function LibraryPage({
       matchesQuery(doc.title, effectiveView.searchText) &&
       (effectiveView.statusFilter === 'all' || doc.state === effectiveView.statusFilter),
   );
-  const selectedDocument = items.find((doc) => doc.id === effectiveView.selectedDocumentId) ?? null;
+
+  // Source of truth for "which document is open" is the URL, not local
+  // state — see this file's module doc. `selectedDocumentId` may name a
+  // document that is not on the currently-fetched page (a citation deep-link
+  // or a reload can point at any document in the collection, not just page
+  // 1), so a miss against `items` falls back to fetching that one document
+  // directly by id rather than silently showing nothing.
+  const selectedDocumentId = searchParams.get('doc');
+  const documentFromList = items.find((doc) => doc.id === selectedDocumentId) ?? null;
+  const directDocumentResult = useScopeSafeRequest(
+    async (signal) => {
+      if (!selectedDocumentId || documentFromList) return null;
+      return client.request('get', '/documents/{documentId}', {
+        params: { path: { documentId: selectedDocumentId } },
+        signal,
+      });
+    },
+    [client, selectedDocumentId, documentFromList],
+  );
+  // A directly-fetched fallback is only trusted when it actually belongs to
+  // the collection currently open — `GET /documents/{documentId}` is
+  // permission-checked (so a cross-collection id in the query string is
+  // never a data leak), but a mismatch here would still be the wrong
+  // document for this collection's heading/breadcrumb.
+  const directDocument =
+    directDocumentResult.data && directDocumentResult.data.collectionId === collectionId
+      ? directDocumentResult.data
+      : null;
+  const selectedDocument = documentFromList ?? directDocument;
 
   const previewResult = useScopeSafeRequest(
     async (signal) => {
@@ -171,7 +212,8 @@ export function LibraryPage({
   );
 
   function selectDocument(documentId: string) {
-    setView((v) => ({ ...v, selectedDocumentId: documentId }));
+    if (!collectionId) return;
+    navigate(buildLibraryDocPath(collectionId, documentId));
   }
 
   // Re-runs the documents request (and, through the selected document's
@@ -181,19 +223,33 @@ export function LibraryPage({
     setDocumentsRetry((n) => n + 1);
   }
 
+  // Turning the page drops whatever `?doc=` is open — the previously
+  // selected document belonged to a different page's results, same as
+  // before this became a URL param (`selectedDocumentId: null` on the old
+  // local `ViewState`). Only navigates when there was a selection to clear,
+  // so plain pagination without a preview open doesn't grow history for no
+  // reason.
+  function clearSelection() {
+    if (collectionId && searchParams.get('doc')) {
+      navigate(buildScopedPath('library', collectionId));
+    }
+  }
+
   function goToPrevPage() {
-    setView((v) =>
-      v.pageIndex === 0 ? v : { ...v, pageIndex: v.pageIndex - 1, selectedDocumentId: null },
-    );
+    if (effectiveView.pageIndex === 0) return;
+    clearSelection();
+    setView((v) => ({ ...v, pageIndex: v.pageIndex - 1 }));
   }
 
   function goToNextPage() {
+    const page = documentsResult.data?.page;
+    const nextCursor = page?.nextCursor;
+    if (!page?.hasMore || !nextCursor) return;
+    clearSelection();
     setView((v) => {
-      const page = documentsResult.data?.page;
-      if (!page?.hasMore || !page.nextCursor) return v;
       const cursors = v.cursors.slice(0, v.pageIndex + 1);
-      cursors.push(page.nextCursor);
-      return { ...v, pageIndex: v.pageIndex + 1, cursors, selectedDocumentId: null };
+      cursors.push(nextCursor);
+      return { ...v, pageIndex: v.pageIndex + 1, cursors };
     });
   }
 
@@ -245,7 +301,37 @@ export function LibraryPage({
       />
 
       {!collectionId ? (
-        <Notice tone="info">Chọn một bộ sưu tập ở trên để xem danh sách tài liệu.</Notice>
+        <Notice
+          tone="info"
+          // UX gap (owner backlog): "Tất cả bộ sưu tập" has no upload panel of
+          // its own (`POST /uploads` needs a `collectionId` — see the module
+          // doc above), so the fastest path to actually uploading something is
+          // one click into whichever collection already exists. Navigation
+          // only — this is deliberately not a second, cross-collection upload
+          // panel bolted onto this screen; see the P2-07 report for why.
+          action={
+            collections.length > 0 ? (
+              <RouteLink
+                className="btn btn-secondary btn-sm"
+                to={buildScopedPath('library', collections[0].id)}
+                // Explicit `aria-label` (generic, no collection name):
+                // `CollectionNav` already renders a same-named link for this
+                // exact collection, so this button's *visible* text
+                // includes the name for sighted users, but its accessible
+                // name deliberately does not — otherwise "Employee Handbook"
+                // (say) would resolve to two links by accessible name, which
+                // is exactly the ambiguity `e2e/support.ts`'s
+                // `openEmployeeHandbook` (and several other suites) would
+                // trip on.
+                aria-label="Mở bộ sưu tập đầu tiên để tải lên"
+              >
+                Mở {collections[0].name} để tải lên
+              </RouteLink>
+            ) : undefined
+          }
+        >
+          Chọn một bộ sưu tập ở trên để xem danh sách tài liệu.
+        </Notice>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
           {/* Scoped to the open collection — `POST /uploads` needs a
@@ -295,7 +381,7 @@ export function LibraryPage({
               <DocumentList
                 items={visibleItems}
                 totalOnPage={items.length}
-                selectedDocumentId={effectiveView.selectedDocumentId}
+                selectedDocumentId={selectedDocumentId}
                 onSelect={selectDocument}
                 loading={documentsResult.status === 'loading' && documentsData === undefined}
               />

--- a/web/src/pages/QaPage.test.tsx
+++ b/web/src/pages/QaPage.test.tsx
@@ -89,11 +89,17 @@ describe('QaPage', () => {
       );
     });
     expect(await screen.findByText('CITE-0001')).toBeVisible();
+    // P2-10 gap close: the mock's citation now carries logicalDocumentId/
+    // collectionId (`mocks/handlers/qa.ts`'s `passageToCitation`), so
+    // `CitationCard` renders a real deep-link instead of the old dead-link
+    // note — see `CitationCard.test.tsx` for the link-target assertion.
+    // This question's tokens ("quý") also match the unrelated compare-doc
+    // fixture's budget quote, so more than one citation (and deep-link) can
+    // render here — `getAllByRole` rather than assuming exactly one.
+    expect(screen.getAllByRole('link', { name: 'Xem trước tài liệu' }).length).toBeGreaterThan(0);
     expect(
-      screen.getByText(
-        /Trích dẫn ở đây chưa kèm định danh tài liệu\/phiên bản theo hợp đồng hiện tại/,
-      ),
-    ).toBeVisible();
+      screen.queryByText(/Một số trích dẫn ở đây chưa kèm định danh tài liệu\/phiên bản/),
+    ).not.toBeInTheDocument();
     // Default scenario is not the fallback path.
     expect(screen.queryByText('Trả lời trích xuất (không qua LLM)')).not.toBeInTheDocument();
   });

--- a/web/src/pages/QaPage.tsx
+++ b/web/src/pages/QaPage.tsx
@@ -3,8 +3,9 @@
 // `plans/markhand-web/backlog/phase-2/issues/README.md`'s P2-10 entry). Was a
 // placeholder before this; every field/endpoint used below is one the
 // contract (`web/src/api/generated/contract.ts`) actually declares — see
-// `components/qa/**`'s own module docs for the one verified gap (citations
-// from `ask`/`ask/stream` carry no document/version id to deep-link with).
+// `components/qa/**`'s own module docs for the citation deep-link (`ask`/
+// `ask/stream` citations now carry `logicalDocumentId`/`versionId`/
+// `collectionId` to deep-link with — P2-10 gap close).
 import { useState } from 'react';
 import { apiClient, type ApiClient } from '../api/client';
 import { ChatPanel, SearchPanel, type SearchHit } from '../components/qa';

--- a/web/src/state/RouterProvider.tsx
+++ b/web/src/state/RouterProvider.tsx
@@ -1,7 +1,8 @@
 // Stateful wrapper around the pure matcher in `../lib/router`. This is a
 // hand-rolled "smallest thing that answers the question", not a router: it
-// tracks `window.location.pathname`, reacts to back/forward navigation, and
-// exposes a `navigate` function that does a history push. It does not do
+// tracks `window.location.pathname` (+ `search`, added for P2-07's `?doc=`
+// deep-link — see `searchParams` below), reacts to back/forward navigation,
+// and exposes a `navigate` function that does a history push. It does not do
 // route guards, data loading, nested layouts, or scroll restoration — those
 // belong to whichever agent builds P2.3/P2.5 auth+scope guards on top of
 // this seam.
@@ -19,7 +20,10 @@ import type { RouteMatch } from '../types/routes';
 
 interface RouterContextValue {
   pathname: string;
+  /** Parsed `?query` string of the current URL — e.g. `LibraryPage`'s `?doc=<documentId>` (P2-07). Kept alongside `pathname`/`match` rather than folded into `RouteMatch.params`, since query params are orthogonal to which route matched and `matchRoute` itself only ever needs the path. */
+  searchParams: URLSearchParams;
   match: RouteMatch;
+  /** `to` may include a `?query` string (e.g. `/library/{id}?doc={documentId}`) — passed straight to `history.pushState`, same as a path-only `to` always was. */
   navigate: (to: string) => void;
 }
 
@@ -29,27 +33,43 @@ function currentPathname(): string {
   return typeof window === 'undefined' ? '/' : window.location.pathname;
 }
 
+/** Full path the browser is currently at, `pathname` + `search` — the identity `navigate` compares against so a query-only change (same pathname, different `?doc=`) still pushes a new history entry instead of being treated as a no-op. */
+function currentPath(): string {
+  if (typeof window === 'undefined') return '/';
+  return window.location.pathname + window.location.search;
+}
+
+function currentSearch(): string {
+  return typeof window === 'undefined' ? '' : window.location.search;
+}
+
 export function RouterProvider({ children }: { children: ReactNode }) {
   const [pathname, setPathname] = useState(currentPathname);
+  const [search, setSearch] = useState(currentSearch);
 
   useEffect(() => {
-    const onPopState = () => setPathname(currentPathname());
+    const onPopState = () => {
+      setPathname(currentPathname());
+      setSearch(currentSearch());
+    };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
   const navigate = useCallback((to: string) => {
-    if (to !== currentPathname()) {
+    if (to !== currentPath()) {
       window.history.pushState(null, '', to);
     }
     setPathname(currentPathname());
+    setSearch(currentSearch());
   }, []);
 
   const match = useMemo(() => matchRoute(pathname), [pathname]);
+  const searchParams = useMemo(() => new URLSearchParams(search), [search]);
 
   const value = useMemo<RouterContextValue>(
-    () => ({ pathname, match, navigate }),
-    [pathname, match, navigate],
+    () => ({ pathname, searchParams, match, navigate }),
+    [pathname, searchParams, match, navigate],
   );
 
   return <RouterContext.Provider value={value}>{children}</RouterContext.Provider>;


### PR DESCRIPTION
## Outcome

2 commit vòng 9 — trả nợ 2 follow-up đã khai báo trong PR #327:

- **Citation deep-link (`4be02dc`, P2-07/P2-10/P2-18)**: phát hiện gốc — struct Rust `CitationPin` **đã luôn** mang `logicalDocumentId`/`versionId`/`collectionId` trên wire JSON; chỉ OpenAPI schema chưa khai báo nên TS type che mất field sẵn có. Fix tối thiểu: khai báo 3 field (nullable, additive — không schema mới, không đổi pin-count), regenerate contract, không đụng service. Tài liệu đang mở trong Thư viện chuyển từ state cục bộ sang **URL param thật** (`/library/:collectionId?doc=...`): reload giữ tài liệu mở, back/forward hoạt động, `?doc` ngoài trang phân trang hiện tại được fetch thẳng `GET /documents/{id}`. `CitationCard` dựng đúng path đó — **click citation trong Hỏi đáp mở đúng tài liệu**; pin thiếu định danh giữ note giải thích. Kèm: nút mở nhanh bộ sưu tập để upload ở màn "Tất cả bộ sưu tập"; **409 `name_taken`** cho duplicate name projects + collections (map unique-violation theo tiền lệ `SlugTaken`, thay 500 chung).
- **Similarity edges (`9fee4cb`, P2-17)**: `QdrantClient::recommend` mới (API `/points/query` recommend + fallback `/points/recommend`) — **vector không bao giờ rời vector store** (recommend-by-point-id từ ≤3 chunk đại diện/tài liệu qua scroll sẵn có); **mandatory org/collection VectorScope filter** trên mọi truy vấn; aggregate per-cặp giữ max score, chuẩn hóa cosine → weight 0..1, threshold 0.5 (const — cần tune trên corpus thật), cap 500 cạnh/200 node trước prune chung. Service nhận `SimilarityDeps` optional (không đọc AppState) — chưa cấu hình → bỏ qua êm, response không đổi; lỗi vector store khi tính similarity là fail-soft.

## Scope

`crates/server`: `storage/qdrant.rs` (+recommend), `services/graph.rs` (similarity + 7 unit tests), `routes/{graph,projects,collections}.rs`, `openapi.yaml` (CitationPin +3 field nullable, 409 responses), `api/openapi.rs`, tests `graph`(+1 gated)/`projects`(+409)/`ask_grounding_matrix`(+citation id assertions). `web`: `RouterProvider` (+searchParams), `LibraryPage` (URL param + fetch ngoài trang), `CitationCard`/`ChatTurnBubble`/`ChatPanel`, mocks qa, contract regenerate, e2e qa.spec cập nhật. Backlog P2-07/10/17/18.

Không đổi: retrieval path, RLS, hành vi graph khi chưa cấu hình vector store, pin-count schema (49).

## Evidence

- [x] Tests: web **496/496** unit (47 file) + Playwright **29/29**; Rust lib **309/309**; DB-gated đầy đủ trên PG16+MinIO local `--include-ignored --no-fail-fast`: TẤT CẢ binary xanh — gồm graph 6/6, projects 12/12 (+2 test 409), api_http_contracts/citation_authz_matrix/sse/storage/uploads đủ — **ngoại lệ môi trường đã biết**: `worker` 17 test + 1 OCR-sandbox lib test cần syscall namespace container này không cấp (pre-existing, xác minh bằng `git stash` bởi 2 agent độc lập; CI có namespace nên xanh). fmt/clippy `-D warnings`/lint/format/build/make-checks sạch.
- [x] Manual/benchmark/migration evidence: không migration mới. **Test similarity thật (`graph_similarity_edges_from_qdrant_recommend`, gated `MARKHAND_TEST_QDRANT_URL`) CHƯA từng chạy — sandbox không có Qdrant; lần chạy đầu tiên là CI `rust-integration` của chính PR này** — reviewer lưu ý kết quả job đó là bằng chứng chính của tính năng. 7 unit test aggregate/threshold/cap đã xanh. Ảnh chụp citation deep-link flow đã gửi owner trong phiên.

## Boundary and security review

- [x] Dependency boundary check passed. (Không dep mới; route không chứa từ khóa direct-IO — một agent tự bắt vi phạm này trước khi nộp và sửa.)
- [x] Tenant/ACL impact reviewed, or N/A. Similarity: mandatory VectorScope org/collection filter mọi truy vấn, test gated có case cross-org; deep-link: `GET /documents/{id}` đi qua ACL sẵn có, không mở đường mới; 409 không lộ tài nguyên org khác (chỉ trùng tên trong org mình).
- [x] Sensitive logging/secret/egress impact reviewed, or N/A. Không log content; vector không rời store; không egress mới.
- [x] Security review trigger checked. (Không đụng auth path.)

## Follow-up

- [ ] Batch recommend (`points/recommend/batch`) khi tenant >200 tài liệu hiển thị; tune threshold 0.5 trên corpus thật.
- [ ] `check-dependency-policy` từng đỏ giả khi có worktree agent tồn tại (quét cả `.claude/worktrees/`) — cân nhắc exclude path đó trong script.
- [x] Docs/backlog đồng bộ trong PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2AJXqkUkAqRTdCpkwFvwt

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2AJXqkUkAqRTdCpkwFvwt)_