### PR TITLE
ci: document inactive rkyv audit exception

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -37,4 +37,16 @@ ignore = [
     # and does not bind 0.0.0.0; no semver-compatible rmcp fix available.
     # Retire: when rmcp ships the Host-validation fix and we adopt it.
     "RUSTSEC-2026-0189",
+
+    # RUSTSEC-2026-0235 — rkyv 0.7 archive validation can allow out-of-bounds
+    # reads for crafted Rc/Arc archives. The lockfile-only chain is
+    # fileconv-server -> rust_decimal 1.42.1 -> optional rkyv 0.7.46:
+    # fileconv-server enables serde + db-tokio-postgres, not rkyv/rkyv-safe,
+    # and `cargo tree --workspace --all-features --target all -i rkyv@0.7.46`
+    # resolves no active edge. The repository does not process rkyv archives.
+    # rust_decimal 1.42.1 is current and intentionally keeps its optional rkyv
+    # support on 0.7; no patched version is reachable without that feature.
+    # Retire: when rust_decimal removes/upgrades the optional rkyv 0.7 edge, or
+    # immediately if this workspace ever enables rust_decimal's rkyv features.
+    "RUSTSEC-2026-0235",
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Restore the unconditional Rust dependency audit after RustSec published RUSTSEC-2026-0235 by documenting why the affected `rkyv 0.7.46` package is lockfile-only and inactive in this workspace.

## Scope

- Add one narrowly documented cargo-audit exception.
- Record the dependency chain, active-feature evidence, exposure assessment, and retirement conditions.
- Do not change dependencies or application behavior.

## Evidence

- [x] Tests: local `cargo audit` passes with only the existing allowed informational warnings; `cargo metadata --locked --format-version 1 --no-deps`; dependency policy; diff check.
- [x] CI: `changes-and-static` and `security-deps` pass.
- [x] Manual/benchmark/migration evidence: `rust_decimal 1.42.1` is current; `cargo tree --locked -p fileconv-server -e features` enables `serde` and `db-tokio-postgres`, not `rkyv`; `cargo tree --locked --workspace --all-features --target all -i rkyv@0.7.46` reports no active edge.

## Boundary and security review

- [x] Dependency boundary check passed — no manifest/lockfile changes.
- [x] Tenant/ACL impact reviewed, or N/A.
- [x] Sensitive logging/secret/egress impact reviewed, or N/A.
- [x] Security review trigger checked — dependency audit exception requires human review before merge.

## Follow-up

- [x] Docs, ADR, OpenAPI, roadmap or runbook updated where required — exception comments include explicit retirement conditions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f9711cc-150b-47c7-a7b7-e586b904f7e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f9711cc-150b-47c7-a7b7-e586b904f7e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

