### PR TITLE
feat(server): establish canonical Phase 1C RBAC catalog

### DIFF
--- a/crates/server/openapi/README.md
+++ b/crates/server/openapi/README.md
@@ -2,6 +2,12 @@
 
 `openapi.yaml` is the source of truth for Markhand Web public HTTP/SSE contracts.
 
+Built-in RBAC roles, active/reserved permissions, and default grants live in
+`builtin-role-catalog.json`. OpenAPI exposes only the extension reference
+`x-markhand-builtin-role-catalog: ./builtin-role-catalog.json` — it must not
+embed a second grant matrix. Web presentation and PostgreSQL matrix tests
+consume that same fixture; the database remains runtime authority.
+
 ```bash
 pnpm --filter markhand-web api:generate
 pnpm --filter markhand-web api:check

--- a/crates/server/openapi/builtin-role-catalog.json
+++ b/crates/server/openapi/builtin-role-catalog.json
@@ -1,0 +1,141 @@
+{
+  "version": 1,
+  "roles": ["owner", "admin", "editor", "viewer"],
+  "permissions": [
+    {
+      "key": "doc.upload",
+      "status": "active",
+      "description": "Upload documents",
+      "requiredCollectionAccess": "write",
+      "conditionalPolicy": null,
+      "operationRefs": ["src/routes/uploads.rs"]
+    },
+    {
+      "key": "doc.delete",
+      "status": "active",
+      "description": "Delete documents",
+      "requiredCollectionAccess": "admin",
+      "conditionalPolicy": "own_or_explicit_deferred_to_custom_role",
+      "operationRefs": ["src/routes/documents.rs", "src/routes/collections.rs"]
+    },
+    {
+      "key": "doc.publish",
+      "status": "active",
+      "description": "Publish document versions",
+      "requiredCollectionAccess": "write",
+      "conditionalPolicy": null,
+      "operationRefs": ["src/routes/documents.rs"]
+    },
+    {
+      "key": "qa.query",
+      "status": "active",
+      "description": "Query collections",
+      "requiredCollectionAccess": "read",
+      "conditionalPolicy": null,
+      "operationRefs": ["src/services/retrieval/mod.rs"]
+    },
+    {
+      "key": "qa.history",
+      "status": "active",
+      "description": "Read version history",
+      "requiredCollectionAccess": "read",
+      "conditionalPolicy": null,
+      "operationRefs": ["src/services/access.rs"]
+    },
+    {
+      "key": "member.manage",
+      "status": "active",
+      "description": "Manage members",
+      "requiredCollectionAccess": null,
+      "conditionalPolicy": "admin_cannot_manage_owner",
+      "operationRefs": ["src/routes/members.rs"]
+    },
+    {
+      "key": "audit.view",
+      "status": "active",
+      "description": "Read audit entries",
+      "requiredCollectionAccess": null,
+      "conditionalPolicy": null,
+      "operationRefs": ["src/routes/audit.rs"]
+    },
+    {
+      "key": "jobs.system",
+      "status": "active",
+      "description": "Operate system jobs",
+      "requiredCollectionAccess": null,
+      "conditionalPolicy": null,
+      "operationRefs": ["src/services/access.rs"]
+    },
+    {
+      "key": "doc.quarantine.review",
+      "status": "active",
+      "description": "Approve quarantined uploads",
+      "requiredCollectionAccess": "write",
+      "conditionalPolicy": null,
+      "operationRefs": ["src/services/upload/saga.rs"]
+    },
+    {
+      "key": "settings.manage",
+      "status": "reserved",
+      "description": "Reserved for organization settings",
+      "requiredCollectionAccess": null,
+      "conditionalPolicy": "admin_except_owner_security_deferred",
+      "operationRefs": []
+    },
+    {
+      "key": "intel.use",
+      "status": "reserved",
+      "description": "Reserved for intelligence operations",
+      "requiredCollectionAccess": null,
+      "conditionalPolicy": null,
+      "operationRefs": []
+    },
+    {
+      "key": "pii.manage",
+      "status": "reserved",
+      "description": "Reserved for PII operations",
+      "requiredCollectionAccess": null,
+      "conditionalPolicy": null,
+      "operationRefs": []
+    },
+    {
+      "key": "export.run",
+      "status": "reserved",
+      "description": "Reserved for export operations",
+      "requiredCollectionAccess": null,
+      "conditionalPolicy": "viewer_by_org_policy_deferred",
+      "operationRefs": []
+    }
+  ],
+  "grants": {
+    "owner": [
+      "audit.view",
+      "doc.delete",
+      "doc.publish",
+      "doc.upload",
+      "jobs.system",
+      "member.manage",
+      "qa.history",
+      "qa.query"
+    ],
+    "admin": [
+      "audit.view",
+      "doc.delete",
+      "doc.publish",
+      "doc.upload",
+      "jobs.system",
+      "member.manage",
+      "qa.history",
+      "qa.query"
+    ],
+    "editor": ["doc.publish", "doc.upload", "qa.query"],
+    "viewer": ["qa.query"]
+  },
+  "restrictions": [
+    {
+      "id": "admin_cannot_manage_owner",
+      "description": "Only an active owner may grant or manage the owner role",
+      "enforcedBy": "services::members::guard_owner_tier"
+    }
+  ]
+}

--- a/crates/server/openapi/builtin-role-catalog.json
+++ b/crates/server/openapi/builtin-role-catalog.json
@@ -40,7 +40,10 @@
       "description": "Read version history",
       "requiredCollectionAccess": "read",
       "conditionalPolicy": null,
-      "operationRefs": ["src/services/access.rs"]
+      "operationRefs": [
+        "src/services/access.rs",
+        "src/services/retrieval/mod.rs"
+      ]
     },
     {
       "key": "member.manage",

--- a/crates/server/openapi/openapi.yaml
+++ b/crates/server/openapi/openapi.yaml
@@ -7,6 +7,7 @@ servers:
   - url: /api/v1
 security:
   - bearerAuth: []
+x-markhand-builtin-role-catalog: ./builtin-role-catalog.json
 paths:
   /health/live:
     get:

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -596,4 +596,67 @@ mod tests {
         assert!(!get.contains("\"201\":"));
         assert!(post.contains("\"201\":"));
     }
+
+    #[test]
+    fn openapi_role_enums_match_builtin_catalog_roles() {
+        let catalog = crate::auth::rbac_catalog::load_builtin_role_catalog();
+        let yaml = embedded_openapi_yaml();
+        let expected = format!("enum: [{}]", catalog.roles.join(", "));
+        let role_enum_lines: Vec<&str> = yaml
+            .lines()
+            .map(str::trim)
+            .filter(|line| {
+                line.starts_with("enum: [")
+                    && line.contains("owner")
+                    && line.contains("admin")
+                    && line.contains("editor")
+                    && line.contains("viewer")
+            })
+            .collect();
+        assert!(
+            !role_enum_lines.is_empty(),
+            "OpenAPI must declare MembershipRole-style enums"
+        );
+        for line in &role_enum_lines {
+            assert_eq!(
+                *line, expected.as_str(),
+                "role enum must match builtin catalog roles in order"
+            );
+        }
+        // Roles are authoritative via the catalog extension, not a second matrix.
+        assert!(
+            yaml.lines().any(|line| {
+                line.trim() == "x-markhand-builtin-role-catalog: ./builtin-role-catalog.json"
+            }),
+            "OpenAPI must reference the canonical builtin-role-catalog fixture"
+        );
+    }
+
+    #[test]
+    fn openapi_references_builtin_catalog_without_embedding_grants() {
+        let yaml = embedded_openapi_yaml();
+        assert!(
+            yaml.lines().any(|line| {
+                line.trim() == "x-markhand-builtin-role-catalog: ./builtin-role-catalog.json"
+            }),
+            "OpenAPI must expose only a reference to builtin-role-catalog.json"
+        );
+        // Fail closed: never embed a second grant matrix in the YAML document.
+        for line in yaml.lines() {
+            let trimmed = line.trim();
+            assert!(
+                !trimmed.starts_with("grants:") && trimmed != "grants",
+                "OpenAPI must not embed a grants matrix; found: {trimmed}"
+            );
+        }
+        let catalog = crate::auth::rbac_catalog::load_builtin_role_catalog();
+        for (role, keys) in &catalog.grants {
+            // A copied matrix would list grant keys beside a role label.
+            let role_grant_block = format!("{role}: [{keys}]", keys = keys.join(", "));
+            assert!(
+                !yaml.contains(&role_grant_block),
+                "OpenAPI must not embed catalog grants for {role}"
+            );
+        }
+    }
 }

--- a/crates/server/src/api/openapi.rs
+++ b/crates/server/src/api/openapi.rs
@@ -619,7 +619,8 @@ mod tests {
         );
         for line in &role_enum_lines {
             assert_eq!(
-                *line, expected.as_str(),
+                *line,
+                expected.as_str(),
                 "role enum must match builtin catalog roles in order"
             );
         }

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -7,4 +7,5 @@ pub mod middleware;
 pub mod password;
 pub mod permissions;
 pub mod provider;
+pub mod rbac_catalog;
 pub mod session;

--- a/crates/server/src/auth/rbac_catalog.rs
+++ b/crates/server/src/auth/rbac_catalog.rs
@@ -5,6 +5,7 @@
 //! web presentation, and DB matrix tests.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -50,12 +51,111 @@ pub fn load_builtin_role_catalog() -> BuiltinRoleCatalog {
 
 /// Validate catalog structural and grant-matrix invariants.
 ///
-/// Returns sorted error messages when invariants fail. Production behavior is
-/// added in the GREEN phase; this RED stub only establishes the public API.
-pub fn validate_catalog_invariants(
-    _catalog: &BuiltinRoleCatalog,
-) -> Result<(), Vec<String>> {
-    unimplemented!("validate_catalog_invariants: GREEN phase")
+/// Returns sorted error messages when invariants fail. Rejects duplicate roles,
+/// duplicate permission keys, unknown grants, reserved grants, missing
+/// operation references, active references to missing source files, reserved
+/// references, and active keys lacking quoted-literal evidence in at least one
+/// referenced source file.
+pub fn validate_catalog_invariants(catalog: &BuiltinRoleCatalog) -> Result<(), Vec<String>> {
+    let mut errors = Vec::new();
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let mut seen_roles = BTreeSet::new();
+    for role in &catalog.roles {
+        if !seen_roles.insert(role.as_str()) {
+            errors.push(format!("duplicate role: {role}"));
+        }
+    }
+    let role_set: BTreeSet<&str> = catalog.roles.iter().map(String::as_str).collect();
+
+    let mut seen_keys = BTreeSet::new();
+    let mut active_keys = BTreeSet::new();
+    let mut reserved_keys = BTreeSet::new();
+    for perm in &catalog.permissions {
+        if !seen_keys.insert(perm.key.as_str()) {
+            errors.push(format!("duplicate permission key: {}", perm.key));
+        }
+        match perm.status {
+            PermissionStatus::Active => {
+                active_keys.insert(perm.key.as_str());
+                if perm.operation_refs.is_empty() {
+                    errors.push(format!(
+                        "active permission {} is missing operation references",
+                        perm.key
+                    ));
+                } else {
+                    let mut literal_found = false;
+                    let needle = format!("\"{}\"", perm.key);
+                    for rel in &perm.operation_refs {
+                        let path = crate_root.join(rel);
+                        if !path.is_file() {
+                            errors.push(format!(
+                                "active permission {} references missing source file: {rel}",
+                                perm.key
+                            ));
+                            continue;
+                        }
+                        match std::fs::read_to_string(&path) {
+                            Ok(contents) if contents.contains(&needle) => {
+                                literal_found = true;
+                            }
+                            Ok(_) => {}
+                            Err(err) => {
+                                errors.push(format!(
+                                    "active permission {} could not read source file {rel}: {err}",
+                                    perm.key
+                                ));
+                            }
+                        }
+                    }
+                    if !literal_found {
+                        errors.push(format!(
+                            "active permission {} has no operationRefs file containing quoted literal {}",
+                            perm.key, needle
+                        ));
+                    }
+                }
+            }
+            PermissionStatus::Reserved => {
+                reserved_keys.insert(perm.key.as_str());
+                if !perm.operation_refs.is_empty() {
+                    errors.push(format!(
+                        "reserved permission {} must not have operation references",
+                        perm.key
+                    ));
+                }
+            }
+        }
+    }
+
+    let known_keys: BTreeSet<&str> = active_keys.union(&reserved_keys).copied().collect();
+    for (role, keys) in &catalog.grants {
+        if !role_set.contains(role.as_str()) {
+            errors.push(format!("unknown grant role: {role}"));
+        }
+        for key in keys {
+            if !known_keys.contains(key.as_str()) {
+                errors.push(format!("unknown grant permission {key} for role {role}"));
+                continue;
+            }
+            if reserved_keys.contains(key.as_str()) {
+                errors.push(format!(
+                    "reserved permission {key} must not be granted to role {role}"
+                ));
+            } else if !active_keys.contains(key.as_str()) {
+                errors.push(format!(
+                    "grant permission {key} for role {role} is not active"
+                ));
+            }
+        }
+    }
+
+    errors.sort();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
 }
 
 /// Current nine runtime (active) permission keys seeded in `permissions`.
@@ -72,12 +172,8 @@ pub const ACTIVE_RUNTIME_PERMISSIONS: &[&str] = &[
 ];
 
 /// Reserved permission keys that must remain ungranted and absent from runtime rows.
-pub const RESERVED_PERMISSIONS: &[&str] = &[
-    "export.run",
-    "intel.use",
-    "pii.manage",
-    "settings.manage",
-];
+pub const RESERVED_PERMISSIONS: &[&str] =
+    &["export.run", "intel.use", "pii.manage", "settings.manage"];
 
 #[cfg(test)]
 mod tests {

--- a/crates/server/src/auth/rbac_catalog.rs
+++ b/crates/server/src/auth/rbac_catalog.rs
@@ -1,0 +1,230 @@
+//! Canonical built-in role / permission catalog (Phase 1C RBAC foundation).
+//!
+//! Loads `openapi/builtin-role-catalog.json` and validates matrix invariants.
+//! The JSON fixture is the single grant-matrix source of truth for OpenAPI,
+//! web presentation, and DB matrix tests.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuiltinRoleCatalog {
+    pub version: u32,
+    pub roles: Vec<String>,
+    pub permissions: Vec<BuiltinPermission>,
+    pub grants: BTreeMap<String, Vec<String>>,
+    pub restrictions: Vec<RoleRestriction>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleRestriction {
+    pub id: String,
+    pub description: String,
+    pub enforced_by: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionStatus {
+    Active,
+    Reserved,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuiltinPermission {
+    pub key: String,
+    pub status: PermissionStatus,
+    pub description: String,
+    pub required_collection_access: Option<crate::db::models::AccessLevel>,
+    pub conditional_policy: Option<String>,
+    pub operation_refs: Vec<String>,
+}
+
+/// Deserialize the canonical built-in role catalog embedded at compile time.
+pub fn load_builtin_role_catalog() -> BuiltinRoleCatalog {
+    serde_json::from_str(include_str!("../../openapi/builtin-role-catalog.json"))
+        .expect("builtin role catalog must be valid JSON")
+}
+
+/// Validate catalog structural and grant-matrix invariants.
+///
+/// Returns sorted error messages when invariants fail. Production behavior is
+/// added in the GREEN phase; this RED stub only establishes the public API.
+pub fn validate_catalog_invariants(
+    _catalog: &BuiltinRoleCatalog,
+) -> Result<(), Vec<String>> {
+    unimplemented!("validate_catalog_invariants: GREEN phase")
+}
+
+/// Current nine runtime (active) permission keys seeded in `permissions`.
+pub const ACTIVE_RUNTIME_PERMISSIONS: &[&str] = &[
+    "audit.view",
+    "doc.delete",
+    "doc.publish",
+    "doc.quarantine.review",
+    "doc.upload",
+    "jobs.system",
+    "member.manage",
+    "qa.history",
+    "qa.query",
+];
+
+/// Reserved permission keys that must remain ungranted and absent from runtime rows.
+pub const RESERVED_PERMISSIONS: &[&str] = &[
+    "export.run",
+    "intel.use",
+    "pii.manage",
+    "settings.manage",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_catalog_roles_are_canonical() {
+        let catalog = load_builtin_role_catalog();
+        assert_eq!(
+            catalog.roles,
+            vec![
+                "owner".to_string(),
+                "admin".to_string(),
+                "editor".to_string(),
+                "viewer".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn builtin_catalog_active_keys_match_runtime_permissions() {
+        let catalog = load_builtin_role_catalog();
+        let active: BTreeSet<&str> = catalog
+            .permissions
+            .iter()
+            .filter(|p| p.status == PermissionStatus::Active)
+            .map(|p| p.key.as_str())
+            .collect();
+        let expected: BTreeSet<&str> = ACTIVE_RUNTIME_PERMISSIONS.iter().copied().collect();
+        assert_eq!(active, expected);
+    }
+
+    #[test]
+    fn builtin_catalog_reserved_keys_are_canonical() {
+        let catalog = load_builtin_role_catalog();
+        let reserved: BTreeSet<&str> = catalog
+            .permissions
+            .iter()
+            .filter(|p| p.status == PermissionStatus::Reserved)
+            .map(|p| p.key.as_str())
+            .collect();
+        let expected: BTreeSet<&str> = RESERVED_PERMISSIONS.iter().copied().collect();
+        assert_eq!(reserved, expected);
+    }
+
+    #[test]
+    fn every_grant_references_an_active_key() {
+        let catalog = load_builtin_role_catalog();
+        let active: BTreeSet<&str> = catalog
+            .permissions
+            .iter()
+            .filter(|p| p.status == PermissionStatus::Active)
+            .map(|p| p.key.as_str())
+            .collect();
+        for (role, keys) in &catalog.grants {
+            for key in keys {
+                assert!(
+                    active.contains(key.as_str()),
+                    "grant {key} for role {role} is not an active permission"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_reserved_key_is_granted() {
+        let catalog = load_builtin_role_catalog();
+        let reserved: BTreeSet<&str> = catalog
+            .permissions
+            .iter()
+            .filter(|p| p.status == PermissionStatus::Reserved)
+            .map(|p| p.key.as_str())
+            .collect();
+        for (role, keys) in &catalog.grants {
+            for key in keys {
+                assert!(
+                    !reserved.contains(key.as_str()),
+                    "reserved key {key} must not be granted to {role}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn doc_quarantine_review_has_zero_default_grants() {
+        let catalog = load_builtin_role_catalog();
+        for (role, keys) in &catalog.grants {
+            assert!(
+                !keys.iter().any(|k| k == "doc.quarantine.review"),
+                "doc.quarantine.review must have zero default grants; found on {role}"
+            );
+        }
+    }
+
+    #[test]
+    fn editor_has_no_doc_delete() {
+        let catalog = load_builtin_role_catalog();
+        let editor = catalog
+            .grants
+            .get("editor")
+            .expect("editor grants must exist");
+        assert!(
+            !editor.iter().any(|k| k == "doc.delete"),
+            "built-in editor must not have doc.delete"
+        );
+    }
+
+    #[test]
+    fn every_active_key_has_operation_refs() {
+        let catalog = load_builtin_role_catalog();
+        for perm in catalog
+            .permissions
+            .iter()
+            .filter(|p| p.status == PermissionStatus::Active)
+        {
+            assert!(
+                !perm.operation_refs.is_empty(),
+                "active key {} must have at least one operationRefs entry",
+                perm.key
+            );
+        }
+    }
+
+    #[test]
+    fn every_reserved_key_has_no_operation_refs() {
+        let catalog = load_builtin_role_catalog();
+        for perm in catalog
+            .permissions
+            .iter()
+            .filter(|p| p.status == PermissionStatus::Reserved)
+        {
+            assert!(
+                perm.operation_refs.is_empty(),
+                "reserved key {} must have no operationRefs",
+                perm.key
+            );
+        }
+    }
+
+    #[test]
+    fn validate_catalog_invariants_api_accepts_loaded_catalog() {
+        let catalog = load_builtin_role_catalog();
+        let result = validate_catalog_invariants(&catalog);
+        assert!(
+            result.is_ok(),
+            "canonical catalog must satisfy invariants: {:?}",
+            result.err()
+        );
+    }
+}

--- a/crates/server/tests/role_catalog.rs
+++ b/crates/server/tests/role_catalog.rs
@@ -88,26 +88,21 @@ fn test_database_url() -> Option<String> {
 #[tokio::test]
 #[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
 async fn canonical_matrix_matches_builtin_role_catalog_fixture() {
-    // Wired in GREEN: compare sorted DB role grants to load_builtin_role_catalog().
-    panic!("TODO: compare DB matrix to builtin-role-catalog fixture");
-}
+    use fileconv_server::auth::rbac_catalog::load_builtin_role_catalog;
+    use std::collections::BTreeMap;
 
-#[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
-async fn permissions_table_contains_exactly_active_catalog_keys() {
-    // Wired in GREEN: permissions rows must equal active fixture keys exactly.
-    panic!("TODO: compare permissions table to active catalog keys");
-}
-
-#[tokio::test]
-#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
-async fn canonical_matrix_matches_the_current_poc_effective_matrix() {
     let Some(base_url) = test_database_url() else {
         return;
     };
     let ephemeral = EphemeralDb::create(&base_url).await;
     let pool = create_pool(&ephemeral.url).expect("create pool");
     let client = pool.get().await.expect("client");
+
+    let catalog = load_builtin_role_catalog();
+    let mut expected: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (role, keys) in &catalog.grants {
+        expected.insert(role.clone(), keys.iter().cloned().collect());
+    }
 
     let rows = client
         .query(
@@ -119,52 +114,78 @@ async fn canonical_matrix_matches_the_current_poc_effective_matrix() {
         )
         .await
         .expect("query catalog matrix");
-    let mut by_role: std::collections::BTreeMap<String, BTreeSet<String>> = Default::default();
+    let mut by_role: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     for row in &rows {
         let role: String = row.get(0);
         let permission: String = row.get(1);
         by_role.entry(role).or_default().insert(permission);
     }
 
-    let owner_admin_expected: BTreeSet<String> = [
-        "doc.upload",
-        "doc.delete",
-        "doc.publish",
-        "qa.query",
-        "member.manage",
-        "audit.view",
-        "qa.history",
-        "jobs.system",
-    ]
-    .into_iter()
-    .map(String::from)
-    .collect();
-    let editor_expected: BTreeSet<String> = ["doc.upload", "doc.publish", "qa.query"]
-        .into_iter()
-        .map(String::from)
-        .collect();
-    let viewer_expected: BTreeSet<String> = ["qa.query"].into_iter().map(String::from).collect();
-
-    assert_eq!(by_role.get("owner"), Some(&owner_admin_expected));
-    assert_eq!(by_role.get("admin"), Some(&owner_admin_expected));
-    assert_eq!(by_role.get("editor"), Some(&editor_expected));
-    assert_eq!(by_role.get("viewer"), Some(&viewer_expected));
-    // Deliberately NOT granted to any role — see migrations/0030 comment
-    // (matches the POC org's current, unchanged behavior).
-    for permissions in by_role.values() {
-        assert!(!permissions.contains("doc.quarantine.review"));
-    }
+    assert_eq!(
+        by_role, expected,
+        "DB role_catalog_permissions must equal fixture grants exactly"
+    );
 
     // Cross-check: the POC org's OWN `role_permissions` (migrations/0011/
     // 0017/0019) resolve to exactly the same set the catalog now describes —
     // globalizing the catalog changed no existing behavior.
+    let owner_expected = expected
+        .get("owner")
+        .expect("fixture must define owner grants")
+        .clone();
     let poc_org: Uuid = "11111111-1111-1111-1111-111111111111".parse().unwrap();
     let poc_owner: Uuid = "22222222-2222-2222-2222-222222222201".parse().unwrap();
     let ctx = resolve_org_context_in_txn(&pool, poc_org, poc_owner)
         .await
         .expect("POC owner must still resolve");
     let poc_permissions: BTreeSet<String> = ctx.permissions().iter().cloned().collect();
-    assert_eq!(poc_permissions, owner_admin_expected);
+    assert_eq!(poc_permissions, owner_expected);
+
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn permissions_table_contains_exactly_active_catalog_keys() {
+    use fileconv_server::auth::rbac_catalog::{load_builtin_role_catalog, PermissionStatus};
+
+    let Some(base_url) = test_database_url() else {
+        return;
+    };
+    let ephemeral = EphemeralDb::create(&base_url).await;
+    let pool = create_pool(&ephemeral.url).expect("create pool");
+    let client = pool.get().await.expect("client");
+
+    let catalog = load_builtin_role_catalog();
+    let active: BTreeSet<String> = catalog
+        .permissions
+        .iter()
+        .filter(|p| p.status == PermissionStatus::Active)
+        .map(|p| p.key.clone())
+        .collect();
+    let reserved: BTreeSet<String> = catalog
+        .permissions
+        .iter()
+        .filter(|p| p.status == PermissionStatus::Reserved)
+        .map(|p| p.key.clone())
+        .collect();
+
+    let rows = client
+        .query("SELECT code FROM permissions ORDER BY code", &[])
+        .await
+        .expect("query permissions");
+    let db_keys: BTreeSet<String> = rows.iter().map(|row| row.get(0)).collect();
+
+    assert_eq!(
+        db_keys, active,
+        "permissions table must contain exactly the active catalog keys"
+    );
+    for key in &reserved {
+        assert!(
+            !db_keys.contains(key),
+            "reserved permission {key} must be absent from permissions table"
+        );
+    }
 
     ephemeral.drop().await;
 }

--- a/crates/server/tests/role_catalog.rs
+++ b/crates/server/tests/role_catalog.rs
@@ -87,6 +87,20 @@ fn test_database_url() -> Option<String> {
 
 #[tokio::test]
 #[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn canonical_matrix_matches_builtin_role_catalog_fixture() {
+    // Wired in GREEN: compare sorted DB role grants to load_builtin_role_catalog().
+    panic!("TODO: compare DB matrix to builtin-role-catalog fixture");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn permissions_table_contains_exactly_active_catalog_keys() {
+    // Wired in GREEN: permissions rows must equal active fixture keys exactly.
+    panic!("TODO: compare permissions table to active catalog keys");
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
 async fn canonical_matrix_matches_the_current_poc_effective_matrix() {
     let Some(base_url) = test_database_url() else {
         return;

--- a/docs/markhand-web-risk-register.md
+++ b/docs/markhand-web-risk-register.md
@@ -1,7 +1,9 @@
-# Markhand Web Phase 0 risk register
+# Markhand Web risk register
 
-Status: active for Phase 0 close. P0-10 accepts architecture decisions and local
-restore smoke only; high/critical Profile B items remain open where noted.
+Status: active for Phase 0 close and Phase 1C accepted risks. P0-10 accepts
+architecture decisions and local restore smoke only; high/critical Profile B items
+remain open where noted. `AR-1C-AUDIT-RETENTION` is POC/non-production only and
+expires before production multi-org or the Phase 4 gate, whichever comes first.
 
 | ID | Severity | Risk | Owner | Disposition | Evidence / next action |
 |---|---|---|---|---|---|
@@ -15,6 +17,12 @@ restore smoke only; high/critical Profile B items remain open where noted.
 | R-P0-10-UPLOAD-01 | High | Upload sandbox and denial policy are smoke-tested, not proven in container runtime with malware scanning. | security-owner, worker-owner | Block production upload hardening; implement worker sandbox and scanner evidence. | `bench/markhand_web/security/summary.json`; P0-09 notes. |
 | R-P0-10-QUEUE-01 | High | Recovery queue age under 2x normal load is simulated, not observed with real OCR/audio/vector workers. | worker-owner, operations-owner | Block production recovery target; include queue age in Profile B recovery drill. | `docs/markhand-web-sla-targets.md`; P0-08 queue simulation. |
 | R-P0-10-MINIO-01 | High | MinIO originals are not reconstructable; object inventory drift can make restored metadata incomplete. | operations-owner, storage-owner | Require backup manifest and reconciliation before readiness. | ADR 0012; restore smoke emits placeholder checksums only. |
+
+## Phase 1C accepted risks
+
+| ID | Severity | Risk | Owner | Disposition | Evidence / next action |
+|---|---|---|---|---|---|
+| AR-1C-AUDIT-RETENTION | High | P1C.6 calls for configurable audit retention, but Phase 1C ships append-only audit without purge/TTL; unbounded growth and missing lifecycle controls remain for multi-org deployments. | security-owner, operations-owner | Accepted for POC/non-production only. P1C.6: audit retention is deferred to Phase 4 under AR-1C-AUDIT-RETENTION. AR expiry: before production multi-org or Phase 4 gate, whichever comes first. Do not claim production audit lifecycle readiness from a Phase 1C pass. | Phase plan `plans/markhand-web/phase-1c-multi-org-security.md` P1C.6; Phase 4 owns retention/tamper evidence/export. Qualifying reports must record audit row growth and confirm non-production environment. |
 
 ## Closure rule
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -54,11 +54,12 @@
 Phase F, 0 và 1A **đã đóng** (32/32 issue). Phase 1B **24/24 Done — gate đóng**
 (R06 hanging soak pass 2026-07-31). R02–R05 Done với evidence CI rust-integration
 trên `b5cc92c` (run 30603158015). O-chain release (O01–O05) và soak qualification đã
-pass trên live infrastructure (2026-07-26). Phase 1C **12/13 In progress** — nền
-multi-org/RLS/ACL đã có từ 1B, exit gate denial suite chưa đạt. Phase 2 **13/19 Done**
+pass trên live infrastructure (2026-07-26). Phase 1C **3/13 Done** (1C-01/02/03 trên
+CI `a628504`, run 30629207747), **9 In progress**, **1 Backlog** — org/RBAC foundation
+đóng; P1C.3 ACL semantics và exit gate denial suite còn mở. Phase 2 **13/19 Done**
 trên mock/CI (#311–#318, #327, #332); còn P2-10, P2-15, P2-16 và ba issue mở rộng
-P2-17…19. Phase 3–4 chưa activate (Backlog). Catalog aggregate: **69 Done**,
-**18 In progress**, **0 Review**, **29 Backlog**.
+P2-17…19. Phase 3–4 chưa activate (Backlog). Catalog aggregate: **72 Done**,
+**15 In progress**, **0 Review**, **29 Backlog**.
 
 Dashboard: [`../plans/markhand-web/roadmap.html`](../plans/markhand-web/roadmap.html) ·
 Issue catalog: [`../plans/markhand-web/backlog/`](../plans/markhand-web/backlog/)

--- a/docs/superpowers/plans/2026-07-31-phase1c-closure.md
+++ b/docs/superpowers/plans/2026-07-31-phase1c-closure.md
@@ -155,7 +155,7 @@ Create version 1 with these normative grants:
     {"key":"doc.delete","status":"active","description":"Delete documents","requiredCollectionAccess":"admin","conditionalPolicy":"own_or_explicit_deferred_to_custom_role","operationRefs":["src/routes/documents.rs","src/routes/collections.rs"]},
     {"key":"doc.publish","status":"active","description":"Publish document versions","requiredCollectionAccess":"write","conditionalPolicy":null,"operationRefs":["src/routes/documents.rs"]},
     {"key":"qa.query","status":"active","description":"Query collections","requiredCollectionAccess":"read","conditionalPolicy":null,"operationRefs":["src/services/retrieval/mod.rs"]},
-    {"key":"qa.history","status":"active","description":"Read version history","requiredCollectionAccess":"read","conditionalPolicy":null,"operationRefs":["src/services/access.rs"]},
+    {"key":"qa.history","status":"active","description":"Read version history","requiredCollectionAccess":"read","conditionalPolicy":null,"operationRefs":["src/services/access.rs","src/services/retrieval/mod.rs"]},
     {"key":"member.manage","status":"active","description":"Manage members","requiredCollectionAccess":null,"conditionalPolicy":"admin_cannot_manage_owner","operationRefs":["src/routes/members.rs"]},
     {"key":"audit.view","status":"active","description":"Read audit entries","requiredCollectionAccess":null,"conditionalPolicy":null,"operationRefs":["src/routes/audit.rs"]},
     {"key":"jobs.system","status":"active","description":"Operate system jobs","requiredCollectionAccess":null,"conditionalPolicy":null,"operationRefs":["src/services/access.rs"]},
@@ -177,7 +177,7 @@ Create version 1 with these normative grants:
 }
 ```
 
-`validate_catalog_invariants()` returns `Result<(), Vec<String>>`, sorts errors, and rejects duplicate roles, duplicate permission keys, unknown grants, reserved grants, missing operation references, active references to missing source files, and reserved references. For every active key, at least one referenced file must contain the exact quoted permission literal; file existence alone is not sufficient evidence. Task 9 adds `src/bin/worker.rs` to the `jobs.system` references only after the worker binary contains that literal.
+`validate_catalog_invariants()` returns `Result<(), Vec<String>>`, sorts errors, and rejects duplicate roles, duplicate permission keys, unknown grants, reserved grants, missing operation references, active references to missing source files, and reserved references. For every active key, at least one referenced file must contain the exact quoted permission literal; file existence alone is not sufficient evidence. `operationRefs` may list both the real enforcement site and the literal-definition site (as with `qa.history`: `src/services/access.rs` enforces, `src/services/retrieval/mod.rs` defines `"qa.history"`), while at least one must contain the exact quoted literal. Task 9 adds `src/bin/worker.rs` to the `jobs.system` references only after the worker binary contains that literal.
 
 - [ ] **Step 4: Commit, push, and verify GREEN**
 

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -63,7 +63,7 @@ GitHub milestone progress được đồng bộ bởi workflow
 | 0 | 10/10 | 0 | 0 | Discovery gates đạt |
 | 1A | 10/10 | 0 | 0 | Extraction gate đạt |
 | 1B | 24/24 | 0 | 0 | **Gate đạt** — R06 hanging soak pass 2026-07-31 |
-| 1C | 0/13 | 12 | 1 | Substrate 1B đã có; exit gate 1C-12/1C-13 chưa đạt |
+| 1C | 3/13 | 9 | 1 | 1C-01/02/03 Done (CI `a628504`); P1C.3 ACL + exit gate 1C-12/1C-13 còn mở |
 | 2 | 13/19 | 6 | 0 | MVP mock/CI xanh; exit gate chờ 1C + E2E deploy thật |
 | 3 | 0/14 | 0 | 14 | Chưa activate — chờ Phase 2 complete |
 | 4 | 0/14 | 0 | 14 | Chưa activate — chờ Phase 3 |

--- a/plans/markhand-web/backlog/github-issues.json
+++ b/plans/markhand-web/backlog/github-issues.json
@@ -854,42 +854,42 @@
       "phase": "1C",
       "id": "1C-01",
       "title": "1C-01 — Organization lifecycle và validated context",
-      "status": "in_progress",
+      "status": "done",
       "milestone": "Phase 1C — Multi-org Security",
       "labels": [
         "markhand-web",
         "docs",
         "web-p1c"
       ],
-      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-01\n- Status: `in_progress`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\nPhase 1B auth/schema.\nforged/stale header deny; two-org resolver/integration tests.\n\n## Required tests / evidence\n\nChỉ thấy org của mình;\n\n## Security and migration notes\n\nKhông global org state; audit switch.\n\n## Out of scope\n\nbilling/OIDC.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-01\n- Status: `done`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\nPhase 1B auth/schema.\nforged/stale header deny; two-org resolver/integration tests — green on CI\n`a62850422dd070e7e1195bfe1d4f1dee0d73566d` run\n[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)\n(`rust`/`web`/`rust-integration`).\n\n## Required tests / evidence\n\nChỉ thấy org của mình;\n\n## Security and migration notes\n\nKhông global org state; audit switch.\n\n## Out of scope\n\nbilling/OIDC.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
       "catalog": "backlog/phase-1c/issues/README.md"
     },
     {
       "phase": "1C",
       "id": "1C-02",
       "title": "1C-02 — Membership, invites và last-owner invariant",
-      "status": "in_progress",
+      "status": "done",
       "milestone": "Phase 1C — Multi-org Security",
       "labels": [
         "markhand-web",
         "docs",
         "web-p1c"
       ],
-      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-02\n- Status: `in_progress`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\n1C-01.\nthao tác chính mình); admin không quản owner; concurrent owner removal, invite\nreplay/expiry, escalation tests — **đã có trong `tests/members.rs`, DB-gated\n`#[ignore]`, cần chạy trong CI `rust-integration` (`MARKHAND_TEST_DATABASE_URL`) để\nđóng gate, chưa tự chạy trong `cargo test` mặc định**.\n\n## Required tests / evidence\n\nKhông remove/downgrade last owner (kể cả tự\n\n## Security and migration notes\n\nRow lock (`FOR UPDATE` trên owner rows), expand/backfill\nversion (deferred, xem trên); plaintext invite không lưu DB/log (chỉ trả 1 lần trong\nresponse). **Out:** automated email delivery/SCIM/MFA.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-02\n- Status: `done`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\n1C-01.\nthao tác chính mình); admin không quản owner; concurrent owner removal, invite\nreplay/expiry, escalation tests — green on CI\n`a62850422dd070e7e1195bfe1d4f1dee0d73566d` run\n[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)\n(`tests/members.rs` in `rust-integration`).\n\n## Required tests / evidence\n\nKhông remove/downgrade last owner (kể cả tự\n\n## Security and migration notes\n\nRow lock (`FOR UPDATE` trên owner rows), expand/backfill\nversion (deferred to 1C-05); plaintext invite không lưu DB/log (chỉ trả 1 lần trong\nresponse). **Out:** automated email delivery/SCIM/MFA.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
       "catalog": "backlog/phase-1c/issues/README.md"
     },
     {
       "phase": "1C",
       "id": "1C-03",
       "title": "1C-03 — Canonical RBAC seed",
-      "status": "in_progress",
+      "status": "done",
       "milestone": "Phase 1C — Multi-org Security",
       "labels": [
         "markhand-web",
         "docs",
         "web-p1c"
       ],
-      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-03\n- Status: `in_progress`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\nPhase 1B role schema.\nduplicate/missing/immutable mutation tests; UI không hard-code matrix.\n\n## Required tests / evidence\n\nMatrix đúng/idempotent,\n\n## Security and migration notes\n\nStable keys, expand/backfill.\n\n## Out of scope\n\ncustom role builder.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-03\n- Status: `done`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\nPhase 1B role schema.\nduplicate/missing/immutable mutation tests; UI không hard-code matrix — green on CI\n`a62850422dd070e7e1195bfe1d4f1dee0d73566d` run\n[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)\n(`role_catalog` in `rust-integration`).\n\n## Required tests / evidence\n\nMatrix đúng/idempotent,\n\n## Security and migration notes\n\nStable keys, expand/backfill.\n\n## Out of scope\n\ncustom role builder.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
       "catalog": "backlog/phase-1c/issues/README.md"
     },
     {

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -4,26 +4,24 @@ Parent plan: [`../../../phase-1c-multi-org-security.md`](../../../phase-1c-multi
 
 <!-- roadmap-default-status: backlog -->
 
-**Audit 2026-07-27 (đọc code, không đoán).** Con số cũ "0/13" gây hiểu nhầm: phần lớn
-**nền tảng thực thi 1C đã được xây sẵn trong Phase 1B** (RLS FORCE, ACL predicate ở
-retrieval, Qdrant mandatory filter, quota atomic, rate-limit, audit append-only) — nhưng
-**chưa issue nào đạt full acceptance**, nên không tick Done cái nào. Kết quả audit:
+**Audit 2026-07-31 (PR 1 RBAC foundation).** Substrate 1B vẫn là nền; PR 1 đóng org
+lifecycle / membership / canonical RBAC catalog với CI exact-SHA evidence. P1C.3 ACL
+semantics còn mở cho PR 2. `AR-1C-AUDIT-RETENTION` giữ POC/non-production only.
 
-- **11 In progress** — có building block thật + có test, nhưng thiếu phần định nghĩa 1C.
-- **2 Backlog** — chỉ có schema/prose, logic chính chưa viết: **1C-02** (invite/last-owner)
-  và **1C-13** (security/load gate).
-- **0 Done.**
+- **3 Done** — **1C-01**, **1C-02**, **1C-03** (CI `rust` + `web` + `rust-integration` trên
+  `a628504`, run [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)).
+- **9 In progress** — 1C-04…1C-12 (ACL/guards/denial còn mở).
+- **1 Backlog** — **1C-13** (security/load gate).
 
 > **Hai ranh giới quan trọng, áp cho MỌI issue dưới đây:**
 > 1. **Test enforcement gần như toàn bộ là `#[ignore]` DB-gated** — chỉ chạy trong job CI
 >    `rust-integration` khi có `MARKHAND_TEST_DATABASE_URL`/MinIO/Qdrant, KHÔNG chạy trong
 >    `cargo test` mặc định. Fast-unit chỉ phủ logic thuần (scope resolve, filter, HMAC).
 > 2. **`context.rs:11-12` tự ghi "full ACL resolution belongs to Phase 1C"** — substrate
->    hiện tại xây cho single-org POC (1B), chưa phải multi-org đầy đủ.
+>    hiện tại xây cho single-org POC (1B); full multi-org ACL semantics vẫn thuộc PR 2+.
 >
-> **Exit gate Phase 1C (1C-12 + 1C-13) CHƯA đạt** — cả hai deliverable "suite gắn kết" và
-> "gate có report" đều chưa tồn tại như deliverable. Và Phase 1C chỉ activate sau khi
-> **Phase 1B gate đóng** (2026-07-31 — R06 hanging soak pass); toàn phase vẫn là công việc phía trước.
+> **Exit gate Phase 1C (1C-12 + 1C-13) CHƯA đạt** — denial suite gắn kết và security/load
+> gate chưa đóng. Phase 1B gate đã đóng (2026-07-31 — R06 hanging soak pass).
 
 ## Dependency
 
@@ -36,73 +34,81 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-01 — Organization lifecycle và validated context
 
-- **Status:** In progress — nửa *validated-context* đã có + test DB-gated: resolver `auth/permissions.rs:39`, membership re-verify (JWT chỉ là hint) `auth/middleware.rs:144`, fail-closed `auth/context.rs:30`, RLS `migrations/0002`. **Nửa lifecycle đã landed phần lớn**: `GET /orgs` (chỉ org của mình), `GET /orgs/{id}` (404 đồng nhất cho "không tồn tại"/"không phải member" — không oracle), `POST /orgs/switch` (re-verify membership từ PG, mint session mới độc lập scoped target org, audit `org.switch` cả success/deny; deny với org không tồn tại thì không ghi audit để tránh FK-oracle) — routes bearer-identity-only theo tiền lệ `accept_invite`, kèm two-org resolver test DB-gated (`tests/orgs.rs`, 8 test: forged/stale/suspended deny + audit). **`POST /orgs` (create) đã landed** sau khi owner chốt thiết kế catalog toàn cục (xem 1C-03/migration `0030`): tạo org + owner membership + `provision_org_role_catalog(org_id)` trong MỘT transaction, audit `org.create`, validate slug khớp CHECK constraint, rate-limit auth-IP, 409 slug taken; test DB-gated create (happy/duplicate/unauth/audit + owner resolve đủ permission không cần seed riêng) trong `tests/orgs.rs` (12 test).
+- **Status:** Done — CI exact-SHA evidence on `a62850422dd070e7e1195bfe1d4f1dee0d73566d`
+  (run [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)):
+  `rust` [91151657403](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657403),
+  `web` [91151657388](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657388),
+  `rust-integration` [91151657399](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657399)
+  (not path-filter skip / soft pass). Integration log executed `orgs` binary tests
+  including `create_org_succeeds_and_caller_becomes_owner` and
+  `list_orgs_shows_only_the_callers_own_orgs`; job summary reports no ignored tests
+  for that binary. Validated-context + lifecycle already landed: membership
+  re-verify, fail-closed OrgContext, RLS, `GET /orgs` / `GET /orgs/{id}` /
+  `POST /orgs/switch` / `POST /orgs` with owner provision + audit.
 
 - **Plan/files:** Org create/list/detail/switch, service/repo/middleware; issue new
   context/session after verified membership.
 - **Depends:** Phase 1B auth/schema. **Acceptance/tests:** Chỉ thấy org của mình;
-  forged/stale header deny; two-org resolver/integration tests.
+  forged/stale header deny; two-org resolver/integration tests — green on CI
+  `a62850422dd070e7e1195bfe1d4f1dee0d73566d` run
+  [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)
+  (`rust`/`web`/`rust-integration`).
 - **Security/migration:** Không global org state; audit switch. **Out:** billing/OIDC.
 
 ## 1C-02 — Membership, invites và last-owner invariant
 
-- **Status:** In progress — gần Done; **đã landed đầy đủ trong #317** (đọc code xác
-  minh 2026-07-28, không phải backlog cũ ghi "Backlog"): invite create/accept/revoke/list
-  hashed single-use `routes/members.rs` E1-E5, **`PATCH /api/v1/members/{userId}`** (đổi
-  role/state, `routes/members.rs:450 patch_member`) và **`DELETE /api/v1/members/{userId}`**
-  (`routes/members.rs:551 delete_member`) đều đã có — không chỉ GET như một đợt audit
-  trước từng nêu. Last-owner invariant transactional + row-lock: `check_last_owner_invariant`
-  (pure, `services/members.rs:143`) + `guard_last_owner` (`FOR UPDATE` qua
-  `db::members::lock_owner_rows`, `services/members.rs:159`) chạy cùng transaction với
-  `change_role`/`remove_member`/`suspend_member` (`services/members.rs:476/540`); riêng
-  cả tự-hạ-role/tự-xóa của owner cuối cũng 409 (không có ngoại lệ cho "chính mình").
-  `guard_owner_tier` (`services/members.rs:176`) chặn thêm escalation: chỉ active owner
-  mới được cấp/thao tác owner khác — admin có `member.manage` không tự thăng owner hay
-  quản owner khác (403). Membership **state** (`active|suspended`, KHÔNG có "removed" —
-  remove là hard-delete có chủ đích vì FK `refresh_tokens` không có `ON DELETE`, xem
-  migration `0029_expand_org_membership_state.sql` + doc `services/members.rs:25-35`)
-  đã dùng cho suspend/reactivate; **version** cho ACL cache (1C-05) cố ý CHƯA thêm (chưa
-  có cache để invalidate). Downgrade/suspend/remove đều gọi
-  `auth::session::revoke_all_user_families` (route layer, `routes/members.rs:532/587`)
-  để refresh-token family cũ không sống quá TTL. Audit `member.role_change` (old→new
-  role/state trong metadata) và `member.remove` (old_role) ghi cùng transaction
-  (`services/audit.rs` allowlist `member.role_change`/`member.remove`). OpenAPI
-  (`openapi/openapi.yaml:1180`, `ROUTE_INVENTORY`/`BODY_TAKING_OPERATIONS` trong
-  `api/openapi.rs`) + web codegen + admin UI (`web/src/components/admin/membersApi.ts`,
-  `memberPresentation.ts`) đã có, pin-count schema vẫn 38 (không schema mới). Migration
-  MỚI không cần — `0029` đã đủ.
-  **Bổ sung trong phiên này** (worktree, chưa chạy DB-gated CI): thêm vào
-  `tests/members.rs` 4 test còn thiếu so với danh sách acceptance — last-owner 409
-  *deterministic* (không chỉ qua race) cho tự-downgrade/tự-remove/tự-suspend của owner
-  cuối cùng, 403 khi thiếu `member.manage` (kèm audit-deny), 404 cho user id chưa từng
-  tồn tại trong org (khác case cross-org RLS-hidden), và audit before/after cho
-  role-change + remove trên happy path.
-  **Còn thiếu thật** (không phải của 1C-02, thuộc issue khác): 1C-05 chưa có ACL
-  version/cache nên chưa cần cột `version`; 1C-11 vẫn chưa có endpoint đọc audit log
-  (chỉ ghi, `db::audit::list_recent` chưa có route). MVP token invite vẫn chỉ hiển thị
-  1 lần qua response body — automated email delivery vẫn out of scope như thiết kế.
+- **Status:** Done — CI exact-SHA evidence on `a62850422dd070e7e1195bfe1d4f1dee0d73566d`
+  (run [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)):
+  `rust` [91151657403](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657403),
+  `web` [91151657388](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657388),
+  `rust-integration` [91151657399](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657399)
+  (not path-filter skip / soft pass). Integration log executed `members` binary tests
+  including `concurrent_last_owner_race_exactly_one_survives`,
+  `cross_org_denial_covers_every_member_endpoint`, and
+  `member_manage_permission_required_for_patch_and_delete`; job summary reports no
+  ignored tests for that binary. Implementation landed in #317+: hashed single-use
+  invites, PATCH/DELETE members, transactional last-owner + owner-tier guards,
+  suspend/reactivate, session family revoke, audit allowlist. Membership ACL
+  `version` remains deferred to 1C-05; automated email delivery remains out of scope.
 
 - **Plan/files:** Hashed single-use invite; membership state; transactional last-owner;
   membership version (deferred to 1C-05); session revoke. MVP chưa có mail dùng invite
   URL/token hiển thị đúng một lần cho admin copy qua kênh được tổ chức phê duyệt;
-  expiry/revoke/audit bắt buộc — **tất cả đã landed**.
+  expiry/revoke/audit bắt buộc — **đã landed**.
 - **Depends:** 1C-01. **Acceptance/tests:** Không remove/downgrade last owner (kể cả tự
   thao tác chính mình); admin không quản owner; concurrent owner removal, invite
-  replay/expiry, escalation tests — **đã có trong `tests/members.rs`, DB-gated
-  `#[ignore]`, cần chạy trong CI `rust-integration` (`MARKHAND_TEST_DATABASE_URL`) để
-  đóng gate, chưa tự chạy trong `cargo test` mặc định**.
+  replay/expiry, escalation tests — green on CI
+  `a62850422dd070e7e1195bfe1d4f1dee0d73566d` run
+  [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)
+  (`tests/members.rs` in `rust-integration`).
 - **Security/migration:** Row lock (`FOR UPDATE` trên owner rows), expand/backfill
-  version (deferred, xem trên); plaintext invite không lưu DB/log (chỉ trả 1 lần trong
+  version (deferred to 1C-05); plaintext invite không lưu DB/log (chỉ trả 1 lần trong
   response). **Out:** automated email delivery/SCIM/MFA.
 
 ## 1C-03 — Canonical RBAC seed
 
-- **Status:** In progress — bảng `permissions/roles/role_permissions` + seed 4 role owner/admin/editor/viewer + matrix (`migrations/0011:38`, `is_system=true`), idempotent (`tests/schema_migrations.rs` DB-gated). **Đã thêm (migration `0030`)**: catalog toàn cục `role_catalog`/`role_catalog_permissions` làm template bất biến duy nhất (trigger chặn UPDATE/DELETE/TRUNCATE — immutable system roles), seed idempotent đúng matrix hiệu lực POC, hàm `provision_org_role_catalog(org_id)` copy per-org khi tạo org (cố ý KHÔNG trigger tự động trên `orgs` INSERT và KHÔNG đổi resolver join — per-org rows vẫn là nguồn resolve runtime để `acl_mutate` revoke containment hoạt động); test matrix + immutability + no-seed-resolve trong `tests/role_catalog.rs`. **Còn thiếu**: OpenAPI fixture cho matrix, đối chiếu UI không hard-code matrix.
+- **Status:** Done — CI exact-SHA evidence on `a62850422dd070e7e1195bfe1d4f1dee0d73566d`
+  (run [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)):
+  `rust` [91151657403](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657403),
+  `web` [91151657388](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657388),
+  `rust-integration` [91151657399](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657399)
+  (not path-filter skip / soft pass). Integration log executed `role_catalog` tests
+  including `permissions_table_contains_exactly_active_catalog_keys ... ok` and
+  `canonical_matrix_matches_builtin_role_catalog_fixture ... ok`; job summary reports
+  no ignored tests for that binary. Canonical fixture
+  `crates/server/openapi/builtin-role-catalog.json` is the sole built-in
+  active/reserved matrix; OpenAPI references it (no embedded grants); web imports it
+  for role order; DB parity tests compare exact active keys/grants. Historical
+  migration `0030` catalog + per-org provision unchanged. P1C.2 disposition: matrix
+  follows the fixture. Guard inventory for active operations remains 1C-04 / later PRs.
 
 - **Plan/files:** Permission constants + DB seed owner/admin/editor/viewer; immutable
-  system roles; OpenAPI fixture.
+  system roles; OpenAPI/web fixture consumers.
 - **Depends:** Phase 1B role schema. **Acceptance/tests:** Matrix đúng/idempotent,
-  duplicate/missing/immutable mutation tests; UI không hard-code matrix.
+  duplicate/missing/immutable mutation tests; UI không hard-code matrix — green on CI
+  `a62850422dd070e7e1195bfe1d4f1dee0d73566d` run
+  [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)
+  (`role_catalog` in `rust-integration`).
 - **Security/migration:** Stable keys, expand/backfill. **Out:** custom role builder.
 
 ## 1C-04 — Route/service guards và service identities

--- a/plans/markhand-web/phase-1c-multi-org-security.md
+++ b/plans/markhand-web/phase-1c-multi-org-security.md
@@ -5,6 +5,14 @@
 Mở kiến trúc single-org POC thành multi-org an toàn. Phase này hoàn thiện policy,
 fairness và denial suite; không retrofit `org_id` vì tenancy primitives đã có từ 1B.
 
+**PR 1 progress (2026-07-31):** 1C-01 / 1C-02 / 1C-03 Done with exact-SHA CI evidence
+on `a62850422dd070e7e1195bfe1d4f1dee0d73566d` (run
+[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747);
+jobs `rust` / `web` / `rust-integration`). P1C.3 collection ACL semantics remain open
+for PR 2. Audit retention stays deferred under `AR-1C-AUDIT-RETENTION`
+(POC/non-production only; expires before production multi-org or Phase 4 gate).
+Qualifying embedding remains local/mock until embedding-token metering exists.
+
 ## P1C.1 — Organization và membership
 
 - Tạo/join/switch org.

--- a/plans/markhand-web/phase-1c-multi-org-security.md
+++ b/plans/markhand-web/phase-1c-multi-org-security.md
@@ -19,41 +19,57 @@ API gồm org list/detail, members CRUD và org switch/session refresh.
 
 ## P1C.2 — RBAC level 2
 
-Permission constants:
+**Disposition (PR 1):** P1C.2: active/reserved matrix follows
+`crates/server/openapi/builtin-role-catalog.json`. That fixture is the sole normative
+built-in contract; the table below is a human summary and must not diverge from it.
+Role→permission runtime authority remains PostgreSQL; OpenAPI/web consumers reference
+the same fixture (no second hard-coded grant matrix).
 
-- `doc.upload`, `doc.delete`;
+Active permission keys (seeded when operations exist):
+
+- `doc.upload`, `doc.delete`, `doc.publish`, `doc.quarantine.review`;
 - `qa.query`, `qa.history`;
-- `member.manage`, `settings.manage`;
-- `intel.use`, `pii.manage`, `export.run`;
-- `audit.view`.
+- `member.manage`, `audit.view`, `jobs.system`.
 
-Role→permission lưu DB, system role immutable; schema cho custom role tương lai nhưng
-chưa cần UI editor phức tạp. Mỗi route và service operation có explicit guard.
-Worker/admin/reconcile cũng dùng service identity với permission tối thiểu.
+Reserved permission keys (ungranted until a real operation activates them):
 
-Canonical built-in matrix:
+- `settings.manage`, `intel.use`, `pii.manage`, `export.run`.
 
-| Permission | Owner | Admin | Editor | Viewer |
-|---|---:|---:|---:|---:|
-| `doc.upload` | ✓ | ✓ | ✓ | |
-| `doc.delete` | ✓ | ✓ | own/explicit policy | |
-| `qa.query` | ✓ | ✓ | ✓ | ✓ |
-| `qa.history` | ✓ | ✓ | | |
-| `member.manage` | ✓ | ✓, không quản owner | | |
-| `settings.manage` | ✓ | ✓, trừ owner/security | | |
-| `intel.use` | ✓ | ✓ | ✓ | theo org policy |
-| `pii.manage` | ✓ | ✓ | | |
-| `export.run` | ✓ | ✓ | ✓ | theo org policy |
-| `audit.view` | ✓ | ✓ | | |
+System roles immutable; schema may allow custom roles later without a complex UI
+editor. Each route and service operation has an explicit guard. Worker/admin/reconcile
+use least-privilege service identities.
+
+Canonical built-in matrix (active grants only; matches `builtin-role-catalog.json`):
+
+| Permission | Owner | Admin | Editor | Viewer | Notes |
+|---|---:|---:|---:|---:|---|
+| `doc.upload` | ✓ | ✓ | ✓ | | |
+| `doc.delete` | ✓ | ✓ | | | Editor “own/explicit” deferred; not a built-in grant |
+| `doc.publish` | ✓ | ✓ | ✓ | | Active; was missing from older plan prose |
+| `doc.quarantine.review` | | | | | Active with zero default grants (intentional) |
+| `qa.query` | ✓ | ✓ | ✓ | ✓ | |
+| `qa.history` | ✓ | ✓ | | | |
+| `member.manage` | ✓ | ✓ | | | Admin cannot manage owner (`admin_cannot_manage_owner`) |
+| `audit.view` | ✓ | ✓ | | | |
+| `jobs.system` | ✓ | ✓ | | | Active; was missing from older plan prose |
+| `settings.manage` | | | | | Reserved / ungranted |
+| `intel.use` | | | | | Reserved / ungranted |
+| `pii.manage` | | | | | Reserved / ungranted |
+| `export.run` | | | | | Reserved / ungranted |
 
 Chỉ owner được assign/remove owner, đổi security/SSO policy, xóa org và thay quota
 hard limit. Admin không được nâng chính mình hoặc người khác lên owner. Test allow/
-deny phải phủ mỗi permission ở route lẫn service layer; matrix có migration seed và
-fixture duy nhất, không hard-code bản thứ hai trong UI.
+deny phải phủ mỗi *active* permission ở route lẫn service layer; matrix có migration
+seed và fixture duy nhất, không hard-code bản thứ hai trong UI. Guard inventory for
+active operations belongs to later PRs (1C-04), not the catalog seed itself.
 
 ## P1C.3 — Collection ACL
 
-Chốt semantics từ ADR:
+**Disposition (PR 1):** P1C.3 remains open for PR 2 ACL semantics. PR 1 does not close
+collection ACL resolver equivalence, grant/revoke invalidation, or dormant-grant
+containment; those remain Phase 1C work after the RBAC catalog foundation.
+
+Target semantics from ADR (to be machine-checked in PR 2):
 
 - `private`: owner + principal được grant;
 - `org`: thành viên org có permission tương ứng;
@@ -91,6 +107,11 @@ application authorization.
 
 ## P1C.5 — Atomic quota và fairness
 
+**Disposition (PR 1):** P1C.5: embedding-token metering is N/A only for local/mock
+qualifying runtime. Phase 1C qualification must use local/mock embedding; cloud/shared
+embedding profiles are out of scope until embedding-token metering exists. LLM/chat
+token reserve/finalize remains in scope where a chat provider is configured.
+
 Flow transaction:
 
 ```text
@@ -100,7 +121,8 @@ reserve → finalize(actual) | refund
 Resource:
 
 - upload/storage bytes;
-- LLM/embedding tokens;
+- LLM tokens (when a chat provider is configured);
+- embedding tokens — N/A for local/mock qualifying runtime only (see disposition);
 - concurrent convert/embed/intelligence jobs;
 - request rate.
 
@@ -115,11 +137,18 @@ Yêu cầu:
 
 ## P1C.6 — Audit/admin APIs
 
+**Disposition (PR 1):** P1C.6: audit retention is deferred to Phase 4 under
+`AR-1C-AUDIT-RETENTION`. Phase 1C keeps append-only audit without configurable
+purge/TTL; Phase 4 owns retention, tamper evidence, and export. Accepted risk scope
+is POC/non-production only. AR expiry: before production multi-org or Phase 4 gate,
+whichever comes first.
+
 - Member/role/ACL/config/quota changes.
 - Upload/delete/export/PII/cloud-LLM use.
 - Authorization deny và quota exceed.
 - Read-only audit endpoint có pagination/filter và `audit.view`.
-- Retention được config; log không chứa document text, prompt, token hoặc PII.
+- Retention/TTL deferred (see disposition / `AR-1C-AUDIT-RETENTION`); log không chứa
+  document text, prompt, token hoặc PII.
 
 ## P1C.7 — Denial suite
 

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "0c315f20d4ff105d";
+    const ROADMAP_SOURCE_HASH = "09d8e7cf2b8094a1";
     const phases = [
       {
         "id": "phase-f",
@@ -1252,17 +1252,17 @@
           [
             "1C-01",
             "Organization lifecycle và validated context",
-            "in_progress"
+            "done"
           ],
           [
             "1C-02",
             "Membership, invites và last-owner invariant",
-            "in_progress"
+            "done"
           ],
           [
             "1C-03",
             "Canonical RBAC seed",
-            "in_progress"
+            "done"
           ],
           [
             "1C-04",

--- a/web/src/components/admin/memberPresentation.ts
+++ b/web/src/components/admin/memberPresentation.ts
@@ -5,6 +5,7 @@
 // (never render a control that would just 403). Kept side-effect-free and
 // framework-free so each piece is trivial to unit test on its own.
 import { HttpApiError, NetworkError } from '../../api/errors';
+import { ROLE_ORDER } from '../../rbac/builtinRoleCatalog';
 import type {
   Invite,
   InviteStatus,
@@ -19,8 +20,8 @@ export interface TagMeta {
   tagClass: 'tag-neutral' | 'tag-accent' | 'tag-accent-2' | 'tag-outline';
 }
 
-/** Every role the `Membership`/`Invite`/`PatchMemberRequest` schemas declare, in privilege order (most privileged first) — the order the role `<select>` presents them in. */
-export const ROLE_ORDER: readonly MembershipRole[] = ['owner', 'admin', 'editor', 'viewer'];
+/** Privilege order from the canonical builtin-role-catalog fixture (most privileged first) — the order the role `<select>` presents them in. */
+export { ROLE_ORDER };
 
 export const ROLE_META: Record<MembershipRole, TagMeta> = {
   owner: { label: 'Chủ sở hữu', tagClass: 'tag-accent' },

--- a/web/src/rbac/builtinRoleCatalog.test.ts
+++ b/web/src/rbac/builtinRoleCatalog.test.ts
@@ -1,16 +1,20 @@
-import { describe, expect, it } from 'vitest'
-import { BUILTIN_ROLE_CATALOG, ROLE_ORDER } from './builtinRoleCatalog'
+import { describe, expect, it } from 'vitest';
+import { BUILTIN_ROLE_CATALOG, ROLE_ORDER } from './builtinRoleCatalog';
 
 describe('builtin role catalog', () => {
   it('drives role ordering from the canonical fixture', () => {
-    expect(ROLE_ORDER).toEqual(BUILTIN_ROLE_CATALOG.roles)
-  })
+    expect(ROLE_ORDER).toEqual(BUILTIN_ROLE_CATALOG.roles);
+  });
   it('keeps reserved permissions ungranted', () => {
     const reserved = new Set(
       BUILTIN_ROLE_CATALOG.permissions
         .filter((permission) => permission.status === 'reserved')
         .map((permission) => permission.key),
-    )
-    expect(Object.values(BUILTIN_ROLE_CATALOG.grants).flat().some((key) => reserved.has(key))).toBe(false)
-  })
-})
+    );
+    expect(
+      Object.values(BUILTIN_ROLE_CATALOG.grants)
+        .flat()
+        .some((key) => reserved.has(key)),
+    ).toBe(false);
+  });
+});

--- a/web/src/rbac/builtinRoleCatalog.test.ts
+++ b/web/src/rbac/builtinRoleCatalog.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { BUILTIN_ROLE_CATALOG, ROLE_ORDER } from './builtinRoleCatalog'
+
+describe('builtin role catalog', () => {
+  it('drives role ordering from the canonical fixture', () => {
+    expect(ROLE_ORDER).toEqual(BUILTIN_ROLE_CATALOG.roles)
+  })
+  it('keeps reserved permissions ungranted', () => {
+    const reserved = new Set(
+      BUILTIN_ROLE_CATALOG.permissions
+        .filter((permission) => permission.status === 'reserved')
+        .map((permission) => permission.key),
+    )
+    expect(Object.values(BUILTIN_ROLE_CATALOG.grants).flat().some((key) => reserved.has(key))).toBe(false)
+  })
+})

--- a/web/src/rbac/builtinRoleCatalog.ts
+++ b/web/src/rbac/builtinRoleCatalog.ts
@@ -1,0 +1,5 @@
+import catalog from '../../../crates/server/openapi/builtin-role-catalog.json';
+import type { MembershipRole } from '../components/admin/types';
+
+export const BUILTIN_ROLE_CATALOG = catalog;
+export const ROLE_ORDER = catalog.roles as readonly MembershipRole[];

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -11,7 +11,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Establishes one canonical built-in RBAC catalog and closes Phase 1C issues 1C-01, 1C-02, and 1C-03 with exact-SHA CI evidence.

## Scope

- Add and validate `builtin-role-catalog.json` for active/reserved permissions and built-in grants.
- Derive OpenAPI contract checks, web role ordering, and PostgreSQL parity tests from that catalog.
- Record `AR-1C-AUDIT-RETENTION` and local/mock embedding dispositions without closing the remaining ACL work.
- Regenerate roadmap and issue artifacts consistently.

## Evidence

- [x] Tests: Rust catalog/OpenAPI tests, 521 web tests, formatting, lint (0 errors; 8 pre-existing warnings), API generation check, roadmap check, and dependency policy passed locally.
- [x] Manual/benchmark/migration evidence: [exact-SHA CI run](https://github.com/anhnth24/project-example/actions/runs/30629207747) passed `rust`, `web`, and `rust-integration`; org/member/catalog parity tests executed without soft-skips. [Latest branch CI](https://github.com/anhnth24/project-example/actions/runs/30630135345) is also green.

## Boundary and security review

- [x] Dependency boundary check passed.
- [x] Tenant/ACL impact reviewed; P1C.3 ACL semantics remain open for PR 2.
- [x] Sensitive logging/secret/egress impact reviewed; no new secret or egress surface.
- [x] Security review completed through task-scoped and whole-branch Composer reviews; no Critical or Important findings remain.

## Follow-up

- [x] Docs, OpenAPI, roadmap, risk register, and issue export updated where required.
- [ ] Merge this PR before creating PR 2 (`cursor/phase1c-acl-enforcement-6ddb`).
- [ ] Keep audit retention production readiness deferred under `AR-1C-AUDIT-RETENTION` until Phase 4 or production multi-org, whichever comes first.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8504871-2ef2-4a0b-bf3a-9f2b969c6ddb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8504871-2ef2-4a0b-bf3a-9f2b969c6ddb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

