### PR TITLE
[intern-10] Test conv/text strip UTF-8 BOM + decode_text

### DIFF
--- a/crates/core/src/conv/text.rs
+++ b/crates/core/src/conv/text.rs
@@ -12,3 +12,37 @@ pub fn to_markdown(path: &Path) -> Result<String, ConvertError> {
         .unwrap_or(bytes.as_slice());
     Ok(crate::viet_legacy::decode_text(bytes))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_txt(name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "fileconv_text_{}_{}.txt",
+            name,
+            std::process::id()
+        ));
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    #[test]
+    fn utf8_bom_stripped_keeps_vietnamese() {
+        // Khóa strip UTF-8 BOM (EF BB BF) trước decode_text: artifact U+FEFF
+        // không được lọt output; nội dung tiếng Việt vẫn còn.
+        let mut bytes = vec![0xEF, 0xBB, 0xBF];
+        bytes.extend_from_slice("Xin chào Việt Nam".as_bytes());
+        let path = temp_txt("utf8_bom", &bytes);
+        let md = to_markdown(&path).expect("text convert");
+        assert!(
+            md.contains("Xin chào Việt Nam"),
+            "expected Vietnamese body, got: {md:?}"
+        );
+        assert!(
+            !md.contains('\u{feff}'),
+            "UTF-8 BOM must be stripped, got: {md:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/crates/core/src/conv/text.rs
+++ b/crates/core/src/conv/text.rs
@@ -17,15 +17,23 @@ pub fn to_markdown(path: &Path) -> Result<String, ConvertError> {
 mod tests {
     use super::*;
 
+    fn write_temp_text(suffix: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "fileconv_text_{}_{}.txt",
+            suffix,
+            std::process::id()
+        ));
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
     #[test]
     fn utf8_bom_stripped_keeps_vietnamese() {
         // Khóa strip UTF-8 BOM (EF BB BF) trước decode_text: artifact U+FEFF
         // không được lọt output; nội dung tiếng Việt vẫn còn.
         let mut bytes = vec![0xEF, 0xBB, 0xBF];
         bytes.extend_from_slice("Xin chào Việt Nam".as_bytes());
-        let path =
-            std::env::temp_dir().join(format!("fileconv_text_utf8_bom_{}.txt", std::process::id()));
-        std::fs::write(&path, &bytes).unwrap();
+        let path = write_temp_text("utf8_bom_vi", &bytes);
         let md = to_markdown(&path).expect("text convert");
         assert!(
             md.contains("Xin chào Việt Nam"),
@@ -35,6 +43,56 @@ mod tests {
             !md.contains('\u{feff}'),
             "UTF-8 BOM must be stripped, got: {md:?}"
         );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn utf8_without_bom_decodes_vietnamese() {
+        let body = "Tài liệu kiểm thử.";
+        let path = write_temp_text("utf8_no_bom", body.as_bytes());
+        let md = to_markdown(&path).expect("text convert");
+        assert_eq!(md, body);
+        assert!(!md.contains('\u{feff}'));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn utf8_bom_only_yields_empty_without_feff() {
+        let path = write_temp_text("utf8_bom_only", &[0xEF, 0xBB, 0xBF]);
+        let md = to_markdown(&path).expect("text convert");
+        assert!(md.is_empty(), "expected empty body, got: {md:?}");
+        assert!(!md.contains('\u{feff}'));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn strip_prefix_only_at_file_start() {
+        // Chỉ cắt BOM ở byte 0; chuỗi EF BB BF giữa file vẫn decode thành U+FEFF.
+        let mut bytes = b"start".to_vec();
+        bytes.extend_from_slice(&[0xEF, 0xBB, 0xBF]);
+        bytes.extend_from_slice(b"end");
+        let path = write_temp_text("bom_in_middle", &bytes);
+        let md = to_markdown(&path).expect("text convert");
+        assert!(md.starts_with("start"));
+        assert!(md.ends_with("end"));
+        assert!(
+            md.contains('\u{feff}'),
+            "inner BOM bytes must not be stripped by strip_prefix, got: {md:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn legacy_tcvn3_routes_through_decode_text() {
+        // Cùng bytes TCVN3 mẫu như viet_legacy::tests (không BOM) — text path gọi decode_text.
+        const TCVN3_SAMPLE: &[u8] = &[
+            0x43, 0xE9, 0x6E, 0x67, 0x20, 0x68, 0xDF, 0x61, 0x20, 0x78, 0xB7, 0x20, 0x68, 0xE9,
+            0x69, 0x20, 0x63, 0x68, 0xF1, 0x20, 0x6E, 0x67, 0x68, 0xDC, 0x61, 0x20, 0x56, 0x69,
+            0xD6, 0x74, 0x20, 0x4E, 0x61, 0x6D,
+        ];
+        let path = write_temp_text("tcvn3_legacy", TCVN3_SAMPLE);
+        let md = to_markdown(&path).expect("text convert");
+        assert_eq!(md, "Cộng hòa xã hội chủ nghĩa Việt Nam");
         let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/core/src/conv/text.rs
+++ b/crates/core/src/conv/text.rs
@@ -18,11 +18,8 @@ mod tests {
     use super::*;
 
     fn temp_txt(name: &str, bytes: &[u8]) -> std::path::PathBuf {
-        let path = std::env::temp_dir().join(format!(
-            "fileconv_text_{}_{}.txt",
-            name,
-            std::process::id()
-        ));
+        let path =
+            std::env::temp_dir().join(format!("fileconv_text_{}_{}.txt", name, std::process::id()));
         std::fs::write(&path, bytes).unwrap();
         path
     }

--- a/crates/core/src/conv/text.rs
+++ b/crates/core/src/conv/text.rs
@@ -17,20 +17,15 @@ pub fn to_markdown(path: &Path) -> Result<String, ConvertError> {
 mod tests {
     use super::*;
 
-    fn temp_txt(name: &str, bytes: &[u8]) -> std::path::PathBuf {
-        let path =
-            std::env::temp_dir().join(format!("fileconv_text_{}_{}.txt", name, std::process::id()));
-        std::fs::write(&path, bytes).unwrap();
-        path
-    }
-
     #[test]
     fn utf8_bom_stripped_keeps_vietnamese() {
         // Khóa strip UTF-8 BOM (EF BB BF) trước decode_text: artifact U+FEFF
         // không được lọt output; nội dung tiếng Việt vẫn còn.
         let mut bytes = vec![0xEF, 0xBB, 0xBF];
         bytes.extend_from_slice("Xin chào Việt Nam".as_bytes());
-        let path = temp_txt("utf8_bom", &bytes);
+        let path =
+            std::env::temp_dir().join(format!("fileconv_text_utf8_bom_{}.txt", std::process::id()));
+        std::fs::write(&path, &bytes).unwrap();
         let md = to_markdown(&path).expect("text convert");
         assert!(
             md.contains("Xin chào Việt Nam"),


### PR DESCRIPTION
Closes #293

cc @anhnth24 — em xin gửi PR intern-10 để anh review ạ.

## Thay đổi là gì

- File sửa: `crates/core/src/conv/text.rs` — thêm `#[cfg(test)]` với **5 test** (không sửa `to_markdown`).
- Khóa strip UTF-8 BOM đầu file + luồng `decode_text` trên plain-text path.

## Vì sao test dùng `write_temp_text` (ghi file tạm)

`to_markdown` nhận **`&Path`** và đọc bằng `fs::read` — không có API test trực tiếp từ `&[u8]`. Muốn khóa đúng hàm production (strip BOM rồi `decode_text`) thì test phải có **file trên đĩa**.

Issue #293 ghi *bytes → file tạm theo pattern repo*. Em dùng `temp_dir` + `write` + `remove_file` vì:

- Nhiều case cần **bytes tự ghép** (BOM `EF BB BF`, BOM giữa chuỗi, bytes TCVN3) — khó/không cần commit fixture nhị phân riêng cho từng biến thể.
- **Không bắt buộc** tên “temp”: fixture cố định trong repo cũng được; temp chỉ là cách gọn để tạo đúng bytes rồi gọi `to_markdown(&path)`.

Helper `write_temp_text` gom 3 dòng lặp (path theo `suffix` + pid, ghi, trả path) — **5 test** cùng pattern, không đổi production.

## Test cases

| Test | Mục đích |
|------|-----------|
| `utf8_bom_stripped_keeps_vietnamese` | AC issue: BOM + tiếng Việt → không `\u{feff}`, giữ dấu |
| `utf8_without_bom_decodes_vietnamese` | UTF-8 thường không bị strip làm hỏng nội dung |
| `utf8_bom_only_yields_empty_without_feff` | File chỉ có BOM → chuỗi rỗng, không artifact |
| `strip_prefix_only_at_file_start` | `strip_prefix` chỉ cắt **đầu file**, không cắt byte BOM giữa nội dung |
| `legacy_tcvn3_routes_through_decode_text` | Bytes TCVN3 (mẫu `viet_legacy`) qua `to_markdown` → `decode_text` |

## Vì sao làm (tóm tắt)

BOM UTF-8 hợp lệ nhưng thành `\u{feff}` nếu không strip trước `decode_text`. Text path chỉ gọi `decode_text` (không `UppercaseFont`). CSV cùng strip BOM + decode, khác bước format bảng.

## Red check (phá tạm `to_markdown`, từng test một → phải đỏ → restore → xanh)

| Test | Cách phá tạm | Vì sao test đỏ |
|------|----------------|----------------|
| `utf8_bom_stripped_keeps_vietnamese` | Bỏ `strip_prefix`, gọi `decode_text(&bytes)` thẳng | Output còn `\u{feff}` → fail `!contains('\u{feff}')` |
| `utf8_without_bom_decodes_vietnamese` | Trả `Ok("wrong".to_string())` | Fail `assert_eq` với body UTF-8 |
| `utf8_bom_only_yields_empty_without_feff` | Bỏ `strip_prefix` | File chỉ BOM → chuỗi `\u{feff}`, fail `is_empty()` |
| `strip_prefix_only_at_file_start` | Cắt **mọi** cụm `EF BB BF` trong file (loop), không chỉ prefix | Byte BOM giữa `start`/`end` bị xóa → fail `contains('\u{feff}')` |
| `legacy_tcvn3_routes_through_decode_text` | Chỉ `String::from_utf8_lossy(bytes)`, bỏ `decode_text` | Không decode TCVN3 → fail `assert_eq` câu tiếng Việt |

Sau mỗi lần phá: restore `text.rs`, `cargo test -p fileconv-core conv::text::tests` → **5/5 pass**.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p fileconv-core conv::text::tests`
- [x] Red check **5/5** test (bảng trên)
- [x] `cargo test -p fileconv-core`