### PR TITLE
fix(deploy): run workers in real web upload harness

### DIFF
--- a/deploy/scripts/dev-stack-ci.sh
+++ b/deploy/scripts/dev-stack-ci.sh
@@ -31,9 +31,9 @@ fi
 # Real-deployment half of P2-15 (web-e2e-real.sh): reuses this same dev-up
 # stack while it's still up, so it runs before dev-down, not after. Gated on
 # MODE == full only, same as spike-* below — it always needs its own
-# fileconv-server + web build regardless of DEV_STACK_RUST_SERVER (unlike
-# dev-server-smoke's skip above, this is new coverage the Rust job's own
-# tests don't provide, not a duplicate of them).
+# fileconv-server + convert/index/embedding workers + web build regardless of
+# DEV_STACK_RUST_SERVER (unlike dev-server-smoke's skip above, this is new
+# coverage the Rust job's own tests don't provide, not a duplicate of them).
 if [[ "$MODE" == "full" ]]; then
   bash deploy/scripts/web-e2e-real.sh
 fi

--- a/deploy/scripts/test_web_e2e_real_orchestration.py
+++ b/deploy/scripts/test_web_e2e_real_orchestration.py
@@ -78,13 +78,14 @@ class OrchestrationHarness:
             f"""\
             #!/usr/bin/env bash
             set -euo pipefail
+            echo "server:$$" >> "{state}/child.pids"
             echo "MARKHAND_AUTH_SIGNING_KEY=super-secret-key-at-least-32-bytes"
             echo "server-start pid=$$" >> "{state}/server.events"
             if [[ "${{WEB_E2E_REAL_SERVER_EXIT_EARLY:-}}" == "1" ]]; then
               echo "server-exit-early" >> "{state}/server.events"
               exit 1
             fi
-            trap 'echo server-term >> "{state}/server.events"; exit 0' TERM INT
+            trap 'echo server-reaped:$$ >> "{state}/cleanup.reaped"; echo server-term >> "{state}/server.events"; exit 0' TERM INT
             while true; do sleep 0.05; done
             """,
         )
@@ -94,6 +95,7 @@ class OrchestrationHarness:
             f"""\
             #!/usr/bin/env bash
             set -euo pipefail
+            echo "worker-${{MARKHAND_WORKER_KIND}}:$$" >> "{state}/child.pids"
             echo "kind=${{MARKHAND_WORKER_KIND:-unset}}" >> "{state}/workers.started"
             echo "db=${{MARKHAND_WORKER_DATABASE_URL:-}}" >> "{state}/workers.env"
             if [[ -n "${{MARKHAND_CONVERTER_ARGV_JSON:-}}" ]]; then
@@ -109,7 +111,7 @@ class OrchestrationHarness:
                 kill -TERM "$$" 2>/dev/null || exit 1
               ) &
             fi
-            trap 'echo worker-term-${{MARKHAND_WORKER_KIND}} >> "{state}/cleanup.signals"; exit 0' TERM INT
+            trap 'echo worker-reaped-${{MARKHAND_WORKER_KIND}}:$$ >> "{state}/cleanup.reaped"; echo worker-term-${{MARKHAND_WORKER_KIND}} >> "{state}/cleanup.signals"; exit 0' TERM INT
             while true; do sleep 0.05; done
             """,
         )
@@ -242,6 +244,39 @@ class OrchestrationHarness:
             check=False,
         )
 
+    def install_failing_redactor(self) -> None:
+        redact = self.root / "deploy" / "scripts" / "redact_secrets.py"
+        _write_executable(
+            redact,
+            """\
+            #!/usr/bin/env python3
+            import sys
+            from pathlib import Path
+            raw = Path(sys.argv[1]).read_text(encoding="utf-8")
+            if "super-secret-key-at-least-32-bytes" in raw:
+                sys.stderr.write("INJECTED_REDACT_FAIL\\n")
+            sys.exit(1)
+            """,
+        )
+
+    def child_pids(self) -> list[int]:
+        pids_file = self.state / "child.pids"
+        if not pids_file.exists():
+            return []
+        pids: list[int] = []
+        for line in pids_file.read_text(encoding="utf-8").splitlines():
+            _, pid_text = line.split(":", 1)
+            pids.append(int(pid_text))
+        return pids
+
+    def assert_no_live_child_pids(self) -> None:
+        for pid in self.child_pids():
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                continue
+            self.fail(f"pid {pid} still alive")
+
     def cleanup(self) -> None:
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
@@ -314,6 +349,49 @@ class WebE2eRealExecutableOrchestrationTests(unittest.TestCase):
         finally:
             harness.cleanup()
 
+    def test_failing_redactor_emits_only_safe_withholding_text(self) -> None:
+        harness = OrchestrationHarness()
+        try:
+            harness.install_failing_redactor()
+            result = harness.run(
+                extra_env={"WEB_E2E_REAL_PLAYWRIGHT_FAIL": "1"},
+                timeout=15.0,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            combined = result.stdout + result.stderr
+            self.assertNotIn("super-secret-key-at-least-32-bytes", combined)
+            self.assertIn("raw log withheld", combined.lower())
+            self.assertNotRegex(combined, r"MARKHAND_AUTH_SIGNING_KEY=super-secret")
+        finally:
+            harness.cleanup()
+
+    def test_cleanup_terminates_and_waits_all_children_after_failure(self) -> None:
+        harness = OrchestrationHarness()
+        try:
+            result = harness.run(
+                extra_env={"WEB_E2E_REAL_PLAYWRIGHT_FAIL": "1"},
+                timeout=15.0,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertGreaterEqual(len(harness.child_pids()), 4)
+            reaped = (harness.state / "cleanup.reaped").read_text(encoding="utf-8")
+            self.assertIn("server-reaped:", reaped)
+            for kind in ("convert", "index", "embedding"):
+                self.assertIn(f"worker-reaped-{kind}:", reaped)
+            harness.assert_no_live_child_pids()
+        finally:
+            harness.cleanup()
+
+    def test_unified_liveness_check_after_seed(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+        self.assertRegex(
+            text,
+            r'required_processes_alive[^\n]*after seed, before Playwright',
+            msg="must use unified server+worker liveness after seed",
+        )
+        seed_to_playwright = text.split('seed-dev-all.sh" --skip-init', 1)[1]
+        self.assertNotIn("workers_alive", seed_to_playwright.split("run_playwright_supervised", 1)[0])
+
     def test_forbids_fail_open_redaction_flags(self) -> None:
         text = SCRIPT.read_text(encoding="utf-8")
         self.assertNotIn("--allow-residual", text)
@@ -322,6 +400,12 @@ class WebE2eRealExecutableOrchestrationTests(unittest.TestCase):
             r'redact_secrets\.py[^\n]*\|\|\s*cat',
             msg="must not fall back to raw cat after redaction failure",
         )
+        self.assertNotRegex(
+            text,
+            r"set -e\s*\n\s*run_playwright_supervised\s*\n\s*playwright_status=\$\?",
+            msg="must not re-enable errexit before capturing Playwright status",
+        )
+        self.assertIn("run_playwright_supervised || playwright_status=", text)
 
 
 def main() -> int:

--- a/deploy/scripts/test_web_e2e_real_orchestration.py
+++ b/deploy/scripts/test_web_e2e_real_orchestration.py
@@ -1,72 +1,326 @@
 #!/usr/bin/env python3
-"""Hermetic regression tests for web-e2e-real.sh process orchestration.
-
-The real Playwright upload suite needs convert/index/embedding workers plus
-fileconv-server. These tests fail when the harness starts the API alone.
-"""
+"""Hermetic executable tests for web-e2e-real.sh process orchestration."""
 
 from __future__ import annotations
 
+import os
 import re
+import shutil
+import signal
+import subprocess
 import sys
+import tempfile
+import textwrap
+import time
 import unittest
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent / "web-e2e-real.sh"
+REPO_ROOT = SCRIPT.resolve().parents[2]
 
 
-def _read_script() -> str:
-    return SCRIPT.read_text(encoding="utf-8")
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+    path.chmod(0o755)
 
 
-class WebE2eRealOrchestrationTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.text = _read_script()
+class OrchestrationHarness:
+    def __init__(self) -> None:
+        self.tempdir = Path(tempfile.mkdtemp(prefix="web-e2e-real-orch-"))
+        self.root = self.tempdir / "repo"
+        self.state = self.tempdir / "state"
+        self.shim_bin = self.tempdir / "shims"
+        self.path_bin = self.tempdir / "path"
+        self.state.mkdir()
+        self.shim_bin.mkdir()
+        self.path_bin.mkdir()
+        self._install_shims()
+        self._install_env()
 
-    def _require(self, pattern: str, label: str) -> None:
-        if not re.search(pattern, self.text, re.MULTILINE | re.DOTALL):
-            self.fail(f"{label} (pattern not found in web-e2e-real.sh)")
-
-    def _forbid(self, pattern: str, label: str) -> None:
-        if re.search(pattern, self.text, re.MULTILINE | re.IGNORECASE):
-            self.fail(label)
-
-    def test_starts_convert_index_embedding_workers(self) -> None:
-        self._require(r"MARKHAND_WORKER_KIND=convert", "convert worker kind")
-        self._require(r"MARKHAND_WORKER_KIND=index", "index worker kind")
-        self._require(r"MARKHAND_WORKER_KIND=embedding", "embedding worker kind")
-        self._require(r"fileconv-worker", "fileconv-worker binary")
-
-    def test_builds_repository_fileconv_binary(self) -> None:
-        self._require(r"cargo build[^\n]*fileconv-cli", "build fileconv-cli")
-        self._require(
-            r'MARKHAND_CONVERTER_ARGV_JSON=[^\n]*target/(?:debug|release)/fileconv',
-            "converter argv points at repo-built fileconv",
+    def _install_env(self) -> None:
+        env_dir = self.root / "deploy" / "dev"
+        env_dir.mkdir(parents=True)
+        (env_dir / ".env").write_text(
+            "\n".join(
+                [
+                    "MARKHAND_BIND_ADDR=127.0.0.1:8787",
+                    "MARKHAND_WORKER_DB_USER=markhand_worker",
+                    "MARKHAND_WORKER_DB_PASSWORD=markhand_worker_dev_only",
+                    "MARKHAND_POSTGRES_PORT=54329",
+                    "MARKHAND_POSTGRES_DB=markhand",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
         )
 
-    def test_uses_markhand_worker_database_url(self) -> None:
-        self._require(
-            r"MARKHAND_WORKER_DATABASE_URL=[^\n]*markhand_worker",
-            "dedicated markhand_worker database URL",
+    def _install_shims(self) -> None:
+        state = self.state
+        shim_bin = self.shim_bin
+        root = self.root
+
+        _write_executable(
+            shim_bin / "cargo",
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            bin_dir="{root}/target/debug"
+            mkdir -p "$bin_dir"
+            install -m 0755 "{shim_bin}/fileconv-server" "$bin_dir/fileconv-server"
+            install -m 0755 "{shim_bin}/fileconv-worker" "$bin_dir/fileconv-worker"
+            install -m 0755 "{shim_bin}/fileconv" "$bin_dir/fileconv"
+            exit 0
+            """,
         )
-        self._forbid(
-            r"MARKHAND_WORKER_ALLOW_APP_DB_FALLBACK",
-            "must not weaken worker identity with app-role fallback",
+
+        _write_executable(
+            shim_bin / "fileconv-server",
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            echo "MARKHAND_AUTH_SIGNING_KEY=super-secret-key-at-least-32-bytes"
+            echo "server-start pid=$$" >> "{state}/server.events"
+            if [[ "${{WEB_E2E_REAL_SERVER_EXIT_EARLY:-}}" == "1" ]]; then
+              echo "server-exit-early" >> "{state}/server.events"
+              exit 1
+            fi
+            trap 'echo server-term >> "{state}/server.events"; exit 0' TERM INT
+            while true; do sleep 0.05; done
+            """,
         )
 
-    def test_separate_worker_logs_and_redacted_failure_dump(self) -> None:
-        self._require(r"worker.*log|convert_log|index_log|embedding_log", "worker log paths")
-        self._require(r"redact_secrets\.py", "redacted log dump on failure")
+        _write_executable(
+            shim_bin / "fileconv-worker",
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            echo "kind=${{MARKHAND_WORKER_KIND:-unset}}" >> "{state}/workers.started"
+            echo "db=${{MARKHAND_WORKER_DATABASE_URL:-}}" >> "{state}/workers.env"
+            if [[ -n "${{MARKHAND_CONVERTER_ARGV_JSON:-}}" ]]; then
+              echo "converter=${{MARKHAND_CONVERTER_ARGV_JSON}}" >> "{state}/workers.env"
+            fi
+            delay="${{WEB_E2E_REAL_WORKER_DIE_DELAY:-}}"
+            die_kind="${{WEB_E2E_REAL_WORKER_DIE_KIND:-convert}}"
+            if [[ -n "$delay" && "$delay" != "999" && "${{MARKHAND_WORKER_KIND}}" == "$die_kind" ]]; then
+              (
+                while [[ ! -f "{state}/playwright.started" ]]; do sleep 0.05; done
+                sleep "$delay"
+                echo "worker-die-${{MARKHAND_WORKER_KIND}}" >> "{state}/workers.events"
+                kill -TERM "$$" 2>/dev/null || exit 1
+              ) &
+            fi
+            trap 'echo worker-term-${{MARKHAND_WORKER_KIND}} >> "{state}/cleanup.signals"; exit 0' TERM INT
+            while true; do sleep 0.05; done
+            """,
+        )
 
-    def test_waits_for_all_child_processes_on_exit(self) -> None:
-        self._require(r"worker_pids", "tracks worker pids")
-        self._require(r"wait[^\n]*worker", "waits for worker processes on cleanup")
+        _write_executable(
+            shim_bin / "fileconv",
+            "#!/usr/bin/env bash\nexit 0\n",
+        )
 
-    def test_fail_fast_if_worker_dies_before_playwright(self) -> None:
-        self._require(
-            r"kill -0[^\n]*worker",
-            "readiness loop checks worker processes are still alive",
+        _write_executable(
+            shim_bin / "curl",
+            """\
+            #!/usr/bin/env bash
+            if [[ "${*: -1}" == */api/v1/health/ready ]]; then
+              exit 0
+            fi
+            exit 0
+            """,
+        )
+
+        _write_executable(
+            shim_bin / "pnpm",
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            if [[ "$1" == "--dir" && "$3" == "build" ]]; then
+              mkdir -p "{root}/web/dist"
+              touch "{root}/web/dist/index.html"
+              exit 0
+            fi
+            if [[ "$1" == "--dir" && "$3" == "exec" && "$4" == "playwright" ]]; then
+              exec "{shim_bin}/playwright-shim" "$@"
+            fi
+            echo "unexpected pnpm invocation: $*" >&2
+            exit 1
+            """,
+        )
+
+        _write_executable(
+            shim_bin / "playwright-shim",
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            echo "playwright-start pid=$$" >> "{state}/playwright.events"
+            touch "{state}/playwright.started"
+            if [[ "${{WEB_E2E_REAL_PLAYWRIGHT_FAIL:-}}" == "1" ]]; then
+              echo "playwright-fail" >> "{state}/playwright.events"
+              exit 9
+            fi
+            trap 'echo playwright-term >> "{state}/playwright.events"; exit 143' TERM INT
+            i=0
+            while [[ $i -lt 40 ]]; do
+              sleep 0.05
+              i=$((i + 1))
+            done
+            echo "playwright-done" >> "{state}/playwright.events"
+            exit 0
+            """,
+        )
+
+        for name in ("bootstrap-server-role.sh", "migrate.sh", "seed-dev-all.sh"):
+            script_path = self.root / "deploy" / "scripts" / name
+            script_path.parent.mkdir(parents=True, exist_ok=True)
+            _write_executable(
+                script_path,
+                "#!/usr/bin/env bash\nexit 0\n",
+            )
+        (self.root / "deploy" / "poc").mkdir(parents=True, exist_ok=True)
+        (self.root / "deploy" / "poc" / "qdrant-init.py").write_text(
+            "#!/usr/bin/env python3\n", encoding="utf-8"
+        )
+
+        deploy_scripts = REPO_ROOT / "deploy" / "scripts"
+        script_dest = self.root / "deploy" / "scripts" / "web-e2e-real.sh"
+        script_dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(SCRIPT, script_dest)
+        shutil.copy2(
+            deploy_scripts / "redact_secrets.py",
+            self.root / "deploy" / "scripts" / "redact_secrets.py",
+        )
+        shutil.copy2(
+            deploy_scripts / "init-dev-env.sh",
+            self.root / "deploy" / "scripts" / "init-dev-env.sh",
+        )
+
+    def run(
+        self,
+        *,
+        extra_env: dict[str, str] | None = None,
+        timeout: float = 30.0,
+        failing_cargo: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "WEB_E2E_REAL_ORCHESTRATION_TEST": "1",
+                "WEB_E2E_REAL_ENV_FILE": str(self.root / "deploy" / "dev" / ".env"),
+                "WEB_E2E_REAL_ROOT": str(self.root),
+                "WEB_E2E_REAL_SHIM_BIN_DIR": str(self.shim_bin),
+                "WEB_E2E_REAL_PLAYWRIGHT_CMD": f"exec {self.shim_bin}/playwright-shim",
+                "PATH": f"{self.path_bin}:{self.shim_bin}:{env.get('PATH', '')}",
+                "HOME": str(self.tempdir),
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+        for shim_name in (
+            "curl",
+            "pnpm",
+            "fileconv-server",
+            "fileconv-worker",
+            "fileconv",
+            "playwright-shim",
+        ):
+            shutil.copy2(self.shim_bin / shim_name, self.path_bin / shim_name)
+        if failing_cargo:
+            _write_executable(
+                self.path_bin / "cargo",
+                "#!/usr/bin/env bash\nexit 17\n",
+            )
+        else:
+            shutil.copy2(self.shim_bin / "cargo", self.path_bin / "cargo")
+        return subprocess.run(
+            ["bash", str(self.root / "deploy" / "scripts" / "web-e2e-real.sh")],
+            cwd=str(self.root),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+
+class WebE2eRealExecutableOrchestrationTests(unittest.TestCase):
+    def test_starts_workers_with_dedicated_role_and_repo_fileconv(self) -> None:
+        harness = OrchestrationHarness()
+        try:
+            result = harness.run(timeout=20.0)
+            self.assertEqual(
+                result.returncode,
+                0,
+                msg=f"stdout={result.stdout}\nstderr={result.stderr}",
+            )
+            started = (harness.state / "workers.started").read_text(encoding="utf-8")
+            self.assertIn("kind=convert", started)
+            self.assertIn("kind=index", started)
+            self.assertIn("kind=embedding", started)
+            env_dump = (harness.state / "workers.env").read_text(encoding="utf-8")
+            self.assertRegex(env_dump, r"markhand_worker")
+            self.assertRegex(env_dump, r"target/debug/fileconv")
+            self.assertIn("playwright-done", (harness.state / "playwright.events").read_text())
+        finally:
+            harness.cleanup()
+
+    def test_fail_closed_log_dump_withholds_raw_secrets(self) -> None:
+        harness = OrchestrationHarness()
+        try:
+            result = harness.run(
+                extra_env={"WEB_E2E_REAL_SERVER_EXIT_EARLY": "1"},
+                timeout=15.0,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            combined = result.stdout + result.stderr
+            self.assertNotIn("super-secret-key-at-least-32-bytes", combined)
+            self.assertIn("=== web-e2e-real:", result.stderr)
+            self.assertTrue(
+                "raw log withheld" in combined.lower()
+                or "redaction failed" in combined.lower()
+                or "<REDACTED" in combined
+                or "SECRET_REDACT_FAIL_CLOSED" in combined,
+                msg=combined,
+            )
+        finally:
+            harness.cleanup()
+
+    def test_supervises_and_aborts_playwright_when_worker_dies(self) -> None:
+        harness = OrchestrationHarness()
+        try:
+            result = harness.run(
+                extra_env={"WEB_E2E_REAL_WORKER_DIE_DELAY": "0.15"},
+                timeout=15.0,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("during Playwright", result.stderr)
+            events = (harness.state / "playwright.events").read_text(encoding="utf-8")
+            self.assertIn("playwright-start", events)
+            self.assertIn("playwright-term", events)
+            self.assertNotIn("playwright-done", events)
+            self.assertIn("worker-die-convert", (harness.state / "workers.events").read_text())
+        finally:
+            harness.cleanup()
+
+    def test_cleanup_waits_children_after_build_failure(self) -> None:
+        harness = OrchestrationHarness()
+        try:
+            result = harness.run(timeout=10.0, failing_cargo=True)
+            self.assertEqual(result.returncode, 17)
+            self.assertNotIn("unbound variable", result.stderr.lower())
+        finally:
+            harness.cleanup()
+
+    def test_forbids_fail_open_redaction_flags(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+        self.assertNotIn("--allow-residual", text)
+        self.assertNotRegex(
+            text,
+            r'redact_secrets\.py[^\n]*\|\|\s*cat',
+            msg="must not fall back to raw cat after redaction failure",
         )
 
 

--- a/deploy/scripts/test_web_e2e_real_orchestration.py
+++ b/deploy/scripts/test_web_e2e_real_orchestration.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Hermetic regression tests for web-e2e-real.sh process orchestration.
+
+The real Playwright upload suite needs convert/index/embedding workers plus
+fileconv-server. These tests fail when the harness starts the API alone.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "web-e2e-real.sh"
+
+
+def _read_script() -> str:
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+class WebE2eRealOrchestrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = _read_script()
+
+    def _require(self, pattern: str, label: str) -> None:
+        if not re.search(pattern, self.text, re.MULTILINE | re.DOTALL):
+            self.fail(f"{label} (pattern not found in web-e2e-real.sh)")
+
+    def _forbid(self, pattern: str, label: str) -> None:
+        if re.search(pattern, self.text, re.MULTILINE | re.IGNORECASE):
+            self.fail(label)
+
+    def test_starts_convert_index_embedding_workers(self) -> None:
+        self._require(r"MARKHAND_WORKER_KIND=convert", "convert worker kind")
+        self._require(r"MARKHAND_WORKER_KIND=index", "index worker kind")
+        self._require(r"MARKHAND_WORKER_KIND=embedding", "embedding worker kind")
+        self._require(r"fileconv-worker", "fileconv-worker binary")
+
+    def test_builds_repository_fileconv_binary(self) -> None:
+        self._require(r"cargo build[^\n]*fileconv-cli", "build fileconv-cli")
+        self._require(
+            r'MARKHAND_CONVERTER_ARGV_JSON=[^\n]*target/(?:debug|release)/fileconv',
+            "converter argv points at repo-built fileconv",
+        )
+
+    def test_uses_markhand_worker_database_url(self) -> None:
+        self._require(
+            r"MARKHAND_WORKER_DATABASE_URL=[^\n]*markhand_worker",
+            "dedicated markhand_worker database URL",
+        )
+        self._forbid(
+            r"MARKHAND_WORKER_ALLOW_APP_DB_FALLBACK",
+            "must not weaken worker identity with app-role fallback",
+        )
+
+    def test_separate_worker_logs_and_redacted_failure_dump(self) -> None:
+        self._require(r"worker.*log|convert_log|index_log|embedding_log", "worker log paths")
+        self._require(r"redact_secrets\.py", "redacted log dump on failure")
+
+    def test_waits_for_all_child_processes_on_exit(self) -> None:
+        self._require(r"worker_pids", "tracks worker pids")
+        self._require(r"wait[^\n]*worker", "waits for worker processes on cleanup")
+
+    def test_fail_fast_if_worker_dies_before_playwright(self) -> None:
+        self._require(
+            r"kill -0[^\n]*worker",
+            "readiness loop checks worker processes are still alive",
+        )
+
+
+def main() -> int:
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(sys.modules[__name__])
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/scripts/web-e2e-real.sh
+++ b/deploy/scripts/web-e2e-real.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Real-deployment half of P2-15: build the web SPA, boot fileconv-server
-# against the already-up dev Compose stack (Postgres/Qdrant/MinIO/embedding),
-# and run the Playwright `real` project against it. Smoke scope only — see
-# web/e2e-real/support.ts for what this suite covers and why.
+# Real-deployment half of P2-15: build the web SPA, boot fileconv-server plus
+# convert/index/embedding workers against the already-up dev Compose stack
+# (Postgres/Qdrant/MinIO/embedding), and run the Playwright `real` project
+# against it. Smoke scope — see web/e2e-real/support.ts for coverage.
 #
 # Pattern follows server-smoke.sh (init env -> source .env -> bootstrap ->
-# migrate -> qdrant-init -> run fileconv-server -> poll /health/ready -> seed)
-# but does not tear the server down until Playwright has run against it, and
+# migrate -> qdrant-init -> run fileconv-server + workers -> poll /health/ready
+# -> seed) but does not tear processes down until Playwright has run, and
 # additionally builds + serves the SPA from the same process (see
 # deploy/README.md's "Web SPA static serving (P2-16)" section).
 #
@@ -21,6 +21,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 ENV_FILE="$ROOT/deploy/dev/.env"
 WEB_DIR="$ROOT/web"
+REDACT="$ROOT/deploy/scripts/redact_secrets.py"
 
 # Mock signature / dims must match deploy/dev/.env.example mock block and mock-embedding.py.
 MOCK_INDEX_SIGNATURE="0f59a26d542340c3c2c062a227417e47f9303c2db67569cf9031fe4707e44bf0"
@@ -62,19 +63,102 @@ python3 "$ROOT/deploy/poc/qdrant-init.py"
 pnpm --dir "$WEB_DIR" build
 export MARKHAND_WEB_DIST_DIR="$WEB_DIR/dist"
 
-log_file="$(mktemp)"
-cargo build -p fileconv-server
-"$ROOT/target/debug/fileconv-server" >"$log_file" 2>&1 &
-server_pid=$!
+export MARKHAND_WORKER_DATABASE_URL="postgres://${MARKHAND_WORKER_DB_USER:-markhand_worker}:${MARKHAND_WORKER_DB_PASSWORD:-markhand_worker_dev_only}@127.0.0.1:${MARKHAND_POSTGRES_PORT:-54329}/${MARKHAND_POSTGRES_DB:-markhand}"
+export MARKHAND_CONVERTER_ARGV_JSON="[\"${ROOT}/target/debug/fileconv\",\"one\",\"{input}\"]"
+server_log="$(mktemp)"
+convert_log="$(mktemp)"
+index_log="$(mktemp)"
+embedding_log="$(mktemp)"
+worker_pids=()
+
+dump_redacted_logs() {
+  local reason="${1:-failure}"
+  echo "=== web-e2e-real: ${reason} ===" >&2
+  local entries=(
+    "server:$server_log"
+    "convert:$convert_log"
+    "index:$index_log"
+    "embedding:$embedding_log"
+  )
+  local entry label path
+  for entry in "${entries[@]}"; do
+    label="${entry%%:*}"
+    path="${entry#*:}"
+    echo "--- ${label} ---" >&2
+    if [[ -f "$path" ]]; then
+      python3 "$REDACT" --allow-residual "$path" >&2 || cat "$path" >&2
+    else
+      echo "(no log file)" >&2
+    fi
+  done
+}
+
+workers_alive() {
+  local worker_pid
+  for worker_pid in "${worker_pids[@]}"; do
+    if ! kill -0 "$worker_pid" 2>/dev/null; then
+      dump_redacted_logs "worker process ${worker_pid} exited before Playwright"
+      return 1
+    fi
+  done
+  return 0
+}
+
+start_worker() {
+  local kind="$1"
+  local worker_id="$2"
+  local worker_log="$3"
+  local converter_argv="${4:-}"
+
+  (
+    unset MARKHAND_AUTH_ISSUER MARKHAND_AUTH_AUDIENCE MARKHAND_AUTH_SIGNING_KEY MARKHAND_AUTH_KID
+    unset MARKHAND_DATABASE_URL MARKHAND_MIGRATOR_DATABASE_URL
+
+    export MARKHAND_WORKER_DATABASE_URL
+    export MARKHAND_WORKER_ORG_ID="${MARKHAND_WORKER_ORG_ID:-11111111-1111-1111-1111-111111111111}"
+    export MARKHAND_WORKER_USER_ID="${MARKHAND_WORKER_USER_ID:-22222222-2222-2222-2222-222222222201}"
+    case "$kind" in
+      convert) export MARKHAND_WORKER_KIND=convert ;;
+      index) export MARKHAND_WORKER_KIND=index ;;
+      embedding) export MARKHAND_WORKER_KIND=embedding ;;
+      *) echo "unknown worker kind: $kind" >&2; exit 1 ;;
+    esac
+    export MARKHAND_WORKER_ID="$worker_id"
+    if [[ -n "$converter_argv" ]]; then
+      export MARKHAND_CONVERTER_ARGV_JSON="$converter_argv"
+    fi
+
+    exec "$ROOT/target/debug/fileconv-worker" >"$worker_log" 2>&1
+  ) &
+  worker_pids+=("$!")
+}
+
 cleanup() {
   kill "$server_pid" 2>/dev/null || true
+  local worker_pid
+  for worker_pid in "${worker_pids[@]}"; do
+    kill "$worker_pid" 2>/dev/null || true
+  done
   wait "$server_pid" 2>/dev/null || true
-  rm -f "$log_file"
+  for worker_pid in "${worker_pids[@]}"; do
+    wait "$worker_pid" 2>/dev/null || true
+  done
+  rm -f "$server_log" "$convert_log" "$index_log" "$embedding_log"
   if [[ "$created_env" == true ]]; then
     rm -f "$ENV_FILE"
   fi
 }
 trap cleanup EXIT
+
+cargo build -p fileconv-server
+cargo build -p fileconv-cli --bin fileconv
+
+start_worker convert e2e-real-convert-1 "$convert_log" "$MARKHAND_CONVERTER_ARGV_JSON"
+start_worker index e2e-real-index-1 "$index_log"
+start_worker embedding e2e-real-embedding-1 "$embedding_log"
+
+"$ROOT/target/debug/fileconv-server" >"$server_log" 2>&1 &
+server_pid=$!
 
 bind_addr="${MARKHAND_BIND_ADDR:-127.0.0.1:8787}"
 healthy=false
@@ -85,21 +169,38 @@ for _ in $(seq 1 60); do
     break
   fi
   if ! kill -0 "$server_pid" 2>/dev/null; then
-    cat "$log_file" >&2
+    dump_redacted_logs "fileconv-server exited during readiness"
+    exit 1
+  fi
+  if ! workers_alive; then
     exit 1
   fi
   sleep 1
 done
 
 if [[ "$healthy" != true ]]; then
-  cat "$log_file" >&2
+  dump_redacted_logs "fileconv-server never became ready"
   echo "unhealthy: fileconv-server" >&2
   exit 1
 fi
 
-"$ROOT/deploy/scripts/seed-dev-all.sh" --skip-init
-echo "healthy: fileconv-server (serving web/dist from $MARKHAND_WEB_DIST_DIR)"
+if ! workers_alive; then
+  exit 1
+fi
 
+"$ROOT/deploy/scripts/seed-dev-all.sh" --skip-init
+echo "healthy: fileconv-server + convert/index/embedding workers (web/dist from $MARKHAND_WEB_DIST_DIR)"
+
+set +e
 MARKHAND_E2E_REAL=1 \
   MARKHAND_E2E_REAL_BASE_URL="http://${bind_addr}" \
   pnpm --dir "$WEB_DIR" exec playwright test --project=real
+playwright_status=$?
+set -e
+
+if [[ "$playwright_status" -ne 0 ]]; then
+  dump_redacted_logs "Playwright real project failed (exit ${playwright_status})"
+  exit "$playwright_status"
+fi
+
+exit 0

--- a/deploy/scripts/web-e2e-real.sh
+++ b/deploy/scripts/web-e2e-real.sh
@@ -40,6 +40,9 @@ created_env=false
 
 cleanup() {
   local worker_pid
+  if [[ -n "${WEB_E2E_REAL_CLEANUP_DELAY_SECS:-}" ]]; then
+    sleep "$WEB_E2E_REAL_CLEANUP_DELAY_SECS"
+  fi
   if [[ -n "$server_pid" ]]; then
     kill "$server_pid" 2>/dev/null || true
     wait "$server_pid" 2>/dev/null || true
@@ -88,8 +91,12 @@ dump_redacted_logs() {
   done
 }
 
-workers_alive() {
+required_processes_alive() {
   local context="${1:-before Playwright}"
+  if [[ -z "$server_pid" ]] || ! kill -0 "$server_pid" 2>/dev/null; then
+    dump_redacted_logs "fileconv-server exited ${context}"
+    return 1
+  fi
   local worker_pid
   for worker_pid in "${worker_pids[@]}"; do
     if ! kill -0 "$worker_pid" 2>/dev/null; then
@@ -130,7 +137,7 @@ start_worker() {
 }
 
 run_playwright_supervised() {
-  local playwright_pid
+  local playwright_pid playwright_status=0
   set +e
   if [[ -n "${WEB_E2E_REAL_PLAYWRIGHT_CMD:-}" ]]; then
     bash -c "$WEB_E2E_REAL_PLAYWRIGHT_CMD" &
@@ -141,16 +148,9 @@ run_playwright_supervised() {
       pnpm --dir "$WEB_DIR" exec playwright test --project=real &
     playwright_pid=$!
   fi
-  set -e
 
   while kill -0 "$playwright_pid" 2>/dev/null; do
-    if [[ -n "$server_pid" ]] && ! kill -0 "$server_pid" 2>/dev/null; then
-      kill "$playwright_pid" 2>/dev/null || true
-      wait "$playwright_pid" 2>/dev/null || true
-      dump_redacted_logs "fileconv-server exited during Playwright"
-      return 1
-    fi
-    if ! workers_alive "during Playwright"; then
+    if ! required_processes_alive "during Playwright"; then
       kill -TERM "$playwright_pid" 2>/dev/null || true
       local _w
       for _w in $(seq 1 20); do
@@ -164,7 +164,6 @@ run_playwright_supervised() {
     sleep 0.1
   done
 
-  local playwright_status=0
   wait "$playwright_pid" 2>/dev/null || playwright_status=$?
   return "$playwright_status"
 }
@@ -237,7 +236,7 @@ for _ in $(seq 1 "$readiness_attempts"); do
     dump_redacted_logs "fileconv-server exited during readiness"
     exit 1
   fi
-  if ! workers_alive "during readiness"; then
+  if ! required_processes_alive "during readiness"; then
     exit 1
   fi
   sleep 1
@@ -249,22 +248,19 @@ if [[ "$healthy" != true ]]; then
   exit 1
 fi
 
-if ! workers_alive "after readiness, before seed"; then
+if ! required_processes_alive "after readiness, before seed"; then
   exit 1
 fi
 
 "$ROOT/deploy/scripts/seed-dev-all.sh" --skip-init
 echo "healthy: fileconv-server + convert/index/embedding workers (web/dist from $MARKHAND_WEB_DIST_DIR)"
 
-if ! workers_alive "after seed, before Playwright"; then
+if ! required_processes_alive "after seed, before Playwright"; then
   exit 1
 fi
 
-set +e
-run_playwright_supervised
-playwright_status=$?
-set -e
-
+playwright_status=0
+run_playwright_supervised || playwright_status=$?
 if [[ "$playwright_status" -ne 0 ]]; then
   dump_redacted_logs "Playwright real project failed (exit ${playwright_status})"
   exit "$playwright_status"

--- a/deploy/scripts/web-e2e-real.sh
+++ b/deploy/scripts/web-e2e-real.sh
@@ -19,57 +19,50 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-ENV_FILE="$ROOT/deploy/dev/.env"
+ORCHESTRATION_TEST="${WEB_E2E_REAL_ORCHESTRATION_TEST:-0}"
+ENV_FILE="${WEB_E2E_REAL_ENV_FILE:-$ROOT/deploy/dev/.env}"
 WEB_DIR="$ROOT/web"
 REDACT="$ROOT/deploy/scripts/redact_secrets.py"
+SERVER_BIN="${WEB_E2E_REAL_SERVER_BIN:-$ROOT/target/debug/fileconv-server}"
+WORKER_BIN="${WEB_E2E_REAL_WORKER_BIN:-$ROOT/target/debug/fileconv-worker}"
+FILECONV_BIN="${WEB_E2E_REAL_FILECONV_BIN:-$ROOT/target/debug/fileconv}"
 
 # Mock signature / dims must match deploy/dev/.env.example mock block and mock-embedding.py.
 MOCK_INDEX_SIGNATURE="0f59a26d542340c3c2c062a227417e47f9303c2db67569cf9031fe4707e44bf0"
 
+server_pid=""
+worker_pids=()
+server_log=""
+convert_log=""
+index_log=""
+embedding_log=""
 created_env=false
-if [[ ! -f "$ENV_FILE" ]]; then
-  "$ROOT/deploy/scripts/init-dev-env.sh"
-  created_env=true
-fi
 
-# CI sets COMPOSE_PROFILES=mock; do not let .env clobber it.
-incoming_profiles="${COMPOSE_PROFILES:-}"
+cleanup() {
+  local worker_pid
+  if [[ -n "$server_pid" ]]; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  for worker_pid in "${worker_pids[@]}"; do
+    kill "$worker_pid" 2>/dev/null || true
+  done
+  for worker_pid in "${worker_pids[@]}"; do
+    wait "$worker_pid" 2>/dev/null || true
+  done
+  if [[ -n "$server_log" ]]; then
+    rm -f "$server_log" "$convert_log" "$index_log" "$embedding_log"
+  fi
+  if [[ "$created_env" == true ]]; then
+    rm -f "$ENV_FILE"
+  fi
+}
 
-set -a
-# shellcheck disable=SC1090
-source "$ENV_FILE"
-set +a
-
-if [[ -n "$incoming_profiles" ]]; then
-  export COMPOSE_PROFILES="$incoming_profiles"
-fi
-
-if [[ "${COMPOSE_PROFILES:-}" == *mock* ]]; then
-  export MARKHAND_EMBEDDING_MODEL=markhand-mock
-  export MARKHAND_EMBEDDING_REVISION=dev-local
-  export MARKHAND_EMBEDDING_DIMENSIONS=8
-  export MARKHAND_EMBEDDING_API_KEY=dev-mock-key
-  export MARKHAND_INDEX_SIGNATURE="$MOCK_INDEX_SIGNATURE"
-  export MARKHAND_MOCK_EMBEDDING_DIMENSIONS=8
-fi
-
-"$ROOT/deploy/scripts/bootstrap-server-role.sh"
-"$ROOT/deploy/scripts/migrate.sh"
-python3 "$ROOT/deploy/poc/qdrant-init.py"
-
-# Build the SPA before the server starts: resolve_web_dist_dir() is checked
-# once at router bootstrap, so a `web/dist` that appears after the server is
-# already running would never be picked up.
-pnpm --dir "$WEB_DIR" build
-export MARKHAND_WEB_DIST_DIR="$WEB_DIR/dist"
-
-export MARKHAND_WORKER_DATABASE_URL="postgres://${MARKHAND_WORKER_DB_USER:-markhand_worker}:${MARKHAND_WORKER_DB_PASSWORD:-markhand_worker_dev_only}@127.0.0.1:${MARKHAND_POSTGRES_PORT:-54329}/${MARKHAND_POSTGRES_DB:-markhand}"
-export MARKHAND_CONVERTER_ARGV_JSON="[\"${ROOT}/target/debug/fileconv\",\"one\",\"{input}\"]"
 server_log="$(mktemp)"
 convert_log="$(mktemp)"
 index_log="$(mktemp)"
 embedding_log="$(mktemp)"
-worker_pids=()
+trap cleanup EXIT
 
 dump_redacted_logs() {
   local reason="${1:-failure}"
@@ -85,19 +78,22 @@ dump_redacted_logs() {
     label="${entry%%:*}"
     path="${entry#*:}"
     echo "--- ${label} ---" >&2
-    if [[ -f "$path" ]]; then
-      python3 "$REDACT" --allow-residual "$path" >&2 || cat "$path" >&2
-    else
+    if [[ ! -f "$path" ]]; then
       echo "(no log file)" >&2
+      continue
+    fi
+    if ! python3 "$REDACT" "$path" >&2; then
+      echo "(log redaction failed for ${label} — raw log withheld)" >&2
     fi
   done
 }
 
 workers_alive() {
+  local context="${1:-before Playwright}"
   local worker_pid
   for worker_pid in "${worker_pids[@]}"; do
     if ! kill -0 "$worker_pid" 2>/dev/null; then
-      dump_redacted_logs "worker process ${worker_pid} exited before Playwright"
+      dump_redacted_logs "worker process ${worker_pid} exited ${context}"
       return 1
     fi
   done
@@ -128,27 +124,91 @@ start_worker() {
       export MARKHAND_CONVERTER_ARGV_JSON="$converter_argv"
     fi
 
-    exec "$ROOT/target/debug/fileconv-worker" >"$worker_log" 2>&1
+    exec "$WORKER_BIN" >"$worker_log" 2>&1
   ) &
   worker_pids+=("$!")
 }
 
-cleanup() {
-  kill "$server_pid" 2>/dev/null || true
-  local worker_pid
-  for worker_pid in "${worker_pids[@]}"; do
-    kill "$worker_pid" 2>/dev/null || true
-  done
-  wait "$server_pid" 2>/dev/null || true
-  for worker_pid in "${worker_pids[@]}"; do
-    wait "$worker_pid" 2>/dev/null || true
-  done
-  rm -f "$server_log" "$convert_log" "$index_log" "$embedding_log"
-  if [[ "$created_env" == true ]]; then
-    rm -f "$ENV_FILE"
+run_playwright_supervised() {
+  local playwright_pid
+  set +e
+  if [[ -n "${WEB_E2E_REAL_PLAYWRIGHT_CMD:-}" ]]; then
+    bash -c "$WEB_E2E_REAL_PLAYWRIGHT_CMD" &
+    playwright_pid=$!
+  else
+    MARKHAND_E2E_REAL=1 \
+      MARKHAND_E2E_REAL_BASE_URL="http://${bind_addr}" \
+      pnpm --dir "$WEB_DIR" exec playwright test --project=real &
+    playwright_pid=$!
   fi
+  set -e
+
+  while kill -0 "$playwright_pid" 2>/dev/null; do
+    if [[ -n "$server_pid" ]] && ! kill -0 "$server_pid" 2>/dev/null; then
+      kill "$playwright_pid" 2>/dev/null || true
+      wait "$playwright_pid" 2>/dev/null || true
+      dump_redacted_logs "fileconv-server exited during Playwright"
+      return 1
+    fi
+    if ! workers_alive "during Playwright"; then
+      kill -TERM "$playwright_pid" 2>/dev/null || true
+      local _w
+      for _w in $(seq 1 20); do
+        kill -0 "$playwright_pid" 2>/dev/null || break
+        sleep 0.05
+      done
+      kill -KILL "$playwright_pid" 2>/dev/null || true
+      wait "$playwright_pid" 2>/dev/null || true
+      return 1
+    fi
+    sleep 0.1
+  done
+
+  local playwright_status=0
+  wait "$playwright_pid" 2>/dev/null || playwright_status=$?
+  return "$playwright_status"
 }
-trap cleanup EXIT
+
+if [[ "$ORCHESTRATION_TEST" != "1" && ! -f "$ENV_FILE" ]]; then
+  "$ROOT/deploy/scripts/init-dev-env.sh"
+  created_env=true
+fi
+
+# CI sets COMPOSE_PROFILES=mock; do not let .env clobber it.
+incoming_profiles="${COMPOSE_PROFILES:-}"
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+if [[ -n "$incoming_profiles" ]]; then
+  export COMPOSE_PROFILES="$incoming_profiles"
+fi
+
+if [[ "${COMPOSE_PROFILES:-}" == *mock* ]]; then
+  export MARKHAND_EMBEDDING_MODEL=markhand-mock
+  export MARKHAND_EMBEDDING_REVISION=dev-local
+  export MARKHAND_EMBEDDING_DIMENSIONS=8
+  export MARKHAND_EMBEDDING_API_KEY=dev-mock-key
+  export MARKHAND_INDEX_SIGNATURE="$MOCK_INDEX_SIGNATURE"
+  export MARKHAND_MOCK_EMBEDDING_DIMENSIONS=8
+fi
+
+if [[ "$ORCHESTRATION_TEST" != "1" ]]; then
+  "$ROOT/deploy/scripts/bootstrap-server-role.sh"
+  "$ROOT/deploy/scripts/migrate.sh"
+  python3 "$ROOT/deploy/poc/qdrant-init.py"
+fi
+
+# Build the SPA before the server starts: resolve_web_dist_dir() is checked
+# once at router bootstrap, so a `web/dist` that appears after the server is
+# already running would never be picked up.
+pnpm --dir "$WEB_DIR" build
+export MARKHAND_WEB_DIST_DIR="$WEB_DIR/dist"
+
+export MARKHAND_WORKER_DATABASE_URL="postgres://${MARKHAND_WORKER_DB_USER:-markhand_worker}:${MARKHAND_WORKER_DB_PASSWORD:-markhand_worker_dev_only}@127.0.0.1:${MARKHAND_POSTGRES_PORT:-54329}/${MARKHAND_POSTGRES_DB:-markhand}"
+export MARKHAND_CONVERTER_ARGV_JSON="[\"${FILECONV_BIN}\",\"one\",\"{input}\"]"
 
 cargo build -p fileconv-server
 cargo build -p fileconv-cli --bin fileconv
@@ -157,22 +217,27 @@ start_worker convert e2e-real-convert-1 "$convert_log" "$MARKHAND_CONVERTER_ARGV
 start_worker index e2e-real-index-1 "$index_log"
 start_worker embedding e2e-real-embedding-1 "$embedding_log"
 
-"$ROOT/target/debug/fileconv-server" >"$server_log" 2>&1 &
+"$SERVER_BIN" >"$server_log" 2>&1 &
 server_pid=$!
 
 bind_addr="${MARKHAND_BIND_ADDR:-127.0.0.1:8787}"
+readiness_attempts="${WEB_E2E_REAL_READINESS_ATTEMPTS:-60}"
 healthy=false
-for _ in $(seq 1 60); do
+for _ in $(seq 1 "$readiness_attempts"); do
   if curl --fail --silent --show-error \
     "http://${bind_addr}/api/v1/health/ready" >/dev/null; then
-    healthy=true
-    break
+    if kill -0 "$server_pid" 2>/dev/null; then
+      healthy=true
+      break
+    fi
+    dump_redacted_logs "fileconv-server exited during readiness"
+    exit 1
   fi
   if ! kill -0 "$server_pid" 2>/dev/null; then
     dump_redacted_logs "fileconv-server exited during readiness"
     exit 1
   fi
-  if ! workers_alive; then
+  if ! workers_alive "during readiness"; then
     exit 1
   fi
   sleep 1
@@ -184,17 +249,19 @@ if [[ "$healthy" != true ]]; then
   exit 1
 fi
 
-if ! workers_alive; then
+if ! workers_alive "after readiness, before seed"; then
   exit 1
 fi
 
 "$ROOT/deploy/scripts/seed-dev-all.sh" --skip-init
 echo "healthy: fileconv-server + convert/index/embedding workers (web/dist from $MARKHAND_WEB_DIST_DIR)"
 
+if ! workers_alive "after seed, before Playwright"; then
+  exit 1
+fi
+
 set +e
-MARKHAND_E2E_REAL=1 \
-  MARKHAND_E2E_REAL_BASE_URL="http://${bind_addr}" \
-  pnpm --dir "$WEB_DIR" exec playwright test --project=real
+run_playwright_supervised
 playwright_status=$?
 set -e
 

--- a/web/e2e-real/support.ts
+++ b/web/e2e-real/support.ts
@@ -7,14 +7,14 @@
 //     SPA static serving" section and `crates/server/src/spa.rs`). There is
 //     no fetch mock here: every request is a real HTTP round-trip.
 //   - Only `deploy/scripts/web-e2e-real.sh` is meant to run this suite: it
-//     brings the stack up, migrates, seeds, builds the SPA, starts the
-//     server, and only then runs `playwright test --project=real`. Running
-//     this suite any other way requires reproducing all of that by hand.
+//     brings the stack up, migrates, seeds, builds the SPA, starts
+//     fileconv-server plus convert/index/embedding workers, and only then runs
+//     `playwright test --project=real`. Running this suite any other way
+//     requires reproducing all of that by hand.
 //   - Smoke scope only, deliberately small: login against a seeded real
-//     account, then confirm the library shell renders with its seeded
-//     collection. Broader flows (upload → indexed, actions, org switch)
-//     belong to a later pass once this harness is proven — see P2-15's
-//     status note.
+//     account, library shell on the seeded collection, and upload → indexed
+//     against the real conversion/indexing pipeline. Broader flows (actions,
+//     org switch) belong to a later pass — see P2-15's status note.
 //
 // FIXTURE GROUND TRUTH: the admin account and its password come from the
 // same seed the dev stack always uses — `crates/server/migrations/

--- a/web/e2e-real/upload.spec.ts
+++ b/web/e2e-real/upload.spec.ts
@@ -68,12 +68,10 @@ test('uploading a file against the real backend reaches indexed, and its preview
   //    purpose) — the state badge below is the stable signal instead.
   await expect(row).toBeVisible({ timeout: 15_000 });
 
-  // 2. No intermediate-state assertion on purpose: the real worker converts
-  //    this tiny .txt in well under the list's 5s poll tick, so the
-  //    transient "Đang chuyển đổi" badge is never reliably rendered — the
-  //    first CI run against the real stack confirmed exactly the loosening
-  //    this comment's earlier version predicted (run 30806030510). The state
-  //    machine's intermediate steps stay covered by the mock suite
+  // 2. No intermediate-state assertion on purpose: with workers running, this
+  //    tiny .txt often converts in well under the list's 5s poll tick, so the
+  //    transient "Đang chuyển đổi" badge is not reliably observable. The
+  //    state machine's intermediate steps stay covered by the mock suite
   //    (`e2e/document-status-polling.spec.ts`), which can freeze each stage;
   //    the real-deployment signal here is the terminal state below.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Restores the missing runtime half of the real P2-15 upload harness: the harness now starts and supervises real convert, index, and embedding workers instead of waiting for an upload job that no process could claim.

## Scope

- Build the repository CLI used by the convert worker.
- Start workers with the dedicated `markhand_worker` database role and mock embedding configuration used by CI.
- Check server and worker liveness after seeding and supervise all required processes while Playwright runs.
- Terminate and wait for Playwright if a required child exits; track, terminate, and reap every child on all exit paths.
- Capture separate logs and redact them fail-closed; raw logs are withheld when redaction fails.
- Add executable, hermetic process-orchestration regression tests and correct stale suite comments.

## Evidence

- [x] Tests: `python3 deploy/scripts/test_web_e2e_real_orchestration.py` — 8/8 passed after RED runs exposed missing workers and two review rounds; behavioral shims cover startup/config, worker death during Playwright, Playwright failure propagation, failing redactor, and post-child cleanup/reaping. `bash -n` passed for both changed shell scripts.
- [x] Manual/benchmark/migration evidence: [CI run 30835682218](https://github.com/anhnth24/project-example/actions/runs/30835682218) passed `dev-stack`, proving the real upload → convert → index → indexed flow; security image/dependency scans, web and web-e2e also passed. No migration or benchmark change.

## Boundary and security review

- [x] Dependency boundary check passed. `scripts/check-dependency-policy.py` passed; no dependency changes.
- [x] Tenant/ACL impact reviewed, or N/A. Workers use the dedicated non-app `markhand_worker` role; no fallback is enabled.
- [x] Sensitive logging/secret/egress impact reviewed, or N/A. Failure logs use the existing redactor in fail-closed mode, raw fallback is forbidden, and worker subshells remove auth variables.
- [x] Security review trigger checked. No auth/API surface changed; worker identity is preserved.

## Follow-up

- [x] Docs, ADR, OpenAPI, roadmap or runbook updated where required. In-code harness documentation was corrected; roadmap status can be updated after acceptance/merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc887-94bd-7787-8e55-b01ea86906b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc887-94bd-7787-8e55-b01ea86906b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

