### PR TITLE
feat(server): enforce canonical Phase 1C collection ACLs

### DIFF
--- a/crates/server/migrations/0036_expand_acl_groups_invariants.sql
+++ b/crates/server/migrations/0036_expand_acl_groups_invariants.sql
@@ -1,8 +1,9 @@
 -- Phase: 1C
 -- Owner: security-owner
 -- Change: expand
--- Lock/data risk: three trigger functions + six row-level triggers on existing
---   ACL tables; preflight DO block scans collections/grants once at apply time.
+-- Lock/data risk: four SQL functions (three visibility guards + replacement
+--   bump_org_acl_version) and six row-level triggers on existing ACL tables;
+--   preflight DO block scans collections/grants once at apply time.
 --   Grant/visibility writers serialize on the parent collection row via
 --   FOR NO KEY UPDATE under READ COMMITTED — low-volume admin paths only.
 -- Rollback compatibility: additive only; dropping triggers/functions in a later
@@ -46,6 +47,13 @@ RETURNS trigger AS $$
 DECLARE
     parent_visibility text;
 BEGIN
+    IF TG_OP = 'UPDATE' AND (
+        OLD.org_id IS DISTINCT FROM NEW.org_id
+        OR OLD.collection_id IS DISTINCT FROM NEW.collection_id
+    ) THEN
+        RAISE EXCEPTION 'group/role grant parent keys (org_id, collection_id) are immutable; delete and re-insert to retarget';
+    END IF;
+
     SELECT visibility
     INTO parent_visibility
     FROM collections
@@ -104,6 +112,29 @@ DROP TRIGGER IF EXISTS collections_enforce_visibility_grant_invariant ON collect
 CREATE TRIGGER collections_enforce_visibility_grant_invariant
     BEFORE UPDATE OF visibility ON collections
     FOR EACH ROW EXECUTE FUNCTION enforce_collection_visibility_grant_invariant();
+
+-- Replace the 0033 helper so cross-org UPDATE bumps both orgs exactly once;
+-- same-org INSERT/UPDATE/DELETE still bump once.
+CREATE OR REPLACE FUNCTION bump_org_acl_version() RETURNS trigger AS $$
+DECLARE
+    target_org uuid;
+BEGIN
+    IF TG_OP = 'UPDATE' AND OLD.org_id IS DISTINCT FROM NEW.org_id THEN
+        IF OLD.org_id IS NOT NULL THEN
+            UPDATE orgs SET acl_version = acl_version + 1 WHERE id = OLD.org_id;
+        END IF;
+        IF NEW.org_id IS NOT NULL THEN
+            UPDATE orgs SET acl_version = acl_version + 1 WHERE id = NEW.org_id;
+        END IF;
+    ELSE
+        target_org := COALESCE(NEW.org_id, OLD.org_id);
+        IF target_org IS NOT NULL THEN
+            UPDATE orgs SET acl_version = acl_version + 1 WHERE id = target_org;
+        END IF;
+    END IF;
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
 
 DROP TRIGGER IF EXISTS collection_group_access_bump_acl_version ON collection_group_access;
 CREATE TRIGGER collection_group_access_bump_acl_version

--- a/crates/server/migrations/0036_expand_acl_groups_invariants.sql
+++ b/crates/server/migrations/0036_expand_acl_groups_invariants.sql
@@ -1,0 +1,121 @@
+-- Phase: 1C
+-- Owner: security-owner
+-- Change: expand
+-- Lock/data risk: three trigger functions + six row-level triggers on existing
+--   ACL tables; preflight DO block scans collections/grants once at apply time.
+--   Grant/visibility writers serialize on the parent collection row via
+--   FOR NO KEY UPDATE under READ COMMITTED — low-volume admin paths only.
+-- Rollback compatibility: additive only; dropping triggers/functions in a later
+--   contract migration restores pre-0036 grant semantics.
+
+-- Preflight: fail deterministically with sorted collection IDs when dormant
+-- group/role grants already exist on non-groups collections. Never silently
+-- delete or activate them.
+DO $$
+DECLARE
+    bad_ids text;
+BEGIN
+    SELECT string_agg(bad.id::text, ', ' ORDER BY bad.id)
+    INTO bad_ids
+    FROM (
+        SELECT DISTINCT c.id
+        FROM collections c
+        WHERE c.visibility <> 'groups'
+          AND (
+              EXISTS (
+                  SELECT 1
+                  FROM collection_group_access g
+                  WHERE g.org_id = c.org_id
+                    AND g.collection_id = c.id
+              )
+              OR EXISTS (
+                  SELECT 1
+                  FROM collection_role_access r
+                  WHERE r.org_id = c.org_id
+                    AND r.collection_id = c.id
+              )
+          )
+    ) AS bad;
+    IF bad_ids IS NOT NULL THEN
+        RAISE EXCEPTION 'preflight: dormant group/role grants on non-groups collections: %', bad_ids;
+    END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION enforce_collection_group_role_grant_visibility()
+RETURNS trigger AS $$
+DECLARE
+    parent_visibility text;
+BEGIN
+    SELECT visibility
+    INTO parent_visibility
+    FROM collections
+    WHERE org_id = NEW.org_id AND id = NEW.collection_id
+    FOR NO KEY UPDATE;
+
+    IF parent_visibility IS NULL THEN
+        RAISE EXCEPTION 'collection % not found in org %', NEW.collection_id, NEW.org_id;
+    END IF;
+
+    IF parent_visibility <> 'groups' THEN
+        RAISE EXCEPTION 'group/role grants require collection visibility groups (got %)', parent_visibility;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS collection_group_access_enforce_visibility ON collection_group_access;
+CREATE TRIGGER collection_group_access_enforce_visibility
+    BEFORE INSERT OR UPDATE ON collection_group_access
+    FOR EACH ROW EXECUTE FUNCTION enforce_collection_group_role_grant_visibility();
+
+DROP TRIGGER IF EXISTS collection_role_access_enforce_visibility ON collection_role_access;
+CREATE TRIGGER collection_role_access_enforce_visibility
+    BEFORE INSERT OR UPDATE ON collection_role_access
+    FOR EACH ROW EXECUTE FUNCTION enforce_collection_group_role_grant_visibility();
+
+CREATE OR REPLACE FUNCTION enforce_collection_visibility_grant_invariant()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM 1
+    FROM collections
+    WHERE org_id = NEW.org_id AND id = NEW.id
+    FOR NO KEY UPDATE;
+
+    IF NEW.visibility <> 'groups' THEN
+        IF EXISTS (
+            SELECT 1
+            FROM collection_group_access g
+            WHERE g.org_id = NEW.org_id AND g.collection_id = NEW.id
+        ) OR EXISTS (
+            SELECT 1
+            FROM collection_role_access r
+            WHERE r.org_id = NEW.org_id AND r.collection_id = NEW.id
+        ) THEN
+            RAISE EXCEPTION 'cannot change visibility away from groups while group/role grants remain';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS collections_enforce_visibility_grant_invariant ON collections;
+CREATE TRIGGER collections_enforce_visibility_grant_invariant
+    BEFORE UPDATE OF visibility ON collections
+    FOR EACH ROW EXECUTE FUNCTION enforce_collection_visibility_grant_invariant();
+
+DROP TRIGGER IF EXISTS collection_group_access_bump_acl_version ON collection_group_access;
+CREATE TRIGGER collection_group_access_bump_acl_version
+    AFTER INSERT OR UPDATE OR DELETE ON collection_group_access
+    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version();
+
+DROP TRIGGER IF EXISTS collection_role_access_bump_acl_version ON collection_role_access;
+CREATE TRIGGER collection_role_access_bump_acl_version
+    AFTER INSERT OR UPDATE OR DELETE ON collection_role_access
+    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version();
+
+DROP TRIGGER IF EXISTS group_memberships_bump_acl_version ON group_memberships;
+CREATE TRIGGER group_memberships_bump_acl_version
+    AFTER INSERT OR UPDATE OR DELETE ON group_memberships
+    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version();

--- a/crates/server/migrations/manifest.json
+++ b/crates/server/migrations/manifest.json
@@ -35,6 +35,7 @@
     "0032_expand_projects.sql": "f3c1b556fb3f3304401b3188555cbdc48b243a0834c203ddec93fd5b47d78fb9",
     "0033_expand_acl_version_triggers.sql": "c4a51ae6e5a3676d9493d0174e0f5d41758d0b137ae3d94f7ce4c4a8573592a3",
     "0034_expand_qa_chat_history.sql": "383f7347cf1e09145a4dbf38df101949f571981dfb90b5287f5fa3c21c60ffc1",
-    "0035_expand_worker_role.sql": "0daa913d8dca0b6c6013f0aa3f854a924eb6b6832ffe93d6908016901a520c5b"
+    "0035_expand_worker_role.sql": "0daa913d8dca0b6c6013f0aa3f854a924eb6b6832ffe93d6908016901a520c5b",
+    "0036_expand_acl_groups_invariants.sql": "1978bf07503f8177eae47fe56499e1207db2e4acf07c858280e6676b6b32ad1b"
   }
 }

--- a/crates/server/migrations/manifest.json
+++ b/crates/server/migrations/manifest.json
@@ -36,6 +36,6 @@
     "0033_expand_acl_version_triggers.sql": "c4a51ae6e5a3676d9493d0174e0f5d41758d0b137ae3d94f7ce4c4a8573592a3",
     "0034_expand_qa_chat_history.sql": "383f7347cf1e09145a4dbf38df101949f571981dfb90b5287f5fa3c21c60ffc1",
     "0035_expand_worker_role.sql": "0daa913d8dca0b6c6013f0aa3f854a924eb6b6832ffe93d6908016901a520c5b",
-    "0036_expand_acl_groups_invariants.sql": "1978bf07503f8177eae47fe56499e1207db2e4acf07c858280e6676b6b32ad1b"
+    "0036_expand_acl_groups_invariants.sql": "5b0a3b478712d31da39dbee9677ba349d03f1f05dadc6b4c6f72250a19656b1c"
   }
 }

--- a/crates/server/src/auth/acl.rs
+++ b/crates/server/src/auth/acl.rs
@@ -34,12 +34,38 @@ pub struct CollectionAclSnapshot {
 
 /// Fail-closed collection ACL predicate (semantic reference).
 pub fn allowed(
-    _principal: &AclPrincipal,
-    _collection: &CollectionAclSnapshot,
-    _permission: &str,
-    _required_access: AccessLevel,
+    principal: &AclPrincipal,
+    collection: &CollectionAclSnapshot,
+    permission: &str,
+    required_access: AccessLevel,
 ) -> bool {
-    todo!("Phase 1C ACL semantics not implemented")
+    if !principal.membership_active
+        || principal.user_disabled
+        || principal.org_id != collection.org_id
+        || !principal.permissions.contains(permission)
+    {
+        return false;
+    }
+    let grant_allows = |grant: Option<AccessLevel>| {
+        grant.is_some_and(|level| level.satisfies(required_access))
+    };
+    match collection.visibility {
+        CollectionVisibility::Private => {
+            principal.user_id == collection.owner_user_id
+                || grant_allows(collection.user_grant)
+        }
+        CollectionVisibility::Org => true,
+        CollectionVisibility::Groups => {
+            principal.user_id == collection.owner_user_id
+                || grant_allows(collection.user_grant)
+                || collection
+                    .group_grants
+                    .iter()
+                    .copied()
+                    .any(|level| level.satisfies(required_access))
+                || grant_allows(collection.role_grant)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/auth/acl.rs
+++ b/crates/server/src/auth/acl.rs
@@ -291,6 +291,18 @@ mod tests {
     }
 
     #[test]
+    fn groups_denies_without_grants() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let collection = collection_snapshot(CollectionVisibility::Groups);
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
     fn access_level_ordering_read_write_admin() {
         assert!(AccessLevel::Read.satisfies(AccessLevel::Read));
         assert!(AccessLevel::Write.satisfies(AccessLevel::Read));

--- a/crates/server/src/auth/acl.rs
+++ b/crates/server/src/auth/acl.rs
@@ -1,0 +1,300 @@
+//! Canonical collection ACL semantics (Phase 1C).
+//!
+//! Pure predicate reference consumed by the org-context resolver, upload saga,
+//! FTS/hydration, and direct operation guards. PostgreSQL builders live in
+//! [`crate::db::acl_sql`].
+
+use std::collections::BTreeSet;
+
+use uuid::Uuid;
+
+use crate::db::models::{AccessLevel, CollectionVisibility};
+
+/// Principal snapshot for ACL evaluation (membership, user state, base permissions).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AclPrincipal {
+    pub org_id: Uuid,
+    pub user_id: Uuid,
+    pub membership_active: bool,
+    pub user_disabled: bool,
+    pub permissions: BTreeSet<String>,
+}
+
+/// Collection ACL snapshot for pure predicate evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CollectionAclSnapshot {
+    pub collection_id: Uuid,
+    pub org_id: Uuid,
+    pub owner_user_id: Uuid,
+    pub visibility: CollectionVisibility,
+    pub user_grant: Option<AccessLevel>,
+    pub group_grants: Vec<AccessLevel>,
+    pub role_grant: Option<AccessLevel>,
+}
+
+/// Fail-closed collection ACL predicate (semantic reference).
+pub fn allowed(
+    _principal: &AclPrincipal,
+    _collection: &CollectionAclSnapshot,
+    _permission: &str,
+    _required_access: AccessLevel,
+) -> bool {
+    todo!("Phase 1C ACL semantics not implemented")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PERMISSION: &str = "qa.query";
+
+    fn org_id() -> Uuid {
+        Uuid::from_u128(1)
+    }
+
+    fn user_id() -> Uuid {
+        Uuid::from_u128(2)
+    }
+
+    fn other_user_id() -> Uuid {
+        Uuid::from_u128(3)
+    }
+
+    fn collection_id() -> Uuid {
+        Uuid::from_u128(4)
+    }
+
+    fn principal_with_permissions(permissions: &[&str]) -> AclPrincipal {
+        AclPrincipal {
+            org_id: org_id(),
+            user_id: user_id(),
+            membership_active: true,
+            user_disabled: false,
+            permissions: permissions.iter().map(|p| (*p).to_string()).collect(),
+        }
+    }
+
+    fn collection_snapshot(visibility: CollectionVisibility) -> CollectionAclSnapshot {
+        CollectionAclSnapshot {
+            collection_id: collection_id(),
+            org_id: org_id(),
+            owner_user_id: other_user_id(),
+            visibility,
+            user_grant: None,
+            group_grants: Vec::new(),
+            role_grant: None,
+        }
+    }
+
+    #[test]
+    fn inactive_membership_denies() {
+        let mut principal = principal_with_permissions(&[PERMISSION]);
+        principal.membership_active = false;
+        let collection = collection_snapshot(CollectionVisibility::Org);
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn disabled_user_denies() {
+        let mut principal = principal_with_permissions(&[PERMISSION]);
+        principal.user_disabled = true;
+        let collection = collection_snapshot(CollectionVisibility::Org);
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn missing_base_permission_denies() {
+        let principal = principal_with_permissions(&[]);
+        let collection = collection_snapshot(CollectionVisibility::Org);
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn org_mismatch_denies() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Org);
+        collection.org_id = Uuid::from_u128(99);
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn private_ignores_group_grant() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Private);
+        collection.group_grants = vec![AccessLevel::Admin];
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn private_ignores_role_grant() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Private);
+        collection.role_grant = Some(AccessLevel::Admin);
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn private_allows_owner() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Private);
+        collection.owner_user_id = principal.user_id;
+        assert!(allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn private_allows_sufficient_direct_user_grant() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Private);
+        collection.user_grant = Some(AccessLevel::Write);
+        assert!(allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn private_denies_insufficient_direct_user_grant() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Private);
+        collection.user_grant = Some(AccessLevel::Read);
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Write
+        ));
+    }
+
+    #[test]
+    fn org_allows_active_member_with_base_permission() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let collection = collection_snapshot(CollectionVisibility::Org);
+        assert!(allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn groups_allows_sufficient_user_grant() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Groups);
+        collection.user_grant = Some(AccessLevel::Write);
+        assert!(allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn groups_allows_sufficient_group_grant() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Groups);
+        collection.group_grants = vec![AccessLevel::Write];
+        assert!(allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn groups_allows_sufficient_role_grant() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Groups);
+        collection.role_grant = Some(AccessLevel::Write);
+        assert!(allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn groups_allows_owner_without_explicit_grant() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Groups);
+        collection.owner_user_id = principal.user_id;
+        assert!(allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Read
+        ));
+    }
+
+    #[test]
+    fn access_level_ordering_read_write_admin() {
+        assert!(AccessLevel::Read.satisfies(AccessLevel::Read));
+        assert!(AccessLevel::Write.satisfies(AccessLevel::Read));
+        assert!(AccessLevel::Write.satisfies(AccessLevel::Write));
+        assert!(AccessLevel::Admin.satisfies(AccessLevel::Read));
+        assert!(AccessLevel::Admin.satisfies(AccessLevel::Write));
+        assert!(AccessLevel::Admin.satisfies(AccessLevel::Admin));
+        assert!(!AccessLevel::Read.satisfies(AccessLevel::Write));
+        assert!(!AccessLevel::Read.satisfies(AccessLevel::Admin));
+        assert!(!AccessLevel::Write.satisfies(AccessLevel::Admin));
+    }
+
+    #[test]
+    fn read_grant_never_satisfies_write_or_admin() {
+        let principal = principal_with_permissions(&[PERMISSION]);
+        let mut collection = collection_snapshot(CollectionVisibility::Groups);
+        collection.user_grant = Some(AccessLevel::Read);
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Write
+        ));
+        assert!(!allowed(
+            &principal,
+            &collection,
+            PERMISSION,
+            AccessLevel::Admin
+        ));
+    }
+}

--- a/crates/server/src/auth/acl.rs
+++ b/crates/server/src/auth/acl.rs
@@ -46,13 +46,11 @@ pub fn allowed(
     {
         return false;
     }
-    let grant_allows = |grant: Option<AccessLevel>| {
-        grant.is_some_and(|level| level.satisfies(required_access))
-    };
+    let grant_allows =
+        |grant: Option<AccessLevel>| grant.is_some_and(|level| level.satisfies(required_access));
     match collection.visibility {
         CollectionVisibility::Private => {
-            principal.user_id == collection.owner_user_id
-                || grant_allows(collection.user_grant)
+            principal.user_id == collection.owner_user_id || grant_allows(collection.user_grant)
         }
         CollectionVisibility::Org => true,
         CollectionVisibility::Groups => {

--- a/crates/server/src/auth/mod.rs
+++ b/crates/server/src/auth/mod.rs
@@ -1,5 +1,6 @@
 //! Authentication and tenant context (ADR 0007 / ADR 0010).
 
+pub mod acl;
 pub mod context;
 pub mod context_cache;
 pub mod jwt;

--- a/crates/server/src/auth/permissions.rs
+++ b/crates/server/src/auth/permissions.rs
@@ -6,7 +6,12 @@ use tokio_postgres::Transaction;
 use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
+use crate::db::acl_sql::{acl_predicate_sql, allowed_collections_sql};
 use crate::db::error::DbError;
+use crate::db::models::AccessLevel;
+
+/// Base permission for the org-context collection allow-list (`read` access).
+pub const COLLECTION_SCOPE_PERMISSION: &str = "qa.query";
 
 /// Failures when resolving authorization from current PG membership state.
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -86,28 +91,7 @@ pub async fn resolve_org_context(
         .map_err(|_| ResolveError::Database)?;
     let permissions: Vec<String> = permission_rows.iter().map(|row| row.get(0)).collect();
 
-    // POC collection allow-list (full ACL is Phase 1C): org-visible, owned, or direct user grant.
-    let collection_rows = client
-        .query(
-            "SELECT c.id
-             FROM collections c
-             WHERE c.org_id = $1
-               AND c.deleted_at IS NULL
-               AND (
-                 c.visibility = 'org'
-                 OR c.owner_user_id = $2
-                 OR EXISTS (
-                   SELECT 1 FROM collection_user_access cua
-                   WHERE cua.org_id = c.org_id
-                     AND cua.collection_id = c.id
-                     AND cua.user_id = $2
-                 )
-               )",
-            &[&org_id, &user_id],
-        )
-        .await
-        .map_err(|_| ResolveError::Database)?;
-    let collections: Vec<Uuid> = collection_rows.iter().map(|row| row.get(0)).collect();
+    let collections = query_allowed_collection_ids_client(client, org_id, user_id).await?;
 
     OrgContext::try_new(org_id, user_id, permissions, collections)
         .map_err(|_| ResolveError::InvalidContext)
@@ -185,29 +169,82 @@ pub async fn resolve_org_context_on_txn(
         .await
         .map_err(|_| ResolveError::Database)?;
     let permissions: Vec<String> = permission_rows.iter().map(|row| row.get(0)).collect();
-    let collection_rows = txn
-        .query(
-            "SELECT c.id
-             FROM collections c
-             WHERE c.org_id = $1
-               AND c.deleted_at IS NULL
-               AND (
-                 c.visibility = 'org'
-                 OR c.owner_user_id = $2
-                 OR EXISTS (
-                   SELECT 1 FROM collection_user_access cua
-                   WHERE cua.org_id = c.org_id
-                     AND cua.collection_id = c.id
-                     AND cua.user_id = $2
-                 )
-               )",
-            &[&org_id, &user_id],
-        )
-        .await
-        .map_err(|_| ResolveError::Database)?;
-    let collections: Vec<Uuid> = collection_rows.iter().map(|row| row.get(0)).collect();
+    let collections = query_allowed_collection_ids_on_txn(txn, org_id, user_id).await?;
     OrgContext::try_new(org_id, user_id, permissions, collections)
         .map_err(|_| ResolveError::InvalidContext)
+}
+
+/// Fail-closed collection ACL gate for write/admin services (PR 3 inventory).
+pub async fn require_operation_collection_access_on_txn(
+    txn: &Transaction<'_>,
+    ctx: &OrgContext,
+    collection_id: Uuid,
+    permission: &str,
+    required_access: AccessLevel,
+) -> Result<(), ResolveError> {
+    require_permission(ctx, permission)?;
+    let sql = format!(
+        "SELECT EXISTS (
+           SELECT 1 FROM collections c
+           WHERE c.org_id = $1 AND c.id = $2 AND c.deleted_at IS NULL AND ({})
+         )",
+        acl_predicate_sql("c.org_id", "c.id", "$3", "$4", "$5")
+    );
+    let allowed: bool = txn
+        .query_one(
+            &sql,
+            &[
+                &ctx.org_id(),
+                &collection_id,
+                &ctx.user_id(),
+                &permission,
+                &required_access.as_str(),
+            ],
+        )
+        .await
+        .map_err(|_| ResolveError::Database)?
+        .get(0);
+    if allowed {
+        Ok(())
+    } else {
+        Err(ResolveError::CollectionDenied)
+    }
+}
+
+async fn query_allowed_collection_ids_client(
+    client: &Client,
+    org_id: Uuid,
+    user_id: Uuid,
+) -> Result<Vec<Uuid>, ResolveError> {
+    let sql = format!(
+        "SELECT c.id FROM collections c WHERE {}",
+        allowed_collections_sql("$1", "$2", "$3", "$4")
+    );
+    let permission = COLLECTION_SCOPE_PERMISSION;
+    let access = AccessLevel::Read.as_str();
+    let rows = client
+        .query(&sql, &[&org_id, &user_id, &permission, &access])
+        .await
+        .map_err(|_| ResolveError::Database)?;
+    Ok(rows.iter().map(|row| row.get(0)).collect())
+}
+
+async fn query_allowed_collection_ids_on_txn(
+    txn: &Transaction<'_>,
+    org_id: Uuid,
+    user_id: Uuid,
+) -> Result<Vec<Uuid>, ResolveError> {
+    let sql = format!(
+        "SELECT c.id FROM collections c WHERE {}",
+        allowed_collections_sql("$1", "$2", "$3", "$4")
+    );
+    let permission = COLLECTION_SCOPE_PERMISSION;
+    let access = AccessLevel::Read.as_str();
+    let rows = txn
+        .query(&sql, &[&org_id, &user_id, &permission, &access])
+        .await
+        .map_err(|_| ResolveError::Database)?;
+    Ok(rows.iter().map(|row| row.get(0)).collect())
 }
 
 /// Convenience: resolve inside a transaction-local org GUC scope.

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -434,4 +434,65 @@ mod tests {
         assert!(source.contains("'pending', 'writing', 'cleaned', 'committed'"));
         assert!(source.contains("status = 'committed'"));
     }
+
+    #[test]
+    fn acl_groups_invariants_migration_shape() {
+        let source = MIGRATIONS
+            .iter()
+            .find(|(name, _)| *name == "0036_expand_acl_groups_invariants.sql")
+            .expect("0036 ACL groups invariants migration")
+            .1;
+
+        assert!(
+            source.contains("ORDER BY bad.id"),
+            "preflight must report sorted collection IDs"
+        );
+        assert!(
+            source.contains("preflight"),
+            "migration must include a preflight guard for dormant grants"
+        );
+        assert!(
+            source.contains("FOR NO KEY UPDATE"),
+            "grant triggers must lock the parent collection row"
+        );
+
+        for table in ["collection_group_access", "collection_role_access"] {
+            assert!(
+                source.contains(&format!(
+                    "BEFORE INSERT OR UPDATE ON {table}\n    FOR EACH ROW"
+                )),
+                "{table} must have a BEFORE INSERT OR UPDATE visibility guard"
+            );
+            assert!(
+                source.contains(&format!(
+                    "WHERE org_id = NEW.org_id AND id = NEW.collection_id\n    FOR NO KEY UPDATE"
+                )) || source.contains(
+                    "WHERE org_id = NEW.org_id AND id = NEW.collection_id FOR NO KEY UPDATE"
+                ),
+                "{table} grant trigger must lock parent by org_id + collection_id"
+            );
+        }
+
+        assert!(
+            source.contains("BEFORE UPDATE OF visibility ON collections"),
+            "collections must guard visibility transitions away from groups"
+        );
+        assert!(
+            source.contains("NEW.visibility <> 'groups'"),
+            "visibility guard must fire when leaving groups"
+        );
+
+        for table in [
+            "collection_group_access",
+            "collection_role_access",
+            "group_memberships",
+        ] {
+            assert!(
+                source.contains(&format!(
+                    "ON {table}\n    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version()"
+                )),
+                "{table} must bump org acl_version"
+            );
+        }
+    }
 }

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -459,13 +459,46 @@ mod tests {
             source.contains("FOR NO KEY UPDATE"),
             "grant triggers must lock the parent collection row"
         );
+        assert!(
+            source.contains("OLD.org_id IS DISTINCT FROM NEW.org_id"),
+            "grant trigger must reject in-place org_id retargeting"
+        );
+        assert!(
+            source.contains("OLD.collection_id IS DISTINCT FROM NEW.collection_id"),
+            "grant trigger must reject in-place collection_id retargeting"
+        );
+        assert!(
+            source.contains("delete and re-insert"),
+            "grant retarget rejection must direct callers to delete+insert"
+        );
+        assert!(
+            source.contains("CREATE OR REPLACE FUNCTION bump_org_acl_version()"),
+            "0036 must replace the shared bump_org_acl_version function"
+        );
+        assert!(
+            source.contains("OLD.org_id IS DISTINCT FROM NEW.org_id")
+                && source
+                    .matches("UPDATE orgs SET acl_version = acl_version + 1")
+                    .count()
+                    >= 2,
+            "bump_org_acl_version must bump both OLD and NEW orgs on cross-org UPDATE"
+        );
 
-        for table in ["collection_group_access", "collection_role_access"] {
+        for (table, trigger) in [
+            (
+                "collection_group_access",
+                "collection_group_access_enforce_visibility",
+            ),
+            (
+                "collection_role_access",
+                "collection_role_access_enforce_visibility",
+            ),
+        ] {
             assert!(
                 source.contains(&format!(
-                    "BEFORE INSERT OR UPDATE ON {table}\n    FOR EACH ROW"
+                    "CREATE TRIGGER {trigger}\n    BEFORE INSERT OR UPDATE ON {table}"
                 )),
-                "{table} must have a BEFORE INSERT OR UPDATE visibility guard"
+                "{table} must have a named BEFORE INSERT OR UPDATE visibility guard"
             );
             assert!(
                 source.contains(&format!(
@@ -478,24 +511,32 @@ mod tests {
         }
 
         assert!(
-            source.contains("BEFORE UPDATE OF visibility ON collections"),
-            "collections must guard visibility transitions away from groups"
+            source.contains(
+                "CREATE TRIGGER collections_enforce_visibility_grant_invariant\n    BEFORE UPDATE OF visibility ON collections"
+            ),
+            "collections must have a named visibility transition guard"
         );
         assert!(
             source.contains("NEW.visibility <> 'groups'"),
             "visibility guard must fire when leaving groups"
         );
 
-        for table in [
-            "collection_group_access",
-            "collection_role_access",
-            "group_memberships",
+        for (table, trigger) in [
+            (
+                "collection_group_access",
+                "collection_group_access_bump_acl_version",
+            ),
+            (
+                "collection_role_access",
+                "collection_role_access_bump_acl_version",
+            ),
+            ("group_memberships", "group_memberships_bump_acl_version"),
         ] {
             assert!(
                 source.contains(&format!(
-                    "ON {table}\n    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version()"
+                    "CREATE TRIGGER {trigger}\n    AFTER INSERT OR UPDATE OR DELETE ON {table}\n    FOR EACH ROW EXECUTE FUNCTION bump_org_acl_version()"
                 )),
-                "{table} must bump org acl_version"
+                "{table} must have a named acl_version bump trigger"
             );
         }
     }

--- a/crates/server/src/database.rs
+++ b/crates/server/src/database.rs
@@ -146,6 +146,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0035_expand_worker_role.sql",
         include_str!("../migrations/0035_expand_worker_role.sql"),
     ),
+    (
+        "0036_expand_acl_groups_invariants.sql",
+        include_str!("../migrations/0036_expand_acl_groups_invariants.sql"),
+    ),
 ];
 
 /// Embedded migration sources in apply order (name, SQL). Used by integration tests.

--- a/crates/server/src/db/acl_sql.rs
+++ b/crates/server/src/db/acl_sql.rs
@@ -2,8 +2,11 @@
 //!
 //! Emits the same visibility and access-level branches as [`crate::auth::acl::allowed`].
 
-const ACCESS_LEVEL_RANK: &str =
-    "CASE access_level WHEN 'read' THEN 1 WHEN 'write' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END";
+fn access_level_rank_expr(column: &str) -> String {
+    format!(
+        "CASE {column} WHEN 'read' THEN 1 WHEN 'write' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END"
+    )
+}
 
 fn required_access_rank(required_access_param: &str) -> String {
     format!(
@@ -11,38 +14,45 @@ fn required_access_rank(required_access_param: &str) -> String {
     )
 }
 
-fn grant_meets_required(required_access_param: &str) -> String {
+fn grant_meets_required(grant_column: &str, required_access_param: &str) -> String {
     format!(
-        "({ACCESS_LEVEL_RANK}) >= ({})",
+        "({}) >= ({})",
+        access_level_rank_expr(grant_column),
         required_access_rank(required_access_param)
     )
 }
 
-fn visibility_route_sql(user_id_param: &str, required_access_param: &str) -> String {
-    let grant_meets = grant_meets_required(required_access_param);
+fn visibility_route_sql(
+    collection_alias: &str,
+    user_id_param: &str,
+    required_access_param: &str,
+) -> String {
+    let user_grant = grant_meets_required("cua.access_level", required_access_param);
+    let group_grant = grant_meets_required("cga.access_level", required_access_param);
+    let role_grant = grant_meets_required("cra.access_level", required_access_param);
     format!(
         "(
-           c.visibility = 'org'
-           OR c.owner_user_id = {user_id_param}
+           {collection_alias}.visibility = 'org'
+           OR {collection_alias}.owner_user_id = {user_id_param}
            OR (
-             c.visibility = 'private'
+             {collection_alias}.visibility = 'private'
              AND EXISTS (
                SELECT 1 FROM collection_user_access cua
-               WHERE cua.org_id = c.org_id
-                 AND cua.collection_id = c.id
+               WHERE cua.org_id = {collection_alias}.org_id
+                 AND cua.collection_id = {collection_alias}.id
                  AND cua.user_id = {user_id_param}
-                 AND {grant_meets}
+                 AND {user_grant}
              )
            )
            OR (
-             c.visibility = 'groups'
+             {collection_alias}.visibility = 'groups'
              AND (
                EXISTS (
                  SELECT 1 FROM collection_user_access cua
-                 WHERE cua.org_id = c.org_id
-                   AND cua.collection_id = c.id
+                 WHERE cua.org_id = {collection_alias}.org_id
+                   AND cua.collection_id = {collection_alias}.id
                    AND cua.user_id = {user_id_param}
-                   AND {grant_meets}
+                   AND {user_grant}
                )
                OR EXISTS (
                  SELECT 1 FROM collection_group_access cga
@@ -50,9 +60,9 @@ fn visibility_route_sql(user_id_param: &str, required_access_param: &str) -> Str
                    ON gm.org_id = cga.org_id
                   AND gm.group_id = cga.group_id
                   AND gm.user_id = {user_id_param}
-                 WHERE cga.org_id = c.org_id
-                   AND cga.collection_id = c.id
-                   AND {grant_meets}
+                 WHERE cga.org_id = {collection_alias}.org_id
+                   AND cga.collection_id = {collection_alias}.id
+                   AND {group_grant}
                )
                OR EXISTS (
                  SELECT 1 FROM collection_role_access cra
@@ -64,9 +74,9 @@ fn visibility_route_sql(user_id_param: &str, required_access_param: &str) -> Str
                   AND cra_m.user_id = {user_id_param}
                   AND cra_m.role = cra_r.code
                   AND cra_m.state = 'active'
-                 WHERE cra.org_id = c.org_id
-                   AND cra.collection_id = c.id
-                   AND {grant_meets}
+                 WHERE cra.org_id = {collection_alias}.org_id
+                   AND cra.collection_id = {collection_alias}.id
+                   AND {role_grant}
                )
              )
            )
@@ -98,7 +108,10 @@ fn membership_permission_exists_sql(
     )
 }
 
-/// SQL fragment listing collection ids visible to a principal for a permission/access pair.
+/// WHERE predicate for collection rows visible to a principal.
+///
+/// The outer query must alias the `collections` row as `c` (for example
+/// `FROM collections c WHERE ... AND ({allowed_collections_sql(...)})`).
 pub fn allowed_collections_sql(
     org_id_param: &str,
     user_id_param: &str,
@@ -107,7 +120,7 @@ pub fn allowed_collections_sql(
 ) -> String {
     let membership =
         membership_permission_exists_sql(org_id_param, user_id_param, permission_param);
-    let visibility = visibility_route_sql(user_id_param, required_access_param);
+    let visibility = visibility_route_sql("c", user_id_param, required_access_param);
     format!(
         "c.org_id = {org_id_param}
          AND c.deleted_at IS NULL
@@ -124,7 +137,7 @@ pub fn acl_predicate_sql(
     permission_param: &str,
     required_access_param: &str,
 ) -> String {
-    let grant_meets = grant_meets_required(required_access_param);
+    let visibility = visibility_route_sql("acl_c", user_id_param, required_access_param);
     format!(
         "EXISTS (
            SELECT 1
@@ -143,56 +156,7 @@ pub fn acl_predicate_sql(
              AND acl_c.deleted_at IS NULL
              AND acl_u.disabled_at IS NULL
              AND acl_p.code = {permission_param}
-             AND (
-               acl_c.visibility = 'org'
-               OR acl_c.owner_user_id = {user_id_param}
-               OR (
-                 acl_c.visibility = 'private'
-                 AND EXISTS (
-                   SELECT 1 FROM collection_user_access cua
-                   WHERE cua.org_id = acl_c.org_id
-                     AND cua.collection_id = acl_c.id
-                     AND cua.user_id = {user_id_param}
-                     AND {grant_meets}
-                 )
-               )
-               OR (
-                 acl_c.visibility = 'groups'
-                 AND (
-                   EXISTS (
-                     SELECT 1 FROM collection_user_access cua
-                     WHERE cua.org_id = acl_c.org_id
-                       AND cua.collection_id = acl_c.id
-                       AND cua.user_id = {user_id_param}
-                       AND {grant_meets}
-                   )
-                   OR EXISTS (
-                     SELECT 1 FROM collection_group_access cga
-                     JOIN group_memberships gm
-                       ON gm.org_id = cga.org_id
-                      AND gm.group_id = cga.group_id
-                      AND gm.user_id = {user_id_param}
-                     WHERE cga.org_id = acl_c.org_id
-                       AND cga.collection_id = acl_c.id
-                       AND {grant_meets}
-                   )
-                   OR EXISTS (
-                     SELECT 1 FROM collection_role_access cra
-                     JOIN roles cra_r
-                       ON cra_r.org_id = cra.org_id
-                      AND cra_r.id = cra.role_id
-                     JOIN org_memberships cra_m
-                       ON cra_m.org_id = cra_r.org_id
-                      AND cra_m.user_id = {user_id_param}
-                      AND cra_m.role = cra_r.code
-                      AND cra_m.state = 'active'
-                     WHERE cra.org_id = acl_c.org_id
-                       AND cra.collection_id = acl_c.id
-                       AND {grant_meets}
-                   )
-                 )
-               )
-             )
+             AND {visibility}
          )"
     )
 }
@@ -201,8 +165,9 @@ pub fn acl_predicate_sql(
 mod tests {
     use super::*;
 
-    const ACCESS_LEVEL_RANK: &str =
-        "CASE access_level WHEN 'read' THEN 1 WHEN 'write' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END";
+    fn qualified_access_level_rank(column: &str) -> String {
+        access_level_rank_expr(column)
+    }
 
     fn visibility_arm<'a>(sql: &'a str, collection_alias: &str, visibility: &str) -> &'a str {
         let marker = format!("{collection_alias}.visibility = '{visibility}'");
@@ -257,15 +222,21 @@ mod tests {
     #[test]
     fn access_level_rank_expression_is_canonical() {
         let sql = allowed_collections_sql("$1", "$2", "$3", "$4");
-        assert!(
-            sql.contains(ACCESS_LEVEL_RANK),
-            "allowed_collections_sql must use canonical access_level rank expression;\ngot:\n{sql}"
-        );
+        for column in ["cua.access_level", "cga.access_level", "cra.access_level"] {
+            let expected = qualified_access_level_rank(column);
+            assert!(
+                sql.contains(&expected),
+                "allowed_collections_sql must qualify rank on {column};\ngot:\n{sql}"
+            );
+        }
         let predicate = acl_predicate_sql("c.org_id", "c.id", "$3", "$4", "$5");
-        assert!(
-            predicate.contains(ACCESS_LEVEL_RANK),
-            "acl_predicate_sql must use canonical access_level rank expression;\ngot:\n{predicate}"
-        );
+        for column in ["cua.access_level", "cga.access_level", "cra.access_level"] {
+            let expected = qualified_access_level_rank(column);
+            assert!(
+                predicate.contains(&expected),
+                "acl_predicate_sql must qualify rank on {column};\ngot:\n{predicate}"
+            );
+        }
     }
 
     #[test]
@@ -286,7 +257,9 @@ mod tests {
             "collection_group_access",
             "collection_role_access",
             "$4",
-            ACCESS_LEVEL_RANK,
+            "cua.access_level",
+            "cga.access_level",
+            "cra.access_level",
         ] {
             assert!(
                 sql.contains(expected),
@@ -316,7 +289,9 @@ mod tests {
             "collection_group_access",
             "collection_role_access",
             "$6",
-            ACCESS_LEVEL_RANK,
+            "cua.access_level",
+            "cga.access_level",
+            "cra.access_level",
         ] {
             assert!(
                 sql.contains(expected),

--- a/crates/server/src/db/acl_sql.rs
+++ b/crates/server/src/db/acl_sql.rs
@@ -2,25 +2,195 @@
 //!
 //! Emits the same visibility and access-level branches as [`crate::auth::acl::allowed`].
 
+const ACCESS_LEVEL_RANK: &str =
+    "CASE access_level WHEN 'read' THEN 1 WHEN 'write' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END";
+
+fn required_access_rank(required_access_param: &str) -> String {
+    format!(
+        "CASE {required_access_param} WHEN 'read' THEN 1 WHEN 'write' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END"
+    )
+}
+
+fn grant_meets_required(required_access_param: &str) -> String {
+    format!("({ACCESS_LEVEL_RANK}) >= ({})", required_access_rank(required_access_param))
+}
+
+fn visibility_route_sql(user_id_param: &str, required_access_param: &str) -> String {
+    let grant_meets = grant_meets_required(required_access_param);
+    format!(
+        "(
+           c.visibility = 'org'
+           OR c.owner_user_id = {user_id_param}
+           OR (
+             c.visibility = 'private'
+             AND EXISTS (
+               SELECT 1 FROM collection_user_access cua
+               WHERE cua.org_id = c.org_id
+                 AND cua.collection_id = c.id
+                 AND cua.user_id = {user_id_param}
+                 AND {grant_meets}
+             )
+           )
+           OR (
+             c.visibility = 'groups'
+             AND (
+               EXISTS (
+                 SELECT 1 FROM collection_user_access cua
+                 WHERE cua.org_id = c.org_id
+                   AND cua.collection_id = c.id
+                   AND cua.user_id = {user_id_param}
+                   AND {grant_meets}
+               )
+               OR EXISTS (
+                 SELECT 1 FROM collection_group_access cga
+                 JOIN group_memberships gm
+                   ON gm.org_id = cga.org_id
+                  AND gm.group_id = cga.group_id
+                  AND gm.user_id = {user_id_param}
+                 WHERE cga.org_id = c.org_id
+                   AND cga.collection_id = c.id
+                   AND {grant_meets}
+               )
+               OR EXISTS (
+                 SELECT 1 FROM collection_role_access cra
+                 JOIN roles cra_r
+                   ON cra_r.org_id = cra.org_id
+                  AND cra_r.id = cra.role_id
+                 JOIN org_memberships cra_m
+                   ON cra_m.org_id = cra_r.org_id
+                  AND cra_m.user_id = {user_id_param}
+                  AND cra_m.role = cra_r.code
+                  AND cra_m.state = 'active'
+                 WHERE cra.org_id = c.org_id
+                   AND cra.collection_id = c.id
+                   AND {grant_meets}
+               )
+             )
+           )
+         )"
+    )
+}
+
+fn membership_permission_exists_sql(
+    org_id_param: &str,
+    user_id_param: &str,
+    permission_param: &str,
+) -> String {
+    format!(
+        "EXISTS (
+           SELECT 1
+           FROM org_memberships m
+           JOIN users u ON u.id = m.user_id
+           JOIN roles r
+             ON r.org_id = m.org_id AND r.code = m.role
+           JOIN role_permissions rp
+             ON rp.org_id = r.org_id AND rp.role_id = r.id
+           JOIN permissions p ON p.id = rp.permission_id
+           WHERE m.org_id = {org_id_param}
+             AND m.user_id = {user_id_param}
+             AND m.state = 'active'
+             AND u.disabled_at IS NULL
+             AND p.code = {permission_param}
+         )"
+    )
+}
+
 /// SQL fragment listing collection ids visible to a principal for a permission/access pair.
 pub fn allowed_collections_sql(
-    _org_id_param: &str,
-    _user_id_param: &str,
-    _permission_param: &str,
-    _required_access_param: &str,
+    org_id_param: &str,
+    user_id_param: &str,
+    permission_param: &str,
+    required_access_param: &str,
 ) -> String {
-    String::new()
+    let membership = membership_permission_exists_sql(org_id_param, user_id_param, permission_param);
+    let visibility = visibility_route_sql(user_id_param, required_access_param);
+    format!(
+        "c.org_id = {org_id_param}
+         AND c.deleted_at IS NULL
+         AND {membership}
+         AND {visibility}"
+    )
 }
 
 /// EXISTS predicate gating chunk/claim/document reads by collection ACL.
 pub fn acl_predicate_sql(
-    _org_id_expr: &str,
-    _collection_id_expr: &str,
-    _user_id_param: &str,
-    _permission_param: &str,
-    _required_access_param: &str,
+    org_id_expr: &str,
+    collection_id_expr: &str,
+    user_id_param: &str,
+    permission_param: &str,
+    required_access_param: &str,
 ) -> String {
-    String::new()
+    let grant_meets = grant_meets_required(required_access_param);
+    format!(
+        "EXISTS (
+           SELECT 1
+           FROM collections acl_c
+           JOIN org_memberships acl_m
+             ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = {user_id_param}
+            AND acl_m.state = 'active'
+           JOIN users acl_u ON acl_u.id = acl_m.user_id
+           JOIN roles acl_r
+             ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
+           JOIN role_permissions acl_rp
+             ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
+           JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
+           WHERE acl_c.org_id = {org_id_expr}
+             AND acl_c.id = {collection_id_expr}
+             AND acl_c.deleted_at IS NULL
+             AND acl_u.disabled_at IS NULL
+             AND acl_p.code = {permission_param}
+             AND (
+               acl_c.visibility = 'org'
+               OR acl_c.owner_user_id = {user_id_param}
+               OR (
+                 acl_c.visibility = 'private'
+                 AND EXISTS (
+                   SELECT 1 FROM collection_user_access cua
+                   WHERE cua.org_id = acl_c.org_id
+                     AND cua.collection_id = acl_c.id
+                     AND cua.user_id = {user_id_param}
+                     AND {grant_meets}
+                 )
+               )
+               OR (
+                 acl_c.visibility = 'groups'
+                 AND (
+                   EXISTS (
+                     SELECT 1 FROM collection_user_access cua
+                     WHERE cua.org_id = acl_c.org_id
+                       AND cua.collection_id = acl_c.id
+                       AND cua.user_id = {user_id_param}
+                       AND {grant_meets}
+                   )
+                   OR EXISTS (
+                     SELECT 1 FROM collection_group_access cga
+                     JOIN group_memberships gm
+                       ON gm.org_id = cga.org_id
+                      AND gm.group_id = cga.group_id
+                      AND gm.user_id = {user_id_param}
+                     WHERE cga.org_id = acl_c.org_id
+                       AND cga.collection_id = acl_c.id
+                       AND {grant_meets}
+                   )
+                   OR EXISTS (
+                     SELECT 1 FROM collection_role_access cra
+                     JOIN roles cra_r
+                       ON cra_r.org_id = cra.org_id
+                      AND cra_r.id = cra.role_id
+                     JOIN org_memberships cra_m
+                       ON cra_m.org_id = cra_r.org_id
+                      AND cra_m.user_id = {user_id_param}
+                      AND cra_m.role = cra_r.code
+                      AND cra_m.state = 'active'
+                     WHERE cra.org_id = acl_c.org_id
+                       AND cra.collection_id = acl_c.id
+                       AND {grant_meets}
+                   )
+                 )
+               )
+             )
+         )"
+    )
 }
 
 #[cfg(test)]

--- a/crates/server/src/db/acl_sql.rs
+++ b/crates/server/src/db/acl_sql.rs
@@ -204,6 +204,56 @@ mod tests {
     const ACCESS_LEVEL_RANK: &str =
         "CASE access_level WHEN 'read' THEN 1 WHEN 'write' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END";
 
+    fn visibility_arm<'a>(sql: &'a str, collection_alias: &str, visibility: &str) -> &'a str {
+        let marker = format!("{collection_alias}.visibility = '{visibility}'");
+        let start = sql
+            .find(&marker)
+            .unwrap_or_else(|| panic!("missing visibility marker {marker:?} in:\n{sql}"));
+        let end = if visibility == "private" {
+            let groups_marker = format!("{collection_alias}.visibility = 'groups'");
+            sql[start..]
+                .find(&groups_marker)
+                .map(|offset| start + offset)
+                .unwrap_or(sql.len())
+        } else {
+            sql.len()
+        };
+        &sql[start..end]
+    }
+
+    fn assert_private_arm_isolated(sql: &str, collection_alias: &str) {
+        let arm = visibility_arm(sql, collection_alias, "private");
+        assert!(
+            arm.contains("collection_user_access"),
+            "private arm must allow direct user grants:\n{arm}"
+        );
+        for forbidden in [
+            "collection_group_access",
+            "collection_role_access",
+            "group_memberships",
+        ] {
+            assert!(
+                !arm.contains(forbidden),
+                "private arm must not reference {forbidden}:\n{arm}"
+            );
+        }
+    }
+
+    fn assert_groups_arm_has_grant_branches(sql: &str, collection_alias: &str) {
+        let arm = visibility_arm(sql, collection_alias, "groups");
+        for required in [
+            "collection_user_access",
+            "collection_group_access",
+            "collection_role_access",
+            "group_memberships",
+        ] {
+            assert!(
+                arm.contains(required),
+                "groups arm must reference {required}:\n{arm}"
+            );
+        }
+    }
+
     #[test]
     fn access_level_rank_expression_is_canonical() {
         let sql = allowed_collections_sql("$1", "$2", "$3", "$4");
@@ -273,5 +323,56 @@ mod tests {
                 "acl_predicate_sql missing required clause {expected:?} in:\n{sql}"
             );
         }
+    }
+
+    #[test]
+    fn visibility_markers_are_pinned_in_allowed_collections_sql() {
+        let sql = allowed_collections_sql("$1", "$2", "$3", "$4");
+        for marker in ["c.visibility = 'org'", "c.visibility = 'private'", "c.visibility = 'groups'"]
+        {
+            assert!(
+                sql.contains(marker),
+                "allowed_collections_sql missing visibility marker {marker:?} in:\n{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn visibility_markers_are_pinned_in_acl_predicate_sql() {
+        let sql = acl_predicate_sql("d.org_id", "d.collection_id", "$4", "$5", "$6");
+        for marker in [
+            "acl_c.visibility = 'org'",
+            "acl_c.visibility = 'private'",
+            "acl_c.visibility = 'groups'",
+        ] {
+            assert!(
+                sql.contains(marker),
+                "acl_predicate_sql missing visibility marker {marker:?} in:\n{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn allowed_collections_private_arm_has_no_group_or_role_leak() {
+        let sql = allowed_collections_sql("$1", "$2", "$3", "$4");
+        assert_private_arm_isolated(&sql, "c");
+    }
+
+    #[test]
+    fn acl_predicate_private_arm_has_no_group_or_role_leak() {
+        let sql = acl_predicate_sql("d.org_id", "d.collection_id", "$4", "$5", "$6");
+        assert_private_arm_isolated(&sql, "acl_c");
+    }
+
+    #[test]
+    fn allowed_collections_groups_arm_has_group_and_role_branches() {
+        let sql = allowed_collections_sql("$1", "$2", "$3", "$4");
+        assert_groups_arm_has_grant_branches(&sql, "c");
+    }
+
+    #[test]
+    fn acl_predicate_groups_arm_has_group_and_role_branches() {
+        let sql = acl_predicate_sql("d.org_id", "d.collection_id", "$4", "$5", "$6");
+        assert_groups_arm_has_grant_branches(&sql, "acl_c");
     }
 }

--- a/crates/server/src/db/acl_sql.rs
+++ b/crates/server/src/db/acl_sql.rs
@@ -3,9 +3,7 @@
 //! Emits the same visibility and access-level branches as [`crate::auth::acl::allowed`].
 
 fn access_level_rank_expr(column: &str) -> String {
-    format!(
-        "CASE {column} WHEN 'read' THEN 1 WHEN 'write' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END"
-    )
+    format!("CASE {column} WHEN 'read' THEN 1 WHEN 'write' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END")
 }
 
 fn required_access_rank(required_access_param: &str) -> String {
@@ -303,8 +301,11 @@ mod tests {
     #[test]
     fn visibility_markers_are_pinned_in_allowed_collections_sql() {
         let sql = allowed_collections_sql("$1", "$2", "$3", "$4");
-        for marker in ["c.visibility = 'org'", "c.visibility = 'private'", "c.visibility = 'groups'"]
-        {
+        for marker in [
+            "c.visibility = 'org'",
+            "c.visibility = 'private'",
+            "c.visibility = 'groups'",
+        ] {
             assert!(
                 sql.contains(marker),
                 "allowed_collections_sql missing visibility marker {marker:?} in:\n{sql}"

--- a/crates/server/src/db/acl_sql.rs
+++ b/crates/server/src/db/acl_sql.rs
@@ -12,7 +12,10 @@ fn required_access_rank(required_access_param: &str) -> String {
 }
 
 fn grant_meets_required(required_access_param: &str) -> String {
-    format!("({ACCESS_LEVEL_RANK}) >= ({})", required_access_rank(required_access_param))
+    format!(
+        "({ACCESS_LEVEL_RANK}) >= ({})",
+        required_access_rank(required_access_param)
+    )
 }
 
 fn visibility_route_sql(user_id_param: &str, required_access_param: &str) -> String {
@@ -102,7 +105,8 @@ pub fn allowed_collections_sql(
     permission_param: &str,
     required_access_param: &str,
 ) -> String {
-    let membership = membership_permission_exists_sql(org_id_param, user_id_param, permission_param);
+    let membership =
+        membership_permission_exists_sql(org_id_param, user_id_param, permission_param);
     let visibility = visibility_route_sql(user_id_param, required_access_param);
     format!(
         "c.org_id = {org_id_param}

--- a/crates/server/src/db/acl_sql.rs
+++ b/crates/server/src/db/acl_sql.rs
@@ -1,0 +1,103 @@
+//! Shared PostgreSQL ACL builders (Phase 1C).
+//!
+//! Emits the same visibility and access-level branches as [`crate::auth::acl::allowed`].
+
+/// SQL fragment listing collection ids visible to a principal for a permission/access pair.
+pub fn allowed_collections_sql(
+    _org_id_param: &str,
+    _user_id_param: &str,
+    _permission_param: &str,
+    _required_access_param: &str,
+) -> String {
+    String::new()
+}
+
+/// EXISTS predicate gating chunk/claim/document reads by collection ACL.
+pub fn acl_predicate_sql(
+    _org_id_expr: &str,
+    _collection_id_expr: &str,
+    _user_id_param: &str,
+    _permission_param: &str,
+    _required_access_param: &str,
+) -> String {
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACCESS_LEVEL_RANK: &str =
+        "CASE access_level WHEN 'read' THEN 1 WHEN 'write' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END";
+
+    #[test]
+    fn access_level_rank_expression_is_canonical() {
+        let sql = allowed_collections_sql("$1", "$2", "$3", "$4");
+        assert!(
+            sql.contains(ACCESS_LEVEL_RANK),
+            "allowed_collections_sql must use canonical access_level rank expression;\ngot:\n{sql}"
+        );
+        let predicate = acl_predicate_sql("c.org_id", "c.id", "$3", "$4", "$5");
+        assert!(
+            predicate.contains(ACCESS_LEVEL_RANK),
+            "acl_predicate_sql must use canonical access_level rank expression;\ngot:\n{predicate}"
+        );
+    }
+
+    #[test]
+    fn allowed_collections_sql_shape_is_pinned() {
+        let sql = allowed_collections_sql("$1", "$2", "$3", "$4");
+        for expected in [
+            "org_memberships",
+            "state = 'active'",
+            "users",
+            "disabled_at IS NULL",
+            "c.org_id = $1",
+            "c.deleted_at IS NULL",
+            "permissions",
+            "p.code = $3",
+            "c.visibility = 'org'",
+            "c.owner_user_id = $2",
+            "collection_user_access",
+            "collection_group_access",
+            "collection_role_access",
+            "$4",
+            ACCESS_LEVEL_RANK,
+        ] {
+            assert!(
+                sql.contains(expected),
+                "allowed_collections_sql missing required clause {expected:?} in:\n{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn acl_predicate_sql_shape_is_pinned() {
+        let sql = acl_predicate_sql("d.org_id", "d.collection_id", "$4", "$5", "$6");
+        for expected in [
+            "collections acl_c",
+            "org_memberships acl_m",
+            "acl_m.user_id = $4",
+            "acl_m.state = 'active'",
+            "users acl_u",
+            "acl_u.disabled_at IS NULL",
+            "acl_c.org_id = d.org_id",
+            "acl_c.id = d.collection_id",
+            "acl_c.deleted_at IS NULL",
+            "permissions acl_p",
+            "acl_p.code = $5",
+            "acl_c.visibility = 'org'",
+            "acl_c.owner_user_id = $4",
+            "collection_user_access",
+            "collection_group_access",
+            "collection_role_access",
+            "$6",
+            ACCESS_LEVEL_RANK,
+        ] {
+            assert!(
+                sql.contains(expected),
+                "acl_predicate_sql missing required clause {expected:?} in:\n{sql}"
+            );
+        }
+    }
+}

--- a/crates/server/src/db/mod.rs
+++ b/crates/server/src/db/mod.rs
@@ -1,5 +1,6 @@
 //! Database models, pool, and tenant-scoped repositories.
 
+pub mod acl_sql;
 pub mod ask_streams;
 pub mod audit;
 pub mod chat_sessions;

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -262,12 +262,24 @@ pub enum AccessLevel {
 }
 
 impl AccessLevel {
-    pub fn rank(self) -> u8 {
-        todo!("Phase 1C AccessLevel::rank not implemented")
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::Admin => "admin",
+        }
     }
 
-    pub fn satisfies(self, _required: Self) -> bool {
-        todo!("Phase 1C AccessLevel::satisfies not implemented")
+    pub const fn rank(self) -> u8 {
+        match self {
+            Self::Read => 1,
+            Self::Write => 2,
+            Self::Admin => 3,
+        }
+    }
+
+    pub const fn satisfies(self, required: Self) -> bool {
+        self.rank() >= required.rank()
     }
 }
 

--- a/crates/server/src/db/models.rs
+++ b/crates/server/src/db/models.rs
@@ -261,6 +261,16 @@ pub enum AccessLevel {
     Admin,
 }
 
+impl AccessLevel {
+    pub fn rank(self) -> u8 {
+        todo!("Phase 1C AccessLevel::rank not implemented")
+    }
+
+    pub fn satisfies(self, _required: Self) -> bool {
+        todo!("Phase 1C AccessLevel::satisfies not implemented")
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CollectionUserAccess {
     pub id: Uuid,

--- a/crates/server/src/db/search.rs
+++ b/crates/server/src/db/search.rs
@@ -109,6 +109,55 @@ fn acl_read_access_param() -> &'static str {
     AccessLevel::Read.as_str()
 }
 
+const PERMISSION_QA_QUERY: &str = "qa.query";
+const PERMISSION_QA_HISTORY: &str = "qa.history";
+
+/// Current retrieval (`VersionVisibility::Current`) — canonical `qa.query` + read.
+fn current_retrieval_acl_predicate(
+    org_id_expr: &str,
+    collection_id_expr: &str,
+    user_param: &str,
+    permission_param: &str,
+    access_param: &str,
+) -> String {
+    acl_predicate_sql(
+        org_id_expr,
+        collection_id_expr,
+        user_param,
+        permission_param,
+        access_param,
+    )
+}
+
+/// Historical/as-of/compare retrieval — requires both `qa.query` and `qa.history`
+/// at read access against current DB membership state.
+fn historical_retrieval_acl_predicate(
+    org_id_expr: &str,
+    collection_id_expr: &str,
+    user_param: &str,
+    query_permission_param: &str,
+    history_permission_param: &str,
+    access_param: &str,
+) -> String {
+    format!(
+        "({}) AND ({})",
+        acl_predicate_sql(
+            org_id_expr,
+            collection_id_expr,
+            user_param,
+            query_permission_param,
+            access_param,
+        ),
+        acl_predicate_sql(
+            org_id_expr,
+            collection_id_expr,
+            user_param,
+            history_permission_param,
+            access_param,
+        ),
+    )
+}
+
 fn normalize_fts_query(query: &str) -> String {
     const QUESTION_STOP_WORDS: &[&str] = &["bao", "nhieu", "la", "gi", "nao"];
     let normalized = fileconv_core::intelligence::normalize_search_text(query);
@@ -245,8 +294,9 @@ pub async fn fts_search(
         VersionVisibility::Current => {
             // 1C-06: candidate leg now carries its own ACL predicate
             // (defense-in-depth) instead of relying solely on the
-            // hydration re-check downstream — see `acl_predicate_sql`.
-            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$5", "$6", "$7");
+            // hydration re-check downstream — see `current_retrieval_acl_predicate`.
+            let acl =
+                current_retrieval_acl_predicate("d.org_id", "d.collection_id", "$5", "$6", "$7");
             let sql = format!(
                 "SELECT c.id, c.chunk_identity_sha256, c.document_id, c.version_id,
                         d.collection_id,
@@ -292,7 +342,14 @@ pub async fn fts_search(
                 return Ok(Vec::new());
             }
             let versions: Vec<Uuid> = version_ids.iter().copied().collect();
-            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$6", "$7", "$8");
+            let acl = historical_retrieval_acl_predicate(
+                "d.org_id",
+                "d.collection_id",
+                "$6",
+                "$7",
+                "$9",
+                "$8",
+            );
             let sql = format!(
                 "SELECT c.id, c.chunk_identity_sha256, c.document_id, c.version_id,
                         d.collection_id,
@@ -328,8 +385,9 @@ pub async fn fts_search(
                     &limit_i64,
                     &folded,
                     &ctx.user_id(),
-                    &visibility.required_permission(),
+                    &PERMISSION_QA_QUERY,
                     &acl_read_access_param(),
+                    &PERMISSION_QA_HISTORY,
                 ],
             )
             .await?
@@ -351,7 +409,8 @@ pub async fn hydrate_chunks_by_identity(
     }
     let rows = match visibility {
         VersionVisibility::Current => {
-            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$4", "$5", "$6");
+            let acl =
+                current_retrieval_acl_predicate("d.org_id", "d.collection_id", "$4", "$5", "$6");
             let sql = format!(
                 "SELECT c.id, c.chunk_identity_sha256, c.org_id, d.collection_id,
                         c.document_id, c.version_id, dv.version_number, dv.content_sha256,
@@ -403,7 +462,14 @@ pub async fn hydrate_chunks_by_identity(
                 return Ok(Vec::new());
             }
             let versions: Vec<Uuid> = version_ids.iter().copied().collect();
-            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$5", "$6", "$7");
+            let acl = historical_retrieval_acl_predicate(
+                "d.org_id",
+                "d.collection_id",
+                "$5",
+                "$6",
+                "$8",
+                "$7",
+            );
             let sql = format!(
                 "SELECT c.id, c.chunk_identity_sha256, c.org_id, d.collection_id,
                         c.document_id, c.version_id, dv.version_number, dv.content_sha256,
@@ -445,8 +511,9 @@ pub async fn hydrate_chunks_by_identity(
                     &identities,
                     &versions,
                     &ctx.user_id(),
-                    &visibility.required_permission(),
+                    &PERMISSION_QA_QUERY,
                     &acl_read_access_param(),
+                    &PERMISSION_QA_HISTORY,
                 ],
             )
             .await?
@@ -469,8 +536,10 @@ pub async fn load_authorized_conflict_evidence(
     }
     let rows = match visibility {
         VersionVisibility::Current => {
-            let acl_a = acl_predicate_sql("da.org_id", "da.collection_id", "$4", "$5", "$6");
-            let acl_b = acl_predicate_sql("db.org_id", "db.collection_id", "$4", "$5", "$6");
+            let acl_a =
+                current_retrieval_acl_predicate("da.org_id", "da.collection_id", "$4", "$5", "$6");
+            let acl_b =
+                current_retrieval_acl_predicate("db.org_id", "db.collection_id", "$4", "$5", "$6");
             let sql = format!(
                 "SELECT conf.id AS conflict_id,
                         conf.status, conf.resolution_note, conf.resolved_at,
@@ -537,8 +606,22 @@ pub async fn load_authorized_conflict_evidence(
                 return Ok(Vec::new());
             }
             let versions: Vec<Uuid> = version_ids.iter().copied().collect();
-            let acl_a = acl_predicate_sql("da.org_id", "da.collection_id", "$5", "$6", "$7");
-            let acl_b = acl_predicate_sql("db.org_id", "db.collection_id", "$5", "$6", "$7");
+            let acl_a = historical_retrieval_acl_predicate(
+                "da.org_id",
+                "da.collection_id",
+                "$5",
+                "$6",
+                "$8",
+                "$7",
+            );
+            let acl_b = historical_retrieval_acl_predicate(
+                "db.org_id",
+                "db.collection_id",
+                "$5",
+                "$6",
+                "$8",
+                "$7",
+            );
             let sql = format!(
                 "SELECT conf.id AS conflict_id,
                         conf.status, conf.resolution_note, conf.resolved_at,
@@ -595,8 +678,9 @@ pub async fn load_authorized_conflict_evidence(
                     &collection_ids,
                     &versions,
                     &ctx.user_id(),
-                    &visibility.required_permission(),
+                    &PERMISSION_QA_QUERY,
                     &acl_read_access_param(),
+                    &PERMISSION_QA_HISTORY,
                 ],
             )
             .await?
@@ -783,21 +867,26 @@ mod tests {
 
     /// 1C-06 regression guard: every SQL string in this module that reads
     /// `chunks`/`claims` content scoped by collection must route its ACL
-    /// check through `db::acl_sql::acl_predicate_sql(...)` rather than a
-    /// hand-rolled EXISTS clause.
+    /// check through the shared retrieval helpers rather than a hand-rolled
+    /// EXISTS clause.
     #[test]
     fn every_chunk_scoped_query_embeds_acl_predicate() {
         let src = include_str!("search.rs");
         let production = src.split("#[cfg(test)]").next().unwrap();
 
-        let builder_calls = production.matches("= acl_predicate_sql(").count();
+        let current_calls = production
+            .matches("= current_retrieval_acl_predicate(")
+            .count();
+        let historical_calls = production
+            .matches("= historical_retrieval_acl_predicate(")
+            .count();
         assert_eq!(
-            builder_calls, 8,
-            "expected exactly 8 acl_predicate_sql(...) call sites in production code \
-             (fts_search x2, hydrate_chunks_by_identity x2, \
-             load_authorized_conflict_evidence x4); got {builder_calls}. If you added a \
-             new chunk/claim query, route its ACL check through acl_predicate_sql and \
-             update this count deliberately."
+            current_calls, 4,
+            "expected current_retrieval_acl_predicate at fts/hydrate/conflict-current x2; got {current_calls}"
+        );
+        assert_eq!(
+            historical_calls, 4,
+            "expected historical_retrieval_acl_predicate at fts/hydrate/conflict-historical x2; got {historical_calls}"
         );
 
         assert!(
@@ -813,6 +902,44 @@ mod tests {
         assert!(
             !production.contains("collections acl_c"),
             "found a hand-rolled ACL EXISTS block; route through db::acl_sql::acl_predicate_sql"
+        );
+    }
+
+    #[test]
+    fn historical_retrieval_acl_predicate_requires_query_and_history() {
+        let sql = historical_retrieval_acl_predicate(
+            "d.org_id",
+            "d.collection_id",
+            "$4",
+            "$5",
+            "$7",
+            "$6",
+        );
+        assert!(
+            sql.contains("acl_p.code = $5"),
+            "historical predicate must gate qa.query: {sql}"
+        );
+        assert!(
+            sql.contains("acl_p.code = $7"),
+            "historical predicate must gate qa.history: {sql}"
+        );
+        assert_eq!(
+            sql.matches("acl_p.code =").count(),
+            2,
+            "historical predicate must combine qa.query and qa.history ACL arms"
+        );
+    }
+
+    #[test]
+    fn seed_acl_org_fixture_grants_qa_query_to_viewer_role() {
+        let src = include_str!("../../tests/common/acl_fixture.rs");
+        assert!(
+            src.contains("SELECT id FROM roles WHERE org_id = $1 AND code = 'viewer'"),
+            "fixture must resolve persisted viewer role id"
+        );
+        assert!(
+            src.contains("INSERT INTO role_permissions") && src.contains("PERMISSION_QA_QUERY"),
+            "fixture must grant qa.query to viewer role before membership downgrade"
         );
     }
 }

--- a/crates/server/src/db/search.rs
+++ b/crates/server/src/db/search.rs
@@ -10,8 +10,9 @@ use tokio_postgres::{Row, Transaction};
 use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
+use crate::db::acl_sql::acl_predicate_sql;
 use crate::db::error::DbError;
-use crate::db::models::{DocumentState, IndexGenerationState, PublicationState};
+use crate::db::models::{AccessLevel, DocumentState, IndexGenerationState, PublicationState};
 
 /// Lexical candidate before PG hydration (scores only; no body text).
 #[derive(Debug, Clone, PartialEq)]
@@ -104,72 +105,8 @@ pub fn index_generation_visible_for_retrieval(
     is_active && state == IndexGenerationState::Active
 }
 
-/// Central ACL predicate embedded in every chunk/claim query scoped by
-/// collection (1C-06). Proves the acting user holds `permission_param`
-/// (base-gated by `qa.query`, since history/compare modes require both) on
-/// the collection identified by `collection_id_expr` within
-/// `org_id_expr`'s org: an active (non-suspended, non-disabled) membership
-/// with a role granting the permission, AND collection visibility
-/// (org-wide, owned, or an explicit `collection_user_access` grant).
-///
-/// `org_id_expr`/`collection_id_expr` are correlated column references from
-/// the enclosing query (e.g. `"d.org_id"`/`"d.collection_id"`);
-/// `user_param`/`permission_param` are the `$N` placeholders already bound
-/// in the caller's parameter list — this function only composes SQL text,
-/// it never binds values itself.
-///
-/// Every query in this module that reads `chunks`/`claims` content scoped
-/// by collection MUST embed this rather than hand-roll an equivalent
-/// EXISTS — see `tests::every_chunk_scoped_query_embeds_acl_predicate` for
-/// the regression guard that enforces it, and
-/// `tests::acl_predicate_denies_suspended_membership_shape` for the
-/// membership-state contract this closes (a bare `org_memberships` row is
-/// not enough; `state = 'active'` is required — see migration `0029` /
-/// 1C-02's "suspended resolves like missing").
-fn acl_predicate_sql(
-    org_id_expr: &str,
-    collection_id_expr: &str,
-    user_param: &str,
-    permission_param: &str,
-) -> String {
-    format!(
-        "EXISTS (
-           SELECT 1
-           FROM collections acl_c
-           JOIN org_memberships acl_m
-             ON acl_m.org_id = acl_c.org_id AND acl_m.user_id = {user_param}
-            AND acl_m.state = 'active'
-           JOIN users acl_u ON acl_u.id = acl_m.user_id
-           JOIN roles acl_r
-             ON acl_r.org_id = acl_m.org_id AND acl_r.code = acl_m.role
-           JOIN role_permissions acl_rp
-             ON acl_rp.org_id = acl_r.org_id AND acl_rp.role_id = acl_r.id
-           JOIN permissions acl_p ON acl_p.id = acl_rp.permission_id
-           WHERE acl_c.org_id = {org_id_expr}
-             AND acl_c.id = {collection_id_expr}
-             AND acl_c.deleted_at IS NULL
-             AND acl_u.disabled_at IS NULL
-             AND acl_p.code = {permission_param}
-             AND EXISTS (
-               SELECT 1
-               FROM role_permissions query_rp
-               JOIN permissions query_p ON query_p.id = query_rp.permission_id
-               WHERE query_rp.org_id = acl_r.org_id
-                 AND query_rp.role_id = acl_r.id
-                 AND query_p.code = 'qa.query'
-             )
-             AND (
-               acl_c.visibility = 'org'
-               OR acl_c.owner_user_id = {user_param}
-               OR EXISTS (
-                 SELECT 1 FROM collection_user_access cua
-                 WHERE cua.org_id = acl_c.org_id
-                   AND cua.collection_id = acl_c.id
-                   AND cua.user_id = {user_param}
-               )
-             )
-         )"
-    )
+fn acl_read_access_param() -> &'static str {
+    AccessLevel::Read.as_str()
 }
 
 fn normalize_fts_query(query: &str) -> String {
@@ -309,7 +246,7 @@ pub async fn fts_search(
             // 1C-06: candidate leg now carries its own ACL predicate
             // (defense-in-depth) instead of relying solely on the
             // hydration re-check downstream — see `acl_predicate_sql`.
-            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$5", "$6");
+            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$5", "$6", "$7");
             let sql = format!(
                 "SELECT c.id, c.chunk_identity_sha256, c.document_id, c.version_id,
                         d.collection_id,
@@ -345,6 +282,7 @@ pub async fn fts_search(
                     &folded,
                     &ctx.user_id(),
                     &visibility.required_permission(),
+                    &acl_read_access_param(),
                 ],
             )
             .await?
@@ -354,7 +292,7 @@ pub async fn fts_search(
                 return Ok(Vec::new());
             }
             let versions: Vec<Uuid> = version_ids.iter().copied().collect();
-            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$6", "$7");
+            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$6", "$7", "$8");
             let sql = format!(
                 "SELECT c.id, c.chunk_identity_sha256, c.document_id, c.version_id,
                         d.collection_id,
@@ -391,6 +329,7 @@ pub async fn fts_search(
                     &folded,
                     &ctx.user_id(),
                     &visibility.required_permission(),
+                    &acl_read_access_param(),
                 ],
             )
             .await?
@@ -412,7 +351,7 @@ pub async fn hydrate_chunks_by_identity(
     }
     let rows = match visibility {
         VersionVisibility::Current => {
-            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$4", "$5");
+            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$4", "$5", "$6");
             let sql = format!(
                 "SELECT c.id, c.chunk_identity_sha256, c.org_id, d.collection_id,
                         c.document_id, c.version_id, dv.version_number, dv.content_sha256,
@@ -454,6 +393,7 @@ pub async fn hydrate_chunks_by_identity(
                     &identities,
                     &ctx.user_id(),
                     &visibility.required_permission(),
+                    &acl_read_access_param(),
                 ],
             )
             .await?
@@ -463,7 +403,7 @@ pub async fn hydrate_chunks_by_identity(
                 return Ok(Vec::new());
             }
             let versions: Vec<Uuid> = version_ids.iter().copied().collect();
-            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$5", "$6");
+            let acl = acl_predicate_sql("d.org_id", "d.collection_id", "$5", "$6", "$7");
             let sql = format!(
                 "SELECT c.id, c.chunk_identity_sha256, c.org_id, d.collection_id,
                         c.document_id, c.version_id, dv.version_number, dv.content_sha256,
@@ -506,6 +446,7 @@ pub async fn hydrate_chunks_by_identity(
                     &versions,
                     &ctx.user_id(),
                     &visibility.required_permission(),
+                    &acl_read_access_param(),
                 ],
             )
             .await?
@@ -528,8 +469,8 @@ pub async fn load_authorized_conflict_evidence(
     }
     let rows = match visibility {
         VersionVisibility::Current => {
-            let acl_a = acl_predicate_sql("da.org_id", "da.collection_id", "$4", "$5");
-            let acl_b = acl_predicate_sql("db.org_id", "db.collection_id", "$4", "$5");
+            let acl_a = acl_predicate_sql("da.org_id", "da.collection_id", "$4", "$5", "$6");
+            let acl_b = acl_predicate_sql("db.org_id", "db.collection_id", "$4", "$5", "$6");
             let sql = format!(
                 "SELECT conf.id AS conflict_id,
                         conf.status, conf.resolution_note, conf.resolved_at,
@@ -586,6 +527,7 @@ pub async fn load_authorized_conflict_evidence(
                     &collection_ids,
                     &ctx.user_id(),
                     &visibility.required_permission(),
+                    &acl_read_access_param(),
                 ],
             )
             .await?
@@ -595,8 +537,8 @@ pub async fn load_authorized_conflict_evidence(
                 return Ok(Vec::new());
             }
             let versions: Vec<Uuid> = version_ids.iter().copied().collect();
-            let acl_a = acl_predicate_sql("da.org_id", "da.collection_id", "$5", "$6");
-            let acl_b = acl_predicate_sql("db.org_id", "db.collection_id", "$5", "$6");
+            let acl_a = acl_predicate_sql("da.org_id", "da.collection_id", "$5", "$6", "$7");
+            let acl_b = acl_predicate_sql("db.org_id", "db.collection_id", "$5", "$6", "$7");
             let sql = format!(
                 "SELECT conf.id AS conflict_id,
                         conf.status, conf.resolution_note, conf.resolved_at,
@@ -654,6 +596,7 @@ pub async fn load_authorized_conflict_evidence(
                     &versions,
                     &ctx.user_id(),
                     &visibility.required_permission(),
+                    &acl_read_access_param(),
                 ],
             )
             .await?
@@ -811,15 +754,11 @@ mod tests {
         );
     }
 
-    /// 1C-06: the shared ACL predicate must gate on active membership,
-    /// non-disabled user, the requested permission gated by `qa.query`, and
-    /// one of the three collection-visibility routes. This is the contract
-    /// every candidate/hydration/evidence query relies on — pin its shape so
-    /// a future edit can't silently drop a clause (e.g. the `state =
-    /// 'active'` check that was missing before this round, see module doc).
+    /// 1C-06: chunk/claim queries route ACL through the shared
+    /// `db::acl_sql::acl_predicate_sql` builder (read access for retrieval).
     #[test]
     fn acl_predicate_sql_shape_is_pinned() {
-        let sql = acl_predicate_sql("d.org_id", "d.collection_id", "$4", "$5");
+        let sql = acl_predicate_sql("d.org_id", "d.collection_id", "$4", "$5", "$6");
         for expected in [
             "acl_m.user_id = $4",
             "acl_m.state = 'active'",
@@ -828,10 +767,12 @@ mod tests {
             "acl_c.id = d.collection_id",
             "acl_c.deleted_at IS NULL",
             "acl_p.code = $5",
-            "query_p.code = 'qa.query'",
+            "$6",
             "acl_c.visibility = 'org'",
             "acl_c.owner_user_id = $4",
             "collection_user_access",
+            "collection_group_access",
+            "collection_role_access",
         ] {
             assert!(
                 sql.contains(expected),
@@ -842,32 +783,14 @@ mod tests {
 
     /// 1C-06 regression guard: every SQL string in this module that reads
     /// `chunks`/`claims` content scoped by collection must route its ACL
-    /// check through `acl_predicate_sql(...)` rather than a hand-rolled
-    /// EXISTS clause. This is a fast, DB-free architecture-contract test in
-    /// the same family as
-    /// `middleware::write_gate::tests::middleware_source_holds_shared_lock_across_next_run`:
-    /// it source-scans this file (excluding the test module itself) and
-    /// pins the exact call-site count. Adding a new FTS/hydration/evidence
-    /// query branch without calling `acl_predicate_sql` will NOT change this
-    /// count and so will NOT fail this test by omission alone — the design
-    /// intent is that any new chunk/claim query copies an existing branch
-    /// (which already calls the builder) as its starting point. What this
-    /// test actually catches is someone reintroducing a literal inline
-    /// `collections acl_c` / `org_memberships acl_m` EXISTS block instead of
-    /// calling the builder (which would make the two counts below diverge:
-    /// a raw `acl_c` join without a matching `acl_predicate_sql(` call).
+    /// check through `db::acl_sql::acl_predicate_sql(...)` rather than a
+    /// hand-rolled EXISTS clause.
     #[test]
     fn every_chunk_scoped_query_embeds_acl_predicate() {
         let src = include_str!("search.rs");
         let production = src.split("#[cfg(test)]").next().unwrap();
 
-        // `= acl_predicate_sql(` (not the bare substring, which would also
-        // match the `fn acl_predicate_sql(` definition itself) — each call
-        // site binds the composed SQL to a local (`let acl = ...` / `let
-        // acl_a = ...` / `let acl_b = ...`).
         let builder_calls = production.matches("= acl_predicate_sql(").count();
-        // fts_search (2 branches) + hydrate_chunks_by_identity (2 branches)
-        // + load_authorized_conflict_evidence (2 branches x 2 claim sides).
         assert_eq!(
             builder_calls, 8,
             "expected exactly 8 acl_predicate_sql(...) call sites in production code \
@@ -877,23 +800,19 @@ mod tests {
              update this count deliberately."
         );
 
-        // No hand-rolled ACL EXISTS block may exist outside the shared
-        // builder function's own definition — every occurrence of the
-        // `collections acl_c` join marker must live inside
-        // `acl_predicate_sql`'s own SQL template, not duplicated ad hoc in
-        // a query string.
-        let builder_start = production
-            .find("fn acl_predicate_sql(")
-            .expect("acl_predicate_sql definition must exist");
-        let builder_end = production
-            .find("fn normalize_fts_query(")
-            .expect("normalize_fts_query definition must exist");
-        assert!(builder_start < builder_end);
-        let after_builder = &production[builder_end..];
         assert!(
-            !after_builder.contains("collections acl_c"),
-            "found a hand-rolled ACL EXISTS block outside acl_predicate_sql; \
-             route it through the shared builder instead"
+            production.contains("use crate::db::acl_sql::acl_predicate_sql"),
+            "search.rs must import the shared ACL predicate builder"
+        );
+
+        assert!(
+            !production.contains("fn acl_predicate_sql("),
+            "search.rs must not define a local acl_predicate_sql; use db::acl_sql"
+        );
+
+        assert!(
+            !production.contains("collections acl_c"),
+            "found a hand-rolled ACL EXISTS block; route through db::acl_sql::acl_predicate_sql"
         );
     }
 }

--- a/crates/server/src/db/search.rs
+++ b/crates/server/src/db/search.rs
@@ -875,11 +875,13 @@ mod tests {
         let production = src.split("#[cfg(test)]").next().unwrap();
 
         let current_calls = production
-            .matches("= current_retrieval_acl_predicate(")
-            .count();
+            .matches("current_retrieval_acl_predicate(")
+            .count()
+            .saturating_sub(1); // exclude `fn current_retrieval_acl_predicate(`
         let historical_calls = production
-            .matches("= historical_retrieval_acl_predicate(")
-            .count();
+            .matches("historical_retrieval_acl_predicate(")
+            .count()
+            .saturating_sub(1); // exclude `fn historical_retrieval_acl_predicate(`
         assert_eq!(
             current_calls, 4,
             "expected current_retrieval_acl_predicate at fts/hydrate/conflict-current x2; got {current_calls}"

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -24,7 +24,7 @@ use crate::auth::permissions::{
 use crate::db::documents;
 use crate::db::error::DbError;
 use crate::db::models::{AccessLevel, DocumentState};
-use crate::db::pool::with_org_txn;
+use crate::db::pool::{with_org_txn, with_org_txn_typed};
 use crate::http::AppState;
 use crate::services::quota::{self, QuotaError, QuotaSnapshot};
 use uuid::Uuid;
@@ -127,46 +127,33 @@ async fn create_upload(
     let collection_id = pending.collection_id.ok_or_else(|| {
         UploadRouteError::Validation("collectionId is required".into(), request_id.clone())
     })?;
-    if with_org_txn(state.pool(), &auth.context, {
-        let ctx = auth.context.clone();
-        move |txn| {
-            Box::pin(async move {
-                require_operation_collection_access_on_txn(
-                    txn,
-                    &ctx,
-                    collection_id,
-                    "doc.upload",
-                    AccessLevel::Write,
-                )
-                .await
-                .map_err(|error| match error {
-                    ResolveError::PermissionDenied | ResolveError::CollectionDenied => {
-                        DbError::Config("collection_denied".into())
-                    }
-                    _ => DbError::Config("collection_access_check".into()),
-                })
-            })
-        }
-    })
-    .await
-    .is_err()
+    match ensure_upload_collection_write_access(state.pool(), &auth.context, collection_id).await
     {
-        let resource_id = collection_id.to_string();
-        crate::services::audit::record_deny(
-            state.pool(),
-            &auth.context,
-            &request_id,
-            "document.upload",
-            "collection",
-            Some(&resource_id),
-            "collection_denied",
-        )
-        .await
-        .map_err(|_| UploadRouteError::Upload(UploadError::Internal, request_id.clone()))?;
-        return Err(UploadRouteError::Upload(
-            UploadError::PermissionDenied,
-            request_id.clone(),
-        ));
+        UploadCollectionAccessCheck::Allowed => {}
+        UploadCollectionAccessCheck::AuthorizationDenied => {
+            let resource_id = collection_id.to_string();
+            crate::services::audit::record_deny(
+                state.pool(),
+                &auth.context,
+                &request_id,
+                "document.upload",
+                "collection",
+                Some(&resource_id),
+                "collection_denied",
+            )
+            .await
+            .map_err(|_| UploadRouteError::Upload(UploadError::Internal, request_id.clone()))?;
+            return Err(UploadRouteError::Upload(
+                UploadError::PermissionDenied,
+                request_id.clone(),
+            ));
+        }
+        UploadCollectionAccessCheck::Internal => {
+            return Err(UploadRouteError::Upload(
+                UploadError::Internal,
+                request_id.clone(),
+            ));
+        }
     }
 
     let document_id = if let Some(document_id) = pending.document_id {
@@ -465,6 +452,77 @@ fn success_response(
     response
 }
 
+/// Outcome of the HTTP upload collection write ACL gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UploadCollectionAccessCheck {
+    Allowed,
+    AuthorizationDenied,
+    Internal,
+}
+
+#[derive(Debug)]
+enum UploadCollectionAccessTxnError {
+    AuthorizationDenied,
+    Internal,
+}
+
+impl From<DbError> for UploadCollectionAccessTxnError {
+    fn from(_: DbError) -> Self {
+        Self::Internal
+    }
+}
+
+fn classify_collection_access_resolve_error(error: ResolveError) -> UploadCollectionAccessCheck {
+    match error {
+        ResolveError::PermissionDenied | ResolveError::CollectionDenied => {
+            UploadCollectionAccessCheck::AuthorizationDenied
+        }
+        ResolveError::UserDisabled
+        | ResolveError::MembershipMissing
+        | ResolveError::InvalidContext
+        | ResolveError::Database => UploadCollectionAccessCheck::Internal,
+    }
+}
+
+fn upload_collection_access_records_deny_audit(check: UploadCollectionAccessCheck) -> bool {
+    matches!(check, UploadCollectionAccessCheck::AuthorizationDenied)
+}
+
+async fn ensure_upload_collection_write_access(
+    pool: &deadpool_postgres::Pool,
+    ctx: &crate::auth::context::OrgContext,
+    collection_id: Uuid,
+) -> UploadCollectionAccessCheck {
+    let ctx = ctx.clone();
+    match with_org_txn_typed(pool, &ctx, move |txn| {
+        let ctx = ctx.clone();
+        Box::pin(async move {
+            require_operation_collection_access_on_txn(
+                txn,
+                &ctx,
+                collection_id,
+                "doc.upload",
+                AccessLevel::Write,
+            )
+            .await
+            .map_err(|error| match error {
+                ResolveError::PermissionDenied | ResolveError::CollectionDenied => {
+                    UploadCollectionAccessTxnError::AuthorizationDenied
+                }
+                _ => UploadCollectionAccessTxnError::Internal,
+            })
+        })
+    })
+    .await
+    {
+        Ok(()) => UploadCollectionAccessCheck::Allowed,
+        Err(UploadCollectionAccessTxnError::AuthorizationDenied) => {
+            UploadCollectionAccessCheck::AuthorizationDenied
+        }
+        Err(UploadCollectionAccessTxnError::Internal) => UploadCollectionAccessCheck::Internal,
+    }
+}
+
 enum UploadRouteError {
     Upload(UploadError, String),
     Quota(QuotaError, String),
@@ -582,4 +640,46 @@ fn validate_idempotency_key(value: &str) -> Result<(), String> {
         return Err("Idempotency-Key contains unsupported characters".into());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collection_access_resolve_denies_only_map_explicit_acl_errors() {
+        assert_eq!(
+            classify_collection_access_resolve_error(ResolveError::PermissionDenied),
+            UploadCollectionAccessCheck::AuthorizationDenied
+        );
+        assert_eq!(
+            classify_collection_access_resolve_error(ResolveError::CollectionDenied),
+            UploadCollectionAccessCheck::AuthorizationDenied
+        );
+        for error in [
+            ResolveError::Database,
+            ResolveError::InvalidContext,
+            ResolveError::MembershipMissing,
+            ResolveError::UserDisabled,
+        ] {
+            assert_eq!(
+                classify_collection_access_resolve_error(error),
+                UploadCollectionAccessCheck::Internal,
+                "infrastructure fault must not be classified as authorization deny: {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn collection_access_check_records_deny_audit_only_for_authorization_denied() {
+        assert!(upload_collection_access_records_deny_audit(
+            UploadCollectionAccessCheck::AuthorizationDenied
+        ));
+        assert!(!upload_collection_access_records_deny_audit(
+            UploadCollectionAccessCheck::Internal
+        ));
+        assert!(!upload_collection_access_records_deny_audit(
+            UploadCollectionAccessCheck::Allowed
+        ));
+    }
 }

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -127,8 +127,7 @@ async fn create_upload(
     let collection_id = pending.collection_id.ok_or_else(|| {
         UploadRouteError::Validation("collectionId is required".into(), request_id.clone())
     })?;
-    match ensure_upload_collection_write_access(state.pool(), &auth.context, collection_id).await
-    {
+    match ensure_upload_collection_write_access(state.pool(), &auth.context, collection_id).await {
         UploadCollectionAccessCheck::Allowed => {}
         UploadCollectionAccessCheck::AuthorizationDenied => {
             let resource_id = collection_id.to_string();
@@ -493,13 +492,14 @@ async fn ensure_upload_collection_write_access(
     ctx: &crate::auth::context::OrgContext,
     collection_id: Uuid,
 ) -> UploadCollectionAccessCheck {
-    let ctx = ctx.clone();
-    match with_org_txn_typed(pool, &ctx, move |txn| {
-        let ctx = ctx.clone();
+    let gate_ctx = ctx.clone();
+    let txn_scope = ctx.clone();
+    match with_org_txn_typed(pool, &txn_scope, move |txn| {
+        let gate_ctx = gate_ctx;
         Box::pin(async move {
             require_operation_collection_access_on_txn(
                 txn,
-                &ctx,
+                &gate_ctx,
                 collection_id,
                 "doc.upload",
                 AccessLevel::Write,
@@ -656,16 +656,16 @@ mod tests {
             classify_collection_access_resolve_error(ResolveError::CollectionDenied),
             UploadCollectionAccessCheck::AuthorizationDenied
         );
-        for error in [
-            ResolveError::Database,
-            ResolveError::InvalidContext,
-            ResolveError::MembershipMissing,
-            ResolveError::UserDisabled,
+        for (label, error) in [
+            ("database", ResolveError::Database),
+            ("invalid_context", ResolveError::InvalidContext),
+            ("membership_missing", ResolveError::MembershipMissing),
+            ("user_disabled", ResolveError::UserDisabled),
         ] {
             assert_eq!(
                 classify_collection_access_resolve_error(error),
                 UploadCollectionAccessCheck::Internal,
-                "infrastructure fault must not be classified as authorization deny: {error:?}"
+                "infrastructure fault must not be classified as authorization deny: {label}"
             );
         }
     }

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -18,7 +18,9 @@ use sha2::{Digest, Sha256};
 
 use crate::api::ApiError;
 use crate::auth::middleware::AuthenticatedOrg;
-use crate::auth::permissions::{require_operation_collection_access_on_txn, require_permission, ResolveError};
+use crate::auth::permissions::{
+    require_operation_collection_access_on_txn, require_permission, ResolveError,
+};
 use crate::db::documents;
 use crate::db::error::DbError;
 use crate::db::models::{AccessLevel, DocumentState};

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -18,10 +18,10 @@ use sha2::{Digest, Sha256};
 
 use crate::api::ApiError;
 use crate::auth::middleware::AuthenticatedOrg;
-use crate::auth::permissions::require_permission;
+use crate::auth::permissions::{require_operation_collection_access_on_txn, require_permission, ResolveError};
 use crate::db::documents;
 use crate::db::error::DbError;
-use crate::db::models::DocumentState;
+use crate::db::models::{AccessLevel, DocumentState};
 use crate::db::pool::with_org_txn;
 use crate::http::AppState;
 use crate::services::quota::{self, QuotaError, QuotaSnapshot};
@@ -125,7 +125,30 @@ async fn create_upload(
     let collection_id = pending.collection_id.ok_or_else(|| {
         UploadRouteError::Validation("collectionId is required".into(), request_id.clone())
     })?;
-    if !auth.context.allows_collection(collection_id) {
+    if with_org_txn(state.pool(), &auth.context, {
+        let ctx = auth.context.clone();
+        move |txn| {
+            Box::pin(async move {
+                require_operation_collection_access_on_txn(
+                    txn,
+                    &ctx,
+                    collection_id,
+                    "doc.upload",
+                    AccessLevel::Write,
+                )
+                .await
+                .map_err(|error| match error {
+                    ResolveError::PermissionDenied | ResolveError::CollectionDenied => {
+                        DbError::Config("collection_denied".into())
+                    }
+                    _ => DbError::Config("collection_access_check".into()),
+                })
+            })
+        }
+    })
+    .await
+    .is_err()
+    {
         let resource_id = collection_id.to_string();
         crate::services::audit::record_deny(
             state.pool(),

--- a/crates/server/src/routes/uploads.rs
+++ b/crates/server/src/routes/uploads.rs
@@ -459,7 +459,7 @@ enum UploadCollectionAccessCheck {
     Internal,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum UploadCollectionAccessTxnError {
     AuthorizationDenied,
     Internal,
@@ -471,20 +471,25 @@ impl From<DbError> for UploadCollectionAccessTxnError {
     }
 }
 
-fn classify_collection_access_resolve_error(error: ResolveError) -> UploadCollectionAccessCheck {
+fn map_collection_access_resolve_error(error: ResolveError) -> UploadCollectionAccessTxnError {
     match error {
         ResolveError::PermissionDenied | ResolveError::CollectionDenied => {
-            UploadCollectionAccessCheck::AuthorizationDenied
+            UploadCollectionAccessTxnError::AuthorizationDenied
         }
         ResolveError::UserDisabled
         | ResolveError::MembershipMissing
         | ResolveError::InvalidContext
-        | ResolveError::Database => UploadCollectionAccessCheck::Internal,
+        | ResolveError::Database => UploadCollectionAccessTxnError::Internal,
     }
 }
 
-fn upload_collection_access_records_deny_audit(check: UploadCollectionAccessCheck) -> bool {
-    matches!(check, UploadCollectionAccessCheck::AuthorizationDenied)
+impl From<UploadCollectionAccessTxnError> for UploadCollectionAccessCheck {
+    fn from(error: UploadCollectionAccessTxnError) -> Self {
+        match error {
+            UploadCollectionAccessTxnError::AuthorizationDenied => Self::AuthorizationDenied,
+            UploadCollectionAccessTxnError::Internal => Self::Internal,
+        }
+    }
 }
 
 async fn ensure_upload_collection_write_access(
@@ -505,21 +510,13 @@ async fn ensure_upload_collection_write_access(
                 AccessLevel::Write,
             )
             .await
-            .map_err(|error| match error {
-                ResolveError::PermissionDenied | ResolveError::CollectionDenied => {
-                    UploadCollectionAccessTxnError::AuthorizationDenied
-                }
-                _ => UploadCollectionAccessTxnError::Internal,
-            })
+            .map_err(map_collection_access_resolve_error)
         })
     })
     .await
     {
         Ok(()) => UploadCollectionAccessCheck::Allowed,
-        Err(UploadCollectionAccessTxnError::AuthorizationDenied) => {
-            UploadCollectionAccessCheck::AuthorizationDenied
-        }
-        Err(UploadCollectionAccessTxnError::Internal) => UploadCollectionAccessCheck::Internal,
+        Err(error) => error.into(),
     }
 }
 
@@ -647,14 +644,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn collection_access_resolve_denies_only_map_explicit_acl_errors() {
+    fn map_collection_access_resolve_error_classifies_acl_vs_infrastructure() {
         assert_eq!(
-            classify_collection_access_resolve_error(ResolveError::PermissionDenied),
-            UploadCollectionAccessCheck::AuthorizationDenied
+            map_collection_access_resolve_error(ResolveError::PermissionDenied),
+            UploadCollectionAccessTxnError::AuthorizationDenied
         );
         assert_eq!(
-            classify_collection_access_resolve_error(ResolveError::CollectionDenied),
-            UploadCollectionAccessCheck::AuthorizationDenied
+            map_collection_access_resolve_error(ResolveError::CollectionDenied),
+            UploadCollectionAccessTxnError::AuthorizationDenied
         );
         for (label, error) in [
             ("database", ResolveError::Database),
@@ -663,23 +660,26 @@ mod tests {
             ("user_disabled", ResolveError::UserDisabled),
         ] {
             assert_eq!(
-                classify_collection_access_resolve_error(error),
-                UploadCollectionAccessCheck::Internal,
+                map_collection_access_resolve_error(error),
+                UploadCollectionAccessTxnError::Internal,
                 "infrastructure fault must not be classified as authorization deny: {label}"
             );
         }
     }
 
     #[test]
-    fn collection_access_check_records_deny_audit_only_for_authorization_denied() {
-        assert!(upload_collection_access_records_deny_audit(
-            UploadCollectionAccessCheck::AuthorizationDenied
-        ));
-        assert!(!upload_collection_access_records_deny_audit(
-            UploadCollectionAccessCheck::Internal
-        ));
-        assert!(!upload_collection_access_records_deny_audit(
-            UploadCollectionAccessCheck::Allowed
-        ));
+    fn create_upload_collection_gate_pins_deny_audit_to_authorization_denied_arm() {
+        let src = include_str!("uploads.rs");
+        let production = src.split("#[cfg(test)]").next().unwrap();
+        assert!(
+            production.contains("UploadCollectionAccessCheck::AuthorizationDenied =>")
+                && production.contains("record_deny("),
+            "deny audit must live only on the AuthorizationDenied arm"
+        );
+        assert!(
+            production.contains("UploadCollectionAccessCheck::Internal =>")
+                && production.matches("UploadError::Internal").count() >= 2,
+            "internal faults must return UploadError::Internal without deny audit"
+        );
     }
 }

--- a/crates/server/src/services/acl_mutate.rs
+++ b/crates/server/src/services/acl_mutate.rs
@@ -79,3 +79,33 @@ pub async fn revoke_collection_access_for_principal(
     orgs::bump_acl_version(txn, org_id).await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn revoke_collection_access_follows_parent_lock_and_grant_delete_order() {
+        let source = include_str!("acl_mutate.rs");
+        let lock = source
+            .find("FOR NO KEY UPDATE")
+            .expect("collection parent lock");
+        let delete_group = source
+            .find("DELETE FROM collection_group_access")
+            .expect("delete group grants");
+        let delete_role = source
+            .find("DELETE FROM collection_role_access")
+            .expect("delete role grants");
+        let visibility = source
+            .find("SET visibility = 'private'")
+            .expect("visibility update");
+        let delete_user = source
+            .find("DELETE FROM collection_user_access")
+            .expect("delete target user grant");
+        assert!(
+            lock < delete_group
+                && delete_group < delete_role
+                && delete_role < visibility
+                && visibility < delete_user,
+            "revoke_collection_access_for_principal must lock parent, delete group/role grants, update visibility, then delete only the target user grant"
+        );
+    }
+}

--- a/crates/server/src/services/acl_mutate.rs
+++ b/crates/server/src/services/acl_mutate.rs
@@ -57,23 +57,50 @@ pub async fn revoke_collection_access_for_principal(
     new_owner_user_id: Uuid,
 ) -> Result<(), DbError> {
     authz_lock::lock_principal_authz(txn, org_id, user_id).await?;
-    txn.execute(
-        "UPDATE collections
-         SET visibility = 'private',
-             owner_user_id = $3,
-             updated_at = now()
-         WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL",
-        &[&org_id, &collection_id, &new_owner_user_id],
-    )
-    .await
-    .map_err(DbError::from)?;
-    txn.execute(
-        "DELETE FROM collection_user_access
-         WHERE org_id = $1 AND collection_id = $2 AND user_id = $3",
-        &[&org_id, &collection_id, &user_id],
-    )
-    .await
-    .map_err(DbError::from)?;
+    txn
+        .query_one(
+            "SELECT 1 FROM collections
+             WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL
+             FOR NO KEY UPDATE",
+            &[&org_id, &collection_id],
+        )
+        .await
+        .map_err(DbError::from)?;
+    txn
+        .execute(
+            "DELETE FROM collection_group_access
+             WHERE org_id = $1 AND collection_id = $2",
+            &[&org_id, &collection_id],
+        )
+        .await
+        .map_err(DbError::from)?;
+    txn
+        .execute(
+            "DELETE FROM collection_role_access
+             WHERE org_id = $1 AND collection_id = $2",
+            &[&org_id, &collection_id],
+        )
+        .await
+        .map_err(DbError::from)?;
+    txn
+        .execute(
+            "UPDATE collections
+             SET visibility = 'private',
+                 owner_user_id = $3,
+                 updated_at = now()
+             WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL",
+            &[&org_id, &collection_id, &new_owner_user_id],
+        )
+        .await
+        .map_err(DbError::from)?;
+    txn
+        .execute(
+            "DELETE FROM collection_user_access
+             WHERE org_id = $1 AND collection_id = $2 AND user_id = $3",
+            &[&org_id, &collection_id, &user_id],
+        )
+        .await
+        .map_err(DbError::from)?;
     // 1C-05: this changes visibility/ownership org-wide (not just for
     // `user_id`), so the cache invalidation is org-wide too.
     orgs::bump_acl_version(txn, org_id).await?;

--- a/crates/server/src/services/acl_mutate.rs
+++ b/crates/server/src/services/acl_mutate.rs
@@ -57,50 +57,45 @@ pub async fn revoke_collection_access_for_principal(
     new_owner_user_id: Uuid,
 ) -> Result<(), DbError> {
     authz_lock::lock_principal_authz(txn, org_id, user_id).await?;
-    txn
-        .query_one(
-            "SELECT 1 FROM collections
+    txn.query_one(
+        "SELECT 1 FROM collections
              WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL
              FOR NO KEY UPDATE",
-            &[&org_id, &collection_id],
-        )
-        .await
-        .map_err(DbError::from)?;
-    txn
-        .execute(
-            "DELETE FROM collection_group_access
+        &[&org_id, &collection_id],
+    )
+    .await
+    .map_err(DbError::from)?;
+    txn.execute(
+        "DELETE FROM collection_group_access
              WHERE org_id = $1 AND collection_id = $2",
-            &[&org_id, &collection_id],
-        )
-        .await
-        .map_err(DbError::from)?;
-    txn
-        .execute(
-            "DELETE FROM collection_role_access
+        &[&org_id, &collection_id],
+    )
+    .await
+    .map_err(DbError::from)?;
+    txn.execute(
+        "DELETE FROM collection_role_access
              WHERE org_id = $1 AND collection_id = $2",
-            &[&org_id, &collection_id],
-        )
-        .await
-        .map_err(DbError::from)?;
-    txn
-        .execute(
-            "UPDATE collections
+        &[&org_id, &collection_id],
+    )
+    .await
+    .map_err(DbError::from)?;
+    txn.execute(
+        "UPDATE collections
              SET visibility = 'private',
                  owner_user_id = $3,
                  updated_at = now()
              WHERE org_id = $1 AND id = $2 AND deleted_at IS NULL",
-            &[&org_id, &collection_id, &new_owner_user_id],
-        )
-        .await
-        .map_err(DbError::from)?;
-    txn
-        .execute(
-            "DELETE FROM collection_user_access
+        &[&org_id, &collection_id, &new_owner_user_id],
+    )
+    .await
+    .map_err(DbError::from)?;
+    txn.execute(
+        "DELETE FROM collection_user_access
              WHERE org_id = $1 AND collection_id = $2 AND user_id = $3",
-            &[&org_id, &collection_id, &user_id],
-        )
-        .await
-        .map_err(DbError::from)?;
+        &[&org_id, &collection_id, &user_id],
+    )
+    .await
+    .map_err(DbError::from)?;
     // 1C-05: this changes visibility/ownership org-wide (not just for
     // `user_id`), so the cache invalidation is org-wide too.
     orgs::bump_acl_version(txn, org_id).await?;

--- a/crates/server/src/services/upload/saga.rs
+++ b/crates/server/src/services/upload/saga.rs
@@ -9,10 +9,11 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
-use crate::auth::permissions::require_permission;
+use crate::auth::permissions::{require_permission, COLLECTION_SCOPE_PERMISSION};
+use crate::db::acl_sql::allowed_collections_sql;
 use crate::db::documents::{self, NewDocument};
 use crate::db::error::DbError;
-use crate::db::models::{AuditOutcome, DocumentState, JobType};
+use crate::db::models::{AccessLevel, AuditOutcome, DocumentState, JobType};
 use crate::db::pool::with_org_txn_typed;
 use crate::db::upload_operations::{
     self, NewUploadOperation, UploadOperation, UploadOperationState,
@@ -930,24 +931,14 @@ async fn reload_principal_locked(
         .map_err(DbError::from)?;
     let permissions: Vec<String> = permission_rows.iter().map(|row| row.get(0)).collect();
 
+    let collection_sql = format!(
+        "SELECT c.id FROM collections c WHERE {}",
+        allowed_collections_sql("$1", "$2", "$3", "$4")
+    );
+    let permission = COLLECTION_SCOPE_PERMISSION;
+    let access = AccessLevel::Read.as_str();
     let collection_rows = txn
-        .query(
-            "SELECT c.id
-             FROM collections c
-             WHERE c.org_id = $1
-               AND c.deleted_at IS NULL
-               AND (
-                 c.visibility = 'org'
-                 OR c.owner_user_id = $2
-                 OR EXISTS (
-                   SELECT 1 FROM collection_user_access cua
-                   WHERE cua.org_id = c.org_id
-                     AND cua.collection_id = c.id
-                     AND cua.user_id = $2
-                 )
-               )",
-            &[&org_id, &user_id],
-        )
+        .query(&collection_sql, &[&org_id, &user_id, &permission, &access])
         .await
         .map_err(DbError::from)?;
     let collections: Vec<Uuid> = collection_rows.iter().map(|row| row.get(0)).collect();

--- a/crates/server/src/services/upload/saga.rs
+++ b/crates/server/src/services/upload/saga.rs
@@ -9,7 +9,10 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::auth::context::OrgContext;
-use crate::auth::permissions::{require_permission, COLLECTION_SCOPE_PERMISSION};
+use crate::auth::permissions::{
+    require_operation_collection_access_on_txn, require_permission, ResolveError,
+    COLLECTION_SCOPE_PERMISSION,
+};
 use crate::db::acl_sql::allowed_collections_sql;
 use crate::db::documents::{self, NewDocument};
 use crate::db::error::DbError;
@@ -30,6 +33,7 @@ use crate::storage::{parse_key_for_org, ObjectKey};
 use super::{Disposition, QuarantineIdentity, UploadError, UploadOutcome};
 
 pub const PERMISSION_QUARANTINE_REVIEW: &str = "doc.quarantine.review";
+const PERMISSION_DOC_UPLOAD: &str = "doc.upload";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegisteredUpload {
@@ -626,9 +630,13 @@ async fn begin_or_replay(
                     UploadOperationState::Completed => {
                         // Fresh-auth original operation collection before returning.
                         let fresh = reload_principal_locked(txn, &ctx).await?;
-                        require_permission(&fresh, "doc.upload")
-                            .map_err(|_| SagaError::PermissionDenied)?;
-                        ensure_collection_writable(txn, &fresh, op.collection_id).await?;
+                        ensure_collection_writable(
+                            txn,
+                            &fresh,
+                            op.collection_id,
+                            PERMISSION_DOC_UPLOAD,
+                        )
+                        .await?;
                         Ok(Some(replay_from_operation(&op)?))
                     }
                     UploadOperationState::Started
@@ -800,7 +808,13 @@ async fn commit_registration_and_finalize(
                     upload_operations::get_by_id_for_update(txn, &provisional_ctx, op_id).await?;
                 if op.state == UploadOperationState::Completed {
                     let fresh = reload_principal_locked(txn, &provisional_ctx).await?;
-                    ensure_collection_writable(txn, &fresh, op.collection_id).await?;
+                    ensure_collection_writable(
+                        txn,
+                        &fresh,
+                        op.collection_id,
+                        PERMISSION_DOC_UPLOAD,
+                    )
+                    .await?;
                     return replay_from_operation(&op);
                 }
                 if op.state == UploadOperationState::Reconciling
@@ -814,9 +828,8 @@ async fn commit_registration_and_finalize(
                 }
 
                 let fresh = reload_principal_locked(txn, &provisional_ctx).await?;
-                require_permission(&fresh, "doc.upload")
-                    .map_err(|_| SagaError::PermissionDenied)?;
-                ensure_collection_writable(txn, &fresh, collection_id).await?;
+                ensure_collection_writable(txn, &fresh, collection_id, PERMISSION_DOC_UPLOAD)
+                    .await?;
 
                 let registered = register_rows(
                     txn,
@@ -950,10 +963,18 @@ async fn ensure_collection_writable(
     txn: &tokio_postgres::Transaction<'_>,
     ctx: &OrgContext,
     collection_id: Uuid,
+    permission: &str,
 ) -> Result<(), SagaError> {
-    if !ctx.allows_collection(collection_id) {
-        return Err(SagaError::PermissionDenied);
-    }
+    require_operation_collection_access_on_txn(
+        txn,
+        ctx,
+        collection_id,
+        permission,
+        AccessLevel::Write,
+    )
+    .await
+    .map_err(collection_access_denied)?;
+
     let row = txn
         .query_opt(
             "SELECT id FROM collections
@@ -1136,9 +1157,13 @@ pub async fn approve_quarantined_upload(
             Box::pin(async move {
                 authz_lock::lock_principal_authz(txn, ctx.org_id(), ctx.user_id()).await?;
                 let fresh = reload_principal_locked(txn, &ctx).await?;
-                require_permission(&fresh, PERMISSION_QUARANTINE_REVIEW)
-                    .map_err(|_| SagaError::PermissionDenied)?;
-                ensure_collection_writable(txn, &fresh, collection_id).await?;
+                ensure_collection_writable(
+                    txn,
+                    &fresh,
+                    collection_id,
+                    PERMISSION_QUARANTINE_REVIEW,
+                )
+                .await?;
 
                 let op = upload_operations::get_by_collection_document_for_update(
                     txn,
@@ -1511,5 +1536,41 @@ fn mime_for(format: super::CanonicalFormat) -> &'static str {
         super::CanonicalFormat::Xls => "application/vnd.ms-excel",
         super::CanonicalFormat::Xlsb => "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
         super::CanonicalFormat::ZipContainer => "application/zip",
+    }
+}
+
+fn collection_access_denied(error: ResolveError) -> SagaError {
+    match error {
+        ResolveError::PermissionDenied | ResolveError::CollectionDenied => {
+            SagaError::PermissionDenied
+        }
+        _ => SagaError::Database(DbError::Config("collection_access_check".into())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ensure_collection_writable_uses_operation_guard_not_read_allow_list() {
+        let src = include_str!("saga.rs");
+        let production = src.split("#[cfg(test)]").next().unwrap();
+
+        assert!(
+            production.contains("require_operation_collection_access_on_txn"),
+            "upload write gate must use operation-scoped ACL SQL"
+        );
+        assert!(
+            !production.contains("ctx.allows_collection(collection_id)"),
+            "upload write gate must not consult qa.query read allow-list"
+        );
+        assert!(
+            production.matches("ensure_collection_writable(").count() >= 4,
+            "expected upload/quarantine call sites to route through ensure_collection_writable"
+        );
+        assert!(
+            production.contains("PERMISSION_DOC_UPLOAD")
+                && production.contains("PERMISSION_QUARANTINE_REVIEW"),
+            "upload and quarantine approval must pass distinct operation permissions"
+        );
     }
 }

--- a/crates/server/tests/acl_cache.rs
+++ b/crates/server/tests/acl_cache.rs
@@ -14,12 +14,17 @@ mod common;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use common::{
+    acl_fixture::{
+        boot_acl_pool, grant_group_access, insert_collection, resolver_allowed_collection_ids,
+        seed_acl_org, PERMISSION_QA_QUERY,
+    },
     admin_database_url, app_database_url, boot_app_pool, build_router, login_access_token,
     seed_user_with_permissions, test_auth_config,
 };
 use fileconv_server::auth::context::OrgContext;
 use fileconv_server::auth::jwt::JwtKeys;
 use fileconv_server::auth::provider::PasswordAuthProvider;
+use fileconv_server::db::models::AccessLevel;
 use fileconv_server::db::pool::with_org_txn;
 use http_body_util::BodyExt;
 use serde_json::{json, Value};
@@ -146,6 +151,7 @@ async fn cached_context_denies_immediately_after_role_downgrade() {
     let org = Uuid::new_v4();
     let owner = Uuid::new_v4();
     let admin = Uuid::new_v4();
+    // `member.manage` only — no `qa.query`; collection scope is not under test here.
     seed_user_with_permissions(
         &pool,
         org,
@@ -197,6 +203,7 @@ async fn cached_context_denies_immediately_after_suspend() {
     let org = Uuid::new_v4();
     let owner = Uuid::new_v4();
     let admin = Uuid::new_v4();
+    // `member.manage` only — no `qa.query`; collection scope is not under test here.
     seed_user_with_permissions(
         &pool,
         org,
@@ -243,6 +250,7 @@ async fn cached_context_denies_immediately_after_remove() {
     let org = Uuid::new_v4();
     let owner = Uuid::new_v4();
     let admin = Uuid::new_v4();
+    // `member.manage` only — no `qa.query`; collection scope is not under test here.
     seed_user_with_permissions(
         &pool,
         org,
@@ -304,14 +312,13 @@ async fn cached_context_drops_collection_access_immediately_after_acl_revoke() {
         user,
         "owner@acl-cache-coll.test",
         PASSWORD,
-        &["doc.upload"],
+        &["doc.upload", "qa.query"],
     )
     .await;
 
     // Give `user` a private collection they own (the resolver's
-    // `owner_user_id = $2` branch), matching `tests/uploads.rs`'s ACL-revoke
-    // fixture shape.
-    let ctx = OrgContext::try_new(org, user, ["doc.upload"], []).unwrap();
+    // `(qa.query, read)` projection must include owned private collections).
+    let ctx = OrgContext::try_new(org, user, ["doc.upload", "qa.query"], []).unwrap();
     with_org_txn(&pool, &ctx, {
         let ctx = ctx.clone();
         move |txn| {
@@ -383,6 +390,93 @@ async fn cached_context_drops_collection_access_immediately_after_acl_revoke() {
     assert!(
         !after.allows_collection(collection),
         "cached context must not keep granting a collection revoked out from under it"
+    );
+
+    ephemeral.drop().await;
+}
+
+/// Removing a principal from a group must invalidate the cached `(qa.query, read)`
+/// collection projection on the very next `OrgContextCache::resolve` call.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn group_membership_revoke_invalidates_cached_context() {
+    let Some((ephemeral, pool)) = boot_acl_pool().await else {
+        return;
+    };
+
+    let fixture = seed_acl_org(&pool).await;
+    let owner_ctx =
+        OrgContext::try_new(fixture.org, fixture.owner, [PERMISSION_QA_QUERY], []).unwrap();
+    let collection = with_org_txn(&pool, &owner_ctx, {
+        let fixture = fixture.clone();
+        move |txn| {
+            Box::pin(async move {
+                let collection =
+                    insert_collection(txn, fixture.org, fixture.owner, "groups", "cache").await?;
+                grant_group_access(
+                    txn,
+                    fixture.org,
+                    collection,
+                    fixture.group_id,
+                    AccessLevel::Write,
+                )
+                .await?;
+                Ok(collection)
+            })
+        }
+    })
+    .await
+    .expect("seed groups collection");
+
+    let auth = PasswordAuthProvider::new(
+        pool.clone(),
+        test_auth_config(),
+        JwtKeys::from_auth(&test_auth_config()).unwrap(),
+    );
+
+    let warm = auth
+        .context_cache()
+        .resolve(&pool, fixture.org, fixture.member)
+        .await
+        .expect("initial resolve");
+    assert!(
+        warm.allows_collection(collection),
+        "member must initially see groups collection via group membership"
+    );
+
+    let owner_ctx =
+        OrgContext::try_new(fixture.org, fixture.owner, [PERMISSION_QA_QUERY], []).unwrap();
+    with_org_txn(&pool, &owner_ctx, {
+        let fixture = fixture.clone();
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "DELETE FROM group_memberships
+                     WHERE org_id = $1 AND group_id = $2 AND user_id = $3",
+                    &[&fixture.org, &fixture.group_id, &fixture.member],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("revoke group membership");
+
+    let after = auth
+        .context_cache()
+        .resolve(&pool, fixture.org, fixture.member)
+        .await
+        .expect("resolve after membership revoke");
+    assert!(
+        !after.allows_collection(collection),
+        "cached context must drop group-backed collection access after membership revoke"
+    );
+
+    let fresh = resolver_allowed_collection_ids(&pool, fixture.org, fixture.member).await;
+    assert!(
+        !fresh.contains(&collection),
+        "uncached resolver must also deny after membership revoke"
     );
 
     ephemeral.drop().await;

--- a/crates/server/tests/acl_concurrency.rs
+++ b/crates/server/tests/acl_concurrency.rs
@@ -191,6 +191,59 @@ async fn dormant_grant_count(client: &Client) -> i64 {
         .get(0)
 }
 
+async fn collection_group_grant_state(
+    client: &Client,
+    org: Uuid,
+    collection: Uuid,
+) -> (String, i64) {
+    let visibility: String = client
+        .query_one(
+            "SELECT visibility FROM collections WHERE org_id = $1 AND id = $2",
+            &[&org, &collection],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    let grants: i64 = client
+        .query_one(
+            "SELECT count(*)::bigint FROM collection_group_access
+             WHERE org_id = $1 AND collection_id = $2",
+            &[&org, &collection],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    (visibility, grants)
+}
+
+async fn org_acl_version(client: &Client, org: Uuid) -> i64 {
+    client
+        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&org])
+        .await
+        .unwrap()
+        .get(0)
+}
+
+async fn seed_second_groups_collection(client: &mut Client, fixture: &AclFixture) -> Uuid {
+    let collection = Uuid::new_v4();
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collections (id, org_id, name, slug, owner_user_id, visibility)
+         VALUES ($1, $2, 'Archive', $3, $4, 'groups')",
+        &[
+            &collection,
+            &fixture.org,
+            &format!("archive-{}", &collection.simple().to_string()[..8]),
+            &fixture._owner,
+        ],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+    collection
+}
+
 async fn boot_db() -> Option<EphemeralDb> {
     let base = admin_database_url()?;
     let ephemeral = EphemeralDb::create(&base).await;
@@ -285,6 +338,41 @@ async fn groups_visibility_accepts_group_and_role_grants() {
 
 #[tokio::test]
 #[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn groups_to_private_fails_while_role_grants_remain() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collection_role_access (org_id, collection_id, role_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.role_id],
+    )
+    .await
+    .unwrap();
+    let err = tx
+        .execute(
+            "UPDATE collections SET visibility = 'private'
+             WHERE org_id = $1 AND id = $2",
+            &[&fixture.org, &fixture.collection],
+        )
+        .await
+        .expect_err("visibility flip with remaining role grants must fail");
+    assert!(
+        pg_error_text(&err).contains("grants remain"),
+        "{}",
+        pg_error_text(&err)
+    );
+    tx.rollback().await.unwrap();
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
 async fn groups_to_private_fails_while_grants_remain() {
     let Some(ephemeral) = boot_db().await else {
         return;
@@ -336,19 +424,24 @@ async fn concurrent_grant_vs_visibility_flip_cannot_leave_dormant_rows() {
         let org = fixture.org;
         let collection = fixture.collection;
         tokio::spawn(async move {
-            barrier.wait().await;
             let mut client = connect(&url).await;
             let tx = client.transaction().await.unwrap();
             set_org(&tx, org).await;
-            let result = tx
+            barrier.wait().await;
+            let dml = tx
                 .execute(
                     "UPDATE collections SET visibility = 'private'
                      WHERE org_id = $1 AND id = $2",
                     &[&org, &collection],
                 )
                 .await;
-            let _ = tx.commit().await;
-            result
+            match dml {
+                Ok(_) => tx.commit().await.is_ok(),
+                Err(_) => {
+                    tx.rollback().await.ok();
+                    false
+                }
+            }
         })
     };
 
@@ -359,33 +452,34 @@ async fn concurrent_grant_vs_visibility_flip_cannot_leave_dormant_rows() {
         let collection = fixture.collection;
         let group_id = fixture.group_id;
         tokio::spawn(async move {
-            barrier.wait().await;
             let mut client = connect(&url).await;
             let tx = client.transaction().await.unwrap();
             set_org(&tx, org).await;
-            let result = tx
+            barrier.wait().await;
+            let dml = tx
                 .execute(
                     "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
                      VALUES ($1, $2, $3, 'read')",
                     &[&org, &collection, &group_id],
                 )
                 .await;
-            let _ = tx.commit().await;
-            result
+            match dml {
+                Ok(_) => tx.commit().await.is_ok(),
+                Err(_) => {
+                    tx.rollback().await.ok();
+                    false
+                }
+            }
         })
     };
 
-    let (flip_result, grant_result) = tokio::join!(flip, grant);
-    let flip_result = flip_result.expect("flip task join");
-    let grant_result = grant_result.expect("grant task join");
+    let flip_committed = flip.await.expect("flip task join");
+    let grant_committed = grant.await.expect("grant task join");
 
-    let successes = [flip_result.is_ok(), grant_result.is_ok()]
-        .iter()
-        .filter(|ok| **ok)
-        .count();
-    assert!(
-        successes <= 1,
-        "grant-vs-flip race must not let both commit: flip={flip_result:?} grant={grant_result:?}"
+    assert_eq!(
+        usize::from(flip_committed) + usize::from(grant_committed),
+        1,
+        "grant-vs-flip race must leave exactly one durable winner: flip={flip_committed} grant={grant_committed}"
     );
 
     let client = connect(&ephemeral.url).await;
@@ -394,6 +488,94 @@ async fn concurrent_grant_vs_visibility_flip_cannot_leave_dormant_rows() {
         0,
         "no interleaving may leave group/role grants on non-groups collections"
     );
+    let (visibility, grants) =
+        collection_group_grant_state(&client, fixture.org, fixture.collection).await;
+    match (visibility.as_str(), grants) {
+        ("private", 0) | ("groups", 1) => {}
+        other => panic!("incoherent durable final state: {other:?}"),
+    }
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn grant_retargeting_collection_id_is_rejected() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+    let other_collection = seed_second_groups_collection(&mut client, &fixture).await;
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.group_id],
+    )
+    .await
+    .unwrap();
+    let err = tx
+        .execute(
+            "UPDATE collection_group_access
+             SET collection_id = $4
+             WHERE org_id = $1 AND collection_id = $2 AND group_id = $3",
+            &[
+                &fixture.org,
+                &fixture.collection,
+                &fixture.group_id,
+                &other_collection,
+            ],
+        )
+        .await
+        .expect_err("in-place collection retargeting must fail");
+    let message = pg_error_text(&err);
+    assert!(
+        message.contains("delete and re-insert") || message.contains("immutable"),
+        "{message}"
+    );
+    tx.rollback().await.unwrap();
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn grant_access_level_update_still_validates_parent() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.group_id],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "UPDATE collection_group_access
+         SET access_level = 'write'
+         WHERE org_id = $1 AND collection_id = $2 AND group_id = $3",
+        &[&fixture.org, &fixture.collection, &fixture.group_id],
+    )
+    .await
+    .unwrap();
+    let level: String = tx
+        .query_one(
+            "SELECT access_level FROM collection_group_access
+             WHERE org_id = $1 AND collection_id = $2 AND group_id = $3",
+            &[&fixture.org, &fixture.collection, &fixture.group_id],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(level, "write");
+    tx.commit().await.unwrap();
     ephemeral.drop().await;
 }
 
@@ -476,6 +658,200 @@ async fn acl_version_bumps_on_role_grant() {
         .unwrap()
         .get(0);
     assert_eq!(after, before + 1);
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn acl_version_bumps_on_group_grant_update_and_delete() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.group_id],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    let before_update = org_acl_version(&client, fixture.org).await;
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "UPDATE collection_group_access
+         SET access_level = 'write'
+         WHERE org_id = $1 AND collection_id = $2 AND group_id = $3",
+        &[&fixture.org, &fixture.collection, &fixture.group_id],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(
+        org_acl_version(&client, fixture.org).await,
+        before_update + 1,
+        "group grant UPDATE must bump acl_version once"
+    );
+
+    let before_delete = org_acl_version(&client, fixture.org).await;
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "DELETE FROM collection_group_access
+         WHERE org_id = $1 AND collection_id = $2 AND group_id = $3",
+        &[&fixture.org, &fixture.collection, &fixture.group_id],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(
+        org_acl_version(&client, fixture.org).await,
+        before_delete + 1,
+        "group grant DELETE must bump acl_version once"
+    );
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn acl_version_bumps_on_role_grant_update_and_delete() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collection_role_access (org_id, collection_id, role_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.role_id],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    let before_update = org_acl_version(&client, fixture.org).await;
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "UPDATE collection_role_access
+         SET access_level = 'write'
+         WHERE org_id = $1 AND collection_id = $2 AND role_id = $3",
+        &[&fixture.org, &fixture.collection, &fixture.role_id],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(
+        org_acl_version(&client, fixture.org).await,
+        before_update + 1,
+        "role grant UPDATE must bump acl_version once"
+    );
+
+    let before_delete = org_acl_version(&client, fixture.org).await;
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "DELETE FROM collection_role_access
+         WHERE org_id = $1 AND collection_id = $2 AND role_id = $3",
+        &[&fixture.org, &fixture.collection, &fixture.role_id],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(
+        org_acl_version(&client, fixture.org).await,
+        before_delete + 1,
+        "role grant DELETE must bump acl_version once"
+    );
+    ephemeral.drop().await;
+}
+
+// Grant tables forbid in-place org_id/collection_id retargeting (see
+// `grant_retargeting_collection_id_is_rejected`), so cross-org dual-bump
+// behavior of `bump_org_acl_version` is pinned by the migration shape test and
+// exercised here through same-org membership UPDATE/DELETE on `group_memberships`.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn acl_version_bumps_on_group_membership_update_and_delete() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+    let member = Uuid::new_v4();
+    let second_group = Uuid::new_v4();
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO users (id, email, display_name) VALUES ($1, $2, 'Member')",
+        &[&member, &format!("member-{}@acl-it.test", member.simple())],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO org_memberships (org_id, user_id, role) VALUES ($1, $2, 'viewer')",
+        &[&fixture.org, &member],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO groups (id, org_id, name) VALUES ($1, $2, 'Reviewers')",
+        &[&second_group, &fixture.org],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO group_memberships (org_id, group_id, user_id) VALUES ($1, $2, $3)",
+        &[&fixture.org, &fixture.group_id, &member],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    let before_update = org_acl_version(&client, fixture.org).await;
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "UPDATE group_memberships
+         SET group_id = $4
+         WHERE org_id = $1 AND group_id = $2 AND user_id = $3",
+        &[&fixture.org, &fixture.group_id, &member, &second_group],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(
+        org_acl_version(&client, fixture.org).await,
+        before_update + 1,
+        "group membership UPDATE within the same org must bump acl_version once"
+    );
+
+    let before_delete = org_acl_version(&client, fixture.org).await;
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "DELETE FROM group_memberships
+         WHERE org_id = $1 AND group_id = $2 AND user_id = $3",
+        &[&fixture.org, &second_group, &member],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+    assert_eq!(
+        org_acl_version(&client, fixture.org).await,
+        before_delete + 1,
+        "group membership DELETE must bump acl_version once"
+    );
     ephemeral.drop().await;
 }
 

--- a/crates/server/tests/acl_concurrency.rs
+++ b/crates/server/tests/acl_concurrency.rs
@@ -97,7 +97,7 @@ async fn set_org<C: GenericClient>(client: &C, org_id: Uuid) {
 
 struct AclFixture {
     org: Uuid,
-    owner: Uuid,
+    _owner: Uuid,
     collection: Uuid,
     group_id: Uuid,
     role_id: Uuid,
@@ -161,7 +161,7 @@ async fn seed_acl_fixture(client: &mut Client, visibility: &str) -> AclFixture {
 
     AclFixture {
         org,
-        owner,
+        _owner: owner,
         collection,
         group_id,
         role_id,
@@ -407,7 +407,10 @@ async fn acl_version_bumps_on_group_grant() {
     let fixture = seed_acl_fixture(&mut client, "groups").await;
 
     let before: i64 = client
-        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .query_one(
+            "SELECT acl_version FROM orgs WHERE id = $1",
+            &[&fixture.org],
+        )
         .await
         .unwrap()
         .get(0);
@@ -424,7 +427,10 @@ async fn acl_version_bumps_on_group_grant() {
     tx.commit().await.unwrap();
 
     let after: i64 = client
-        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .query_one(
+            "SELECT acl_version FROM orgs WHERE id = $1",
+            &[&fixture.org],
+        )
         .await
         .unwrap()
         .get(0);
@@ -442,7 +448,10 @@ async fn acl_version_bumps_on_role_grant() {
     let fixture = seed_acl_fixture(&mut client, "groups").await;
 
     let before: i64 = client
-        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .query_one(
+            "SELECT acl_version FROM orgs WHERE id = $1",
+            &[&fixture.org],
+        )
         .await
         .unwrap()
         .get(0);
@@ -459,7 +468,10 @@ async fn acl_version_bumps_on_role_grant() {
     tx.commit().await.unwrap();
 
     let after: i64 = client
-        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .query_one(
+            "SELECT acl_version FROM orgs WHERE id = $1",
+            &[&fixture.org],
+        )
         .await
         .unwrap()
         .get(0);
@@ -494,7 +506,10 @@ async fn acl_version_bumps_on_group_membership_change() {
     tx.commit().await.unwrap();
 
     let before: i64 = client
-        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .query_one(
+            "SELECT acl_version FROM orgs WHERE id = $1",
+            &[&fixture.org],
+        )
         .await
         .unwrap()
         .get(0);
@@ -510,7 +525,10 @@ async fn acl_version_bumps_on_group_membership_change() {
     tx.commit().await.unwrap();
 
     let after: i64 = client
-        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .query_one(
+            "SELECT acl_version FROM orgs WHERE id = $1",
+            &[&fixture.org],
+        )
         .await
         .unwrap()
         .get(0);

--- a/crates/server/tests/acl_concurrency.rs
+++ b/crates/server/tests/acl_concurrency.rs
@@ -1,0 +1,519 @@
+//! DB-gated concurrency tests for migration `0036_expand_acl_groups_invariants.sql`.
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` is unset; runs in GitHub
+//! `rust-integration` with live PostgreSQL.
+
+mod common;
+
+use common::admin_database_url;
+use fileconv_server::database::apply_migrations;
+use std::sync::Arc;
+use tokio::sync::Barrier;
+use tokio_postgres::GenericClient;
+use tokio_postgres::{Client, NoTls};
+use uuid::Uuid;
+
+fn pg_error_text(error: &tokio_postgres::Error) -> String {
+    if let Some(db) = error.as_db_error() {
+        format!("{} {}", db.message(), db.detail().unwrap_or(""))
+    } else {
+        format!("{error:?}")
+    }
+}
+
+fn rewrite_database_url(base_url: &str, database_name: &str) -> String {
+    let (without_query, query) = match base_url.split_once('?') {
+        Some((head, tail)) => (head, Some(tail)),
+        None => (base_url, None),
+    };
+    let prefix = without_query
+        .rsplit_once('/')
+        .map(|(head, _)| head)
+        .expect("database URL must include a path");
+    match query {
+        Some(tail) => format!("{prefix}/{database_name}?{tail}"),
+        None => format!("{prefix}/{database_name}"),
+    }
+}
+
+async fn connect(database_url: &str) -> Client {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .unwrap_or_else(|error| panic!("connect failed for {database_url}: {error}"));
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    client
+}
+
+struct EphemeralDb {
+    admin_url: String,
+    db_name: String,
+    url: String,
+}
+
+impl EphemeralDb {
+    async fn create(base_url: &str) -> Self {
+        let db_name = format!("markhand_it_{}", Uuid::new_v4().simple());
+        let admin_url = rewrite_database_url(base_url, "postgres");
+        let admin = connect(&admin_url).await;
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("CREATE DATABASE");
+        Self {
+            admin_url,
+            db_name: db_name.clone(),
+            url: rewrite_database_url(base_url, &db_name),
+        }
+    }
+
+    async fn drop(self) {
+        let admin = connect(&self.admin_url).await;
+        admin
+            .batch_execute(&format!(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                 WHERE datname = '{}' AND pid <> pg_backend_pid()",
+                self.db_name
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("terminate backends failed: {error}"));
+        admin
+            .batch_execute(&format!(
+                "DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)",
+                self.db_name
+            ))
+            .await
+            .unwrap_or_else(|error| panic!("DROP DATABASE WITH (FORCE) failed: {error}"));
+    }
+}
+
+async fn set_org<C: GenericClient>(client: &C, org_id: Uuid) {
+    client
+        .batch_execute(&format!("SET LOCAL app.org_id = '{org_id}'"))
+        .await
+        .expect("SET LOCAL app.org_id");
+}
+
+struct AclFixture {
+    org: Uuid,
+    owner: Uuid,
+    collection: Uuid,
+    group_id: Uuid,
+    role_id: Uuid,
+}
+
+async fn seed_acl_fixture(client: &mut Client, visibility: &str) -> AclFixture {
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let collection = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let role_id = Uuid::new_v4();
+
+    let tx = client.transaction().await.unwrap();
+    let slug = format!("org-{}", &org.simple().to_string()[..8]);
+    let org_name = "ACL IT";
+    tx.execute(
+        "INSERT INTO orgs (id, slug, name) VALUES ($1, $2, $3)",
+        &[&org, &slug, &org_name],
+    )
+    .await
+    .unwrap();
+    set_org(&tx, org).await;
+    tx.execute(
+        "INSERT INTO users (id, email, display_name) VALUES ($1, $2, 'Owner')",
+        &[&owner, &format!("owner-{}@acl-it.test", owner.simple())],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO org_memberships (org_id, user_id, role) VALUES ($1, $2, 'owner')",
+        &[&org, &owner],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO collections (id, org_id, name, slug, owner_user_id, visibility)
+         VALUES ($1, $2, 'Docs', $3, $4, $5)",
+        &[
+            &collection,
+            &org,
+            &format!("docs-{}", &collection.simple().to_string()[..8]),
+            &owner,
+            &visibility,
+        ],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO groups (id, org_id, name) VALUES ($1, $2, 'Editors')",
+        &[&group_id, &org],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO roles (id, org_id, code, name, is_system) VALUES ($1, $2, 'viewer', 'Viewer', true)",
+        &[&role_id, &org],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    AclFixture {
+        org,
+        owner,
+        collection,
+        group_id,
+        role_id,
+    }
+}
+
+async fn dormant_grant_count(client: &Client) -> i64 {
+    client
+        .query_one(
+            "SELECT count(*)::bigint
+             FROM collections c
+             WHERE c.visibility <> 'groups'
+               AND (
+                   EXISTS (
+                       SELECT 1 FROM collection_group_access g
+                       WHERE g.org_id = c.org_id AND g.collection_id = c.id
+                   )
+                   OR EXISTS (
+                       SELECT 1 FROM collection_role_access r
+                       WHERE r.org_id = c.org_id AND r.collection_id = c.id
+                   )
+               )",
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0)
+}
+
+async fn boot_db() -> Option<EphemeralDb> {
+    let base = admin_database_url()?;
+    let ephemeral = EphemeralDb::create(&base).await;
+    apply_migrations(&ephemeral.url).await.unwrap();
+    Some(ephemeral)
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn group_grant_on_private_collection_is_rejected() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "private").await;
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    let err = tx
+        .execute(
+            "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
+             VALUES ($1, $2, $3, 'read')",
+            &[&fixture.org, &fixture.collection, &fixture.group_id],
+        )
+        .await
+        .expect_err("group grant on private collection must fail");
+    assert!(
+        pg_error_text(&err).contains("visibility groups"),
+        "{}",
+        pg_error_text(&err)
+    );
+    tx.rollback().await.unwrap();
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn role_grant_on_org_collection_is_rejected() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "org").await;
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    let err = tx
+        .execute(
+            "INSERT INTO collection_role_access (org_id, collection_id, role_id, access_level)
+             VALUES ($1, $2, $3, 'read')",
+            &[&fixture.org, &fixture.collection, &fixture.role_id],
+        )
+        .await
+        .expect_err("role grant on org collection must fail");
+    assert!(
+        pg_error_text(&err).contains("visibility groups"),
+        "{}",
+        pg_error_text(&err)
+    );
+    tx.rollback().await.unwrap();
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn groups_visibility_accepts_group_and_role_grants() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.group_id],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO collection_role_access (org_id, collection_id, role_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.role_id],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn groups_to_private_fails_while_grants_remain() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.group_id],
+    )
+    .await
+    .unwrap();
+    let err = tx
+        .execute(
+            "UPDATE collections SET visibility = 'private'
+             WHERE org_id = $1 AND id = $2",
+            &[&fixture.org, &fixture.collection],
+        )
+        .await
+        .expect_err("visibility flip with remaining grants must fail");
+    assert!(
+        pg_error_text(&err).contains("grants remain"),
+        "{}",
+        pg_error_text(&err)
+    );
+    tx.rollback().await.unwrap();
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn concurrent_grant_vs_visibility_flip_cannot_leave_dormant_rows() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+
+    let url = ephemeral.url.clone();
+    let barrier = Arc::new(Barrier::new(2));
+
+    let flip = {
+        let url = url.clone();
+        let barrier = Arc::clone(&barrier);
+        let org = fixture.org;
+        let collection = fixture.collection;
+        tokio::spawn(async move {
+            barrier.wait().await;
+            let mut client = connect(&url).await;
+            let tx = client.transaction().await.unwrap();
+            set_org(&tx, org).await;
+            let result = tx
+                .execute(
+                    "UPDATE collections SET visibility = 'private'
+                     WHERE org_id = $1 AND id = $2",
+                    &[&org, &collection],
+                )
+                .await;
+            let _ = tx.commit().await;
+            result
+        })
+    };
+
+    let grant = {
+        let url = url.clone();
+        let barrier = Arc::clone(&barrier);
+        let org = fixture.org;
+        let collection = fixture.collection;
+        let group_id = fixture.group_id;
+        tokio::spawn(async move {
+            barrier.wait().await;
+            let mut client = connect(&url).await;
+            let tx = client.transaction().await.unwrap();
+            set_org(&tx, org).await;
+            let result = tx
+                .execute(
+                    "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
+                     VALUES ($1, $2, $3, 'read')",
+                    &[&org, &collection, &group_id],
+                )
+                .await;
+            let _ = tx.commit().await;
+            result
+        })
+    };
+
+    let (flip_result, grant_result) = tokio::join!(flip, grant);
+    let flip_result = flip_result.expect("flip task join");
+    let grant_result = grant_result.expect("grant task join");
+
+    let successes = [flip_result.is_ok(), grant_result.is_ok()]
+        .iter()
+        .filter(|ok| **ok)
+        .count();
+    assert!(
+        successes <= 1,
+        "grant-vs-flip race must not let both commit: flip={flip_result:?} grant={grant_result:?}"
+    );
+
+    let client = connect(&ephemeral.url).await;
+    assert_eq!(
+        dormant_grant_count(&client).await,
+        0,
+        "no interleaving may leave group/role grants on non-groups collections"
+    );
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn acl_version_bumps_on_group_grant() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+
+    let before: i64 = client
+        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .await
+        .unwrap()
+        .get(0);
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.group_id],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    let after: i64 = client
+        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(after, before + 1);
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn acl_version_bumps_on_role_grant() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+
+    let before: i64 = client
+        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .await
+        .unwrap()
+        .get(0);
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO collection_role_access (org_id, collection_id, role_id, access_level)
+         VALUES ($1, $2, $3, 'read')",
+        &[&fixture.org, &fixture.collection, &fixture.role_id],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    let after: i64 = client
+        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(after, before + 1);
+    ephemeral.drop().await;
+}
+
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL"]
+async fn acl_version_bumps_on_group_membership_change() {
+    let Some(ephemeral) = boot_db().await else {
+        return;
+    };
+    let mut client = connect(&ephemeral.url).await;
+    let fixture = seed_acl_fixture(&mut client, "groups").await;
+    let member = Uuid::new_v4();
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO users (id, email, display_name) VALUES ($1, $2, 'Member')",
+        &[&member, &format!("member-{}@acl-it.test", member.simple())],
+    )
+    .await
+    .unwrap();
+    tx.execute(
+        "INSERT INTO org_memberships (org_id, user_id, role) VALUES ($1, $2, 'viewer')",
+        &[&fixture.org, &member],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    let before: i64 = client
+        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .await
+        .unwrap()
+        .get(0);
+
+    let tx = client.transaction().await.unwrap();
+    set_org(&tx, fixture.org).await;
+    tx.execute(
+        "INSERT INTO group_memberships (org_id, group_id, user_id) VALUES ($1, $2, $3)",
+        &[&fixture.org, &fixture.group_id, &member],
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    let after: i64 = client
+        .query_one("SELECT acl_version FROM orgs WHERE id = $1", &[&fixture.org])
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(after, before + 1);
+    ephemeral.drop().await;
+}

--- a/crates/server/tests/acl_equivalence.rs
+++ b/crates/server/tests/acl_equivalence.rs
@@ -25,6 +25,7 @@ async fn resolver_matches_sql_predicate_for_acl_fixture_matrix() {
     let matrix = seed_acl_collection_matrix(&pool, &fixture).await;
 
     let resolver_ids = resolver_allowed_collection_ids(&pool, fixture.org, fixture.member).await;
+    let expected = expected_member_read_projection(&matrix);
     let sql_ids = sql_allowed_collection_ids(
         &pool,
         fixture.org,
@@ -35,11 +36,18 @@ async fn resolver_matches_sql_predicate_for_acl_fixture_matrix() {
     .await;
 
     assert_eq!(
+        resolver_ids, expected,
+        "resolver drift: member `(qa.query, read)` projection must match canonical fixture \
+         matrix (org_visible, private_owned, private_user_grant, groups_via_group, \
+         groups_via_role, groups_read_grant, containment); resolver={resolver_ids:?} \
+         expected={expected:?}"
+    );
+
+    assert_eq!(
         resolver_ids, sql_ids,
         "resolver and SQL must agree on the full ACL fixture matrix"
     );
 
-    let expected = expected_member_read_projection(&matrix);
     assert_eq!(
         sql_ids, expected,
         "SQL projection must match canonical matrix expectations"

--- a/crates/server/tests/acl_equivalence.rs
+++ b/crates/server/tests/acl_equivalence.rs
@@ -1,0 +1,105 @@
+//! DB-gated equivalence tests: resolver projection vs `allowed_collections_sql`.
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` / `MARKHAND_TEST_APP_DATABASE_URL`
+//! are unset; runs in GitHub `rust-integration` with live PostgreSQL.
+
+mod common;
+
+use common::acl_fixture::{
+    boot_acl_pool, expected_member_read_projection, resolver_allowed_collection_ids,
+    seed_acl_collection_matrix, seed_acl_org, sql_allowed_collection_ids,
+    sql_collection_access_exists, PERMISSION_QA_QUERY,
+};
+use fileconv_server::db::models::AccessLevel;
+
+/// For every fixture state in the shared matrix, resolver `allowed_collection_ids`
+/// must equal the `allowed_collections_sql(qa.query, read)` set.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn resolver_matches_sql_predicate_for_acl_fixture_matrix() {
+    let Some((ephemeral, pool)) = boot_acl_pool().await else {
+        return;
+    };
+
+    let fixture = seed_acl_org(&pool).await;
+    let matrix = seed_acl_collection_matrix(&pool, &fixture).await;
+
+    let resolver_ids = resolver_allowed_collection_ids(&pool, fixture.org, fixture.member).await;
+    let sql_ids = sql_allowed_collection_ids(
+        &pool,
+        fixture.org,
+        fixture.member,
+        PERMISSION_QA_QUERY,
+        AccessLevel::Read,
+    )
+    .await;
+
+    assert_eq!(
+        resolver_ids, sql_ids,
+        "resolver and SQL must agree on the full ACL fixture matrix"
+    );
+
+    let expected = expected_member_read_projection(&matrix);
+    assert_eq!(
+        sql_ids, expected,
+        "SQL projection must match canonical matrix expectations"
+    );
+
+    ephemeral.drop().await;
+}
+
+/// A `read` direct grant must satisfy the read projection but not write/admin guards.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn read_grant_does_not_satisfy_write_or_admin() {
+    let Some((ephemeral, pool)) = boot_acl_pool().await else {
+        return;
+    };
+
+    let fixture = seed_acl_org(&pool).await;
+    let matrix = seed_acl_collection_matrix(&pool, &fixture).await;
+    let collection = matrix.groups_read_grant;
+
+    let read_sql = sql_allowed_collection_ids(
+        &pool,
+        fixture.org,
+        fixture.member,
+        PERMISSION_QA_QUERY,
+        AccessLevel::Read,
+    )
+    .await;
+    assert!(
+        read_sql.contains(&collection),
+        "read grant must satisfy read projection"
+    );
+
+    let write_allowed = sql_collection_access_exists(
+        &pool,
+        fixture.org,
+        fixture.member,
+        collection,
+        PERMISSION_QA_QUERY,
+        AccessLevel::Write,
+    )
+    .await;
+    assert!(
+        !write_allowed,
+        "read grant must not satisfy write required_access"
+    );
+
+    let admin_allowed = sql_collection_access_exists(
+        &pool,
+        fixture.org,
+        fixture.member,
+        collection,
+        PERMISSION_QA_QUERY,
+        AccessLevel::Admin,
+    )
+    .await;
+    assert!(
+        !admin_allowed,
+        "read grant must not satisfy admin required_access"
+    );
+
+    ephemeral.drop().await;
+}

--- a/crates/server/tests/acl_resolver.rs
+++ b/crates/server/tests/acl_resolver.rs
@@ -5,11 +5,8 @@
 
 mod common;
 
-use std::collections::BTreeSet;
-
 use common::acl_fixture::{
-    attempt_grant_group_access, attempt_grant_role_access, boot_acl_pool,
-    expected_member_read_projection, group_grant_count, poc_resolver_projection,
+    attempt_grant_group_access, attempt_grant_role_access, boot_acl_pool, group_grant_count,
     resolver_allowed_collection_ids, role_grant_count, seed_acl_collection_matrix, seed_acl_org,
     user_grant_count, PERMISSION_QA_QUERY,
 };
@@ -17,7 +14,6 @@ use fileconv_server::auth::context::OrgContext;
 use fileconv_server::db::models::AccessLevel;
 use fileconv_server::db::pool::with_org_txn;
 use fileconv_server::services::acl_mutate::revoke_collection_access_for_principal;
-use uuid::Uuid;
 
 /// Group grant on a `groups` collection must surface via the resolver even when
 /// the member has no direct `collection_user_access` row.
@@ -172,36 +168,4 @@ async fn containment_removes_group_role_grants_but_preserves_other_user_grants()
     );
 
     ephemeral.drop().await;
-}
-
-/// Hermetic contract pin: documents the RED gap between the POC resolver and
-/// the `(qa.query, read)` projection SQL already ships. CI integration runs
-/// prove the live resolver still matches the narrower POC set until Task 6 GREEN.
-#[test]
-fn poc_resolver_projection_is_narrower_than_qa_query_read_matrix() {
-    let matrix = common::acl_fixture::AclCollectionMatrix {
-        org_visible: Uuid::from_u128(1),
-        private_owned: Uuid::from_u128(2),
-        private_foreign: Uuid::from_u128(3),
-        private_user_grant: Uuid::from_u128(4),
-        private_group_leak: Uuid::from_u128(5),
-        private_role_leak: Uuid::from_u128(6),
-        groups_via_group: Uuid::from_u128(7),
-        groups_via_role: Uuid::from_u128(8),
-        groups_denied: Uuid::from_u128(9),
-        groups_read_grant: Uuid::from_u128(10),
-        containment: Uuid::from_u128(11),
-    };
-    let expected = expected_member_read_projection(&matrix);
-    let poc = poc_resolver_projection(&matrix);
-    let missing_from_poc: BTreeSet<_> = expected.difference(&poc).copied().collect();
-    assert!(
-        !missing_from_poc.is_empty(),
-        "Task 6 RED: POC resolver must omit group/role-backed collections until wired; \
-         missing from POC projection: {missing_from_poc:?}"
-    );
-    assert!(
-        missing_from_poc.contains(&matrix.groups_via_group),
-        "groups_via_group is the canonical RED case"
-    );
 }

--- a/crates/server/tests/acl_resolver.rs
+++ b/crates/server/tests/acl_resolver.rs
@@ -112,6 +112,34 @@ async fn containment_removes_group_role_grants_but_preserves_other_user_grants()
     let matrix = seed_acl_collection_matrix(&pool, &fixture).await;
     let collection = matrix.containment;
 
+    assert_eq!(
+        group_grant_count(&pool, fixture.org, collection).await,
+        1,
+        "containment fixture must seed one group grant before revoke"
+    );
+    assert_eq!(
+        role_grant_count(&pool, fixture.org, collection).await,
+        1,
+        "containment fixture must seed one role grant before revoke"
+    );
+    assert_eq!(
+        user_grant_count(&pool, fixture.org, collection, fixture.member).await,
+        1,
+        "containment fixture must seed target member direct grant before revoke"
+    );
+    assert_eq!(
+        user_grant_count(&pool, fixture.org, collection, fixture.other_user).await,
+        1,
+        "containment fixture must seed unrelated other-user direct grant before revoke"
+    );
+
+    let member_allowed_before =
+        resolver_allowed_collection_ids(&pool, fixture.org, fixture.member).await;
+    assert!(
+        member_allowed_before.contains(&collection),
+        "member must resolve containment before revoke; got {member_allowed_before:?}"
+    );
+
     let owner_ctx =
         OrgContext::try_new(fixture.org, fixture.owner, [PERMISSION_QA_QUERY], []).unwrap();
     with_org_txn(&pool, &owner_ctx, {

--- a/crates/server/tests/acl_resolver.rs
+++ b/crates/server/tests/acl_resolver.rs
@@ -1,0 +1,167 @@
+//! DB-gated resolver tests for Phase 1C `(qa.query, read)` collection projection.
+//!
+//! Skips cleanly when `MARKHAND_TEST_DATABASE_URL` / `MARKHAND_TEST_APP_DATABASE_URL`
+//! are unset; runs in GitHub `rust-integration` with live PostgreSQL.
+
+mod common;
+
+use std::collections::BTreeSet;
+
+use common::acl_fixture::{
+    boot_acl_pool, expected_member_read_projection, group_grant_count, poc_resolver_projection,
+    resolver_allowed_collection_ids, role_grant_count, seed_acl_collection_matrix, seed_acl_org,
+    user_grant_count, PERMISSION_QA_QUERY,
+};
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::db::pool::with_org_txn;
+use fileconv_server::services::acl_mutate::revoke_collection_access_for_principal;
+use uuid::Uuid;
+
+/// Group grant on a `groups` collection must surface via the resolver even when
+/// the member has no direct `collection_user_access` row.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn groups_visibility_group_grant_allows_member_without_user_grant() {
+    let Some((ephemeral, pool)) = boot_acl_pool().await else {
+        return;
+    };
+
+    let fixture = seed_acl_org(&pool).await;
+    let matrix = seed_acl_collection_matrix(&pool, &fixture).await;
+
+    let allowed = resolver_allowed_collection_ids(&pool, fixture.org, fixture.member).await;
+    assert!(
+        allowed.contains(&matrix.groups_via_group),
+        "member must see groups collection via group grant; got {allowed:?}"
+    );
+
+    ephemeral.drop().await;
+}
+
+/// Dormant group/role grants on `private` collections must not leak into the
+/// resolver projection (private arm ignores non-user grants).
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn private_visibility_ignores_group_and_role_grants() {
+    let Some((ephemeral, pool)) = boot_acl_pool().await else {
+        return;
+    };
+
+    let fixture = seed_acl_org(&pool).await;
+    let matrix = seed_acl_collection_matrix(&pool, &fixture).await;
+
+    let allowed = resolver_allowed_collection_ids(&pool, fixture.org, fixture.member).await;
+    assert!(
+        !allowed.contains(&matrix.private_group_leak),
+        "private collection must not admit group grant: {allowed:?}"
+    );
+    assert!(
+        !allowed.contains(&matrix.private_role_leak),
+        "private collection must not admit role grant: {allowed:?}"
+    );
+
+    ephemeral.drop().await;
+}
+
+/// `revoke_collection_access_for_principal` must delete group/role grants,
+/// revoke only the target user's direct grant, and leave other users' grants.
+#[tokio::test]
+#[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
+async fn containment_removes_group_role_grants_but_preserves_other_user_grants() {
+    let Some((ephemeral, pool)) = boot_acl_pool().await else {
+        return;
+    };
+
+    let fixture = seed_acl_org(&pool).await;
+    let matrix = seed_acl_collection_matrix(&pool, &fixture).await;
+    let collection = matrix.containment;
+
+    let owner_ctx =
+        OrgContext::try_new(fixture.org, fixture.owner, [PERMISSION_QA_QUERY], []).unwrap();
+    with_org_txn(&pool, &owner_ctx, {
+        let fixture = fixture.clone();
+        move |txn| {
+            Box::pin(async move {
+                revoke_collection_access_for_principal(
+                    txn,
+                    fixture.org,
+                    fixture.member,
+                    collection,
+                    fixture.owner,
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("revoke collection access");
+
+    assert_eq!(
+        group_grant_count(&pool, fixture.org, collection).await,
+        0,
+        "group grants must be removed during containment revoke"
+    );
+    assert_eq!(
+        role_grant_count(&pool, fixture.org, collection).await,
+        0,
+        "role grants must be removed during containment revoke"
+    );
+    assert_eq!(
+        user_grant_count(&pool, fixture.org, collection, fixture.member).await,
+        0,
+        "target user's direct grant must be removed"
+    );
+    assert_eq!(
+        user_grant_count(&pool, fixture.org, collection, fixture.other_user).await,
+        1,
+        "other user's direct grant must survive containment revoke"
+    );
+
+    let member_allowed = resolver_allowed_collection_ids(&pool, fixture.org, fixture.member).await;
+    assert!(
+        !member_allowed.contains(&collection),
+        "revoked member must not retain collection access"
+    );
+
+    let other_allowed =
+        resolver_allowed_collection_ids(&pool, fixture.org, fixture.other_user).await;
+    assert!(
+        other_allowed.contains(&collection),
+        "other user must retain access via preserved direct grant; got {other_allowed:?}"
+    );
+
+    ephemeral.drop().await;
+}
+
+/// Hermetic contract pin: documents the RED gap between the POC resolver and
+/// the `(qa.query, read)` projection SQL already ships. CI integration runs
+/// prove the live resolver still matches the narrower POC set until Task 6 GREEN.
+#[test]
+fn poc_resolver_projection_is_narrower_than_qa_query_read_matrix() {
+    let matrix = common::acl_fixture::AclCollectionMatrix {
+        org_visible: Uuid::from_u128(1),
+        private_owned: Uuid::from_u128(2),
+        private_foreign: Uuid::from_u128(3),
+        private_user_grant: Uuid::from_u128(4),
+        private_group_leak: Uuid::from_u128(5),
+        private_role_leak: Uuid::from_u128(6),
+        groups_via_group: Uuid::from_u128(7),
+        groups_via_role: Uuid::from_u128(8),
+        groups_denied: Uuid::from_u128(9),
+        groups_read_grant: Uuid::from_u128(10),
+        containment: Uuid::from_u128(11),
+    };
+    let expected = expected_member_read_projection(&matrix);
+    let poc = poc_resolver_projection(&matrix);
+    let missing_from_poc: BTreeSet<_> = expected.difference(&poc).copied().collect();
+    assert!(
+        !missing_from_poc.is_empty(),
+        "Task 6 RED: POC resolver must omit group/role-backed collections until wired; \
+         missing from POC projection: {missing_from_poc:?}"
+    );
+    assert!(
+        missing_from_poc.contains(&matrix.groups_via_group),
+        "groups_via_group is the canonical RED case"
+    );
+}

--- a/crates/server/tests/acl_resolver.rs
+++ b/crates/server/tests/acl_resolver.rs
@@ -8,11 +8,13 @@ mod common;
 use std::collections::BTreeSet;
 
 use common::acl_fixture::{
-    boot_acl_pool, expected_member_read_projection, group_grant_count, poc_resolver_projection,
+    attempt_grant_group_access, attempt_grant_role_access, boot_acl_pool,
+    expected_member_read_projection, group_grant_count, poc_resolver_projection,
     resolver_allowed_collection_ids, role_grant_count, seed_acl_collection_matrix, seed_acl_org,
     user_grant_count, PERMISSION_QA_QUERY,
 };
 use fileconv_server::auth::context::OrgContext;
+use fileconv_server::db::models::AccessLevel;
 use fileconv_server::db::pool::with_org_txn;
 use fileconv_server::services::acl_mutate::revoke_collection_access_for_principal;
 use uuid::Uuid;
@@ -38,8 +40,9 @@ async fn groups_visibility_group_grant_allows_member_without_user_grant() {
     ephemeral.drop().await;
 }
 
-/// Dormant group/role grants on `private` collections must not leak into the
-/// resolver projection (private arm ignores non-user grants).
+/// Migration 0036 rejects dormant group/role grants on `private` collections.
+/// Integrated fail-closed: grant attempts roll back independently, counts stay
+/// zero, and the member cannot resolve either private collection.
 #[tokio::test]
 #[ignore = "requires MARKHAND_TEST_DATABASE_URL and MARKHAND_TEST_APP_DATABASE_URL"]
 async fn private_visibility_ignores_group_and_role_grants() {
@@ -50,14 +53,51 @@ async fn private_visibility_ignores_group_and_role_grants() {
     let fixture = seed_acl_org(&pool).await;
     let matrix = seed_acl_collection_matrix(&pool, &fixture).await;
 
+    let group_err = attempt_grant_group_access(
+        &pool,
+        &fixture,
+        matrix.private_group_leak,
+        AccessLevel::Write,
+    )
+    .await
+    .expect_err("group grant on private collection must be rejected");
+    assert!(
+        group_err.contains("visibility groups"),
+        "unexpected group-grant rejection: {group_err}"
+    );
+
+    let role_err = attempt_grant_role_access(
+        &pool,
+        &fixture,
+        matrix.private_role_leak,
+        AccessLevel::Write,
+    )
+    .await
+    .expect_err("role grant on private collection must be rejected");
+    assert!(
+        role_err.contains("visibility groups"),
+        "unexpected role-grant rejection: {role_err}"
+    );
+
+    assert_eq!(
+        group_grant_count(&pool, fixture.org, matrix.private_group_leak).await,
+        0,
+        "rejected group grant must not persist"
+    );
+    assert_eq!(
+        role_grant_count(&pool, fixture.org, matrix.private_role_leak).await,
+        0,
+        "rejected role grant must not persist"
+    );
+
     let allowed = resolver_allowed_collection_ids(&pool, fixture.org, fixture.member).await;
     assert!(
         !allowed.contains(&matrix.private_group_leak),
-        "private collection must not admit group grant: {allowed:?}"
+        "member must not resolve private collection after rejected group grant: {allowed:?}"
     );
     assert!(
         !allowed.contains(&matrix.private_role_leak),
-        "private collection must not admit role grant: {allowed:?}"
+        "member must not resolve private collection after rejected role grant: {allowed:?}"
     );
 
     ephemeral.drop().await;

--- a/crates/server/tests/chat_history.rs
+++ b/crates/server/tests/chat_history.rs
@@ -66,6 +66,7 @@ async fn seed_caller_without_permissions(
     user: Uuid,
     email: &str,
 ) -> String {
+    // Intentionally omits `qa.query`: history CRUD 403 tests, not collection scope.
     common::seed_user_with_permissions(pool, org, user, email, PASSWORD, &[]).await;
     common::login_access_token(pool, email, PASSWORD).await
 }

--- a/crates/server/tests/common/acl_fixture.rs
+++ b/crates/server/tests/common/acl_fixture.rs
@@ -349,17 +349,6 @@ pub fn expected_member_read_projection(matrix: &AclCollectionMatrix) -> BTreeSet
     .collect()
 }
 
-/// Collection ids the POC resolver currently returns (org/owner/direct-user only).
-pub fn poc_resolver_projection(matrix: &AclCollectionMatrix) -> BTreeSet<Uuid> {
-    [
-        matrix.org_visible,
-        matrix.private_owned,
-        matrix.private_user_grant,
-    ]
-    .into_iter()
-    .collect()
-}
-
 pub async fn resolver_allowed_collection_ids(pool: &Pool, org: Uuid, user: Uuid) -> BTreeSet<Uuid> {
     let ctx = resolve_org_context_in_txn(pool, org, user)
         .await

--- a/crates/server/tests/common/acl_fixture.rs
+++ b/crates/server/tests/common/acl_fixture.rs
@@ -9,6 +9,7 @@ use deadpool_postgres::Pool;
 use fileconv_server::auth::context::OrgContext;
 use fileconv_server::auth::permissions::resolve_org_context_in_txn;
 use fileconv_server::db::acl_sql::{acl_predicate_sql, allowed_collections_sql};
+use fileconv_server::db::error::DbError;
 use fileconv_server::db::models::AccessLevel;
 use fileconv_server::db::pool::with_org_txn;
 use tokio_postgres::Transaction;
@@ -37,7 +38,11 @@ pub struct AclCollectionMatrix {
     pub private_owned: Uuid,
     pub private_foreign: Uuid,
     pub private_user_grant: Uuid,
+    /// Private collection used by `private_visibility_ignores_group_and_role_grants`
+    /// to prove migration 0036 rejects dormant group grants (never seeded here).
     pub private_group_leak: Uuid,
+    /// Private collection used by `private_visibility_ignores_group_and_role_grants`
+    /// to prove migration 0036 rejects dormant role grants (never seeded here).
     pub private_role_leak: Uuid,
     pub groups_via_group: Uuid,
     pub groups_via_role: Uuid,
@@ -255,26 +260,10 @@ pub async fn seed_acl_collection_matrix(
                 matrix.private_group_leak =
                     insert_collection(txn, fixture.org, fixture.owner, "private", "group-leak")
                         .await?;
-                grant_group_access(
-                    txn,
-                    fixture.org,
-                    matrix.private_group_leak,
-                    fixture.group_id,
-                    AccessLevel::Write,
-                )
-                .await?;
 
                 matrix.private_role_leak =
                     insert_collection(txn, fixture.org, fixture.owner, "private", "role-leak")
                         .await?;
-                grant_role_access(
-                    txn,
-                    fixture.org,
-                    matrix.private_role_leak,
-                    fixture.viewer_role_id,
-                    AccessLevel::Write,
-                )
-                .await?;
 
                 matrix.groups_via_group =
                     insert_collection(txn, fixture.org, fixture.owner, "groups", "via-group")
@@ -344,6 +333,8 @@ pub async fn seed_acl_collection_matrix(
 }
 
 /// Collection ids `member` should see under the `(qa.query, read)` projection.
+/// Excludes private collections with no user grant and collections denied by
+/// missing group/role grants; dormant grants on private are not seedable (0036).
 pub fn expected_member_read_projection(matrix: &AclCollectionMatrix) -> BTreeSet<Uuid> {
     [
         matrix.org_visible,
@@ -492,4 +483,68 @@ pub async fn user_grant_count(pool: &Pool, org: Uuid, collection_id: Uuid, user_
     })
     .await
     .expect("user grant count")
+}
+
+fn pg_error_text(error: &tokio_postgres::Error) -> String {
+    if let Some(db) = error.as_db_error() {
+        format!("{} {}", db.message(), db.detail().unwrap_or(""))
+    } else {
+        format!("{error:?}")
+    }
+}
+
+/// Attempt a group grant in its own transaction (migration 0036 may reject).
+pub async fn attempt_grant_group_access(
+    pool: &Pool,
+    fixture: &AclOrgFixture,
+    collection_id: Uuid,
+    access_level: AccessLevel,
+) -> Result<(), String> {
+    let ctx = OrgContext::try_new(fixture.org, fixture.owner, [PERMISSION_QA_QUERY], []).unwrap();
+    with_org_txn(pool, &ctx, {
+        let fixture = fixture.clone();
+        move |txn| {
+            Box::pin(async move {
+                grant_group_access(
+                    txn,
+                    fixture.org,
+                    collection_id,
+                    fixture.group_id,
+                    access_level,
+                )
+                .await
+                .map_err(|error| DbError::Config(pg_error_text(&error)))
+            })
+        }
+    })
+    .await
+    .map_err(|error| error.to_string())
+}
+
+/// Attempt a role grant in its own transaction (migration 0036 may reject).
+pub async fn attempt_grant_role_access(
+    pool: &Pool,
+    fixture: &AclOrgFixture,
+    collection_id: Uuid,
+    access_level: AccessLevel,
+) -> Result<(), String> {
+    let ctx = OrgContext::try_new(fixture.org, fixture.owner, [PERMISSION_QA_QUERY], []).unwrap();
+    with_org_txn(pool, &ctx, {
+        let fixture = fixture.clone();
+        move |txn| {
+            Box::pin(async move {
+                grant_role_access(
+                    txn,
+                    fixture.org,
+                    collection_id,
+                    fixture.viewer_role_id,
+                    access_level,
+                )
+                .await
+                .map_err(|error| DbError::Config(pg_error_text(&error)))
+            })
+        }
+    })
+    .await
+    .map_err(|error| error.to_string())
 }

--- a/crates/server/tests/common/acl_fixture.rs
+++ b/crates/server/tests/common/acl_fixture.rs
@@ -96,7 +96,7 @@ pub async fn seed_acl_org(pool: &Pool) -> AclOrgFixture {
 
     let owner_ctx = OrgContext::try_new(org, owner, [PERMISSION_QA_QUERY], []).unwrap();
     let org_id = org;
-    with_org_txn(pool, &owner_ctx, {
+    let resolved_viewer_role_id = with_org_txn(pool, &owner_ctx, {
         move |txn| {
             Box::pin(async move {
                 txn.execute(
@@ -109,6 +109,22 @@ pub async fn seed_acl_org(pool: &Pool) -> AclOrgFixture {
                      VALUES ($1, $2, 'viewer', 'Viewer', true)
                      ON CONFLICT (org_id, code) DO NOTHING",
                     &[&viewer_role_id, &org_id],
+                )
+                .await?;
+                let resolved_viewer_role_id: Uuid = txn
+                    .query_one(
+                        "SELECT id FROM roles WHERE org_id = $1 AND code = 'viewer'",
+                        &[&org_id],
+                    )
+                    .await?
+                    .get(0);
+                txn.execute(
+                    "INSERT INTO role_permissions (org_id, role_id, permission_id)
+                     SELECT $1, $2, p.id
+                     FROM permissions p
+                     WHERE p.code = $3
+                     ON CONFLICT DO NOTHING",
+                    &[&org_id, &resolved_viewer_role_id, &PERMISSION_QA_QUERY],
                 )
                 .await?;
                 txn.execute(
@@ -124,7 +140,7 @@ pub async fn seed_acl_org(pool: &Pool) -> AclOrgFixture {
                     &[&org_id, &member],
                 )
                 .await?;
-                Ok(())
+                Ok(resolved_viewer_role_id)
             })
         }
     })
@@ -137,7 +153,7 @@ pub async fn seed_acl_org(pool: &Pool) -> AclOrgFixture {
         member,
         other_user,
         group_id,
-        viewer_role_id,
+        viewer_role_id: resolved_viewer_role_id,
     }
 }
 

--- a/crates/server/tests/common/acl_fixture.rs
+++ b/crates/server/tests/common/acl_fixture.rs
@@ -1,0 +1,495 @@
+//! Shared ACL integration fixtures for Phase 1C resolver / SQL equivalence tests.
+//!
+//! Seeds real PostgreSQL rows (groups, grants, memberships) and compares
+//! `resolve_org_context_in_txn` against `db::acl_sql::allowed_collections_sql`.
+
+use std::collections::BTreeSet;
+
+use deadpool_postgres::Pool;
+use fileconv_server::auth::context::OrgContext;
+use fileconv_server::auth::permissions::resolve_org_context_in_txn;
+use fileconv_server::db::acl_sql::{acl_predicate_sql, allowed_collections_sql};
+use fileconv_server::db::models::AccessLevel;
+use fileconv_server::db::pool::with_org_txn;
+use tokio_postgres::Transaction;
+use uuid::Uuid;
+
+use super::{admin_database_url, app_database_url, boot_app_pool, seed_user_with_permissions};
+
+pub const PERMISSION_QA_QUERY: &str = "qa.query";
+pub const PASSWORD: &str = "correct-password-1";
+
+/// One org with owner, acting member, secondary user, group, and viewer role.
+#[derive(Debug, Clone)]
+pub struct AclOrgFixture {
+    pub org: Uuid,
+    pub owner: Uuid,
+    pub member: Uuid,
+    pub other_user: Uuid,
+    pub group_id: Uuid,
+    pub viewer_role_id: Uuid,
+}
+
+/// Collection ids keyed by scenario label for matrix assertions.
+#[derive(Debug, Clone, Default)]
+pub struct AclCollectionMatrix {
+    pub org_visible: Uuid,
+    pub private_owned: Uuid,
+    pub private_foreign: Uuid,
+    pub private_user_grant: Uuid,
+    pub private_group_leak: Uuid,
+    pub private_role_leak: Uuid,
+    pub groups_via_group: Uuid,
+    pub groups_via_role: Uuid,
+    pub groups_denied: Uuid,
+    pub groups_read_grant: Uuid,
+    pub containment: Uuid,
+}
+
+pub async fn boot_acl_pool() -> Option<(super::DualRoleEphemeralDb, Pool)> {
+    let admin = admin_database_url()?;
+    let app = app_database_url()?;
+    Some(boot_app_pool(&admin, &app).await)
+}
+
+/// Seeds org/users/roles/group; `member` and `other_user` receive `qa.query`.
+pub async fn seed_acl_org(pool: &Pool) -> AclOrgFixture {
+    let org = Uuid::new_v4();
+    let owner = Uuid::new_v4();
+    let member = Uuid::new_v4();
+    let other_user = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let viewer_role_id = Uuid::new_v4();
+
+    seed_user_with_permissions(
+        pool,
+        org,
+        owner,
+        &format!("owner-{}@acl-fixture.test", owner.simple()),
+        PASSWORD,
+        &[PERMISSION_QA_QUERY],
+    )
+    .await;
+    seed_user_with_permissions(
+        pool,
+        org,
+        member,
+        &format!("member-{}@acl-fixture.test", member.simple()),
+        PASSWORD,
+        &[PERMISSION_QA_QUERY],
+    )
+    .await;
+    seed_user_with_permissions(
+        pool,
+        org,
+        other_user,
+        &format!("other-{}@acl-fixture.test", other_user.simple()),
+        PASSWORD,
+        &[PERMISSION_QA_QUERY],
+    )
+    .await;
+
+    let owner_ctx = OrgContext::try_new(org, owner, [PERMISSION_QA_QUERY], []).unwrap();
+    let org_id = org;
+    with_org_txn(pool, &owner_ctx, {
+        move |txn| {
+            Box::pin(async move {
+                txn.execute(
+                    "INSERT INTO groups (id, org_id, name) VALUES ($1, $2, 'Editors')",
+                    &[&group_id, &org_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO roles (id, org_id, code, name, is_system)
+                     VALUES ($1, $2, 'viewer', 'Viewer', true)
+                     ON CONFLICT (org_id, code) DO NOTHING",
+                    &[&viewer_role_id, &org_id],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO group_memberships (org_id, group_id, user_id)
+                     VALUES ($1, $2, $3)",
+                    &[&org_id, &group_id, &member],
+                )
+                .await?;
+                txn.execute(
+                    "INSERT INTO org_memberships (org_id, user_id, role)
+                     VALUES ($1, $2, 'viewer')
+                     ON CONFLICT (org_id, user_id) DO UPDATE SET role = EXCLUDED.role",
+                    &[&org_id, &member],
+                )
+                .await?;
+                Ok(())
+            })
+        }
+    })
+    .await
+    .expect("seed group and viewer role");
+
+    AclOrgFixture {
+        org,
+        owner,
+        member,
+        other_user,
+        group_id,
+        viewer_role_id,
+    }
+}
+
+pub async fn insert_collection(
+    txn: &Transaction<'_>,
+    org: Uuid,
+    owner_user_id: Uuid,
+    visibility: &str,
+    slug_suffix: &str,
+) -> Result<Uuid, tokio_postgres::Error> {
+    let id = Uuid::new_v4();
+    let slug = format!("acl-{slug_suffix}-{}", &id.simple().to_string()[..8]);
+    let name = format!("ACL {slug_suffix}");
+    txn.execute(
+        "INSERT INTO collections (id, org_id, name, slug, owner_user_id, visibility)
+         VALUES ($1, $2, $3, $4, $5, $6)",
+        &[&id, &org, &name, &slug, &owner_user_id, &visibility],
+    )
+    .await?;
+    Ok(id)
+}
+
+pub async fn grant_user_access(
+    txn: &Transaction<'_>,
+    org: Uuid,
+    collection_id: Uuid,
+    user_id: Uuid,
+    access_level: AccessLevel,
+) -> Result<(), tokio_postgres::Error> {
+    txn.execute(
+        "INSERT INTO collection_user_access (id, org_id, collection_id, user_id, access_level)
+         VALUES ($1, $2, $3, $4, $5)",
+        &[
+            &Uuid::new_v4(),
+            &org,
+            &collection_id,
+            &user_id,
+            &access_level.as_str(),
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn grant_group_access(
+    txn: &Transaction<'_>,
+    org: Uuid,
+    collection_id: Uuid,
+    group_id: Uuid,
+    access_level: AccessLevel,
+) -> Result<(), tokio_postgres::Error> {
+    txn.execute(
+        "INSERT INTO collection_group_access (id, org_id, collection_id, group_id, access_level)
+         VALUES ($1, $2, $3, $4, $5)",
+        &[
+            &Uuid::new_v4(),
+            &org,
+            &collection_id,
+            &group_id,
+            &access_level.as_str(),
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn grant_role_access(
+    txn: &Transaction<'_>,
+    org: Uuid,
+    collection_id: Uuid,
+    role_id: Uuid,
+    access_level: AccessLevel,
+) -> Result<(), tokio_postgres::Error> {
+    txn.execute(
+        "INSERT INTO collection_role_access (id, org_id, collection_id, role_id, access_level)
+         VALUES ($1, $2, $3, $4, $5)",
+        &[
+            &Uuid::new_v4(),
+            &org,
+            &collection_id,
+            &role_id,
+            &access_level.as_str(),
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Seeds the full matrix of collection visibility/grant combinations for `fixture.member`.
+pub async fn seed_acl_collection_matrix(
+    pool: &Pool,
+    fixture: &AclOrgFixture,
+) -> AclCollectionMatrix {
+    let ctx = OrgContext::try_new(fixture.org, fixture.owner, [PERMISSION_QA_QUERY], []).unwrap();
+    with_org_txn(pool, &ctx, {
+        let fixture = fixture.clone();
+        move |txn| {
+            Box::pin(async move {
+                let mut matrix = AclCollectionMatrix::default();
+
+                matrix.org_visible =
+                    insert_collection(txn, fixture.org, fixture.owner, "org", "org").await?;
+                matrix.private_owned =
+                    insert_collection(txn, fixture.org, fixture.member, "private", "owned").await?;
+                matrix.private_foreign =
+                    insert_collection(txn, fixture.org, fixture.owner, "private", "foreign")
+                        .await?;
+                matrix.private_user_grant =
+                    insert_collection(txn, fixture.org, fixture.owner, "private", "user-grant")
+                        .await?;
+                grant_user_access(
+                    txn,
+                    fixture.org,
+                    matrix.private_user_grant,
+                    fixture.member,
+                    AccessLevel::Write,
+                )
+                .await?;
+
+                matrix.private_group_leak =
+                    insert_collection(txn, fixture.org, fixture.owner, "private", "group-leak")
+                        .await?;
+                grant_group_access(
+                    txn,
+                    fixture.org,
+                    matrix.private_group_leak,
+                    fixture.group_id,
+                    AccessLevel::Write,
+                )
+                .await?;
+
+                matrix.private_role_leak =
+                    insert_collection(txn, fixture.org, fixture.owner, "private", "role-leak")
+                        .await?;
+                grant_role_access(
+                    txn,
+                    fixture.org,
+                    matrix.private_role_leak,
+                    fixture.viewer_role_id,
+                    AccessLevel::Write,
+                )
+                .await?;
+
+                matrix.groups_via_group =
+                    insert_collection(txn, fixture.org, fixture.owner, "groups", "via-group")
+                        .await?;
+                grant_group_access(
+                    txn,
+                    fixture.org,
+                    matrix.groups_via_group,
+                    fixture.group_id,
+                    AccessLevel::Write,
+                )
+                .await?;
+
+                matrix.groups_via_role =
+                    insert_collection(txn, fixture.org, fixture.owner, "groups", "via-role")
+                        .await?;
+                grant_role_access(
+                    txn,
+                    fixture.org,
+                    matrix.groups_via_role,
+                    fixture.viewer_role_id,
+                    AccessLevel::Write,
+                )
+                .await?;
+
+                matrix.groups_denied =
+                    insert_collection(txn, fixture.org, fixture.owner, "groups", "denied").await?;
+
+                matrix.groups_read_grant =
+                    insert_collection(txn, fixture.org, fixture.owner, "groups", "read-grant")
+                        .await?;
+                grant_user_access(
+                    txn,
+                    fixture.org,
+                    matrix.groups_read_grant,
+                    fixture.member,
+                    AccessLevel::Read,
+                )
+                .await?;
+
+                matrix.containment =
+                    insert_collection(txn, fixture.org, fixture.member, "groups", "contain")
+                        .await?;
+                grant_group_access(
+                    txn,
+                    fixture.org,
+                    matrix.containment,
+                    fixture.group_id,
+                    AccessLevel::Write,
+                )
+                .await?;
+                grant_user_access(
+                    txn,
+                    fixture.org,
+                    matrix.containment,
+                    fixture.other_user,
+                    AccessLevel::Write,
+                )
+                .await?;
+
+                Ok(matrix)
+            })
+        }
+    })
+    .await
+    .expect("seed acl collection matrix")
+}
+
+/// Collection ids `member` should see under the `(qa.query, read)` projection.
+pub fn expected_member_read_projection(matrix: &AclCollectionMatrix) -> BTreeSet<Uuid> {
+    [
+        matrix.org_visible,
+        matrix.private_owned,
+        matrix.private_user_grant,
+        matrix.groups_via_group,
+        matrix.groups_via_role,
+        matrix.groups_read_grant,
+        matrix.containment,
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// Collection ids the POC resolver currently returns (org/owner/direct-user only).
+pub fn poc_resolver_projection(matrix: &AclCollectionMatrix) -> BTreeSet<Uuid> {
+    [
+        matrix.org_visible,
+        matrix.private_owned,
+        matrix.private_user_grant,
+    ]
+    .into_iter()
+    .collect()
+}
+
+pub async fn resolver_allowed_collection_ids(pool: &Pool, org: Uuid, user: Uuid) -> BTreeSet<Uuid> {
+    let ctx = resolve_org_context_in_txn(pool, org, user)
+        .await
+        .expect("resolve org context");
+    ctx.allowed_collection_ids().clone()
+}
+
+pub async fn sql_allowed_collection_ids(
+    pool: &Pool,
+    org: Uuid,
+    user: Uuid,
+    permission: &str,
+    required_access: AccessLevel,
+) -> BTreeSet<Uuid> {
+    let permission = permission.to_string();
+    let access = required_access.as_str().to_string();
+    let provisional = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    with_org_txn(pool, &provisional, move |txn| {
+        Box::pin(async move {
+            let sql = format!(
+                "SELECT c.id FROM collections c WHERE {}",
+                allowed_collections_sql("$1", "$2", "$3", "$4")
+            );
+            let rows = txn
+                .query(&sql, &[&org, &user, &permission, &access])
+                .await?;
+            Ok(rows
+                .iter()
+                .map(|row| row.get::<_, Uuid>(0))
+                .collect::<BTreeSet<_>>())
+        })
+    })
+    .await
+    .expect("sql allowed collections")
+}
+
+pub async fn sql_collection_access_exists(
+    pool: &Pool,
+    org: Uuid,
+    user: Uuid,
+    collection_id: Uuid,
+    permission: &str,
+    required_access: AccessLevel,
+) -> bool {
+    let permission = permission.to_string();
+    let access = required_access.as_str().to_string();
+    let provisional = OrgContext::try_new(org, user, [] as [&str; 0], []).unwrap();
+    with_org_txn(pool, &provisional, move |txn| {
+        Box::pin(async move {
+            let sql = format!(
+                "SELECT EXISTS (
+                   SELECT 1 FROM collections c
+                   WHERE c.org_id = $1 AND c.id = $2 AND c.deleted_at IS NULL
+                     AND ({})
+                 )",
+                acl_predicate_sql("c.org_id", "c.id", "$3", "$4", "$5")
+            );
+            let allowed: bool = txn
+                .query_one(&sql, &[&org, &collection_id, &user, &permission, &access])
+                .await?
+                .get(0);
+            Ok(allowed)
+        })
+    })
+    .await
+    .expect("sql collection access exists")
+}
+
+pub async fn group_grant_count(pool: &Pool, org: Uuid, collection_id: Uuid) -> i64 {
+    let ctx = OrgContext::try_new(org, Uuid::new_v4(), [] as [&str; 0], []).unwrap();
+    with_org_txn(pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let count: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM collection_group_access
+                     WHERE org_id = $1 AND collection_id = $2",
+                    &[&org, &collection_id],
+                )
+                .await?
+                .get(0);
+            Ok(count)
+        })
+    })
+    .await
+    .expect("group grant count")
+}
+
+pub async fn role_grant_count(pool: &Pool, org: Uuid, collection_id: Uuid) -> i64 {
+    let ctx = OrgContext::try_new(org, Uuid::new_v4(), [] as [&str; 0], []).unwrap();
+    with_org_txn(pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let count: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM collection_role_access
+                     WHERE org_id = $1 AND collection_id = $2",
+                    &[&org, &collection_id],
+                )
+                .await?
+                .get(0);
+            Ok(count)
+        })
+    })
+    .await
+    .expect("role grant count")
+}
+
+pub async fn user_grant_count(pool: &Pool, org: Uuid, collection_id: Uuid, user_id: Uuid) -> i64 {
+    let ctx = OrgContext::try_new(org, user_id, [] as [&str; 0], []).unwrap();
+    with_org_txn(pool, &ctx, move |txn| {
+        Box::pin(async move {
+            let count: i64 = txn
+                .query_one(
+                    "SELECT count(*)::bigint FROM collection_user_access
+                     WHERE org_id = $1 AND collection_id = $2 AND user_id = $3",
+                    &[&org, &collection_id, &user_id],
+                )
+                .await?
+                .get(0);
+            Ok(count)
+        })
+    })
+    .await
+    .expect("user grant count")
+}

--- a/crates/server/tests/common/acl_fixture.rs
+++ b/crates/server/tests/common/acl_fixture.rs
@@ -331,6 +331,22 @@ pub async fn seed_acl_collection_matrix(
                     AccessLevel::Write,
                 )
                 .await?;
+                grant_role_access(
+                    txn,
+                    fixture.org,
+                    matrix.containment,
+                    fixture.viewer_role_id,
+                    AccessLevel::Write,
+                )
+                .await?;
+                grant_user_access(
+                    txn,
+                    fixture.org,
+                    matrix.containment,
+                    fixture.member,
+                    AccessLevel::Write,
+                )
+                .await?;
                 grant_user_access(
                     txn,
                     fixture.org,

--- a/crates/server/tests/common/mod.rs
+++ b/crates/server/tests/common/mod.rs
@@ -5,6 +5,7 @@
 //! - `MARKHAND_TEST_APP_DATABASE_URL` — non-superuser `markhand_app` for FORCE RLS
 #![allow(dead_code)] // not every integration binary uses every helper
 
+pub mod acl_fixture;
 pub mod fixtures;
 pub mod worker_pipeline;
 
@@ -506,6 +507,11 @@ pub async fn minio_cleanup_soak_lane(
 }
 
 /// Seed an org user with the given permission codes (owner role) + password.
+///
+/// Callers that need non-empty `allowed_collection_ids` under the 1C
+/// `(qa.query, read)` projection must include `qa.query` in `permissions`.
+/// Omit it only for fixtures that intentionally prove missing-query denial or
+/// that never assert collection scope (member/org/auth-only tests).
 pub async fn seed_user_with_permissions(
     pool: &Pool,
     org: Uuid,

--- a/crates/server/tests/graph.rs
+++ b/crates/server/tests/graph.rs
@@ -273,6 +273,7 @@ async fn graph_requires_qa_query_permission() {
     let user = Uuid::new_v4();
     common::seed_user_with_permissions(&pool, org, user, "graph-noperm@example.com", PASSWORD, &[])
         .await;
+    // Intentionally no `qa.query`: asserts graph route returns 403 without base permission.
     let token = common::login_access_token(&pool, "graph-noperm@example.com", PASSWORD).await;
     let app = build_router(pool.clone(), &app_database_url().unwrap(), None);
 
@@ -442,6 +443,7 @@ async fn graph_acl_hides_documents_in_a_private_collection_the_caller_cannot_acc
     let viewer = Uuid::new_v4();
     common::seed_user_with_permissions(&pool, org, owner, "graph-owner@example.com", PASSWORD, &[])
         .await;
+    // Owner fixture only seeds a private collection; the graph actor is `viewer` (has `qa.query`).
     common::seed_user_with_permissions(
         &pool,
         org,

--- a/crates/server/tests/members.rs
+++ b/crates/server/tests/members.rs
@@ -52,6 +52,8 @@ async fn seed_admin(pool: &Pool, org: Uuid, user: Uuid, email: &str) -> String {
 
 /// Seeds a member with no special permissions (used purely as "some other
 /// org's authenticated user" for accept-invite auth-only tests).
+///
+/// Intentionally omits `qa.query`: invite acceptance tests do not need collection scope.
 async fn seed_plain_member(pool: &Pool, org: Uuid, user: Uuid, email: &str) -> String {
     seed_user_with_permissions(pool, org, user, email, PASSWORD, &[]).await;
     login_access_token(pool, email, PASSWORD).await

--- a/crates/server/tests/orgs.rs
+++ b/crates/server/tests/orgs.rs
@@ -78,6 +78,8 @@ async fn seed_caller(pool: &Pool, email: &str) -> (Uuid, String) {
 /// build a two-org fixture — the second call's `users` insert is a no-op on
 /// the primary key, but the `org_memberships` insert lands under the new
 /// `(org, user)` key).
+///
+/// Intentionally omits `qa.query`: org-switch tests never assert collection scope.
 async fn seed_member(pool: &Pool, org: Uuid, user: Uuid, email: &str) {
     common::seed_user_with_permissions(pool, org, user, email, PASSWORD, &[]).await;
 }

--- a/crates/server/tests/projects.rs
+++ b/crates/server/tests/projects.rs
@@ -89,6 +89,9 @@ async fn seed_caller(pool: &Pool, org: Uuid, user: Uuid, email: &str) -> (OrgCon
 /// (permitted) caller already granted that same role/org, same "seed a plain
 /// member in some other org" convention `tests/members.rs`'s
 /// `seed_plain_member` documents for the identical reason.
+///
+/// Intentionally omits `qa.query`: these tests assert permission-denied HTTP
+/// responses, not non-empty collection scope under the 1C `(qa.query, read)` projection.
 async fn seed_caller_without_permissions(
     pool: &Pool,
     org: Uuid,

--- a/crates/server/tests/retrieval.rs
+++ b/crates/server/tests/retrieval.rs
@@ -2,6 +2,10 @@
 //!
 //! Hermetic acceptance coverage lives in `services/retrieval` unit tests.
 //! Live PostgreSQL tests are ignored unless `MARKHAND_TEST_DATABASE_URL` is set.
+//!
+//! Fixtures seed `qa.query` / `qa.history` directly on the viewer role (not via
+//! `seed_user_with_permissions`) so FTS/hydration ACL predicates match the 1C
+//! `(qa.query, read)` projection without widening unrelated integration seeds.
 
 use std::collections::BTreeSet;
 use std::time::Instant;

--- a/crates/server/tests/schema_migrations.rs
+++ b/crates/server/tests/schema_migrations.rs
@@ -528,6 +528,13 @@ async fn acl_cascade_and_lineage_fks() {
     .await
     .unwrap();
     tx.execute(
+        "UPDATE collections SET visibility = 'groups'
+         WHERE org_id = $1 AND id = $2",
+        &[&org, &collection],
+    )
+    .await
+    .unwrap();
+    tx.execute(
         "INSERT INTO collection_group_access (org_id, collection_id, group_id, access_level)
          VALUES ($1,$2,$3,'read')",
         &[&org, &collection, &group_id],

--- a/crates/server/tests/telemetry_audit.rs
+++ b/crates/server/tests/telemetry_audit.rs
@@ -1,6 +1,8 @@
 //! P1B-O01 live evidence: correlation, append-only audit, canary redaction, app-role.
 //!
 //! Gated on `MARKHAND_TEST_DATABASE_URL` + `MARKHAND_TEST_APP_DATABASE_URL`.
+//! `qa.query` is seeded for audit action coverage; fixtures use empty collection scope
+//! (audit writes do not traverse the 1C collection projection).
 
 mod common;
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -54,12 +54,13 @@
 Phase F, 0 và 1A **đã đóng** (32/32 issue). Phase 1B **24/24 Done — gate đóng**
 (R06 hanging soak pass 2026-07-31). R02–R05 Done với evidence CI rust-integration
 trên `b5cc92c` (run 30603158015). O-chain release (O01–O05) và soak qualification đã
-pass trên live infrastructure (2026-07-26). Phase 1C **3/13 Done** (1C-01/02/03 trên
-CI `a628504`, run 30629207747), **9 In progress**, **1 Backlog** — org/RBAC foundation
-đóng; P1C.3 ACL semantics và exit gate denial suite còn mở. Phase 2 **13/19 Done**
+pass trên live infrastructure (2026-07-26). Phase 1C **5/13 Done** (1C-01/02/03/05/06 trên
+CI `9074228`, run [30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)),
+**7 In progress**, **1 Backlog** — org/RBAC foundation và PostgreSQL ACL resolver/enforcement
+đóng (P1C.3 semantics resolved trên PR 2); exit gate denial suite còn mở. Phase 2 **13/19 Done**
 trên mock/CI (#311–#318, #327, #332); còn P2-10, P2-15, P2-16 và ba issue mở rộng
-P2-17…19. Phase 3–4 chưa activate (Backlog). Catalog aggregate: **72 Done**,
-**15 In progress**, **0 Review**, **29 Backlog**.
+P2-17…19. Phase 3–4 chưa activate (Backlog). Catalog aggregate: **74 Done**,
+**13 In progress**, **0 Review**, **29 Backlog**.
 
 Dashboard: [`../plans/markhand-web/roadmap.html`](../plans/markhand-web/roadmap.html) ·
 Issue catalog: [`../plans/markhand-web/backlog/`](../plans/markhand-web/backlog/)

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -51,7 +51,7 @@ không bị local override cũ che mất.
 
 ## Tiến độ milestone (2026-07-31)
 
-Tổng **116 issue** trong catalog: **68 Done**, **19 In progress**, **0 Review**, **29 Backlog**.
+Tổng **116 issue** trong catalog: **70 Done**, **17 In progress**, **0 Review**, **29 Backlog**.
 Nguồn sự thật là `**Status:**` trong từng issue catalog; bảng dưới tóm tắt theo phase.
 GitHub milestone progress được đồng bộ bởi workflow
 [`Sync Markhand Web issues`](../../.github/workflows/sync-markhand-issues.yml) khi
@@ -63,7 +63,7 @@ GitHub milestone progress được đồng bộ bởi workflow
 | 0 | 10/10 | 0 | 0 | Discovery gates đạt |
 | 1A | 10/10 | 0 | 0 | Extraction gate đạt |
 | 1B | 24/24 | 0 | 0 | **Gate đạt** — R06 hanging soak pass 2026-07-31 |
-| 1C | 3/13 | 9 | 1 | 1C-01/02/03 Done (CI `a628504`); P1C.3 ACL + exit gate 1C-12/1C-13 còn mở |
+| 1C | 5/13 | 7 | 1 | 1C-05/06 Done (CI `9074228`, run 30649044974); exit gate 1C-12/1C-13 còn mở |
 | 2 | 13/19 | 6 | 0 | MVP mock/CI xanh; exit gate chờ 1C + E2E deploy thật |
 | 3 | 0/14 | 0 | 14 | Chưa activate — chờ Phase 2 complete |
 | 4 | 0/14 | 0 | 14 | Chưa activate — chờ Phase 3 |

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -51,7 +51,7 @@ không bị local override cũ che mất.
 
 ## Tiến độ milestone (2026-07-31)
 
-Tổng **116 issue** trong catalog: **70 Done**, **17 In progress**, **0 Review**, **29 Backlog**.
+Tổng **116 issue** trong catalog: **74 Done**, **13 In progress**, **0 Review**, **29 Backlog**.
 Nguồn sự thật là `**Status:**` trong từng issue catalog; bảng dưới tóm tắt theo phase.
 GitHub milestone progress được đồng bộ bởi workflow
 [`Sync Markhand Web issues`](../../.github/workflows/sync-markhand-issues.yml) khi

--- a/plans/markhand-web/backlog/github-issues.json
+++ b/plans/markhand-web/backlog/github-issues.json
@@ -910,28 +910,28 @@
       "phase": "1C",
       "id": "1C-05",
       "title": "1C-05 — Collection ACL resolver/cache",
-      "status": "in_progress",
+      "status": "done",
       "milestone": "Phase 1C — Multi-org Security",
       "labels": [
         "markhand-web",
         "docs",
         "web-p1c"
       ],
-      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-05\n- Status: `in_progress`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\n1C-02/03.\n(pre-existing, không đổi); grants/status/cache/revoke tests (**done**: `tests/acl_cache.rs`\n+ unit tests `auth::context_cache`).\n\n## Required tests / evidence\n\nSemantics đúng, empty/error fail closed\n\n## Security and migration notes\n\nBackfill ACL version (**done**: `DEFAULT 1`, expand-only,\nmigration `0031`). **Gap version-bump đã ĐÓNG (migration `0033`, 2026-07-29)**: trigger\nDB `bump_org_acl_version()` trên `collections`/`collection_user_access`/\n`org_memberships`/`roles`/`role_permissions` — bump cùng transaction cho MỌI writer,\nkể cả SQL trực tiếp (fixtures/vận hành; CI `rust-integration` bắt được đúng lỗ này\nở `api_http_contracts`/`citation_authz_matrix` trước khi vá). **Out:**\nnested/time-based groups; groups/role-based grant resolution (tính năng mới, không\nphải phần \"cache\" — xem trên); operator-configurable cache capacity/TTL qua env.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-05\n- Status: `done`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\n1C-02/03.\ngrants/status/cache/revoke tests — green on CI\n`90742281e51d3c8ca8a32a78077a07fe3449bc68` run\n[30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)\n(`acl_resolver`, `acl_equivalence`, `acl_cache` in `rust-integration`).\n\n## Required tests / evidence\n\nSemantics đúng, empty/error fail closed;\n\n## Security and migration notes\n\nBackfill ACL version (**done**: `DEFAULT 1`, expand-only,\nmigration `0031`). **Gap version-bump đã ĐÓNG (migration `0033`, 2026-07-29)**: trigger\nDB `bump_org_acl_version()` trên `collections`/`collection_user_access`/\n`org_memberships`/`roles`/`role_permissions` — bump cùng transaction cho MỌI writer,\nkể cả SQL trực tiếp (fixtures/vận hành; CI `rust-integration` bắt được đúng lỗ này\nở `api_http_contracts`/`citation_authz_matrix` trước khi vá). **Out:**\nnested/time-based groups; operator-configurable cache capacity/TTL qua env; collection\ninsert/soft-delete version bump outside `acl_mutate` (accepted TTL-bound gap).\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
       "catalog": "backlog/phase-1c/issues/README.md"
     },
     {
       "phase": "1C",
       "id": "1C-06",
       "title": "1C-06 — PostgreSQL ACL enforcement",
-      "status": "in_progress",
+      "status": "done",
       "milestone": "Phase 1C — Multi-org Security",
       "labels": [
         "markhand-web",
         "docs",
         "web-p1c"
       ],
-      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-06\n- Status: `in_progress`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\n1C-05.\nleak (xác nhận không có route/endpoint count nào tồn tại để leak — xem điểm 2); SQL\njoin/subquery/missing-predicate tests — `tests::every_chunk_scoped_query_embeds_acl_predicate`\n+ `tests::acl_predicate_sql_shape_is_pinned` (`db/search.rs`, fast) và\n`fts_candidate_leg_and_hydration_deny_acl_and_suspended_membership` +\n`org_only_count_helpers_stay_out_of_routes_and_services` (DB-gated/fast, `tests/`).\n\n## Required tests / evidence\n\nKhông path thiếu context; no existence/count\n\n## Security and migration notes\n\nPG authority, prepared queries.\nautocomplete (chưa xây — xem điểm 4).\n\n## Out of scope\n\nvector/object path,\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "body": "## Metadata\n\n- Milestone: Phase 1C — Multi-org Security\n- Phase code: 1C\n- Issue ID: 1C-06\n- Status: `done`\n- Catalog: `backlog/phase-1c/issues/README.md`\n- Phase plan: `phase-1c-multi-org-security.md`\n\n## Dependencies / blocks\n\n1C-05.\nleak; SQL join/subquery/missing-predicate tests — green on CI\n`90742281e51d3c8ca8a32a78077a07fe3449bc68` run\n[30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)\n(`retrieval`, `uploads`, fast unit pins in `db/search.rs` / `db/acl_sql.rs`).\n\n## Required tests / evidence\n\nKhông path thiếu context; no existence/count\n\n## Security and migration notes\n\nPG authority, prepared queries; migration `0036` dormant-grant\nrejection enforced at seed + runtime. **Out:** vector/object path (1C-07), autocomplete,\nbroader route write inventory (PR 3).\n\n### Legacy verification notes (pre-PR-2, retained for audit trail)\n\n1. **FTS candidate ACL subquery** (`db/search.rs`): defense-in-depth EXISTS on candidate\nleg; shared builder includes `acl_m.state = 'active'`.\n2. **Org-only count helpers** (`db/documents::count`, `db/chunks::count`): test-only;\n`org_only_count_helpers_stay_out_of_routes_and_services` source-scan guard.\n3. **Missing-predicate pin**: `every_chunk_scoped_query_embeds_acl_predicate` +\n`acl_predicate_sql_shape_is_pinned`.\n4. **Autocomplete**: không có endpoint — future work must use `acl_predicate_sql` from day one.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
       "catalog": "backlog/phase-1c/issues/README.md"
     },
     {

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -4,13 +4,15 @@ Parent plan: [`../../../phase-1c-multi-org-security.md`](../../../phase-1c-multi
 
 <!-- roadmap-default-status: backlog -->
 
-**Audit 2026-07-31 (PR 1 RBAC foundation).** Substrate 1B vẫn là nền; PR 1 đóng org
-lifecycle / membership / canonical RBAC catalog với CI exact-SHA evidence. P1C.3 ACL
-semantics còn mở cho PR 2. `AR-1C-AUDIT-RETENTION` giữ POC/non-production only.
+**Audit 2026-07-31 (PR 2 ACL enforcement).** Substrate 1B vẫn là nền; PR 1 đóng org
+lifecycle / membership / canonical RBAC catalog; PR 2 đóng collection ACL resolver/cache
+và PostgreSQL enforcement với CI exact-SHA evidence. `AR-1C-AUDIT-RETENTION` giữ
+POC/non-production only.
 
-- **3 Done** — **1C-01**, **1C-02**, **1C-03** (CI `rust` + `web` + `rust-integration` trên
-  `a628504`, run [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)).
-- **9 In progress** — 1C-04…1C-12 (ACL/guards/denial còn mở).
+- **5 Done** — **1C-01**, **1C-02**, **1C-03**, **1C-05**, **1C-06** (CI `rust` +
+  `rust-integration` trên `90742281e51d3c8ca8a32a78077a07fe3449bc68`, run
+  [30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)).
+- **7 In progress** — 1C-04, 1C-07…1C-12 (route guards, Qdrant/RLS/quota/denial suite còn mở).
 - **1 Backlog** — **1C-13** (security/load gate).
 
 > **Hai ranh giới quan trọng, áp cho MỌI issue dưới đây:**
@@ -123,138 +125,91 @@ ADR RLS ───────→ 1C-08 ─────────────�
 
 ## 1C-05 — Collection ACL resolver/cache
 
-- **Status:** In progress — resolver cơ bản (org/private/owner/`collection_user_access`) +
-  fail-closed `services/retrieval/mod.rs:181` + test, **và giờ có version + cache** (phiên
-  này, worktree, chưa chạy DB-gated CI): `orgs.acl_version` (migration
-  `0031_expand_org_acl_version.sql`, cột `bigint NOT NULL DEFAULT 1`, expand-only) là version
-  **org-wide** (cố ý không per-membership/per-role — `revoke_role_permission_for_principal`
-  xoá một hàng `role_permissions` dùng chung bởi mọi member cùng role, nên version hẹp hơn
-  sẽ under-invalidate; over-invalidate cả org là hướng an toàn, chấp nhận được ở quy mô
-  POC). `db::orgs::bump_acl_version` được gọi trong CÙNG transaction với
-  `services::members::{change_role, suspend_member, reactivate_member (qua set_member_state),
-  remove_member}` và `services::acl_mutate::{revoke_role_permission_for_principal,
-  revoke_collection_access_for_principal}` — đúng tập mutation duy nhất ảnh hưởng
-  `auth::permissions::resolve_org_context*` hiện có (đã audit toàn bộ call site, xem báo
-  cáo phiên). Cache in-process `auth::context_cache::OrgContextCache` (bounded, mặc định
-  4096 principal / TTL 3s, field mới trên `auth::provider::PasswordAuthProvider`, không đổi
-  signature `PasswordAuthProvider::new`) bọc **đúng một** điểm vào: `AuthenticatedOrg`
-  extractor (`auth/middleware.rs`) — KHÔNG bọc `resolve_org_context_on_txn` (ask-stream
-  append/pull, cần snapshot không bị xé trong transaction đã khoá) và KHÔNG bọc
-  `services::upload::saga::reload_principal_locked` (saga tự re-check trước commit) — cả
-  hai đường này vẫn luôn-tươi như trước, không có rủi ro hồi quy từ cache. Mỗi cache hit
-  (trong TTL) BẮT BUỘC một freshness-check rẻ (`users.disabled_at` + `orgs.acl_version`,
-  2 bảng không RLS) trước khi tin dữ liệu cache — mismatch/disabled/lỗi truy vấn đều rơi về
-  resolve đầy đủ (fail-closed, không tự chế deny). Vì mọi hit đều hỏi lại PostgreSQL (không
-  bao giờ tin cache "mù" theo TTL), một version bump ở tiến trình khác lập tức thấy được ở
-  request tiếp theo của tiến trình này — nên **không cần cơ chế invalidation cross-instance
-  riêng** (câu hỏi mở nêu trong nhiệm vụ đã tự đóng nhờ thiết kế). TTL chỉ còn là lưới an
-  toàn cho (a) call site tương lai quên bump và (b) KHOẢNG TRỐNG ĐÃ BIẾT: tạo/xoá-mềm
-  collection qua `db::collections` (ngoài `services::acl_mutate`) **chưa** bump version —
-  cố ý để ngoài phạm vi phiên này (xem "Out" bên dưới).
-  Test DB-gated mới `tests/acl_cache.rs` (5 test): role-downgrade/suspend/remove qua route
-  HTTP thật (cùng bearer token, không re-login) đều 403 ngay ở request kế tiếp; ACL
-  collection revoke (gọi thẳng `OrgContextCache::resolve` như extractor thật) drop quyền
-  ngay; và một test tách riêng cơ chế version-check (bump `acl_version` thủ công, không qua
-  helper) để chứng minh chính cơ chế mismatch-detection hoạt động độc lập với nơi gọi nó.
-  Unit test thuần (không DB) trong `auth::context_cache` phủ `trusts_cache`/
-  `should_check_freshness`/bounded-eviction/`clear`. `tests/members.rs`,
-  `tests/uploads.rs`, `tests/sse_stream_readiness.rs`, `tests/orgs.rs`,
-  `tests/schema_migrations.rs` chạy lại xanh không đổi hành vi (xem kết quả verify trong
-  báo cáo phiên).
-  **Cố tình KHÔNG làm trong phiên này** (xem báo cáo phiên để biết lý do đầy đủ): (1)
-  grant theo `groups`/`role` vẫn CHƯA resolve (bảng có, không ai đọc) — đây là một tính
-  năng authz mới (semantics resolve qua `groups`/`group_memberships`), không phải cache
-  key, cần thiết kế/review riêng, không phải phạm vi "version + cache" của vòng này; (2)
-  version bump cho `db::collections::{insert,soft_delete,update_metadata}` — cần audit
-  call-site + test riêng, ghi nhận là khoảng trống đã biết bên trên, giới hạn bởi TTL cho
-  đến khi đóng; (3) cache/version không (chưa) operator-configurable qua env — hằng số
-  module `DEFAULT_CAPACITY`/`DEFAULT_TTL`, có thể nâng cấp thành config sau nếu cần.
+- **Status:** Done — CI exact-SHA evidence on `90742281e51d3c8ca8a32a78077a07fe3449bc68`
+  (run [30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)):
+  changes/static
+  [91217513655](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217513655),
+  `rust`
+  [91217686329](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217686329),
+  `rust-integration`
+  [91217686352](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217686352)
+  (not path-filter skip / soft pass). Task 4 review Approved; Task 5 review Approved.
+  Integration log executed ACL resolver/cache targets including
+  `groups_visibility_group_grant_allows_member_without_user_grant`,
+  `private_visibility_ignores_group_and_role_grants`,
+  `containment_removes_group_role_grants_but_preserves_other_user_grants`,
+  `resolver_matches_sql_predicate_for_acl_fixture_matrix`,
+  `read_grant_does_not_satisfy_write_or_admin`,
+  `group_membership_revoke_invalidates_cached_context`, concurrent grant-vs-flip, and
+  ACL-version bump. Canonical `(qa.query, read)` resolver projection via
+  `allowed_collections_sql` with `private`/`org`/`groups` visibility + group/role grant
+  branches; migration `0036` dormant-grant rejection; org-wide `acl_version` cache
+  invalidation (migrations `0031`/`0033`); `auth::context_cache` freshness check on
+  extractor hits.
 
-- **Plan/files:** Private/org/groups grants (groups **vẫn thiếu**, xem trên); ACL/version
+- **Plan/files:** Private/org/groups grants (**done**); ACL/version
   snapshot (**done**: `orgs.acl_version`, migration `0031`); cache key org/user/membership/
   ACL version (**done**: `auth::context_cache::OrgContextCache`, key `(org_id, user_id)` +
   version check); invalidation APIs (**không làm riêng** — invalidation là version-bump
   trong transaction mutation, không phải API endpoint mới; không có yêu cầu nào đòi một API
   invalidation tách biệt).
-- **Depends:** 1C-02/03. **Acceptance/tests:** Semantics đúng, empty/error fail closed
-  (pre-existing, không đổi); grants/status/cache/revoke tests (**done**: `tests/acl_cache.rs`
-  + unit tests `auth::context_cache`).
+- **Depends:** 1C-02/03. **Acceptance/tests:** Semantics đúng, empty/error fail closed;
+  grants/status/cache/revoke tests — green on CI
+  `90742281e51d3c8ca8a32a78077a07fe3449bc68` run
+  [30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)
+  (`acl_resolver`, `acl_equivalence`, `acl_cache` in `rust-integration`).
 - **Security/migration:** Backfill ACL version (**done**: `DEFAULT 1`, expand-only,
   migration `0031`). **Gap version-bump đã ĐÓNG (migration `0033`, 2026-07-29)**: trigger
   DB `bump_org_acl_version()` trên `collections`/`collection_user_access`/
   `org_memberships`/`roles`/`role_permissions` — bump cùng transaction cho MỌI writer,
   kể cả SQL trực tiếp (fixtures/vận hành; CI `rust-integration` bắt được đúng lỗ này
   ở `api_http_contracts`/`citation_authz_matrix` trước khi vá). **Out:**
-  nested/time-based groups; groups/role-based grant resolution (tính năng mới, không
-  phải phần "cache" — xem trên); operator-configurable cache capacity/TTL qua env.
+  nested/time-based groups; operator-configurable cache capacity/TTL qua env; collection
+  insert/soft-delete version bump outside `acl_mutate` (accepted TTL-bound gap).
 
 ## 1C-06 — PostgreSQL ACL enforcement
 
-- **Status:** In progress — vòng 11-B xác minh lại 4 điểm "Thiếu" trước đó bằng code thật
-  (đọc 2026-07-29; 3/4 stale hoặc đã đóng, 1/4 đúng và đã sửa):
-  1. **Đúng, đã sửa**: nhánh FTS candidate (`db::search::fts_search`, `db/search.rs:290`)
-     trước đây KHÔNG có ACL subquery — chỉ lọc `org_id`/`collection_id = ANY(...)`/version/
-     index-generation, dựa hoàn toàn vào (a) `resolve_scope` intersect
-     `ctx.allowed_collection_ids()` ở tầng service trước khi gọi, và (b) hydration re-check
-     sau đó. Đây là gap thật (defense-in-depth thiếu, TOCTOU nếu `allowed_collection_ids`
-     stale — context cache TTL 3s hoặc phiên ask-stream sống lâu). Đã thêm ACL EXISTS
-     predicate vào cả hai nhánh (`Current`/`VersionIds`) qua hàm builder dùng chung
-     `acl_predicate_sql` (`db/search.rs:128`), cùng pattern JOIN
-     `collections`/`org_memberships`/`roles`/`role_permissions`/`permissions` +
-     `collection_user_access` mà `hydrate_chunks_by_identity`/
-     `load_authorized_conflict_evidence` đã dùng; hydration re-check GIỮ NGUYÊN (không bỏ).
-     **Phát hiện thêm ngoài 4 điểm gốc**: pattern ACL cũ ở cả hydrate lẫn conflict-evidence
-     thiếu `acl_m.state = 'active'` — một membership `suspended` (chưa xóa hẳn) vẫn qua được
-     re-check, khác invariant 1C-02 "suspended resolves like missing". Đã đóng luôn trong hàm
-     builder dùng chung (áp dụng cho cả 3 query family). Test DB-gated mới
-     `fts_candidate_leg_and_hydration_deny_acl_and_suspended_membership`
-     (`tests/retrieval.rs`) phủ cả hai: (a) FTS/hydration không lộ collection ngoài ACL dù
-     `collection_ids` request cố tình chứa nó (mô phỏng stale scope/TOCTOU), (b) suspend
-     (không xóa) membership → cả hai nhánh deny, reactivate → thấy lại (sanity chống
-     false-deny).
-  2. **Stale — không phải leak thật**: `db::documents::count`/`db::chunks::count`
-     (org-only, không ACL) chỉ được gọi từ `tests/repositories.rs`/`tests/index_worker.rs`
-     làm cross-org denial evidence — grep toàn repo xác nhận KHÔNG route/service nào gọi
-     chúng; không có endpoint count/total nào lộ ra HTTP (đã rà `routes/*.rs`,
-     `openapi/openapi.yaml`, response schema của `/api/v1/search` — không trường
-     `count`/`total` nào tồn tại). Không có leak thật để sửa vòng này. Đã siết footgun: doc
-     comment trên cả hai hàm nói rõ "test-only, không ACL, đừng gọi từ route/service" +
-     test source-scan mới `org_only_count_helpers_stay_out_of_routes_and_services`
-     (`tests/repositories.rs`) fail nếu tương lai có ai gọi chúng từ `src/routes`/
-     `src/services`.
-  3. **Đã làm**: cơ chế chống missing-predicate chọn là **builder trung tâm +
-     source-scan test cùng nhà với `middleware::write_gate`'s
-     `middleware_source_holds_shared_lock_across_next_run`** — không cần DB. Mọi query
-     đọc `chunks`/`claims` scoped theo collection PHẢI gọi `acl_predicate_sql(...)`
-     (`db/search.rs:128`) thay vì tự viết EXISTS; test
-     `every_chunk_scoped_query_embeds_acl_predicate` pin đúng 8 call-site (fts_search x2,
-     hydrate_chunks_by_identity x2, load_authorized_conflict_evidence x4) và fail nếu có
-     block `collections acl_c` viết tay ngoài hàm builder; test
-     `acl_predicate_sql_shape_is_pinned` pin đủ các mệnh đề bắt buộc (active membership,
-     disabled_at, permission + qa.query base gate, 3 nhánh visibility). Lựa chọn này thay vì
-     DB-gated so sánh hành vi vì nó chạy được `cargo test` không cần Postgres, bắt lỗi ngay
-     lúc review thay vì chờ CI DB-gated, và khớp tiền lệ đã có trong repo
-     (`write_gate.rs`) thay vì phát minh cơ chế mới.
-  4. **Đúng, xác nhận stale claim cũ đã đóng đúng**: grep `autocomplete` toàn repo (routes,
-     services, openapi.yaml, web/, app/) — không có endpoint/tính năng search-autocomplete
-     nào tồn tại (chỉ có thuộc tính HTML `autoComplete`/`aria-autocomplete` không liên quan
-     trên form đăng nhập). Xác nhận KHÔNG xây trong vòng này (out of scope, tránh thêm
-     surface mới chỉ để tick box) — khi xây sau này PHẢI dùng `acl_predicate_sql` ngay từ
-     đầu, không được lặp lại kiểu "list trước, ACL sau" mà điểm 1 vừa phải vá.
-  - Danh sách "list/count tenant-scoped" ở các vòng trước vẫn đúng cho `documents::
-    list_in_collection`/`db/graph.rs` (đã check `allowed_collection_ids`/`d.collection_id`
-    tại route reachable); không đổi gì thêm ở đó vòng này.
+- **Status:** Done — CI exact-SHA evidence on `90742281e51d3c8ca8a32a78077a07fe3449bc68`
+  (run [30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)):
+  changes/static
+  [91217513655](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217513655),
+  `rust`
+  [91217686329](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217686329),
+  `rust-integration`
+  [91217686352](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217686352)
+  (not path-filter skip / soft pass). Task 6 rereview Approved. Integration log executed
+  PostgreSQL ACL enforcement targets including
+  `fts_rank_accent_fold_and_active_generation_gates` (dual `qa.query` + `qa.history`
+  hydration recheck), `fts_candidate_leg_and_hydration_deny_acl_and_suspended_membership`,
+  upload regression quartet (`http_upload_happy_and_spoof`,
+  `cancelled_http_upload_settles_quota_consistently`,
+  `envelope_binds_collection_and_stable_replay_deep_equality`,
+  `quarantined_review_requires_approval_for_single_job`), private grant rejection, and
+  role-grant leave-groups. Shared `db/acl_sql` predicates on FTS/hydration/conflict paths;
+  explicit resolver↔SQL equivalence oracle; upload/quarantine operation-scoped write guards
+  (`doc.upload` / `doc.quarantine.review` at `AccessLevel::Write`, no read-projection
+  inference).
 
-- **Plan/files:** Tenant+ACL predicates cho list/count/FTS/hydration (autocomplete: không
-  xây, ghi nhận sẽ mang ACL predicate từ đầu nếu xây sau này — xem điểm 4 ở trên).
+- **Plan/files:** Tenant+ACL predicates cho FTS/hydration/conflict (**done**); upload write
+  gate (**done**). Autocomplete không xây (out of scope — xem điểm 4 legacy note bên dưới).
 - **Depends:** 1C-05. **Acceptance/tests:** Không path thiếu context; no existence/count
-  leak (xác nhận không có route/endpoint count nào tồn tại để leak — xem điểm 2); SQL
-  join/subquery/missing-predicate tests — `tests::every_chunk_scoped_query_embeds_acl_predicate`
-  + `tests::acl_predicate_sql_shape_is_pinned` (`db/search.rs`, fast) và
-  `fts_candidate_leg_and_hydration_deny_acl_and_suspended_membership` +
-  `org_only_count_helpers_stay_out_of_routes_and_services` (DB-gated/fast, `tests/`).
-- **Security/migration:** PG authority, prepared queries. **Out:** vector/object path,
-  autocomplete (chưa xây — xem điểm 4).
+  leak; SQL join/subquery/missing-predicate tests — green on CI
+  `90742281e51d3c8ca8a32a78077a07fe3449bc68` run
+  [30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)
+  (`retrieval`, `uploads`, fast unit pins in `db/search.rs` / `db/acl_sql.rs`).
+- **Security/migration:** PG authority, prepared queries; migration `0036` dormant-grant
+  rejection enforced at seed + runtime. **Out:** vector/object path (1C-07), autocomplete,
+  broader route write inventory (PR 3).
+
+### Legacy verification notes (pre-PR-2, retained for audit trail)
+
+  1. **FTS candidate ACL subquery** (`db/search.rs`): defense-in-depth EXISTS on candidate
+     leg; shared builder includes `acl_m.state = 'active'`.
+  2. **Org-only count helpers** (`db/documents::count`, `db/chunks::count`): test-only;
+     `org_only_count_helpers_stay_out_of_routes_and_services` source-scan guard.
+  3. **Missing-predicate pin**: `every_chunk_scoped_query_embeds_acl_predicate` +
+     `acl_predicate_sql_shape_is_pinned`.
+  4. **Autocomplete**: không có endpoint — future work must use `acl_predicate_sql` from day one.
 
 ## 1C-07 — Qdrant/storage/jobs fail-closed enforcement
 

--- a/plans/markhand-web/phase-1c-multi-org-security.md
+++ b/plans/markhand-web/phase-1c-multi-org-security.md
@@ -98,9 +98,11 @@ Remaining P1C.3 surfaces stay with later issues — not reopened here:
 
 Machine-checked semantics delivered in PR 2:
 
-- `private`: owner + principal được grant;
-- `org`: thành viên org có permission tương ứng;
-- `groups`: principal group/user được grant.
+- `private`: collection owner hoặc explicit user grant đủ access; group/role grant
+  bị bỏ qua và không được phép (dormant — migration `0036`);
+- `org`: thành viên org active có base permission tương ứng;
+- `groups`: collection owner, explicit user grant, membership trong group được grant,
+  hoặc role hiện tại được grant qua `collection_role_access`.
 
 Enforce tại:
 

--- a/plans/markhand-web/phase-1c-multi-org-security.md
+++ b/plans/markhand-web/phase-1c-multi-org-security.md
@@ -8,8 +8,14 @@ fairness và denial suite; không retrofit `org_id` vì tenancy primitives đã 
 **PR 1 progress (2026-07-31):** 1C-01 / 1C-02 / 1C-03 Done with exact-SHA CI evidence
 on `a62850422dd070e7e1195bfe1d4f1dee0d73566d` (run
 [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747);
-jobs `rust` / `web` / `rust-integration`). P1C.3 collection ACL semantics remain open
-for PR 2. Audit retention stays deferred under `AR-1C-AUDIT-RETENTION`
+jobs `rust` / `web` / `rust-integration`).
+
+**PR 2 progress (2026-07-31):** 1C-05 / 1C-06 Done with exact-SHA CI evidence on
+`90742281e51d3c8ca8a32a78077a07fe3449bc68` (run
+[30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974);
+jobs changes/static / `rust` / `rust-integration`). Task 4 review Approved; Task 5 review
+Approved; Task 6 rereview Approved. Audit retention stays deferred under
+`AR-1C-AUDIT-RETENTION`
 (POC/non-production only; expires before production multi-org or Phase 4 gate).
 Qualifying embedding remains local/mock until embedding-token metering exists.
 
@@ -73,11 +79,24 @@ active operations belongs to later PRs (1C-04), not the catalog seed itself.
 
 ## P1C.3 — Collection ACL
 
-**Disposition (PR 1):** P1C.3 remains open for PR 2 ACL semantics. PR 1 does not close
-collection ACL resolver equivalence, grant/revoke invalidation, or dormant-grant
-containment; those remain Phase 1C work after the RBAC catalog foundation.
+**Disposition (PR 2):** P1C.3 PostgreSQL collection ACL semantics are **resolved** on
+`90742281e51d3c8ca8a32a78077a07fe3449bc68` (run
+[30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)):
+canonical `(qa.query, read)` resolver projection; `private`/`org`/`groups` visibility with
+group/role grant branches and `read`/`write`/`admin` access-level rank; migration `0036`
+dormant-grant rejection; containment revoke preserving other user grants; resolver↔SQL
+equivalence matrix with explicit oracle assertions; shared `db/acl_sql` predicates on
+FTS/hydration/conflict paths with dual `qa.query` + `qa.history` historical recheck;
+upload/quarantine operation-scoped write guards (no read-projection inference).
 
-Target semantics from ADR (to be machine-checked in PR 2):
+Remaining P1C.3 surfaces stay with later issues — not reopened here:
+
+- Qdrant filter enforcement (1C-07);
+- document list/count/autocomplete when built (must use shared predicates from day one);
+- preview/download/export/job/SSE beyond current PostgreSQL paths;
+- broader route write inventory (PR 3).
+
+Machine-checked semantics delivered in PR 2:
 
 - `private`: owner + principal được grant;
 - `org`: thành viên org có permission tương ứng;

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "09d8e7cf2b8094a1";
+    const ROADMAP_SOURCE_HASH = "a989cb297f1d5eee";
     const phases = [
       {
         "id": "phase-f",
@@ -1272,12 +1272,12 @@
           [
             "1C-05",
             "Collection ACL resolver/cache",
-            "in_progress"
+            "done"
           ],
           [
             "1C-06",
             "PostgreSQL ACL enforcement",
-            "in_progress"
+            "done"
           ],
           [
             "1C-07",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Closes the Phase 1C PostgreSQL collection ACL enforcement slice with one canonical Rust/SQL semantic model, concurrency-safe no-dormant-grant invariants, equivalent resolver/search enforcement, and operation-scoped upload write guards.

## Scope

- Define fail-closed `private` / `org` / `groups` ACL semantics with `read < write < admin`.
- Add shared `allowed_collections_sql` and `acl_predicate_sql` builders.
- Add expand-only migration `0036` with deterministic preflight, parent-row serialization, visibility guards, and ACL-version invalidation.
- Wire org-context resolution, cache invalidation, FTS/hydration/history predicates, upload reloads, and operation write guards.
- Enforce containment lock/delete order while preserving unrelated direct-user grants.
- Mark 1C-05 and 1C-06 Done and resolve P1C.3's PostgreSQL ACL disposition.

## Evidence

- Final head: `76a79aa`
- Final workflow: https://github.com/anhnth24/project-example/actions/runs/30650610925
  - `changes-and-static`: job `91222714974` — success
  - `rust`: job `91222891994` — success
  - `rust-integration`: job `91222891970` — success
- Live integration includes resolver/SQL equivalence, cache invalidation, read-vs-write/admin rank denial, dormant-grant race serialization, ACL-version bumps, retrieval gates, upload regressions, and non-vacuous group+role containment cleanup.
- Local final gates: formatting, locked metadata, dependency policy, migration manifest, roadmap generation, and GitHub issue consistency all pass.

## Boundary and security review

- No dependency or vendor boundary changes.
- Historical migrations remain unchanged; `0036` is expand-only.
- Private collections ignore group/role grants; malformed/DB failures remain fail-closed.
- Write checks use operation permission plus required access rather than inferring from the read allow-list.
- Composer implementation completed with Grok task reviews and final whole-branch rereview; no Critical or Important findings remain.

## Follow-up

- PR 3 completes the broader route/service guard inventory and operational identities.
- Phase 1C exit/security gates 1C-12 and 1C-13 remain open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8504871-2ef2-4a0b-bf3a-9f2b969c6ddb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8504871-2ef2-4a0b-bf3a-9f2b969c6ddb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

