### PR TITLE
[intern-05] Test chunk_markdown giữ heading path

### DIFF
--- a/crates/core/src/chunk.rs
+++ b/crates/core/src/chunk.rs
@@ -211,6 +211,52 @@ mod tests {
     use super::*;
 
     #[test]
+    fn three_level_heading_path_vietnamese() {
+        let md = "\
+# Phần I
+
+Giới thiệu phần I.
+
+## Mục 1
+
+Nội dung mục 1.
+
+### Tiểu mục 1.1
+
+Chi tiết tiểu mục.
+
+## Mục 2
+
+Nội dung mục 2.
+";
+        let c = chunk_markdown(md, 1000);
+
+        assert_eq!(c.len(), 4);
+        assert_eq!(c[0].heading, "Phần I");
+        assert_eq!(c[0].text, "Giới thiệu phần I.");
+        assert_eq!(c[1].heading, "Phần I > Mục 1");
+        assert_eq!(c[1].text, "Nội dung mục 1.");
+        assert_eq!(c[2].heading, "Phần I > Mục 1 > Tiểu mục 1.1");
+        assert_eq!(c[2].text, "Chi tiết tiểu mục.");
+        assert_eq!(c[3].heading, "Phần I > Mục 2");
+        assert_eq!(c[3].text, "Nội dung mục 2.");
+    }
+
+    #[test]
+    fn split_paragraphs_keep_full_heading_path() {
+        let para = "x".repeat(150);
+        let md = format!("# Phụ lục\n\n{para}\n\n{para}\n\n{para}\n");
+        let c = chunk_markdown(&md, 320);
+
+        assert!(c.len() >= 2, "expected split, got {}", c.len());
+        assert!(
+            c.iter().all(|k| k.heading == "Phụ lục"),
+            "every sub-chunk must keep section heading path"
+        );
+        assert!(c.iter().all(|k| k.chars <= 320));
+    }
+
+    #[test]
     fn splits_by_heading_with_path() {
         let md = "# Chương I\n\nMở đầu.\n\n## Điều 1\n\nNội dung điều 1.\n\n## Điều 2\n\nNội dung điều 2.\n";
         let c = chunk_markdown(md, 1000);

--- a/crates/core/src/chunk.rs
+++ b/crates/core/src/chunk.rs
@@ -232,26 +232,30 @@ Nội dung mục 2.
         let c = chunk_markdown(md, 1000);
 
         assert_eq!(c.len(), 4);
-        assert_eq!(c[0].heading, "Phần I");
-        assert_eq!(c[0].text, "Giới thiệu phần I.");
-        assert_eq!(c[1].heading, "Phần I > Mục 1");
-        assert_eq!(c[1].text, "Nội dung mục 1.");
-        assert_eq!(c[2].heading, "Phần I > Mục 1 > Tiểu mục 1.1");
-        assert_eq!(c[2].text, "Chi tiết tiểu mục.");
-        assert_eq!(c[3].heading, "Phần I > Mục 2");
-        assert_eq!(c[3].text, "Nội dung mục 2.");
+        let expected: &[(&str, &str)] = &[
+            ("Phần I", "Giới thiệu phần I."),
+            ("Phần I > Mục 1", "Nội dung mục 1."),
+            ("Phần I > Mục 1 > Tiểu mục 1.1", "Chi tiết tiểu mục."),
+            ("Phần I > Mục 2", "Nội dung mục 2."),
+        ];
+        for (i, (heading, text)) in expected.iter().enumerate() {
+            assert_eq!(c[i].heading, *heading, "chunk {i} heading");
+            assert_eq!(c[i].text, *text, "chunk {i} text");
+        }
     }
 
     #[test]
-    fn split_paragraphs_keep_full_heading_path() {
+    fn split_nested_section_keeps_full_heading_path() {
         let para = "x".repeat(150);
-        let md = format!("# Phụ lục\n\n{para}\n\n{para}\n\n{para}\n");
+        // Body dài chỉ thuộc ## Mục A dưới # Phần I — pha 1 đã flush path 2 cấp trước pha 2.
+        let md = format!("# Phần I\n\n## Mục A\n\n{para}\n\n{para}\n\n{para}\n");
         let c = chunk_markdown(&md, 320);
 
         assert!(c.len() >= 2, "expected split, got {}", c.len());
         assert!(
-            c.iter().all(|k| k.heading == "Phụ lục"),
-            "every sub-chunk must keep section heading path"
+            c.iter().all(|k| k.heading == "Phần I > Mục A"),
+            "nested path must survive paragraph split, got {:?}",
+            c.iter().map(|k| &k.heading).collect::<Vec<_>>()
         );
         assert!(c.iter().all(|k| k.chars <= 320));
     }


### PR DESCRIPTION
Closes #288

cc @anhnth24 — em xin gửi PR intern-05 để anh review ạ.

## Summary

- Thêm unit test trong `crates/core/src/chunk.rs` (`mod tests`) khóa hành vi **heading path** của `chunk_markdown`: path cha → con nối bằng `" > "`, kèm body đúng section.
- **Không** đổi thuật toán production — chỉ test regression cho RAG chunking.
- (Review follow-up) Đổi test split sang section **lồng 2 cấp** (`# Phần I` + `## Mục A`) để bắt regression `join` vs leaf-only; refactor `three_level` assert dạng bảng + loop.

## Thay đổi file

### `crates/core/src/chunk.rs`

1. **`three_level_heading_path_vietnamese`**
   - Markdown mẫu `#` / `##` / `###` + tiêu đề tiếng Việt có dấu; sibling `## Mục 2` sau `###` khóa pop path.
   - Assert 4 chunk qua bảng `(heading, text)` — exact match từng section.

2. **`split_nested_section_keeps_full_heading_path`** (thay test `# Phụ lục` 1 cấp)
   - Body dài dưới `## Mục A` trong `# Phần I` → chia theo `\n\n`, `max_chars = 320`.
   - Assert mọi sub-chunk giữ `heading == "Phần I > Mục A"` (không chỉ leaf `"Mục A"`).

## Vì sao RAG cần heading path (không chỉ body)?

- Chunk chỉ có body thì mất cấu trúc tài liệu: nhiều section có câu chữ tương tự, retrieve/embed khó phân biệt.
- Field `heading` (`"Cha > Con"`) mang ngữ cảnh tiêu đề khi index (server/desktop/MCP gọi `chunk_markdown` → corpus/FTS/citation).
- Khi một section bị cắt nhiều mảnh, **cùng heading path** giúp citation và QA biết các mảnh thuộc một mục.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p fileconv-core three_level_heading_path_vietnamese`
- [x] `cargo test -p fileconv-core split_nested_section_keeps_full_heading_path`
- [x] `cargo test -p fileconv-core chunk`
- [x] `cargo test -p fileconv-core`
- [x] Sabotage local (không commit): `let heading = String::new();` → `three_level` + `split_nested` **đỏ**; restore `join(" > ")` → xanh.
- [x] Sabotage local: `let heading = hpath.last().cloned().unwrap_or_default();` → **`split_nested_section_keeps_full_heading_path` đỏ** (`got ["Mục A", "Mục A"]`), **`three_level_heading_path_vietnamese` đỏ** (chunk 1+ heading leaf); restore → xanh.
