### PR TITLE
Close Phase 1B: R06 hanging soak pass and harness warmup fix

### DIFF
--- a/bench/markhand_web/hanging_soak/gate_report.py
+++ b/bench/markhand_web/hanging_soak/gate_report.py
@@ -46,6 +46,11 @@ PER_PROBE_DEADLINE_SECONDS = 2.0
 # reason (see `assert_hanging_http_probe` / `hanging_router_ready_matrix_...`).
 READY_DEADLINE_SLACK_SECONDS = 2.0
 READY_BOUND_SECONDS = OUTER_DEADLINE_SECONDS + READY_DEADLINE_SLACK_SECONDS  # 6.0
+# After `docker pause`, warm connection pools can still return 200 briefly before
+# the hung probe surfaces. The live harness waits up to this long for the
+# expected 503+code before starting the sustain window.
+POST_PAUSE_HANG_DEADLINE_SECONDS = OUTER_DEADLINE_SECONDS * 2 + READY_DEADLINE_SLACK_SECONDS
+POST_PAUSE_HANG_POLL_INTERVAL_SECONDS = 0.25
 
 # `/api/v1/health/live` (routes/health.rs `liveness`) and
 # `/api/v1/openapi.yaml` (http.rs `openapi_yaml`, serving

--- a/bench/markhand_web/hanging_soak/run_hanging_soak.py
+++ b/bench/markhand_web/hanging_soak/run_hanging_soak.py
@@ -181,6 +181,35 @@ def run_concurrency_batch(
     return {"n": n, "spanSeconds": round(span, 3), "results": results}
 
 
+def wait_for_hung_ready(
+    ready_url: str,
+    *,
+    expected_code: str,
+    timeout_seconds: float,
+    deadline_seconds: float = gate_report.POST_PAUSE_HANG_DEADLINE_SECONDS,
+    poll_interval_seconds: float = gate_report.POST_PAUSE_HANG_POLL_INTERVAL_SECONDS,
+) -> tuple[bool, list[dict[str, Any]]]:
+    """Poll until /ready reports the paused dependency or the deadline expires.
+
+    Transition samples (still-200 while pools drain) are returned for the raw
+    report but must not be counted in the sustain window.
+    """
+    attempts: list[dict[str, Any]] = []
+    deadline = time.monotonic() + deadline_seconds
+    while time.monotonic() < deadline:
+        sample = sample_endpoint(ready_url, timeout_seconds=timeout_seconds)
+        attempts.append(sample)
+        if (
+            sample.get("httpStatus") == 503
+            and sample.get("probeCode") == expected_code
+        ):
+            return True, attempts
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            time.sleep(min(poll_interval_seconds, remaining))
+    return False, attempts
+
+
 # --- Live per-dependency run ------------------------------------------------
 
 
@@ -204,6 +233,7 @@ def run_dependency(
         "service": None,
         "pauseConfirmed": False,
         "baseline": {},
+        "postPauseWarmup": {"hangObserved": False, "ready": []},
         "samples": {"ready": [], "live": [], "openapi": []},
         "concurrencyBatches": [],
         "restore": None,
@@ -256,6 +286,15 @@ def run_dependency(
     try:
         guard.arm_and_pause()
         result["pauseConfirmed"] = guard.pause_confirmed
+        hung_ok, warmup = wait_for_hung_ready(
+            ready_url,
+            expected_code=expected_code,
+            timeout_seconds=ready_timeout,
+        )
+        result["postPauseWarmup"] = {"hangObserved": hung_ok, "ready": warmup}
+        if not hung_ok:
+            result["blockers"].append(f"hang_not_observable:{label}")
+            return result
         deadline = time.monotonic() + sustain_seconds
         batch_every_ticks = max(1, round(10.0 / max(poll_interval_seconds, 0.5)))
         tick = 0

--- a/bench/markhand_web/hanging_soak/test_hanging_soak.py
+++ b/bench/markhand_web/hanging_soak/test_hanging_soak.py
@@ -34,7 +34,7 @@ sys.path.insert(0, str(SELF_DIR))
 
 import failpoint  # noqa: E402
 import gate_report  # noqa: E402
-from run_hanging_soak import sample_endpoint  # noqa: E402
+from run_hanging_soak import sample_endpoint, wait_for_hung_ready  # noqa: E402
 
 
 def _ready_sample(*, code: str, status: int = 503, elapsed: float = 1.0) -> dict:
@@ -83,6 +83,72 @@ class EvaluateDependencyPassTests(unittest.TestCase):
             evaluation["gates"],
         )
         self.assertEqual(evaluation["blockers"], [])
+
+
+class WaitForHungReadyTests(unittest.TestCase):
+    def test_succeeds_after_transient_200(self) -> None:
+        calls: list[dict] = []
+
+        def fake_sample(_url: str, *, timeout_seconds: float) -> dict:
+            if len(calls) == 0:
+                sample = {
+                    "httpStatus": 200,
+                    "probeCode": None,
+                    "elapsedSeconds": 0.004,
+                    "error": None,
+                }
+            else:
+                sample = {
+                    "httpStatus": 503,
+                    "probeCode": "ready_database",
+                    "elapsedSeconds": 1.0,
+                    "error": None,
+                }
+            calls.append(sample)
+            return sample
+
+        original = sys.modules["run_hanging_soak"].sample_endpoint
+        sys.modules["run_hanging_soak"].sample_endpoint = fake_sample
+        try:
+            ok, attempts = wait_for_hung_ready(
+                "http://127.0.0.1:8788/api/v1/health/ready",
+                expected_code="ready_database",
+                timeout_seconds=7.0,
+                deadline_seconds=5.0,
+                poll_interval_seconds=0.01,
+            )
+        finally:
+            sys.modules["run_hanging_soak"].sample_endpoint = original
+
+        self.assertTrue(ok)
+        self.assertEqual(len(attempts), 2)
+        self.assertEqual(attempts[0]["httpStatus"], 200)
+        self.assertEqual(attempts[1]["probeCode"], "ready_database")
+
+    def test_fails_when_hang_never_surfaces(self) -> None:
+        def always_200(_url: str, *, timeout_seconds: float) -> dict:
+            return {
+                "httpStatus": 200,
+                "probeCode": None,
+                "elapsedSeconds": 0.004,
+                "error": None,
+            }
+
+        original = sys.modules["run_hanging_soak"].sample_endpoint
+        sys.modules["run_hanging_soak"].sample_endpoint = always_200
+        try:
+            ok, attempts = wait_for_hung_ready(
+                "http://127.0.0.1:8788/api/v1/health/ready",
+                expected_code="ready_database",
+                timeout_seconds=7.0,
+                deadline_seconds=0.05,
+                poll_interval_seconds=0.01,
+            )
+        finally:
+            sys.modules["run_hanging_soak"].sample_endpoint = original
+
+        self.assertFalse(ok)
+        self.assertGreaterEqual(len(attempts), 1)
 
 
 class HangNotDetectedTests(unittest.TestCase):

--- a/bench/markhand_web/reports/phase-1b-gate/r06-hanging-soak.json
+++ b/bench/markhand_web/reports/phase-1b-gate/r06-hanging-soak.json
@@ -1,0 +1,2456 @@
+{
+  "blockers": [],
+  "canonicalReport": "r06-hanging-soak.json",
+  "coversAllDependencies": true,
+  "dependencies": [
+    {
+      "baseline": {
+        "live": {
+          "elapsedSeconds": 0.002,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        },
+        "openapi": {
+          "elapsedSeconds": 0.002,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        },
+        "ready": {
+          "elapsedSeconds": 0.051,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        }
+      },
+      "blockers": [],
+      "concurrencyBatches": [
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.031,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.031,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.032,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.028,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.026,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.028,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.025,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            }
+          ],
+          "spanSeconds": 0.046
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.017,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.021,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.017,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.021,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.013,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            }
+          ],
+          "spanSeconds": 0.029
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.012,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.012,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.01,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.013,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.009,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            }
+          ],
+          "spanSeconds": 0.022
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.015,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.015,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.008,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_database"
+            }
+          ],
+          "spanSeconds": 0.02
+        }
+      ],
+      "dependencyLabel": "database",
+      "expectedProbeCode": "ready_database",
+      "gates": {
+        "concurrencyBounded": "pass",
+        "concurrencyNoGrowth": "pass",
+        "liveBounded": "pass",
+        "openapiBounded": "pass",
+        "readyBounded": "pass",
+        "readyCodeCorrect": "pass",
+        "recoveryBounded": "pass",
+        "restoreConfirmed": "pass"
+      },
+      "pauseConfirmed": true,
+      "postPauseWarmup": {
+        "hangObserved": true,
+        "ready": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 2.005,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          }
+        ]
+      },
+      "recovery": {
+        "deadlineSeconds": 30.0,
+        "recoveredWithinDeadline": true,
+        "recoverySeconds": 1.097
+      },
+      "restore": {
+        "paused": false,
+        "restoreSkipped": false,
+        "restoredConfirmed": true,
+        "running": true,
+        "unpauseExitCode": 0
+      },
+      "samples": {
+        "live": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.021,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          }
+        ],
+        "openapi": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.005,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.005,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          }
+        ],
+        "ready": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.006,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.006,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.005,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.005,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.006,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.007,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.007,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.006,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.005,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.005,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.007,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.005,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.005,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.005,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          },
+          {
+            "elapsedSeconds": 2.005,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_database"
+          }
+        ]
+      },
+      "service": "postgres"
+    },
+    {
+      "baseline": {
+        "live": {
+          "elapsedSeconds": 0.002,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        },
+        "openapi": {
+          "elapsedSeconds": 0.002,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        },
+        "ready": {
+          "elapsedSeconds": 0.003,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        }
+      },
+      "blockers": [],
+      "concurrencyBatches": [
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.013,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.014,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.003,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            }
+          ],
+          "spanSeconds": 0.018
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.008,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.01,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            }
+          ],
+          "spanSeconds": 0.023
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.039,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.041,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.037,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.036,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.035,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.035,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.032,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            }
+          ],
+          "spanSeconds": 0.047
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.045,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.04,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.042,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.039,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.041,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.037,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.038,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            },
+            {
+              "elapsedSeconds": 0.028,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_vector_store"
+            }
+          ],
+          "spanSeconds": 0.048
+        }
+      ],
+      "dependencyLabel": "vector_store",
+      "expectedProbeCode": "ready_vector_store",
+      "gates": {
+        "concurrencyBounded": "pass",
+        "concurrencyNoGrowth": "pass",
+        "liveBounded": "pass",
+        "openapiBounded": "pass",
+        "readyBounded": "pass",
+        "readyCodeCorrect": "pass",
+        "recoveryBounded": "pass",
+        "restoreConfirmed": "pass"
+      },
+      "pauseConfirmed": true,
+      "postPauseWarmup": {
+        "hangObserved": true,
+        "ready": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 2.047,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          }
+        ]
+      },
+      "recovery": {
+        "deadlineSeconds": 30.0,
+        "recoveredWithinDeadline": true,
+        "recoverySeconds": 1.086
+      },
+      "restore": {
+        "paused": false,
+        "restoreSkipped": false,
+        "restoredConfirmed": true,
+        "running": true,
+        "unpauseExitCode": 0
+      },
+      "samples": {
+        "live": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.005,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.005,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.027,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          }
+        ],
+        "openapi": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.056,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          }
+        ],
+        "ready": [
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.035,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.033,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.03,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.047,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.027,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.029,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.031,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.032,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.045,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.042,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 1.968,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.03,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.034,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.077,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          },
+          {
+            "elapsedSeconds": 2.025,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_vector_store"
+          }
+        ]
+      },
+      "service": "qdrant"
+    },
+    {
+      "baseline": {
+        "live": {
+          "elapsedSeconds": 0.002,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        },
+        "openapi": {
+          "elapsedSeconds": 0.002,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        },
+        "ready": {
+          "elapsedSeconds": 0.003,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        }
+      },
+      "blockers": [],
+      "concurrencyBatches": [
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.011,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.008,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.008,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            }
+          ],
+          "spanSeconds": 0.028
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.014,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.012,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            }
+          ],
+          "spanSeconds": 0.018
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.042,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.041,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.011,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.04,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.034,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.037,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.036,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.033,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            }
+          ],
+          "spanSeconds": 0.049
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.009,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.011,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_object_store"
+            }
+          ],
+          "spanSeconds": 0.021
+        }
+      ],
+      "dependencyLabel": "object_store",
+      "expectedProbeCode": "ready_object_store",
+      "gates": {
+        "concurrencyBounded": "pass",
+        "concurrencyNoGrowth": "pass",
+        "liveBounded": "pass",
+        "openapiBounded": "pass",
+        "readyBounded": "pass",
+        "readyCodeCorrect": "pass",
+        "recoveryBounded": "pass",
+        "restoreConfirmed": "pass"
+      },
+      "pauseConfirmed": true,
+      "postPauseWarmup": {
+        "hangObserved": true,
+        "ready": [
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.005,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.005,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 2.038,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          }
+        ]
+      },
+      "recovery": {
+        "deadlineSeconds": 30.0,
+        "recoveredWithinDeadline": true,
+        "recoverySeconds": 1.052
+      },
+      "restore": {
+        "paused": false,
+        "restoreSkipped": false,
+        "restoredConfirmed": true,
+        "running": true,
+        "unpauseExitCode": 0
+      },
+      "samples": {
+        "live": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.033,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          }
+        ],
+        "openapi": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.034,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          }
+        ],
+        "ready": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 1.56,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.055,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.043,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.036,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.029,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.042,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.031,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.052,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.038,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.044,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.033,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.038,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.014,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.028,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          },
+          {
+            "elapsedSeconds": 2.046,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_object_store"
+          }
+        ]
+      },
+      "service": "minio"
+    },
+    {
+      "baseline": {
+        "live": {
+          "elapsedSeconds": 0.002,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        },
+        "openapi": {
+          "elapsedSeconds": 0.002,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        },
+        "ready": {
+          "elapsedSeconds": 0.003,
+          "error": null,
+          "httpStatus": 200,
+          "probeCode": null
+        }
+      },
+      "blockers": [],
+      "concurrencyBatches": [
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.008,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.008,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.008,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.009,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.009,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.002,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            }
+          ],
+          "spanSeconds": 0.02
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.008,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.009,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.012,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.009,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.005,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            }
+          ],
+          "spanSeconds": 0.022
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.012,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.011,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.008,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.004,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            }
+          ],
+          "spanSeconds": 0.017
+        },
+        {
+          "n": 8,
+          "results": [
+            {
+              "elapsedSeconds": 0.007,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.01,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.015,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.011,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.018,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.012,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.01,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            },
+            {
+              "elapsedSeconds": 0.006,
+              "error": null,
+              "httpStatus": 503,
+              "probeCode": "ready_embedding"
+            }
+          ],
+          "spanSeconds": 0.029
+        }
+      ],
+      "dependencyLabel": "embedding",
+      "expectedProbeCode": "ready_embedding",
+      "gates": {
+        "concurrencyBounded": "pass",
+        "concurrencyNoGrowth": "pass",
+        "liveBounded": "pass",
+        "openapiBounded": "pass",
+        "readyBounded": "pass",
+        "readyCodeCorrect": "pass",
+        "recoveryBounded": "pass",
+        "restoreConfirmed": "pass"
+      },
+      "pauseConfirmed": true,
+      "postPauseWarmup": {
+        "hangObserved": true,
+        "ready": [
+          {
+            "elapsedSeconds": 0.029,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 2.058,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          }
+        ]
+      },
+      "recovery": {
+        "deadlineSeconds": 30.0,
+        "recoveredWithinDeadline": true,
+        "recoverySeconds": 1.084
+      },
+      "restore": {
+        "paused": false,
+        "restoreSkipped": false,
+        "restoredConfirmed": true,
+        "running": true,
+        "unpauseExitCode": 0
+      },
+      "samples": {
+        "live": [
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          }
+        ],
+        "openapi": [
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.033,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.05,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.002,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.006,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          },
+          {
+            "elapsedSeconds": 0.004,
+            "error": null,
+            "httpStatus": 200,
+            "probeCode": null
+          }
+        ],
+        "ready": [
+          {
+            "elapsedSeconds": 0.003,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.039,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.034,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.041,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.055,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 1.977,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.036,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.041,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.076,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.044,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.032,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.05,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.037,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.041,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.057,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          },
+          {
+            "elapsedSeconds": 2.066,
+            "error": null,
+            "httpStatus": 503,
+            "probeCode": "ready_embedding"
+          }
+        ]
+      },
+      "service": "mock-embedding"
+    }
+  ],
+  "dependenciesRequested": [
+    "database",
+    "vector_store",
+    "object_store",
+    "embedding"
+  ],
+  "generatedAt": "2026-07-31T08:09:39Z",
+  "issue": "P1B-R06",
+  "markhandHangingSoak": true,
+  "minQualifyingSustainSeconds": 60,
+  "notes": "Live measured hanging-dependency soak.",
+  "outDir": "bench/markhand_web/reports/phase-1b-gate",
+  "provenance": {
+    "apiBase": "http://127.0.0.1:8788",
+    "composeFileSha256": "ee325ec41ccd12b61f8d72391e4b17e7fb098c846ab4f1885aead3b9773b5f5e",
+    "composeProject": "markhand-poc",
+    "gitDirty": true,
+    "gitSha": "a981fb307",
+    "gitShaFull": "a981fb3076255ae846d7367e2b217ed2f21cd89e",
+    "imageIds": {
+      "api": "sha256:4317e8f482e7784e266a9020001fbaefff6c4cbb2e94fa039f59dbc564067e3f",
+      "minio": "sha256:dacff8306a6e0a734518533992dbdcca26bc1ca47f77cf47cb9945725f92b29b",
+      "postgres": "sha256:1961f96e6029a02c3812d7cb329a3b03a3ac2bb067058dec17b0f5596aca9296",
+      "qdrant": "sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c"
+    },
+    "migrationManifestSha256": "8f6f6c383d927277a6817d4ae4cb99c5f2599c3b9256168473606c52a579539a"
+  },
+  "rawDir": "bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03",
+  "rawManifest": {
+    "files": [
+      {
+        "bytes": 12894,
+        "path": "database-samples.json",
+        "sha256": "1e03210813f68132d719dc4b3b28e1f50ea3e4c7862aa1e2825d4e27be701441"
+      },
+      {
+        "bytes": 12822,
+        "path": "embedding-samples.json",
+        "sha256": "02e5f4948a8aebdf611d987ebfcbcfaebda4d8a2c199aa3da3fad3dcedd0152a"
+      },
+      {
+        "bytes": 12969,
+        "path": "object_store-samples.json",
+        "sha256": "e9efa33bf4e3beb4f2c3d7962ae099d175420c7a43f1895c8c51aadca1deb87f"
+      },
+      {
+        "bytes": 12968,
+        "path": "vector_store-samples.json",
+        "sha256": "97200b0d72cf28aff70e42e5cf6e03ca791e9c15a55f04f3567b029fa93af6e8"
+      }
+    ],
+    "ok": true,
+    "path": "bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/raw-manifest.json",
+    "sha256": "7502ebca2fe278c8bdef82528c37193de6e386e495c217770aa7b6779493da2c"
+  },
+  "redactionScan": {
+    "findings": [],
+    "passed": true
+  },
+  "smoke": false,
+  "smokeNonQualifying": false,
+  "status": "pass",
+  "sustainSeconds": 60.0,
+  "versions": {
+    "composeFileSha256": "ee325ec41ccd12b61f8d72391e4b17e7fb098c846ab4f1885aead3b9773b5f5e",
+    "git": "a981fb307",
+    "gitShaFull": "a981fb3076255ae846d7367e2b217ed2f21cd89e",
+    "imageIds": {
+      "api": "sha256:4317e8f482e7784e266a9020001fbaefff6c4cbb2e94fa039f59dbc564067e3f",
+      "minio": "sha256:dacff8306a6e0a734518533992dbdcca26bc1ca47f77cf47cb9945725f92b29b",
+      "postgres": "sha256:1961f96e6029a02c3812d7cb329a3b03a3ac2bb067058dec17b0f5596aca9296",
+      "qdrant": "sha256:75eab8c4ba42096724fdcfde8b4de0b5713d529dde32f285a1f86fdcb2c9e50c"
+    },
+    "migrationManifestSha256": "8f6f6c383d927277a6817d4ae4cb99c5f2599c3b9256168473606c52a579539a"
+  }
+}

--- a/bench/markhand_web/reports/phase-1b-gate/r06-hanging-soak.md
+++ b/bench/markhand_web/reports/phase-1b-gate/r06-hanging-soak.md
@@ -1,0 +1,17 @@
+# P1B-R06 hanging-dependency Compose soak
+
+- Status: `pass`
+- Issue: `P1B-R06`
+- Canonical JSON: `r06-hanging-soak.json`
+- Raw: `bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03`
+
+## Blockers
+
+- (none)
+
+## Dependencies
+
+- `database` (`postgres`): gates={'readyCodeCorrect': 'pass', 'readyBounded': 'pass', 'liveBounded': 'pass', 'openapiBounded': 'pass', 'concurrencyBounded': 'pass', 'concurrencyNoGrowth': 'pass', 'restoreConfirmed': 'pass', 'recoveryBounded': 'pass'}
+- `vector_store` (`qdrant`): gates={'readyCodeCorrect': 'pass', 'readyBounded': 'pass', 'liveBounded': 'pass', 'openapiBounded': 'pass', 'concurrencyBounded': 'pass', 'concurrencyNoGrowth': 'pass', 'restoreConfirmed': 'pass', 'recoveryBounded': 'pass'}
+- `object_store` (`minio`): gates={'readyCodeCorrect': 'pass', 'readyBounded': 'pass', 'liveBounded': 'pass', 'openapiBounded': 'pass', 'concurrencyBounded': 'pass', 'concurrencyNoGrowth': 'pass', 'restoreConfirmed': 'pass', 'recoveryBounded': 'pass'}
+- `embedding` (`mock-embedding`): gates={'readyCodeCorrect': 'pass', 'readyBounded': 'pass', 'liveBounded': 'pass', 'openapiBounded': 'pass', 'concurrencyBounded': 'pass', 'concurrencyNoGrowth': 'pass', 'restoreConfirmed': 'pass', 'recoveryBounded': 'pass'}

--- a/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/database-samples.json
+++ b/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/database-samples.json
@@ -1,0 +1,584 @@
+{
+  "dependencyLabel": "database",
+  "expectedProbeCode": "ready_database",
+  "service": "postgres",
+  "pauseConfirmed": true,
+  "baseline": {
+    "ready": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.051,
+      "probeCode": null,
+      "error": null
+    },
+    "live": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.002,
+      "probeCode": null,
+      "error": null
+    },
+    "openapi": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.002,
+      "probeCode": null,
+      "error": null
+    }
+  },
+  "postPauseWarmup": {
+    "hangObserved": true,
+    "ready": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.005,
+        "probeCode": "ready_database",
+        "error": null
+      }
+    ]
+  },
+  "samples": {
+    "ready": [
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 0.002,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.006,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.006,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.005,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.005,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.006,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.007,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.007,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.006,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.005,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.005,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.007,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.005,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.005,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.005,
+        "probeCode": "ready_database",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.005,
+        "probeCode": "ready_database",
+        "error": null
+      }
+    ],
+    "live": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.021,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      }
+    ],
+    "openapi": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.005,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.005,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      }
+    ]
+  },
+  "concurrencyBatches": [
+    {
+      "n": 8,
+      "spanSeconds": 0.046,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.031,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.031,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.032,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.028,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.026,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.028,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.025,
+          "probeCode": "ready_database",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.029,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.017,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.021,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.017,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.021,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.013,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_database",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.022,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.012,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.012,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.01,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.013,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.009,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_database",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.02,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.015,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.015,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.008,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_database",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_database",
+          "error": null
+        }
+      ]
+    }
+  ],
+  "restore": {
+    "restoreSkipped": false,
+    "unpauseExitCode": 0,
+    "running": true,
+    "paused": false,
+    "restoredConfirmed": true
+  },
+  "recovery": null,
+  "blockers": []
+}

--- a/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/embedding-samples.json
+++ b/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/embedding-samples.json
@@ -1,0 +1,578 @@
+{
+  "dependencyLabel": "embedding",
+  "expectedProbeCode": "ready_embedding",
+  "service": "mock-embedding",
+  "pauseConfirmed": true,
+  "baseline": {
+    "ready": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.003,
+      "probeCode": null,
+      "error": null
+    },
+    "live": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.002,
+      "probeCode": null,
+      "error": null
+    },
+    "openapi": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.002,
+      "probeCode": null,
+      "error": null
+    }
+  },
+  "postPauseWarmup": {
+    "hangObserved": true,
+    "ready": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.029,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.058,
+        "probeCode": "ready_embedding",
+        "error": null
+      }
+    ]
+  },
+  "samples": {
+    "ready": [
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 0.003,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.039,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.034,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.041,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.055,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 1.977,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.036,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.041,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.076,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.044,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.032,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.05,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.037,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.041,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.057,
+        "probeCode": "ready_embedding",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.066,
+        "probeCode": "ready_embedding",
+        "error": null
+      }
+    ],
+    "live": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      }
+    ],
+    "openapi": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.033,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.05,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.006,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      }
+    ]
+  },
+  "concurrencyBatches": [
+    {
+      "n": 8,
+      "spanSeconds": 0.02,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.008,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.008,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.008,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.009,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.009,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.002,
+          "probeCode": "ready_embedding",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.022,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.008,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.009,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.012,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.009,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_embedding",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.017,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.012,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.011,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.008,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_embedding",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.029,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.01,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.015,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.011,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.018,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.012,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.01,
+          "probeCode": "ready_embedding",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_embedding",
+          "error": null
+        }
+      ]
+    }
+  ],
+  "restore": {
+    "restoreSkipped": false,
+    "unpauseExitCode": 0,
+    "running": true,
+    "paused": false,
+    "restoredConfirmed": true
+  },
+  "recovery": null,
+  "blockers": []
+}

--- a/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/object_store-samples.json
+++ b/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/object_store-samples.json
@@ -1,0 +1,578 @@
+{
+  "dependencyLabel": "object_store",
+  "expectedProbeCode": "ready_object_store",
+  "service": "minio",
+  "pauseConfirmed": true,
+  "baseline": {
+    "ready": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.003,
+      "probeCode": null,
+      "error": null
+    },
+    "live": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.002,
+      "probeCode": null,
+      "error": null
+    },
+    "openapi": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.002,
+      "probeCode": null,
+      "error": null
+    }
+  },
+  "postPauseWarmup": {
+    "hangObserved": true,
+    "ready": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.005,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.005,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.038,
+        "probeCode": "ready_object_store",
+        "error": null
+      }
+    ]
+  },
+  "samples": {
+    "ready": [
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 0.002,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 1.56,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.055,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.043,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.036,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.029,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.042,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.031,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.052,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.038,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.044,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.033,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.038,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.014,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.028,
+        "probeCode": "ready_object_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.046,
+        "probeCode": "ready_object_store",
+        "error": null
+      }
+    ],
+    "live": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.033,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      }
+    ],
+    "openapi": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.034,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      }
+    ]
+  },
+  "concurrencyBatches": [
+    {
+      "n": 8,
+      "spanSeconds": 0.028,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.011,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.008,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.008,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_object_store",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.018,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.014,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.012,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_object_store",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.049,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.042,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.041,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.011,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.04,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.034,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.037,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.036,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.033,
+          "probeCode": "ready_object_store",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.021,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.009,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.011,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.007,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_object_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_object_store",
+          "error": null
+        }
+      ]
+    }
+  ],
+  "restore": {
+    "restoreSkipped": false,
+    "unpauseExitCode": 0,
+    "running": true,
+    "paused": false,
+    "restoredConfirmed": true
+  },
+  "recovery": null,
+  "blockers": []
+}

--- a/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/raw-manifest.json
+++ b/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/raw-manifest.json
@@ -1,0 +1,25 @@
+{
+  "files": [
+    {
+      "bytes": 12894,
+      "path": "database-samples.json",
+      "sha256": "1e03210813f68132d719dc4b3b28e1f50ea3e4c7862aa1e2825d4e27be701441"
+    },
+    {
+      "bytes": 12822,
+      "path": "embedding-samples.json",
+      "sha256": "02e5f4948a8aebdf611d987ebfcbcfaebda4d8a2c199aa3da3fad3dcedd0152a"
+    },
+    {
+      "bytes": 12969,
+      "path": "object_store-samples.json",
+      "sha256": "e9efa33bf4e3beb4f2c3d7962ae099d175420c7a43f1895c8c51aadca1deb87f"
+    },
+    {
+      "bytes": 12968,
+      "path": "vector_store-samples.json",
+      "sha256": "97200b0d72cf28aff70e42e5cf6e03ca791e9c15a55f04f3567b029fa93af6e8"
+    }
+  ],
+  "ok": true
+}

--- a/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/vector_store-samples.json
+++ b/bench/markhand_web/reports/phase-1b-gate/raw/r06-20260731T080518Z-eee30b03/vector_store-samples.json
@@ -1,0 +1,578 @@
+{
+  "dependencyLabel": "vector_store",
+  "expectedProbeCode": "ready_vector_store",
+  "service": "qdrant",
+  "pauseConfirmed": true,
+  "baseline": {
+    "ready": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.003,
+      "probeCode": null,
+      "error": null
+    },
+    "live": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.002,
+      "probeCode": null,
+      "error": null
+    },
+    "openapi": {
+      "httpStatus": 200,
+      "elapsedSeconds": 0.002,
+      "probeCode": null,
+      "error": null
+    }
+  },
+  "postPauseWarmup": {
+    "hangObserved": true,
+    "ready": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.047,
+        "probeCode": "ready_vector_store",
+        "error": null
+      }
+    ]
+  },
+  "samples": {
+    "ready": [
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 0.003,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.035,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.033,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.03,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.047,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.027,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.029,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.031,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.032,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.045,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.042,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 1.968,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.03,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.034,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.077,
+        "probeCode": "ready_vector_store",
+        "error": null
+      },
+      {
+        "httpStatus": 503,
+        "elapsedSeconds": 2.025,
+        "probeCode": "ready_vector_store",
+        "error": null
+      }
+    ],
+    "live": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.005,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.005,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.027,
+        "probeCode": null,
+        "error": null
+      }
+    ],
+    "openapi": [
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.056,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.004,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.003,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      },
+      {
+        "httpStatus": 200,
+        "elapsedSeconds": 0.002,
+        "probeCode": null,
+        "error": null
+      }
+    ]
+  },
+  "concurrencyBatches": [
+    {
+      "n": 8,
+      "spanSeconds": 0.018,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.013,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.014,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.003,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_vector_store",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.023,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.008,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.005,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.01,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.006,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_vector_store",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.047,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.004,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.039,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.041,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.037,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.036,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.035,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.035,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.032,
+          "probeCode": "ready_vector_store",
+          "error": null
+        }
+      ]
+    },
+    {
+      "n": 8,
+      "spanSeconds": 0.048,
+      "results": [
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.045,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.04,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.042,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.039,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.041,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.037,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.038,
+          "probeCode": "ready_vector_store",
+          "error": null
+        },
+        {
+          "httpStatus": 503,
+          "elapsedSeconds": 0.028,
+          "probeCode": "ready_vector_store",
+          "error": null
+        }
+      ]
+    }
+  ],
+  "restore": {
+    "restoreSkipped": false,
+    "unpauseExitCode": 0,
+    "running": true,
+    "paused": false,
+    "restoredConfirmed": true
+  },
+  "recovery": null,
+  "blockers": []
+}

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,6 +1,6 @@
 # Lộ trình dự án
 
-> Trạng thái tính đến 2026-07-30. Backlog desktop rút từ
+> Trạng thái tính đến 2026-07-31. Backlog desktop rút từ
 > [`../bench/RESEARCH_COMPETITORS.md`](../bench/RESEARCH_COMPETITORS.md) và điểm yếu đã biết
 > trong các `REPORT*.md`. Tiến độ Markhand Web: [`../plans/markhand-web/README.md`](../plans/markhand-web/README.md).
 
@@ -51,14 +51,14 @@
 
 ### Markhand Web (on-prem RAG platform)
 
-Phase F, 0 và 1A **đã đóng** (32/32 issue). Phase 1B **23/24 Done** — còn R06
-(owner-run Docker Compose hanging soak). R02–R05 Done với evidence CI rust-integration
+Phase F, 0 và 1A **đã đóng** (32/32 issue). Phase 1B **24/24 Done — gate đóng**
+(R06 hanging soak pass 2026-07-31). R02–R05 Done với evidence CI rust-integration
 trên `b5cc92c` (run 30603158015). O-chain release (O01–O05) và soak qualification đã
 pass trên live infrastructure (2026-07-26). Phase 1C **12/13 In progress** — nền
 multi-org/RLS/ACL đã có từ 1B, exit gate denial suite chưa đạt. Phase 2 **13/19 Done**
 trên mock/CI (#311–#318, #327, #332); còn P2-10, P2-15, P2-16 và ba issue mở rộng
-P2-17…19. Phase 3–4 chưa activate (Backlog). Catalog aggregate: **68 Done**,
-**19 In progress**, **0 Review**, **29 Backlog**.
+P2-17…19. Phase 3–4 chưa activate (Backlog). Catalog aggregate: **69 Done**,
+**18 In progress**, **0 Review**, **29 Backlog**.
 
 Dashboard: [`../plans/markhand-web/roadmap.html`](../plans/markhand-web/roadmap.html) ·
 Issue catalog: [`../plans/markhand-web/backlog/`](../plans/markhand-web/backlog/)

--- a/docs/runbooks/phase-1b/hanging-dependency-soak.md
+++ b/docs/runbooks/phase-1b/hanging-dependency-soak.md
@@ -26,6 +26,11 @@ late; a paused container is the kernel holding the socket open.
 MARKHAND_HANGING_SOAK=1 deploy/scripts/r06-hanging-soak.sh
 ```
 
+The harness waits for the expected hung `/ready` code after `docker pause`
+before starting the 60s sustain window, so warm pool connections that still
+return 200 briefly are recorded under `postPauseWarmup` rather than counted
+against `readyCodeCorrect`.
+
 Self-test only (no stack, runs anywhere, also wired into `make check-markhand-gates`):
 
 ```bash

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -62,14 +62,14 @@ GitHub milestone progress được đồng bộ bởi workflow
 | F | 12/12 | 0 | 0 | Foundation gate đạt |
 | 0 | 10/10 | 0 | 0 | Discovery gates đạt |
 | 1A | 10/10 | 0 | 0 | Extraction gate đạt |
-| 1B | 23/24 | 1 | 0 | **Đang đóng** — còn R06 (owner hanging soak); R02–R05 Done on CI rust-integration |
+| 1B | 24/24 | 0 | 0 | **Gate đạt** — R06 hanging soak pass 2026-07-31 |
 | 1C | 0/13 | 12 | 1 | Substrate 1B đã có; exit gate 1C-12/1C-13 chưa đạt |
 | 2 | 13/19 | 6 | 0 | MVP mock/CI xanh; exit gate chờ 1C + E2E deploy thật |
 | 3 | 0/14 | 0 | 14 | Chưa activate — chờ Phase 2 complete |
 | 4 | 0/14 | 0 | 14 | Chưa activate — chờ Phase 3 |
 
-**Critical path hiện tại:** đóng P1B-R06 → Phase 1B gate → hoàn thiện 1C denial suite
-→ Phase 2 completion gate (P2-15/P2-16 trên backend thật).
+**Critical path hiện tại:** hoàn thiện 1C denial suite (1C-12/1C-13) → Phase 2
+completion gate (P2-15/P2-16 trên backend thật).
 
 Issue mới gần đây trên Phase 2 (owner request 2026-07-29): P2-17 Document graph, P2-18
 Project grouping, P2-19 Chat history — đều In progress (server + web + mock/E2E đã landed,

--- a/plans/markhand-web/backlog/github-issues.json
+++ b/plans/markhand-web/backlog/github-issues.json
@@ -770,14 +770,14 @@
       "phase": "1B",
       "id": "P1B-R06",
       "title": "P1B-R06 — OpenAPI, rate limit và readiness",
-      "status": "in_progress",
+      "status": "done",
       "milestone": "Phase 1B — Single-org POC",
       "labels": [
         "markhand-web",
         "docs",
         "web-p1b"
       ],
-      "body": "## Metadata\n\n- Milestone: Phase 1B — Single-org POC\n- Phase code: 1B\n- Issue ID: P1B-R06\n- Status: `in_progress`\n- Catalog: `backlog/phase-1b/issues/README.md`\n- Phase plan: `phase-1b-single-org-poc.md`\n\n## Implementation plan\n\nComplete OpenAPI/fixtures; request IDs; CORS; IP auth/user limits; quota\nmetadata; live/ready/start checks.\n\n## Files/modules\n\n`api/openapi.rs`, OpenAPI YAML, `middleware/**`, `routes/health.rs`,\n`routes/rate_limit_guard.rs`, `services/readiness.rs`.\n\n## Dependencies / blocks\n\nR04/R05/F05 + G0-SLO.\n\n## Required tests / evidence\n\nEvery route represented two-way; readiness detects required\ndeps/signature/reconciliation with bounded deadlines; 429 metadata; trusted-proxy/\noutage tests.\n\n## Security and migration notes\n\nConservative CORS/proxy trust.\n\n## Out of scope\n\ndistributed limiter.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "body": "## Metadata\n\n- Milestone: Phase 1B — Single-org POC\n- Phase code: 1B\n- Issue ID: P1B-R06\n- Status: `done`\n- Catalog: `backlog/phase-1b/issues/README.md`\n- Phase plan: `phase-1b-single-org-poc.md`\n\n## Implementation plan\n\nComplete OpenAPI/fixtures; request IDs; CORS; IP auth/user limits; quota\nmetadata; live/ready/start checks.\n\n## Files/modules\n\n`api/openapi.rs`, OpenAPI YAML, `middleware/**`, `routes/health.rs`,\n`routes/rate_limit_guard.rs`, `services/readiness.rs`.\n\n## Dependencies / blocks\n\nR04/R05/F05 + G0-SLO.\n\n## Required tests / evidence\n\nEvery route represented two-way; readiness detects required\ndeps/signature/reconciliation with bounded deadlines; 429 metadata; trusted-proxy/\noutage tests.\n\n## Security and migration notes\n\nConservative CORS/proxy trust.\n\n## Out of scope\n\ndistributed limiter.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
       "catalog": "backlog/phase-1b/issues/README.md"
     },
     {

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -5,11 +5,11 @@ Parent plan: [`../../../phase-1b-single-org-poc.md`](../../../phase-1b-single-or
 <!-- roadmap-default-status: blocked -->
 <!-- roadmap-groups: F,I,R,O -->
 
-**Trạng thái tổng quan (cập nhật 2026-07-31).** **23/24 Done** — foundation F01–F06,
-ingest I01–I07, retrieval R01–R05, operations O01–O05 (O-chain + soak pass live 2026-07-26).
-**1 active:** R06 (owner-run Docker Compose hanging soak). Phase 1B gate **chưa đóng**
-cho tới khi R06 đạt acceptance; rust-integration evidence for R02–R05 on commit
-`b5cc92c` (GitHub Actions run
+**Trạng thái tổng quan (cập nhật 2026-07-31).** **24/24 Done** — foundation F01–F06,
+ingest I01–I07, retrieval R01–R06, operations O01–O05 (O-chain + soak pass live
+2026-07-26). **Phase 1B gate đóng** trên commit `a981fb3` + R06 hanging-soak
+evidence 2026-07-31. R02–R05 Done với rust-integration trên `b5cc92c` (GitHub
+Actions run
 [30603158015](https://github.com/anhnth24/project-example/actions/runs/30603158015),
 job
 [91070008980](https://github.com/anhnth24/project-example/actions/runs/30603158015/job/91070008980)).
@@ -348,15 +348,15 @@ ghi trong issue đã `Done`.
 
 ### P1B-R06 — OpenAPI, rate limit và readiness
 
-- **Status:** In progress — Sol R2 complete for rate/readiness/OpenAPI.
-  Implemented: outer readiness timeout reports in-progress probe code; hanging
-  probe router matrix (code+deadline); baseline IP shares ceil `RateLimitRejected`;
-  OpenAPI `/openapi.yaml` 429; hermetic
-  `concurrent_checkers_share_ceil_and_stay_bounded` for shared-ceil + hard-cap
-  cardinality under concurrent pressure; `pnpm --dir web api:check` regenerates
-  TS client from OpenAPI (429 sweep already in `contract.ts`). **Only remaining
-  for Done:** owner-run Docker Compose hanging soak:
-  `MARKHAND_HANGING_SOAK=1 deploy/scripts/r06-hanging-soak.sh`.
+- **Status:** Done — live hanging-dependency Compose soak pass 2026-07-31 on a
+  24-core Ubuntu Docker host: `r06-hanging-soak.json` `status=pass`, 0 blockers,
+  raw `r06-20260731T080518Z-eee30b03`. All four network readiness probes
+  (`database`, `vector_store`, `object_store`, `embedding`) sustained 60s with
+  correct 503 probe codes, bounded `/ready` deadlines, `/health/live` +
+  `/openapi.yaml` within budget, bounded concurrent checkers, and confirmed
+  restore/recovery. Hermetic router/readiness/unit coverage unchanged (Sol R2).
+  Harness fix: post-pause `wait_for_hung_ready` excludes pool-drain transition
+  samples before the sustain window (see `bench/markhand_web/hanging_soak/`).
 - **Plan:** Complete OpenAPI/fixtures; request IDs; CORS; IP auth/user limits; quota
   metadata; live/ready/start checks.
 - **Files:** `api/openapi.rs`, OpenAPI YAML, `middleware/**`, `routes/health.rs`,

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -23,7 +23,7 @@ retrieval, Qdrant mandatory filter, quota atomic, rate-limit, audit append-only)
 >
 > **Exit gate Phase 1C (1C-12 + 1C-13) CHƯA đạt** — cả hai deliverable "suite gắn kết" và
 > "gate có report" đều chưa tồn tại như deliverable. Và Phase 1C chỉ activate sau khi
-> **Phase 1B gate đóng** (chỉ còn R06 pending — owner hanging soak), nên toàn phase vẫn là công việc phía trước.
+> **Phase 1B gate đóng** (2026-07-31 — R06 hanging soak pass); toàn phase vẫn là công việc phía trước.
 
 ## Dependency
 

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "e02066b072668932";
+    const ROADMAP_SOURCE_HASH = "0c315f20d4ff105d";
     const phases = [
       {
         "id": "phase-f",
@@ -1212,7 +1212,7 @@
           [
             "P1B-R06",
             "OpenAPI, rate limit và readiness",
-            "in_progress"
+            "done"
           ],
           [
             "P1B-O01",


### PR DESCRIPTION
## Summary

- Fix R06 hanging-dependency soak harness: after `docker pause`, poll until `/ready` returns the expected hung probe code before starting the sustain window, excluding pool-drain transition samples from gate evaluation.
- Record live PASS evidence from Docker host `10.15.119.102` (`r06-20260731T080518Z-eee30b03`) under `bench/markhand_web/reports/phase-1b-gate/`.
- Sync catalog, roadmap, and `github-issues.json` to mark **Phase 1B 24/24 Done** and shift critical path to Phase 1C.

## Test plan

- [x] `python3 -m unittest bench.markhand_web.hanging_soak.test_hanging_soak -v` (22 tests)
- [x] `python3 scripts/check-github-issue-consistency.py`
- [x] Live R06 soak PASS on owner-run Docker host (`MARKHAND_HANGING_SOAK=1 deploy/scripts/r06-hanging-soak.sh`)
- [x] GitHub: closed #96 (P1B-R06) and milestone "Phase 1B — Single-org POC"

## Notes

- Soak report provenance references `a981fb3` (server ran with hot-patched harness before this PR commit); harness fix and evidence land in this PR.
- `sync-github-issues.py --update` still hits milestone HTTP 422 on create; issue/milestone closure done manually via `gh`.
