### PR TITLE
document update

### DIFF
--- a/plans/markhand-web/backlog/phase-0/issues/README.md
+++ b/plans/markhand-web/backlog/phase-0/issues/README.md
@@ -22,6 +22,7 @@ P1A-01 ──────────> P0-03
 
 - **Status:** Done — approved Profile B, numeric targets and fail-closed validators
   merged to `master`.
+- **Plan file:** [P0-01 detailed implementation plan](../../../../reports/plan-260804-1617-p0-01-khoa-workload-hardware-va-gate-registry.md)
 - **Objective:** Thay giả định scale/SLA bằng workload envelope, hardware profile và
   gate schema được duyệt.
 - **Plan:** Ghi org/collection/document/vector, ingest/query/recovery load; CPU/RAM/
@@ -41,6 +42,7 @@ P1A-01 ──────────> P0-03
 
 - **Status:** Done — deterministic version/conflict corpus, dual adjudication and
   strict reproducibility gates passed.
+- **Plan file:** [P0-02 detailed implementation plan](../../../../reports/plan-260804-1617-p0-02-golden-corpus-tieng-viet-va-adversarial-corpus.md)
 - **Objective:** Dataset tái lập cho conversion, retrieval, citation và upload attack.
 - **Plan:** Thêm mọi format; 200–500 query với expected document/source span/
   relevance/no-answer; multi-document và immutable multi-version citations
@@ -62,6 +64,7 @@ P1A-01 ──────────> P0-03
 
 - **Status:** Done — real release conversion/local-RAG baseline and independently
   recomputed evidence accepted as the current-state reference.
+- **Plan file:** [P0-03 detailed implementation plan](../../../../reports/plan-260804-1617-p0-03-mo-rong-desktop-baseline-tren-corpus-phase-0.md)
 - **Objective:** Mở rộng parity baseline P1A-01 lên corpus/metrics Phase 0; P1A-01 là
   baseline authoritative để việc extraction không phải đợi toàn bộ corpus.
 - **Plan:** Tái dùng fixtures/harness P1A-01; chạy release conversion; snapshot top-k,
@@ -82,6 +85,7 @@ P1A-01 ──────────> P0-03
 
 - **Status:** Done — reproducible stack, pinned images, three-store lifecycle and bound
   CPU-smoke evidence passed; Profile B GPU/IOPS measurements remain downstream gates.
+- **Plan file:** [P0-04 detailed implementation plan](../../../../reports/plan-260804-1617-p0-04-spike-infrastructure-tai-lap.md)
 - **Objective:** Stack disposable PG/Qdrant/MinIO/vLLM/telemetry cho benchmark.
 - **Plan:** Tái dùng compose/services/scripts base từ F-08; thêm benchmark-specific
   override với isolated volumes/data, vLLM/GPU profile, workload sizing, image digest
@@ -104,6 +108,7 @@ P1A-01 ──────────> P0-03
   `local-cpu-quality`. GLM cloud embedding path (ADR 0004) superseded — GLM
   retained for Q&A only. GPU/vLLM capacity deferred (`G0-RET-VLLM-CUTOVER`,
   không chặn Phase 1B).
+- **Plan file:** [P0-05 detailed implementation plan](../../../../reports/plan-260804-1617-p0-05-danh-gia-embedding-tieng-viet.md)
 - **Objective:** Chốt provider/model/revision/dimension/normalization đủ để lập
   trình Phase 0→1B; giữ đường cắt sang on-prem vLLM.
 - **Plan:** So hai family local trên golden corpus: `AITeamVN/Vietnamese_Embedding`
@@ -135,6 +140,7 @@ P1A-01 ──────────> P0-03
   temporal/change/conflict gates via deterministic offline rules. Closes on P0-05
   CPU quality evidence (ADR 0005 may remain Proposed until product model acceptance);
   does not require Profile B / vLLM cutover.
+- **Plan file:** [P0-06 detailed implementation plan](../../../../reports/plan-260804-1617-p0-06-chunking-hybrid-tuning-va-index-signature.md)
 - **Objective:** Chốt chunking/hybrid parameters và canonical signature.
 - **Plan:** So chunk sizes; FTS/vector/hybrid; tune RRF; định nghĩa length-delimited
   signature gồm model/revision/dim/normalize/chunk/text-normalization version;
@@ -158,6 +164,7 @@ P1A-01 ──────────> P0-03
   Qdrant shared collection with mandatory `org_id` filter and PG no-partition
   for the single-org POC. Profile B `G0-SLO-QUERY-P99` / 20M mixed-load
   evidence still blocks production aggregate scale.
+- **Plan file:** [P0-07 detailed implementation plan](../../../../reports/plan-260804-1617-p0-07-pg-qdrant-target-scale-topology.md)
 - **Objective:** Chọn Qdrant topology và PG partition strategy bằng mixed-load evidence.
 - **Plan:** Generate realistic tenants; compare shared/cohort collection and
   PG no-partition/bounded hash offline with query+ingest+delete+snapshot
@@ -180,6 +187,7 @@ P1A-01 ──────────> P0-03
 - **Status:** Done — interim local-cpu sizing harness/report closes P0-08
   deliverables with `targetMatch=false`; Profile B `G0-CAP-INGEST-THROUGHPUT`
   and production headroom remain blocked until measured on `on-prem-reference`.
+- **Plan file:** [P0-08 detailed implementation plan](../../../../reports/plan-260804-1617-p0-08-sizing-converter-va-ingest-backpressure.md)
 - **Objective:** Chốt worker count, limits, timeout, queue và recovery headroom.
 - **Plan:** Benchmark từng format native/scan/audio; single/concurrent; CPU/RAM/temp;
   PDFium serialization; converter-vs-GPU bottleneck.
@@ -201,6 +209,7 @@ P1A-01 ──────────> P0-03
 - **Status:** Done — local-cpu policy/sandbox smoke evidence closes upload
   threat model, adversarial disposition, and runtime license inventory. This
   does not claim Profile B malware scanner coverage.
+- **Plan file:** [P0-09 detailed implementation plan](../../../../reports/plan-260804-1617-p0-09-upload-threat-model-sandbox-va-license-inventory.md)
 - **Objective:** Security policy thực thi được trước khi nhận upload.
 - **Plan:** Threat model spoof/bomb/parser/SSRF/exhaustion/traversal/injection/token/
   quota/tenant/compromised worker; chốt allowlist/limits/quarantine/sandbox; inventory
@@ -225,6 +234,7 @@ P1A-01 ──────────> P0-03
   (`phase0-decisions.json`); SLA/risk register + restore/query-load smoke recorded.
   Not a production Phase 0 numeric exit: Profile B gates (query P95/P99, ingest
   capacity, DR RPO/RTO, vLLM cutover) remain open (`productionPhase0ExitBlocked=true`).
+- **Plan file:** [P0-10 detailed implementation plan](../../../../reports/plan-260804-1617-p0-10-adr-slo-rpo-rto-va-phase-0-gate.md)
 - **Objective:** Chuyển evidence thành quyết định và restore/query-load smoke proof.
 - **Plan:** ADR document/artifact, tenancy/RLS, partition, Qdrant, auth/session,
   index migration, backup order; chốt SLO; offline restore smoke; close decision

--- a/plans/markhand-web/backlog/phase-1a/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1a/issues/README.md
@@ -18,6 +18,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-01 — Freeze desktop RAG và IPC contracts
 
 - **Status:** Done — merged to `master` via PR #184.
+- **Plan file:** [P1A-01 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-01-freeze-desktop-rag-va-ipc-contracts.md)
 - **Objective:** Baseline parity trước khi move code.
 - **Plan:** Inventory tests; fixtures top-k/score/snippet/anchor/answer/fallback/stats/
   incremental; canonical JSON cho 4 hybrid commands; offline + mock-provider flows.
@@ -33,6 +34,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-02 — Populate knowledge skeleton và enforce dependency boundaries
 
 - **Status:** Done — merged to `master` via PR #186.
+- **Plan file:** [P1A-02 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-02-populate-knowledge-skeleton-va-enforce-dependency-bo.md)
 - **Objective:** Hoàn thiện skeleton `crates/knowledge` do F-02 tạo thành reusable
   crate có typed errors và optional desktop features.
 - **Plan:** Populate modules types/embedding/query/rank/citation/ask; features
@@ -49,6 +51,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-03 — Shared DTO và serde contract
 
 - **Status:** Done — merged to `master` via PR #188.
+- **Plan file:** [P1A-03 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-03-shared-dto-va-serde-contract.md)
 - **Objective:** Di chuyển index/search/ask types mà không đổi JSON.
 - **Plan:** Index request/result/stats, hit/anchor/grounded answer/metadata; serde
   fixtures; temporary desktop re-export.
@@ -64,6 +67,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-04 — Durable identities và index signatures
 
 - **Status:** Done — merged to `master` via PR #189.
+- **Plan file:** [P1A-04 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-04-durable-identities-va-index-signatures.md)
 - **Objective:** Deterministic server identities, desktop compatibility.
 - **Plan:** Versioned length-delimited encoding; BLAKE3/SHA-256 document/chunk/index;
   signature model/revision/dim/normalize/chunk/text version; fixed vectors; legacy
@@ -79,6 +83,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-05 — Query, local vectors và embedding plan
 
 - **Status:** Done — merged to `master` after local parity and security gates passed.
+- **Plan file:** [P1A-05 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-05-query-local-vectors-va-embedding-plan.md)
 - **Objective:** Tách pure query/embedding preparation.
 - **Plan:** Normalization, feature hash/vector norm, provider plan, dimension check,
   FTS escape; HTTP client vẫn ở core; giữ local fallback semantics.
@@ -93,6 +98,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-06 — Rank, citation và grounded answer
 
 - **Status:** Done — merged to `master` after parity and prompt-injection gates passed.
+- **Plan file:** [P1A-06 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-06-rank-citation-va-grounded-answer.md)
 - **Objective:** Reusable hybrid merge, anchors và grounding.
 - **Plan:** Cosine/RRF/rerank/sort; snippet/page-slide-sheet anchor; extractive answer;
   citation validator; separate LLM calls.
@@ -107,6 +113,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-07 — SQLite desktop storage feature
 
 - **Status:** Done — merged to `master` with atomic storage and legacy DB gates.
+- **Plan file:** [P1A-07 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-07-sqlite-desktop-storage-feature.md)
 - **Objective:** Move SQLite persistence, bỏ reverse dependency vào Tauri.
 - **Plan:** Schema/metadata/vector/incremental/FTS/hydration; API nhận DB path +
   caller-supplied corpus; Tauri giữ path jail/load.
@@ -122,6 +129,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-08 — Persistent HNSW desktop feature
 
 - **Status:** Done — merged to `master` with legacy binary and recovery gates.
+- **Plan file:** [P1A-08 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-08-persistent-hnsw-desktop-feature.md)
 - **Objective:** Move optional ANN cache, SQLite vẫn authority.
 - **Plan:** Manifest/partition/rebuild/search/clear; legacy signature compatibility;
   corrupt/mismatch fallback exact cosine.
@@ -137,6 +145,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-09 — Thin Tauri adapters
 
 - **Status:** Done — merged to `master` with backend/frontend IPC parity.
+- **Plan file:** [P1A-09 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-09-thin-tauri-adapters.md)
 - **Objective:** Desktop commands delegate shared crate, IPC giữ nguyên.
 - **Plan:** Tauri giữ state/settings/path load/spawn_blocking/error mapping; delegate
   rebuild/stats/search/ask; retain legacy commands; remove duplicate only sau parity.
@@ -152,6 +161,7 @@ P1A-01 → P1A-02 → P1A-03 ─┬→ P1A-04
 ## P1A-10 — CI parity và extraction gate
 
 - **Status:** Done — merged to `master`; full local extraction gate passed.
+- **Plan file:** [P1A-10 detailed implementation plan](../../../../reports/plan-260804-1617-p1a-10-ci-parity-va-extraction-gate.md)
 - **Objective:** Chứng minh desktop equivalence và server usability.
 - **Plan:** Full feature/contract/golden matrix; no-feature server consumer test;
   dependency deny-list; docs compatibility; file perf/concurrency defects riêng.

--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -34,6 +34,7 @@ ghi trong issue đã `Done`.
 ### P1B-F01 — Extend server skeleton với runtime POC
 
 - **Status:** done
+- **Plan file:** [P1B-F01 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-f01-extend-server-skeleton-voi-runtime-poc.md)
 - **Plan:** Mở rộng `crates/server` API/worker skeleton từ F-02/F-07 với runtime
   dependencies, application state, graceful shutdown và các config fields đã được
   Phase 0 phê duyệt. Không tạo lại workspace/config conventions.
@@ -56,6 +57,7 @@ ghi trong issue đã `Done`.
   The run wrote its evidence outside the tree so the gate could bind to a clean
   worktree; the accepted run was then copied in, with only the recorded raw
   directory paths rewritten to repository-relative form.
+- **Plan file:** [P1B-F02 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-f02-poc-deployment-va-isolation-scaffold.md)
 - **Plan:** Pinned API/converter/index images, compose services, health/init, non-root,
   read-only, tmpfs, dropped caps, converter no-egress, resource/secret limits.
 - **Files:** `deploy/{Dockerfile.server,Dockerfile.worker,compose.poc.yml,.env.example}`,
@@ -70,6 +72,7 @@ ghi trong issue đã `Done`.
 ### P1B-F03 — Multi-org-ready schema và immutable migrations
 
 - **Status:** done
+- **Plan file:** [P1B-F03 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-f03-multi-org-ready-schema-va-immutable-migrations.md)
 - **Plan:** Migrations org/auth/RBAC/groups/collections, immutable versions/artifacts,
   atomic current-published pointer, parent/version/effective lineage, chunks/FTS,
   normalized claims, conflict/evidence lifecycle, jobs/outbox, quota/audit/index;
@@ -84,6 +87,7 @@ ghi trong issue đã `Done`.
 ### P1B-F04 — OrgContext, repositories và state machine
 
 - **Status:** done
+- **Plan file:** [P1B-F04 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-f04-orgcontext-repositories-va-state-machine.md)
 - **Plan:** Tenant-scoped repos, transaction helpers, legal document transitions;
   transaction-local RLS context nếu chọn.
 - **Files:** `src/auth/context.rs`, `src/db/{orgs,collections,documents,chunks}.rs`,
@@ -96,6 +100,7 @@ ghi trong issue đã `Done`.
 ### P1B-F05 — Password auth, rotating sessions và browser refresh transport
 
 - **Status:** done
+- **Plan file:** [P1B-F05 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-f05-password-auth-rotating-sessions-va-browser-refresh-t.md)
 - **Plan:** Argon2; pinned JWT issuer/audience/alg/KID; short access; hashed rotating
   refresh family; provider interface; POC guards/audit; chốt transport theo auth ADR.
   Nếu dùng browser cookie: issue/rotate/clear `HttpOnly Secure SameSite`, CSRF token
@@ -112,6 +117,7 @@ ghi trong issue đã `Done`.
 ### P1B-F06 — Fail-closed PG/Qdrant/MinIO adapters
 
 - **Status:** done
+- **Plan file:** [P1B-F06 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-f06-fail-closed-pg-qdrant-minio-adapters.md)
 - **Plan:** Pools, opaque key builder, quarantine/trusted namespace, deterministic
   points, versioned collection, mandatory org/collection filters, typed errors.
 - **Files:** `src/storage/{keys,minio,qdrant}.rs`, `src/db/pool.rs`,
@@ -126,6 +132,7 @@ ghi trong issue đã `Done`.
 ### P1B-I01 — Streaming quarantine upload validation
 
 - **Status:** done
+- **Plan file:** [P1B-I01 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-i01-streaming-quarantine-upload-validation.md)
 - **Plan:** Multipart stream+hash; magic/extension canonical format; OOXML limits;
   PDF/audio limits; retention disposition.
 - **Files:** `routes/uploads.rs`, `services/upload/{stream,sniff,archive,limits}.rs`.
@@ -137,6 +144,7 @@ ghi trong issue đã `Done`.
 ### P1B-I02 — Atomic quota admission
 
 - **Status:** done
+- **Plan file:** [P1B-I02 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-i02-atomic-quota-admission.md)
 - **Plan:** Transactional reserve/finalize/refund, expiry, concurrent-job admission,
   quota headers/errors.
 - **Files:** `src/db/quota.rs`, `services/quota.rs`, quota middleware.
@@ -148,6 +156,7 @@ ghi trong issue đã `Done`.
 ### P1B-I03 — Durable jobs, outbox và event log
 
 - **Status:** done
+- **Plan file:** [P1B-I03 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-i03-durable-jobs-outbox-va-event-log.md)
 - **Plan:** Versioned payload, transactional outbox, leased SKIP LOCKED claims,
   heartbeat/retry/checkpoint/cancel/dead-letter/idempotency/sequenced events.
 - **Files:** `src/jobs/**`, `src/db/jobs.rs`.
@@ -160,6 +169,7 @@ ghi trong issue đã `Done`.
 ### P1B-I04 — Isolated converter worker
 
 - **Status:** done
+- **Plan file:** [P1B-I04 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-i04-isolated-converter-worker.md)
 - **Plan:** Download quarantine; materialize server-derived canonical extension;
   process/cgroup limits and kill descendants; ephemeral cleanup/heartbeat/cancel.
 - **Files:** `src/workers/{convert,sandbox,limits}.rs`, worker image/config.
@@ -171,6 +181,7 @@ ghi trong issue đã `Done`.
 ### P1B-I05 — Idempotent conversion promotion saga
 
 - **Status:** done — merged to `master` via PR #244 (2026-07-20).
+- **Plan file:** [P1B-I05 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-i05-idempotent-conversion-promotion-saga.md)
 - **Plan:** Checkpoint download/convert/stage/promote/DB/cleanup; immutable version;
   publish/current pointer riêng với draft/latest upload; index outbox;
   compensation/refund.
@@ -192,6 +203,7 @@ ghi trong issue đã `Done`.
   `cargo test -p fileconv-server --test index_worker -- --include-ignored`
   → 10 ok (natural A→B, multi-gen demote + idempotent replay, fairness ≤2
   `run_once`, mixed-scope, race, retry).
+- **Plan file:** [P1B-I06 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-i06-chunk-embedding-index-worker.md)
 - **Plan:** Core chunking + knowledge identity/signature chứa `version_id`; PG
   chunks/FTS; separate embedding batches; Qdrant payload version/effective/current;
   extract typed claim key/value/unit/scope; incremental conflict candidate outbox;
@@ -212,6 +224,7 @@ ghi trong issue đã `Done`.
   `live_reconcile_dead_letter_staging_gc` pass under rust-integration. ADR 0015
   (purge retention semantics) remains Proposed — wording follow-up only, not a
   blocker for the delete/reconcile acceptance matrix already covered by live tests.
+- **Plan file:** [P1B-I07 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-i07-tombstone-delete-va-reconcile.md)
 - **Plan:** PG tombstone first; idempotent vector/object cleanup; dry-run/repair
   missing/orphan/stale across three stores.
 - **Files:** `workers/{delete,reconcile}.rs`, `services/{deletion,reconciliation}.rs`.
@@ -226,6 +239,7 @@ ghi trong issue đã `Done`.
 
 - **Status:** done — PR #252 + authorization hardening PR #254 merged; hermetic
   unit acceptance in `services/retrieval` and gated PG tests in `tests/retrieval.rs`.
+- **Plan file:** [P1B-R01 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-r01-tenant-scoped-hybrid-retrieval.md)
 - **Plan:** Resolve scope + current/as-of/compare/history mode; query embed; parallel
   Qdrant/FTS với version filter; knowledge merge/rerank; PG hydration/recheck
   state/ACL/version; hydrate only conflict evidence whose both sides remain authorized.
@@ -247,6 +261,7 @@ ghi trong issue đã `Done`.
   `live_upload_convert_index_citation_vertical_slice` covers all
   `phase1b-mixed.yaml` ingest formats via HTTP upload → ConvertWorker/`fileconv`
   → IndexWorker → citation resolve on worker-produced IDs/artifacts/chunks.
+- **Plan file:** [P1B-R02 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-r02-citation-preview-va-download-authorization.md)
 - **Plan:** Stable anchor pin logical document/version number/version ID/content hash/
   effective time/current flag; fresh auth per resolve; trusted Markdown fetch; short
   single-purpose download capability.
@@ -277,6 +292,7 @@ ghi trong issue đã `Done`.
   `STRUCTURED_ENTAILMENT_AVAILABLE = false` / `force_extractive_only()` stay
   hardcoded; opt-in `MARKHAND_QA_ALLOW_UNVERIFIED_LLM` (default OFF) may emit
   `llm_unverified` with fixed warning, never grounded.
+- **Plan file:** [P1B-R03 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-r03-grounded-q-a-stream-va-fallback.md)
 - **Plan:** Policy-separated prompt, untrusted passage framing, GLM, version-aware
   citation validation, current answer + history/change note, token stream,
   current unresolved-conflict warnings + resolved-history note, token stream,
@@ -306,6 +322,7 @@ ghi trong issue đã `Done`.
   `live_http_collection_document_job_contract_matrix` asserts reindex same
   `jobId` with `created=false` on idempotent replay. Business API mutations
   gated by central `mutation_write_gate` middleware (see O03).
+- **Plan file:** [P1B-R04 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-r04-collection-document-job-rest-api.md)
 - **Plan:** `/api/v1` collection POC; upload/list/get/preview/delete/reindex; immutable
   version list/get/diff/current publish; conflict list/detail/triage + evidence routes;
   job status; pagination/idempotency/error schema.
@@ -332,6 +349,7 @@ ghi trong issue đã `Done`.
   (`live_ask_stream_maintenance_converges_under_bounded_load`) evidence.
   Production ask remains fail-closed extractive when entailment is unavailable
   (by design — see P1B-R03; not a Done blocker).
+- **Plan file:** [P1B-R05 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-r05-search-ask-resumable-sse-api.md)
 - **Plan:** Search/ask/stream routes; versioned sequence; Last-Event-ID replay;
   heartbeat/bounded buffering; auth expiry/revoke close.
 - **Files:** `routes/{search,ask,events}.rs`, `api/{sse,last_event_id}.rs`,
@@ -357,6 +375,7 @@ ghi trong issue đã `Done`.
   restore/recovery. Hermetic router/readiness/unit coverage unchanged (Sol R2).
   Harness fix: post-pause `wait_for_hung_ready` excludes pool-drain transition
   samples before the sustain window (see `bench/markhand_web/hanging_soak/`).
+- **Plan file:** [P1B-R06 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-r06-openapi-rate-limit-va-readiness.md)
 - **Plan:** Complete OpenAPI/fixtures; request IDs; CORS; IP auth/user limits; quota
   metadata; live/ready/start checks.
 - **Files:** `api/openapi.rs`, OpenAPI YAML, `middleware/**`, `routes/health.rs`,
@@ -381,6 +400,7 @@ ghi trong issue đã `Done`.
   Cargo telemetry suite, OTLP capture unit tests, live app-role audit test and
   the negative proof fixtures all passed. Report sha256 prefix
   `e8efc7b6975fdb4b`.
+- **Plan file:** [P1B-O01 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-o01-end-to-end-telemetry-va-safe-audit.md)
 - **Plan:** Traces API→jobs→convert/embed/retrieval/GLM; latency/queue/conversion/
   embedding/retrieval/drift/quota/backup metrics; append-only audit.
 - **Files:** `src/telemetry/**`, `services/audit.rs`, `db/audit.rs`,
@@ -402,6 +422,7 @@ ghi trong issue đã `Done`.
   dry-run→repair→idempotent plus the `worker-reconcile-oneshot` compose job, and
   a clean provenance + broad secret scan. Report sha256 prefix
   `56f0475a26fd174d`.
+- **Plan file:** [P1B-O02 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-o02-dashboards-alerts-va-runbooks.md)
 - **Plan:** SLO/queue/disk/dependency alerts; runbooks jobs/parser/outage/rebuild/disk/
   GLM/key rotation.
 - **Files / scope:** `deploy/observability/**`, `docs/runbooks/phase-1b/**`,
@@ -443,6 +464,7 @@ ghi trong issue đã `Done`.
   ask/stream no session init) and
   `live_write_gate_advisory_lock_concurrency_contract` (shared blocks exclusive;
   exclusive fail-closed; no pool leak).
+- **Plan file:** [P1B-O03 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-o03-backup-restore-va-migration-safety.md)
 - **Plan:** PG PITR, MinIO version inventory, Qdrant snapshot, consistency fence/
   manifest, restore order, reconcile-before-ready, vector rebuild.
 - **Files:** `deploy/backup/**`, `deploy/scripts/o03-bluegreen-restore-drill.sh`,
@@ -466,6 +488,7 @@ ghi trong issue đã `Done`.
   structured external worker kill → lease expiry → reclaim → replay → DB
   verification. Provenance binds the F02 project, container ids and image ids.
   Report sha256 prefix `949e14202849cf8b`.
+- **Plan file:** [P1B-O04 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-o04-vertical-slice-security-release-suite.md)
 - **Plan:** Clean stack, seed org/accounts; every format upload→citation; suspend/
   membership remove/delete; adversarial + fault injection.
 - **Files:** `bench/markhand_web/scripts/run_o04_release_suite.py`,
@@ -487,6 +510,7 @@ ghi trong issue đã `Done`.
   `markhand-poc-f02-20260726t121843z-1815269-17292`, with F02/O01/O02/O03/O04
   passing on that same commit and project. `o05-soak.json` is `status=pass` with
   no blockers; report sha256 prefix `a1a6d0e6ee57df4d`.
+- **Plan file:** [P1B-O05 detailed implementation plan](../../../../reports/plan-260804-1617-p1b-o05-mixed-load-soak-va-poc-qualification.md)
 - **Measured 1800s run (host: 24-core Ubuntu 22.04, Docker capped at 10 CPU):**
   - Capacity: ingest 356 documents/hour (178 of 180 uploads reached terminal
     indexed; gate ≥ 300), query p95 302 ms (≤ 500), p99 418 ms (≤ 1000).

--- a/plans/markhand-web/backlog/phase-1c/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1c/issues/README.md
@@ -52,6 +52,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   re-verify, fail-closed OrgContext, RLS, `GET /orgs` / `GET /orgs/{id}` /
   `POST /orgs/switch` / `POST /orgs` with owner provision + audit.
 
+- **Plan file:** [1C-01 detailed implementation plan](../../../../reports/plan-260804-1617-1c-01-organization-lifecycle-va-validated-context.md)
 - **Plan/files:** Org create/list/detail/switch, service/repo/middleware; issue new
   context/session after verified membership.
 - **Depends:** Phase 1B auth/schema. **Acceptance/tests:** Chỉ thấy org của mình;
@@ -77,6 +78,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   suspend/reactivate, session family revoke, audit allowlist. Membership ACL
   `version` remains deferred to 1C-05; automated email delivery remains out of scope.
 
+- **Plan file:** [1C-02 detailed implementation plan](../../../../reports/plan-260804-1617-1c-02-membership-invites-va-last-owner-invariant.md)
 - **Plan/files:** Hashed single-use invite; membership state; transactional last-owner;
   membership version (deferred to 1C-05); session revoke. MVP chưa có mail dùng invite
   URL/token hiển thị đúng một lần cho admin copy qua kênh được tổ chức phê duyệt;
@@ -108,6 +110,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   migration `0030` catalog + per-org provision unchanged. P1C.2 disposition: matrix
   follows the fixture. Guard inventory for active operations remains 1C-04 / later PRs.
 
+- **Plan file:** [1C-03 detailed implementation plan](../../../../reports/plan-260804-1617-1c-03-canonical-rbac-seed.md)
 - **Plan/files:** Permission constants + DB seed owner/admin/editor/viewer; immutable
   system roles; OpenAPI/web fixture consumers.
 - **Depends:** Phase 1B role schema. **Acceptance/tests:** Matrix đúng/idempotent,
@@ -138,6 +141,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   authorize and least-privilege worker identities landed in PR 3.
 
 
+- **Plan file:** [1C-04 detailed implementation plan](../../../../reports/plan-260804-1617-1c-04-route-service-guards-va-service-identities.md)
 - **Plan/files:** Deny-by-default `authorize`; apply route+service+worker/reconcile;
   least-privilege identities.
 - **Depends:** 1C-01/03. **Acceptance/tests:** Allow/deny mỗi permission cả hai layer;
@@ -168,6 +172,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   invalidation (migrations `0031`/`0033`); `auth::context_cache` freshness check on
   extractor hits.
 
+- **Plan file:** [1C-05 detailed implementation plan](../../../../reports/plan-260804-1617-1c-05-collection-acl-resolver-cache.md)
 - **Plan/files:** Private/org/groups grants (**done**); ACL/version
   snapshot (**done**: `orgs.acl_version`, migration `0031`); cache key org/user/membership/
   ACL version (**done**: `auth::context_cache::OrgContextCache`, key `(org_id, user_id)` +
@@ -211,6 +216,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   (`doc.upload` / `doc.quarantine.review` at `AccessLevel::Write`, no read-projection
   inference).
 
+- **Plan file:** [1C-06 detailed implementation plan](../../../../reports/plan-260804-1617-1c-06-postgresql-acl-enforcement.md)
 - **Plan/files:** Tenant+ACL predicates cho FTS/hydration/conflict (**done**); upload write
   gate (**done**). Autocomplete không xây (out of scope — xem điểm 4 legacy note bên dưới).
 - **Depends:** 1C-05. **Acceptance/tests:** Không path thiếu context; no existence/count
@@ -253,6 +259,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   (capability tokens). Connected cross-org denial suite remains **1C-12**.
 
 
+- **Plan file:** [1C-07 detailed implementation plan](../../../../reports/plan-260804-1617-1c-07-qdrant-storage-jobs-fail-closed-enforcement.md)
 - **Plan/files:** Mandatory org+non-empty collection filter; PG payload validation;
   authorize preview/download/export/job/SSE; abort in-flight on ACL change.
 - **Depends:** 1C-05/06. **Acceptance/tests:** Missing/malformed/timeout/mismatch deny;
@@ -305,6 +312,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   paths. Embedding-provider token metering remains backlog (out of issue scope).
 
 
+- **Plan file:** [1C-09 detailed implementation plan](../../../../reports/plan-260804-1617-1c-09-atomic-quota-lifecycle.md)
 - **Plan/files:** Reserve/finalize/refund, idempotency/expiry/sweeper/reconcile cho
   storage/token/jobs.
 - **Depends:** Phase 1B jobs + 1C-01. **Acceptance/tests:** 100 concurrent reservations
@@ -328,6 +336,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   remains **1C-13**; GPU semaphore remains N/A-until-GPU.
 
 
+- **Plan file:** [1C-10 detailed implementation plan](../../../../reports/plan-260804-1617-1c-10-rate-limit-va-per-org-fairness.md)
 - **Plan/files:** User/IP/auth limits (**done từ trước**); per-org API bucket (**done**:
   `middleware/rate_limit.rs::check_org` + `routes/rate_limit_guard.rs`); per-org worker
   fairness (**done**: `workers/fairness.rs::OrgRotation` + `bin/worker.rs` multi-org
@@ -361,6 +370,7 @@ ADR RLS ───────→ 1C-08 ─────────────�
   green in `tests/direct_service_authz.rs`.
 
 
+- **Plan file:** [1C-11 detailed implementation plan](../../../../reports/plan-260804-1617-1c-11-audit-admin-apis.md)
 - **Plan/files:** Member/role/ACL/config/quota/data/cloud events (**out of scope của
   đợt này — chỉ audit READ**); read-only pagination/filter (**done**: `routes/audit.rs`,
   `db/audit.rs::list_page`)/retention (**out**); owner-only controls (**out — không

--- a/plans/markhand-web/backlog/phase-2/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2/issues/README.md
@@ -52,6 +52,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #311. Web workspace, no Tauri import, CI job `web` xanh.
 
+- **Plan file:** [P2-01 detailed implementation plan](../../../../reports/plan-260804-1617-p2-01-react-vite-workspace-va-ui-foundations.md)
 - **Plan/files:** Tạo `web/` scripts/layout; copy browser-safe tokens/icons/primitives.
 - **Depends:** Không. **Acceptance/tests:** Build/test độc lập; no Tauri import;
   typecheck/lint/unit/dependency-boundary; desktop vẫn xanh.
@@ -61,6 +62,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #311. Generated types + `pnpm api:check` drift gate; mock server sinh từ OpenAPI.
 
+- **Plan file:** [P2-02 detailed implementation plan](../../../../reports/plan-260804-1617-p2-02-openapi-contracts-va-mock-server.md)
 - **Plan/files:** Pin generator; generated types; drift check; auth/org/library/job/
   Q&A/admin/error/SSE fixtures và mock scenarios.
 - **Depends:** Stable 1B OpenAPI. **Acceptance/tests:** Drift fails CI; generated files
@@ -73,6 +75,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #311. Refresh single-flight; ADR 0010 rotation; concurrent-401/revoke tests.
 
+- **Plan file:** [P2-03 detailed implementation plan](../../../../reports/plan-260804-1617-p2-03-typed-http-client-session-refresh.md)
 - **Plan/files:** Fetch wrapper, access token memory, refresh single-flight, one retry,
   normalized errors/request ID/quota, abort.
 - **Depends:** P2-02. **Acceptance/tests:** Concurrent 401 một refresh; revoked refresh
@@ -83,6 +86,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #311. Fetch-based (không EventSource), Last-Event-ID, reconnect/backoff, abort-on-scope.
 
+- **Plan file:** [P2-04 detailed implementation plan](../../../../reports/plan-260804-1617-p2-04-fetch-based-sse-transport.md)
 - **Plan/files:** Streaming parser với bearer, Last-Event-ID, dedupe/gap, refresh/
   reconnect/backoff/snapshot, abort on scope change.
 - **Depends:** P2-02/03. **Acceptance/tests:** Không native EventSource/token URL;
@@ -93,6 +97,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #311. Bearer refresh trong memory (không cookie/CSRF); router + guard matrix.
 
+- **Plan file:** [P2-05 detailed implementation plan](../../../../reports/plan-260804-1617-p2-05-login-session-application-shell.md)
 - **Plan/files:** Router, auth bootstrap/login/protected shell/guards/logout/help stub.
 - **Depends:** P2-01/03 + P1B-F05 browser refresh contract. **Acceptance/tests:**
   Intended route, expiry, guard matrix, login/refresh/logout component tests và
@@ -105,6 +110,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #311. Scope epoch; `useScopeSafeRequest`/`useScopeSafeSse` bỏ response scope cũ.
 
+- **Plan file:** [P2-06 detailed implementation plan](../../../../reports/plan-260804-1617-p2-06-org-switch-va-scope-safe-state.md)
 - **Plan/files:** Org-scoped cache keys; atomic switch; abort REST/SSE; clear stores;
   scope generation ignores late response.
 - **Depends:** P2-03…05 + backend 1C org APIs. **Acceptance/tests:** No old-org render;
@@ -131,6 +137,7 @@ P2-15 + Phase 1C gate → P2-16
   hướng thôi, không phải panel upload cross-collection — giữ đúng giới hạn ghi ở dòng
   Status phía trên).
 
+- **Plan file:** [P2-07 detailed implementation plan](../../../../reports/plan-260804-1617-p2-07-library-list-sanitized-preview.md)
 - **Plan/files:** Adapt browser-safe LibraryView; collection navigation, filter/page,
   status, preview states + SafeMarkdown; unresolved conflict badge/count, side-by-side
   cited BA/design/dev claims và resolved-history link.
@@ -166,6 +173,7 @@ P2-15 + Phase 1C gate → P2-16
   `e2e/document-status-polling.spec.ts` (upload → converting → advance seam 3 lần →
   badge tự chuyển converted/indexing/indexed, không `page.reload()`/`page.goto()`).
 
+- **Plan file:** [P2-08 detailed implementation plan](../../../../reports/plan-260804-1617-p2-08-upload-progress-va-job-lifecycle.md)
 - **Plan/files:** Multipart/progress/cancel; job SSE; reconnect snapshot; accessible
   status for uploaded→indexed/failed.
 - **Depends:** P2-04/07. **Acceptance/tests:** Client/server progress distinct; recover
@@ -177,6 +185,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #312. Capability issue+redeem, delete tombstone có confirm. Không có endpoint retry-convert nên "thử lại" = reindex (ghi rõ trong UI).
 
+- **Plan file:** [P2-09 detailed implementation plan](../../../../reports/plan-260804-1617-p2-09-download-delete-reindex-retry.md)
 - **Plan/files:** Authorized actions, permission/confirm/conflict/idempotency handling.
 - **Depends:** P2-07/08 + backend 1C guards. **Acceptance/tests:** Delete closes preview;
   server deny wins; confirm/concurrency/stale/signed-route tests.
@@ -349,6 +358,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #317. UI member table/invite (one-time token)/suspend/role/remove, owner-tier fail-closed mirror server, last-owner 409 + owner-tier 403 mapped. Mở khoá nhờ lát membership API (1C-02/1C-11) landed cùng #317.
 
+- **Plan file:** [P2-11 detailed implementation plan](../../../../reports/plan-260804-1617-p2-11-member-role-admin.md)
 - **Plan/files:** Member table/invite/suspend/role selector; owner restrictions from API.
 - **Depends:** P2-02/03/05 + backend 1C-02…04. **Acceptance/tests:** Owner/admin matrix,
   last-owner conflict, invite/suspend/role/403/409/stale-update tests.
@@ -358,6 +368,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #317. Usage cards từ `GET /usage` (endpoint tổng hợp landed cùng lát membership); route gate `member.manage`. Actionable 429 dùng chung path với document actions.
 
+- **Plan file:** [P2-12 detailed implementation plan](../../../../reports/plan-260804-1617-p2-12-usage-quota-reservations.md)
 - **Plan/files:** Usage cards, limits, active reservations/jobs, actionable 429.
 - **Depends:** P2-03/05 + backend 1C-09…11. **Acceptance/tests:** API numbers match;
   unit/timezone/403/429/stale tests.
@@ -367,6 +378,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — SafeMarkdown + sanitize allowlist + content bound ở #311; CSP/frame/nosniff/referrer landed cùng P2-16 (#313). HSTS để cho reverse proxy (không set ở app).
 
+- **Plan file:** [P2-13 detailed implementation plan](../../../../reports/plan-260804-1617-p2-13-browser-safemarkdown-hardening.md)
 - **Plan/files:** CSP-compatible app, protocol allowlist, raw HTML/SVG/data URL denial,
   content bounds, header checks.
 - **Depends:** P2-01/07/10. **Acceptance/tests:** Malicious corpus không execute; CSP
@@ -377,6 +389,7 @@ P2-15 + Phase 1C gate → P2-16
 
 - **Status:** Done — #313. axe không critical/serious (login/library/modal), focus-sau-route-change, progressbar job. Keyboard cho "ask" chưa làm được vì P2-10 chưa tồn tại.
 
+- **Plan file:** [P2-14 detailed implementation plan](../../../../reports/plan-260804-1617-p2-14-accessibility-interaction-quality.md)
 - **Plan/files:** Skip/landmark/focus/keyboard/progress labels/contrast/reduced motion.
 - **Depends:** P2-05/07…12. **Acceptance/tests:** No axe critical; keyboard primary
   flows; focus/reduced-motion/screen reader tests.

--- a/plans/markhand-web/backlog/phase-f/issues/README.md
+++ b/plans/markhand-web/backlog/phase-f/issues/README.md
@@ -22,6 +22,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-01 — Architecture boundaries và dependency rules
 
 - **Status:** Done — merged to `master` via PR #160.
+- **Plan file:** [F-01 detailed implementation plan](../../../../reports/plan-260804-1617-f-01-architecture-boundaries-va-dependency-rules.md)
 - **Objective:** Khóa dependency direction và module responsibilities trước scaffold.
 - **Implementation plan:** Viết architecture boundary ADR; define allowed/forbidden
   dependencies; route→service→repository; tenant context rule; browser/Tauri split;
@@ -42,6 +43,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-02 — Workspace và folder skeleton
 
 - **Status:** Done — merged to `master` via PR #160.
+- **Plan file:** [F-02 detailed implementation plan](../../../../reports/plan-260804-1617-f-02-workspace-va-folder-skeleton.md)
 - **Objective:** Tạo khung compile được cho knowledge/server/web/deploy/docs/bench.
 - **Implementation plan:** Add workspace members với minimal libraries/binaries; module
   READMEs/ownership; Vite web shell; deploy/dev placeholders; không copy business
@@ -61,6 +63,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-03 — Rust coding và crate conventions
 
 - **Status:** Done — merged to `master` via PR #160.
+- **Plan file:** [F-03 detailed implementation plan](../../../../reports/plan-260804-1617-f-03-rust-coding-va-crate-conventions.md)
 - **Objective:** Một chuẩn Rust bắt buộc cho core/knowledge/server/workers.
 - **Implementation plan:** Rustfmt/clippy policy; error/context; async vs blocking;
   cancellation/timeouts; panic/unwrap/unsafe/public docs; naming/module visibility.
@@ -77,6 +80,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-04 — TypeScript/React conventions
 
 - **Status:** Done — merged to `master` via PR #160.
+- **Plan file:** [F-04 detailed implementation plan](../../../../reports/plan-260804-1617-f-04-typescript-react-conventions.md)
 - **Objective:** Chuẩn strict TS, component/hook/state và accessibility cho web.
 - **Implementation plan:** TS strict policy; generated API immutable; naming/import
   boundaries; state ownership; loading/error/empty; abort cleanup; a11y checklist.
@@ -92,6 +96,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-05 — SQL/data/migration conventions
 
 - **Status:** Done — merged to `master` via PR #164.
+- **Plan file:** [F-05 detailed implementation plan](../../../../reports/plan-260804-1617-f-05-sql-data-migration-conventions.md)
 - **Objective:** Ngăn schema/tenant/migration conventions bị phát minh theo từng PR.
 - **Implementation plan:** Naming/types/time/UUID/FK/check/index; `org_id`; transaction/
   locking/idempotency; immutable migration; expand/backfill/cutover/contract; rollback.
@@ -108,6 +113,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-06 — REST/OpenAPI/SSE/error conventions
 
 - **Status:** Done — merged to `master` via PR #165.
+- **Plan file:** [F-06 detailed implementation plan](../../../../reports/plan-260804-1617-f-06-rest-openapi-sse-error-conventions.md)
 - **Objective:** Contract thống nhất để backend/web không drift.
 - **Implementation plan:** `/api/v1`; resources/pagination/idempotency; canonical error;
   date/UUID/enum/null; OpenAPI authority; SSE envelope/version/sequence/reconnect;
@@ -126,6 +132,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-07 — Configuration, secrets và environment profiles
 
 - **Status:** Done — merged to `master` via PR #171.
+- **Plan file:** [F-07 detailed implementation plan](../../../../reports/plan-260804-1617-f-07-configuration-secrets-va-environment-profiles.md)
 - **Objective:** Typed, fail-fast, secret-safe config cho local/test/prod.
 - **Implementation plan:** Define precedence; profile schema; mounted secret/env
   references; validation/redacted Debug; `.env.example`; unsafe dev defaults isolated.
@@ -141,6 +148,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-08 — Reproducible local development environment
 
 - **Status:** Done — merged to `master` via PR #173.
+- **Plan file:** [F-08 detailed implementation plan](../../../../reports/plan-260804-1617-f-08-reproducible-local-development-environment.md)
 - **Objective:** One-command CPU-only dev stack, optional GPU profile.
 - **Implementation plan:** Pin PG/Qdrant/MinIO/OTel; init buckets/extensions; health/
   seed/reset; named volumes/private network; mock embedding; optional vLLM profile.
@@ -156,6 +164,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-09 — Root task runner, quality tools và CI baseline
 
 - **Status:** Done — merged to `master` via PR #177.
+- **Plan file:** [F-09 detailed implementation plan](../../../../reports/plan-260804-1617-f-09-root-task-runner-quality-tools-va-ci-baseline.md)
 - **Objective:** Cùng command local/CI cho format/lint/test/build/dev/migrate.
 - **Implementation plan:** Add `just`/equivalent root tasks theo test conventions
   F-10; Rust/TS/SQL checks; dependency/license/security baseline cho cả `app/` và
@@ -174,6 +183,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-10 — Test pyramid, fixtures và golden-data conventions
 
 - **Status:** Done — merged to `master` via PR #175.
+- **Plan file:** [F-10 detailed implementation plan](../../../../reports/plan-260804-1617-f-10-test-pyramid-fixtures-va-golden-data-conventions.md)
 - **Objective:** Chuẩn test/evidence dùng chung trước Phase 0/1A.
 - **Implementation plan:** Define unit/integration/contract/denial/E2E/benchmark/
   migration/restore layers; fixture IDs/time/checksum/license; CI artifact retention.
@@ -190,6 +200,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-11 — Observability/audit conventions
 
 - **Status:** Done — merged to `master` via PR #179.
+- **Plan file:** [F-11 detailed implementation plan](../../../../reports/plan-260804-1617-f-11-observability-audit-conventions.md)
 - **Objective:** Correlation/metrics/log/audit schema ổn định trước business services.
 - **Implementation plan:** Field names; request/job/version/signature propagation;
   metric units/cardinality; log allowlist/redaction; audit envelope; sample middleware.
@@ -207,6 +218,7 @@ Diagram là critical path rút gọn; trường `Dependencies/blocks` là author
 ## F-12 — Contributor workflow, setup docs và foundation gate
 
 - **Status:** Done — merged to `master` via PR #181.
+- **Plan file:** [F-12 detailed implementation plan](../../../../reports/plan-260804-1617-f-12-contributor-workflow-setup-docs-va-foundation-gate.md)
 - **Objective:** Chứng minh contributor mới có thể setup và tuân conventions.
 - **Implementation plan:** ADR/RFC templates/index; ownership/CODEOWNERS; issue/PR
   templates; Definition of Ready/Done; security triggers; setup/troubleshooting.

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -1287,7 +1287,7 @@
           [
             "1C-08",
             "RLS và pool defense",
-            "done"
+            "in_progress"
           ],
           [
             "1C-09",

--- a/plans/reports/plan-260804-1617-1c-01-organization-lifecycle-va-validated-context.md
+++ b/plans/reports/plan-260804-1617-1c-01-organization-lifecycle-va-validated-context.md
@@ -1,0 +1,90 @@
+<!-- generated-done-issue-plan: 1C-01 -->
+# 1C-01 — Organization lifecycle và validated context
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#102](https://github.com/anhnth24/project-example/issues/102)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Organization lifecycle và validated context**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)):
+> `rust` [91151657403](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657403),
+> `web` [91151657388](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657388),
+> `rust-integration` [91151657399](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657399)
+> (not path-filter skip / soft pass). Integration log executed `orgs` binary tests
+> including `create_org_succeeds_and_caller_becomes_owner` and
+> `list_orgs_shows_only_the_callers_own_orgs`; job summary reports no ignored tests
+> for that binary. Validated-context + lifecycle already landed: membership
+> re-verify, fail-closed OrgContext, RLS, `GET /orgs` / `GET /orgs/{id}` /
+> `POST /orgs/switch` / `POST /orgs` with owner provision + audit.
+
+## Implementation plan
+
+Org create/list/detail/switch, service/repo/middleware; issue new
+context/session after verified membership.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+Phase 1B auth/schema.
+
+## Acceptance criteria
+
+Chỉ thấy org của mình;
+forged/stale header deny; two-org resolver/integration tests — green on CI
+`a62850422dd070e7e1195bfe1d4f1dee0d73566d` run
+[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)
+(`rust`/`web`/`rust-integration`).
+
+## Required tests / evidence
+
+Chỉ thấy org của mình;
+forged/stale header deny; two-org resolver/integration tests — green on CI
+`a62850422dd070e7e1195bfe1d4f1dee0d73566d` run
+[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)
+(`rust`/`web`/`rust-integration`).
+
+## Security and migration notes
+
+Không global org state; audit switch.
+
+## Out of scope
+
+billing/OIDC.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30629207747`
+- `91151657388`
+- `91151657399`
+- `91151657403`
+- `a62850422dd070e7e1195bfe1d4f1dee0d73566d`
+
+- GitHub sync-closed timestamp: `2026-08-01T00:18:29Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-1c-02-membership-invites-va-last-owner-invariant.md
+++ b/plans/reports/plan-260804-1617-1c-02-membership-invites-va-last-owner-invariant.md
@@ -1,0 +1,98 @@
+<!-- generated-done-issue-plan: 1C-02 -->
+# 1C-02 — Membership, invites và last-owner invariant
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#103](https://github.com/anhnth24/project-example/issues/103)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Membership, invites và last-owner invariant**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)):
+> `rust` [91151657403](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657403),
+> `web` [91151657388](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657388),
+> `rust-integration` [91151657399](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657399)
+> (not path-filter skip / soft pass). Integration log executed `members` binary tests
+> including `concurrent_last_owner_race_exactly_one_survives`,
+> `cross_org_denial_covers_every_member_endpoint`, and
+> `member_manage_permission_required_for_patch_and_delete`; job summary reports no
+> ignored tests for that binary. Implementation landed in #317+: hashed single-use
+> invites, PATCH/DELETE members, transactional last-owner + owner-tier guards,
+> suspend/reactivate, session family revoke, audit allowlist. Membership ACL
+> `version` remains deferred to 1C-05; automated email delivery remains out of scope.
+
+## Implementation plan
+
+Hashed single-use invite; membership state; transactional last-owner;
+membership version (deferred to 1C-05); session revoke. MVP chưa có mail dùng invite
+URL/token hiển thị đúng một lần cho admin copy qua kênh được tổ chức phê duyệt;
+expiry/revoke/audit bắt buộc — **đã landed**.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+1C-01.
+
+## Acceptance criteria
+
+Không remove/downgrade last owner (kể cả tự
+thao tác chính mình); admin không quản owner; concurrent owner removal, invite
+replay/expiry, escalation tests — green on CI
+`a62850422dd070e7e1195bfe1d4f1dee0d73566d` run
+[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)
+(`tests/members.rs` in `rust-integration`).
+
+## Required tests / evidence
+
+Không remove/downgrade last owner (kể cả tự
+thao tác chính mình); admin không quản owner; concurrent owner removal, invite
+replay/expiry, escalation tests — green on CI
+`a62850422dd070e7e1195bfe1d4f1dee0d73566d` run
+[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)
+(`tests/members.rs` in `rust-integration`).
+
+## Security and migration notes
+
+Row lock (`FOR UPDATE` trên owner rows), expand/backfill
+version (deferred to 1C-05); plaintext invite không lưu DB/log (chỉ trả 1 lần trong
+
+## Out of scope
+
+automated email delivery/SCIM/MFA.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #317](https://github.com/anhnth24/project-example/pull/317) — Membership admin, end to end: server API + web UI (P2-11, P2-12; 1C-02/1C-11 slice); merged `2026-07-28T06:34:53Z`
+
+### Completion/evidence commits
+
+- `30629207747`
+- `64b80d47fecad7d28c4a2b2df2422a892d56e46b`
+- `91151657388`
+- `91151657399`
+- `91151657403`
+- `a62850422dd070e7e1195bfe1d4f1dee0d73566d`
+
+- GitHub sync-closed timestamp: `2026-08-01T00:18:31Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-1c-03-canonical-rbac-seed.md
+++ b/plans/reports/plan-260804-1617-1c-03-canonical-rbac-seed.md
@@ -1,0 +1,93 @@
+<!-- generated-done-issue-plan: 1C-03 -->
+# 1C-03 — Canonical RBAC seed
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#104](https://github.com/anhnth24/project-example/issues/104)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Canonical RBAC seed**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)):
+> `rust` [91151657403](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657403),
+> `web` [91151657388](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657388),
+> `rust-integration` [91151657399](https://github.com/anhnth24/project-example/actions/runs/30629207747/job/91151657399)
+> (not path-filter skip / soft pass). Integration log executed `role_catalog` tests
+> including `permissions_table_contains_exactly_active_catalog_keys ... ok` and
+> `canonical_matrix_matches_builtin_role_catalog_fixture ... ok`; job summary reports
+> no ignored tests for that binary. Canonical fixture
+> `crates/server/openapi/builtin-role-catalog.json` is the sole built-in
+> active/reserved matrix; OpenAPI references it (no embedded grants); web imports it
+> for role order; DB parity tests compare exact active keys/grants. Historical
+> migration `0030` catalog + per-org provision unchanged. P1C.2 disposition: matrix
+> follows the fixture. Guard inventory for active operations remains 1C-04 / later PRs.
+
+## Implementation plan
+
+Permission constants + DB seed owner/admin/editor/viewer; immutable
+system roles; OpenAPI/web fixture consumers.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+Phase 1B role schema.
+
+## Acceptance criteria
+
+Matrix đúng/idempotent,
+duplicate/missing/immutable mutation tests; UI không hard-code matrix — green on CI
+`a62850422dd070e7e1195bfe1d4f1dee0d73566d` run
+[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)
+(`role_catalog` in `rust-integration`).
+
+## Required tests / evidence
+
+Matrix đúng/idempotent,
+duplicate/missing/immutable mutation tests; UI không hard-code matrix — green on CI
+`a62850422dd070e7e1195bfe1d4f1dee0d73566d` run
+[30629207747](https://github.com/anhnth24/project-example/actions/runs/30629207747)
+(`role_catalog` in `rust-integration`).
+
+## Security and migration notes
+
+Stable keys, expand/backfill.
+
+## Out of scope
+
+custom role builder.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30629207747`
+- `91151657388`
+- `91151657399`
+- `91151657403`
+- `a62850422dd070e7e1195bfe1d4f1dee0d73566d`
+
+- GitHub sync-closed timestamp: `2026-08-01T00:18:34Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-1c-04-route-service-guards-va-service-identities.md
+++ b/plans/reports/plan-260804-1617-1c-04-route-service-guards-va-service-identities.md
@@ -1,0 +1,90 @@
+<!-- generated-done-issue-plan: 1C-04 -->
+# 1C-04 — Route/service guards và service identities
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#105](https://github.com/anhnth24/project-example/issues/105)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Route/service guards và service identities**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30678318560](https://github.com/anhnth24/project-example/actions/runs/30678318560)):
+> changes/static
+> [91310040882](https://github.com/anhnth24/project-example/actions/runs/30678318560/job/91310040882),
+> `rust`
+> [91310110938](https://github.com/anhnth24/project-example/actions/runs/30678318560/job/91310110938),
+> `rust-integration`
+> [91310110925](https://github.com/anhnth24/project-example/actions/runs/30678318560/job/91310110925)
+> (not path-filter skip / soft pass). Task 7–9 reviews Approved. Integration log
+> executed `tests/direct_service_authz.rs` (**6 passed; 0 failed**) covering
+> `doc.delete` / `doc.publish` / `member.manage` / `audit.view` / `jobs.system`
+> direct-service denials; `tests/members.rs` (**13 passed; 0 failed**); and
+> `fileconv_worker` unit suite (**9 passed; 0 failed**) including all
+> `worker_permissions_tests::*`. `rust` job ran
+> `auth::guard_inventory` completeness/invariants green (60-row OpenAPI/route
+> inventory) plus worker config fail-closed tests. Dual-layer route+service
+> authorize and least-privilege worker identities landed in PR 3.
+
+## Implementation plan
+
+Deny-by-default `authorize`; apply route+service+worker/reconcile;
+least-privilege identities.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+1C-01/03.
+
+## Acceptance criteria
+
+Allow/deny mỗi permission cả hai layer;
+missing-guard inventory, direct-service và worker misuse tests.
+
+## Required tests / evidence
+
+Allow/deny mỗi permission cả hai layer;
+missing-guard inventory, direct-service và worker misuse tests.
+
+## Security and migration notes
+
+Không `internal=true` bypass.
+
+## Out of scope
+
+generic ABAC.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30678318560`
+- `6833f57d94949c75ea36609e1055a1139e097c8a`
+- `91310040882`
+- `91310110925`
+- `91310110938`
+
+- GitHub sync-closed timestamp: `2026-08-01T04:06:24Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-1c-05-collection-acl-resolver-cache.md
+++ b/plans/reports/plan-260804-1617-1c-05-collection-acl-resolver-cache.md
@@ -1,0 +1,109 @@
+<!-- generated-done-issue-plan: 1C-05 -->
+# 1C-05 — Collection ACL resolver/cache
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#107](https://github.com/anhnth24/project-example/issues/107)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Collection ACL resolver/cache**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)):
+> changes/static
+> [91217513655](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217513655),
+> `rust`
+> [91217686329](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217686329),
+> `rust-integration`
+> [91217686352](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217686352)
+> (not path-filter skip / soft pass). Task 4 review Approved; Task 5 review Approved.
+> Integration log executed ACL resolver/cache targets including
+> `groups_visibility_group_grant_allows_member_without_user_grant`,
+> `private_visibility_ignores_group_and_role_grants`,
+> `containment_removes_group_role_grants_but_preserves_other_user_grants`,
+> `resolver_matches_sql_predicate_for_acl_fixture_matrix`,
+> `read_grant_does_not_satisfy_write_or_admin`,
+> `group_membership_revoke_invalidates_cached_context`, concurrent grant-vs-flip, and
+> ACL-version bump. Canonical `(qa.query, read)` resolver projection via
+> `allowed_collections_sql` with `private`/`org`/`groups` visibility + group/role grant
+> branches; migration `0036` dormant-grant rejection; org-wide `acl_version` cache
+> invalidation (migrations `0031`/`0033`); `auth::context_cache` freshness check on
+> extractor hits.
+
+## Implementation plan
+
+Private/org/groups grants (**done**); ACL/version
+snapshot (**done**: `orgs.acl_version`, migration `0031`); cache key org/user/membership/
+ACL version (**done**: `auth::context_cache::OrgContextCache`, key `(org_id, user_id)` +
+version check); invalidation APIs (**không làm riêng** — invalidation là version-bump
+trong transaction mutation, không phải API endpoint mới; không có yêu cầu nào đòi một API
+invalidation tách biệt).
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+1C-02/03.
+
+## Acceptance criteria
+
+Semantics đúng, empty/error fail closed;
+grants/status/cache/revoke tests — green on CI
+`90742281e51d3c8ca8a32a78077a07fe3449bc68` run
+[30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)
+(`acl_resolver`, `acl_equivalence`, `acl_cache` in `rust-integration`).
+
+## Required tests / evidence
+
+Semantics đúng, empty/error fail closed;
+grants/status/cache/revoke tests — green on CI
+`90742281e51d3c8ca8a32a78077a07fe3449bc68` run
+[30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)
+(`acl_resolver`, `acl_equivalence`, `acl_cache` in `rust-integration`).
+
+## Security and migration notes
+
+Backfill ACL version (**done**: `DEFAULT 1`, expand-only,
+migration `0031`). **Gap version-bump đã ĐÓNG (migration `0033`, 2026-07-29)**: trigger
+DB `bump_org_acl_version()` trên `collections`/`collection_user_access`/
+`org_memberships`/`roles`/`role_permissions` — bump cùng transaction cho MỌI writer,
+kể cả SQL trực tiếp (fixtures/vận hành; CI `rust-integration` bắt được đúng lỗ này
+
+## Out of scope
+
+nested/time-based groups; operator-configurable cache capacity/TTL qua env; collection
+insert/soft-delete version bump outside `acl_mutate` (accepted TTL-bound gap).
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30649044974`
+- `90742281e51d3c8ca8a32a78077a07fe3449bc68`
+- `91217513655`
+- `91217686329`
+- `91217686352`
+
+- GitHub sync-closed timestamp: `2026-08-01T00:18:38Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-1c-06-postgresql-acl-enforcement.md
+++ b/plans/reports/plan-260804-1617-1c-06-postgresql-acl-enforcement.md
@@ -1,0 +1,110 @@
+<!-- generated-done-issue-plan: 1C-06 -->
+# 1C-06 — PostgreSQL ACL enforcement
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#108](https://github.com/anhnth24/project-example/issues/108)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **PostgreSQL ACL enforcement**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)):
+> changes/static
+> [91217513655](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217513655),
+> `rust`
+> [91217686329](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217686329),
+> `rust-integration`
+> [91217686352](https://github.com/anhnth24/project-example/actions/runs/30649044974/job/91217686352)
+> (not path-filter skip / soft pass). Task 6 rereview Approved. Integration log executed
+> PostgreSQL ACL enforcement targets including
+> `fts_rank_accent_fold_and_active_generation_gates` (dual `qa.query` + `qa.history`
+> hydration recheck), `fts_candidate_leg_and_hydration_deny_acl_and_suspended_membership`,
+> upload regression quartet (`http_upload_happy_and_spoof`,
+> `cancelled_http_upload_settles_quota_consistently`,
+> `envelope_binds_collection_and_stable_replay_deep_equality`,
+> `quarantined_review_requires_approval_for_single_job`), private grant rejection, and
+> role-grant leave-groups. Shared `db/acl_sql` predicates on FTS/hydration/conflict paths;
+> explicit resolver↔SQL equivalence oracle; upload/quarantine operation-scoped write guards
+> (`doc.upload` / `doc.quarantine.review` at `AccessLevel::Write`, no read-projection
+> inference).
+
+## Implementation plan
+
+Tenant+ACL predicates cho FTS/hydration/conflict (**done**); upload write
+gate (**done**). Autocomplete không xây (out of scope — xem điểm 4 legacy note bên dưới).
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+1C-05.
+
+## Acceptance criteria
+
+Không path thiếu context; no existence/count
+leak; SQL join/subquery/missing-predicate tests — green on CI
+`90742281e51d3c8ca8a32a78077a07fe3449bc68` run
+[30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)
+(`retrieval`, `uploads`, fast unit pins in `db/search.rs` / `db/acl_sql.rs`).
+
+## Required tests / evidence
+
+Không path thiếu context; no existence/count
+leak; SQL join/subquery/missing-predicate tests — green on CI
+`90742281e51d3c8ca8a32a78077a07fe3449bc68` run
+[30649044974](https://github.com/anhnth24/project-example/actions/runs/30649044974)
+(`retrieval`, `uploads`, fast unit pins in `db/search.rs` / `db/acl_sql.rs`).
+
+## Security and migration notes
+
+PG authority, prepared queries; migration `0036` dormant-grant
+
+## Out of scope
+
+vector/object path (1C-07), autocomplete,
+broader route write inventory (PR 3).
+
+### Legacy verification notes (pre-PR-2, retained for audit trail)
+
+1. **FTS candidate ACL subquery** (`db/search.rs`): defense-in-depth EXISTS on candidate
+leg; shared builder includes `acl_m.state = 'active'`.
+2. **Org-only count helpers** (`db/documents::count`, `db/chunks::count`): test-only;
+`org_only_count_helpers_stay_out_of_routes_and_services` source-scan guard.
+3. **Missing-predicate pin**: `every_chunk_scoped_query_embeds_acl_predicate` +
+`acl_predicate_sql_shape_is_pinned`.
+4. **Autocomplete**: không có endpoint — future work must use `acl_predicate_sql` from day one.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30649044974`
+- `90742281e51d3c8ca8a32a78077a07fe3449bc68`
+- `91217513655`
+- `91217686329`
+- `91217686352`
+
+- GitHub sync-closed timestamp: `2026-08-01T00:18:40Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-1c-07-qdrant-storage-jobs-fail-closed-enforcement.md
+++ b/plans/reports/plan-260804-1617-1c-07-qdrant-storage-jobs-fail-closed-enforcement.md
@@ -1,0 +1,89 @@
+<!-- generated-done-issue-plan: 1C-07 -->
+# 1C-07 — Qdrant/storage/jobs fail-closed enforcement
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#109](https://github.com/anhnth24/project-example/issues/109)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Qdrant/storage/jobs fail-closed enforcement**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30678318560](https://github.com/anhnth24/project-example/actions/runs/30678318560)):
+> `rust`
+> [91310110938](https://github.com/anhnth24/project-example/actions/runs/30678318560/job/91310110938),
+> `rust-integration`
+> [91310110925](https://github.com/anhnth24/project-example/actions/runs/30678318560/job/91310110925)
+> (not path-filter skip / soft pass). Integration log executed
+> `tests/storage.rs` (**ok**; Qdrant/MinIO fail-closed + cross-org overwrite/
+> dimension/missing-scope/object-key denials including
+> `qdrant_connection_failure_fails_closed_as_transport`,
+> `qdrant_unresponsive_endpoint_times_out_as_transport`,
+> `cross_org_point_overwrite_rejected`,
+> `same_org_different_collection_cannot_overwrite`,
+> `missing_scope_rejects_without_network_side_effects`). `rust`/`rust-integration`
+> also ran fast forged-payload / malformed / empty-scope unit pins under
+> `storage::qdrant::tests::*` and retrieval forged-candidate deny. Signed-URL N/A
+> (capability tokens). Connected cross-org denial suite remains **1C-12**.
+
+## Implementation plan
+
+Mandatory org+non-empty collection filter; PG payload validation;
+authorize preview/download/export/job/SSE; abort in-flight on ACL change.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+1C-05/06.
+
+## Acceptance criteria
+
+Missing/malformed/timeout/mismatch deny;
+Qdrant failure, forged payload, job ID, stream revoke, signed URL replay tests.
+
+## Required tests / evidence
+
+Missing/malformed/timeout/mismatch deny;
+Qdrant failure, forged payload, job ID, stream revoke, signed URL replay tests.
+
+## Security and migration notes
+
+No signed URL logs.
+
+## Out of scope
+
+public sharing/CDN.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30678318560`
+- `6833f57d94949c75ea36609e1055a1139e097c8a`
+- `91310110925`
+- `91310110938`
+
+- GitHub sync-closed timestamp: `2026-08-01T04:06:30Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-1c-09-atomic-quota-lifecycle.md
+++ b/plans/reports/plan-260804-1617-1c-09-atomic-quota-lifecycle.md
@@ -1,0 +1,83 @@
+<!-- generated-done-issue-plan: 1C-09 -->
+# 1C-09 — Atomic quota lifecycle
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#111](https://github.com/anhnth24/project-example/issues/111)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Atomic quota lifecycle**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30678318560](https://github.com/anhnth24/project-example/actions/runs/30678318560)):
+> `rust-integration`
+> [91310110925](https://github.com/anhnth24/project-example/actions/runs/30678318560/job/91310110925)
+> (not path-filter skip / soft pass). Integration log executed
+> `tests/quota.rs` (**16 passed; 0 failed**) including
+> `concurrent_reserve_does_not_over_reserve`,
+> `job_claim_enforces_and_releases_concurrent_slots`,
+> `finalize_actual_commits_measured_token_usage`,
+> `reconcile_repairs_counter_drift_and_orphaned_job_slots`,
+> `upload_two_resource_settlement_is_atomic`, and idempotency/expiry/overflow
+> paths. Embedding-provider token metering remains backlog (out of issue scope).
+
+## Implementation plan
+
+Reserve/finalize/refund, idempotency/expiry/sweeper/reconcile cho
+storage/token/jobs.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+Phase 1B jobs + 1C-01.
+
+## Acceptance criteria
+
+100 concurrent reservations
+không over-limit; crash/retry/cancel/timeout/actual-usage tests.
+
+## Required tests / evidence
+
+100 concurrent reservations
+không over-limit; crash/retry/cancel/timeout/actual-usage tests.
+
+## Security and migration notes
+
+Checked arithmetic, org/resource unique key.
+
+## Out of scope
+
+billing.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30678318560`
+- `6833f57d94949c75ea36609e1055a1139e097c8a`
+- `91310110925`
+
+- GitHub sync-closed timestamp: `2026-08-01T04:06:35Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-1c-10-rate-limit-va-per-org-fairness.md
+++ b/plans/reports/plan-260804-1617-1c-10-rate-limit-va-per-org-fairness.md
@@ -1,0 +1,97 @@
+<!-- generated-done-issue-plan: 1C-10 -->
+# 1C-10 — Rate limit và per-org fairness
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#112](https://github.com/anhnth24/project-example/issues/112)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Rate limit và per-org fairness**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30678318560](https://github.com/anhnth24/project-example/actions/runs/30678318560)):
+> `rust`
+> [91310110938](https://github.com/anhnth24/project-example/actions/runs/30678318560/job/91310110938),
+> `rust-integration`
+> [91310110925](https://github.com/anhnth24/project-example/actions/runs/30678318560/job/91310110925)
+> (not path-filter skip / soft pass). Integration log executed
+> `tests/noisy_neighbor.rs` (**3 passed; 0 failed**) —
+> `noisy_org_backlog_does_not_starve_quiet_org`,
+> `slot_exhausted_noisy_org_falls_through_to_quiet_org_same_cycle`, plus shared
+> worker-context pin. Fast unit coverage for per-org rate bucket and
+> `workers::fairness::OrgRotation` green in `rust` job. Fairness SLO wall-clock
+> remains **1C-13**; GPU semaphore remains N/A-until-GPU.
+
+## Implementation plan
+
+User/IP/auth limits (**done từ trước**); per-org API bucket (**done**:
+`middleware/rate_limit.rs::check_org` + `routes/rate_limit_guard.rs`); per-org worker
+fairness (**done**: `workers/fairness.rs::OrgRotation` + `bin/worker.rs` multi-org
+env); GPU scheduler/semaphore (**N/A-until-GPU**, xem điều kiện kích hoạt ở trên);
+headers, privacy-safe metrics (**done từ trước**, scope mới `org` trong 429 details
+là giá trị tĩnh, không PII).
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+1C-09 (dùng lại reservation `concurrent_jobs`) + Phase 0 SLO/capacity
+
+## Acceptance criteria
+
+Noisy org không bỏ đói org
+khác — **done ở mức deterministic-count** (`tests/noisy_neighbor.rs` DB-gated + unit
+fairness/rate-limit fast); burst/window/crash-release/proxy tests đã có từ trước
+(`rate_limit.rs` tests, `sse_stream_readiness.rs` trusted-proxy 429); riêng
+**fairness SLO wall-clock** chuyển 1C-13.
+
+## Required tests / evidence
+
+Noisy org không bỏ đói org
+khác — **done ở mức deterministic-count** (`tests/noisy_neighbor.rs` DB-gated + unit
+fairness/rate-limit fast); burst/window/crash-release/proxy tests đã có từ trước
+(`rate_limit.rs` tests, `sse_stream_readiness.rs` trusted-proxy 429); riêng
+**fairness SLO wall-clock** chuyển 1C-13.
+
+## Security and migration notes
+
+Chỉ trusted proxy IP, bounded state (org bucket nằm trong
+cùng HashMap HARD_CAP 10k key, evictable như các key khác). Không migration mới.
+
+## Out of scope
+
+multi-region; per-org tiered rate limit từ `org_quotas` (đợi yêu cầu tier
+thật); GPU semaphore (until-GPU).
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30678318560`
+- `6833f57d94949c75ea36609e1055a1139e097c8a`
+- `91310110925`
+- `91310110938`
+
+- GitHub sync-closed timestamp: `2026-08-01T04:06:37Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-1c-11-audit-admin-apis.md
+++ b/plans/reports/plan-260804-1617-1c-11-audit-admin-apis.md
@@ -1,0 +1,94 @@
+<!-- generated-done-issue-plan: 1C-11 -->
+# 1C-11 — Audit/admin APIs
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#113](https://github.com/anhnth24/project-example/issues/113)
+Catalog: [`backlog/phase-1c/issues/README.md`](../markhand-web/backlog/phase-1c/issues/README.md)
+Phase plan: [`phase-1c-multi-org-security.md`](../markhand-web/phase-1c-multi-org-security.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Audit/admin APIs**.
+
+## Context
+
+- Phase: `1C`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (run [30678318560](https://github.com/anhnth24/project-example/actions/runs/30678318560)):
+> `rust-integration`
+> [91310110925](https://github.com/anhnth24/project-example/actions/runs/30678318560/job/91310110925)
+> (not path-filter skip / soft pass) for audit coverage, **plus** owner-approved
+> accepted risk `AR-1C-AUDIT-RETENTION` recorded in PR 1 / P1C.6 (POC/
+> non-production only; Phase 4 owns retention/TTL/tamper/export — **retention is
+> not implemented here**). Integration log executed `tests/audit_read.rs`
+> (**9 passed; 0 failed**) including pagination, action/actor/time filters,
+> `audit.view` 403 + deny-audit row, cross-org isolation, and metadata allowlist
+> redaction. Direct-service `audit_view_permission_required_at_direct_list_page`
+> green in `tests/direct_service_authz.rs`.
+
+## Implementation plan
+
+Member/role/ACL/config/quota/data/cloud events (**out of scope của
+đợt này — chỉ audit READ**); read-only pagination/filter (**done**: `routes/audit.rs`,
+`db/audit.rs::list_page`)/retention (**out**); owner-only controls (**out — không
+phải đọc log**).
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+1C-02…10.
+
+## Acceptance criteria
+
+Mọi mutation có actor/org/action/target/
+result/request ID (pre-existing, không đổi ở đây); coverage (pre-existing, không
+đổi)/access (**done**: 403 + deny-audit test)/pagination (**done**: cursor stable
+test)/redaction (**done**: no-leak-beyond-allowlist test)/retention (**out of
+scope**, chưa làm).
+
+## Required tests / evidence
+
+Mọi mutation có actor/org/action/target/
+result/request ID (pre-existing, không đổi ở đây); coverage (pre-existing, không
+đổi)/access (**done**: 403 + deny-audit test)/pagination (**done**: cursor stable
+test)/redaction (**done**: no-leak-beyond-allowlist test)/retention (**out of
+scope**, chưa làm).
+
+## Security and migration notes
+
+No document/prompt/token/PII/URL (allowlist per-action giữ
+nguyên, `audit.read` chỉ thêm `result_count`). Không migration mới — RLS/seed
+
+## Out of scope
+
+SIEM archive, retention/TTL, audit coverage mở
+rộng sang action mới cho ACL/config/quota/cloud mutation, owner-only admin
+controls khác ngoài đọc log.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30678318560`
+- `6833f57d94949c75ea36609e1055a1139e097c8a`
+- `91310110925`
+
+- GitHub sync-closed timestamp: `2026-08-01T04:06:40Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-01-architecture-boundaries-va-dependency-rules.md
+++ b/plans/reports/plan-260804-1617-f-01-architecture-boundaries-va-dependency-rules.md
@@ -1,0 +1,76 @@
+<!-- generated-done-issue-plan: F-01 -->
+# F-01 — Architecture boundaries và dependency rules
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#46](https://github.com/anhnth24/project-example/issues/46)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Khóa dependency direction và module responsibilities trước scaffold.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Viết architecture boundary ADR; define allowed/forbidden
+dependencies; route→service→repository; tenant context rule; browser/Tauri split;
+automated `cargo tree`/import checks. Bootstrap minimum CODEOWNERS, issue/PR
+template, Definition of Ready/Done và security-review triggers để govern chính
+Phase F; F-12 hoàn thiện và kiểm chứng workflow.
+
+## Files/modules
+
+`docs/adr/0001-web-boundaries.md` (new),
+`docs/conventions/dependencies.md` (new), `.github/CODEOWNERS`,
+`.github/{ISSUE_TEMPLATE,PULL_REQUEST_TEMPLATE}.md`, CI boundary scripts.
+
+## Dependencies / blocks
+
+Không; blocks F-02 và mọi crate/web implementation.
+
+## Acceptance criteria
+
+Core không framework/storage; knowledge pure mặc định;
+server không reverse-depend desktop; web không Tauri; vendor không dependency.
+
+## Required tests / evidence
+
+Positive/negative sample boundary checks trong CI;
+architecture diagram và approver.
+
+## Security and migration notes
+
+Tenant context bắt buộc ở repository rule; migration N/A.
+
+## Out of scope
+
+Storage trait tổng quát và business implementation.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #160](https://github.com/anhnth24/project-example/pull/160) — docs: establish Markhand Web architecture boundaries; merged `2026-07-17T08:08:21Z`
+
+### Completion/evidence commits
+
+- `ab3cc97f41a2021a8074500f808e220df9d54bbe`
+
+- GitHub sync-closed timestamp: `2026-07-17T11:06:29Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-02-workspace-va-folder-skeleton.md
+++ b/plans/reports/plan-260804-1617-f-02-workspace-va-folder-skeleton.md
@@ -1,0 +1,75 @@
+<!-- generated-done-issue-plan: F-02 -->
+# F-02 — Workspace và folder skeleton
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#47](https://github.com/anhnth24/project-example/issues/47)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Tạo khung compile được cho knowledge/server/web/deploy/docs/bench.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Add workspace members với minimal libraries/binaries; module
+READMEs/ownership; Vite web shell; deploy/dev placeholders; không copy business
+logic. Chốt root pnpm workspace/lockfile policy cho `app/` + `web/`; pin Node,
+pnpm, task runner và Compose requirements; thêm bootstrap/version-check command.
+
+## Files/modules
+
+`Cargo.toml`, `crates/{knowledge,server}/`, `web/`, `deploy/dev/`,
+`docs/{adr,conventions,runbooks}/`, `bench/markhand_web/`.
+
+## Dependencies / blocks
+
+F-01; blocks coding/tooling/dev environment issues.
+
+## Acceptance criteria
+
+Cargo workspace và web build; server API/worker binaries start
+help/config validation only; no cyclic/forbidden deps; JS workspace/lockfile policy
+và host tool versions được máy kiểm tra.
+
+## Required tests / evidence
+
+`cargo metadata/check`, bootstrap/version check,
+`pnpm install --frozen-lockfile`, app+web build, tree/import boundary.
+
+## Security and migration notes
+
+No credential/default public bind; no DB migration.
+
+## Out of scope
+
+Auth/schema/routes/jobs.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #160](https://github.com/anhnth24/project-example/pull/160) — docs: establish Markhand Web architecture boundaries; merged `2026-07-17T08:08:21Z`
+
+### Completion/evidence commits
+
+- `ab3cc97f41a2021a8074500f808e220df9d54bbe`
+
+- GitHub sync-closed timestamp: `2026-07-17T11:06:31Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-03-rust-coding-va-crate-conventions.md
+++ b/plans/reports/plan-260804-1617-f-03-rust-coding-va-crate-conventions.md
@@ -1,0 +1,72 @@
+<!-- generated-done-issue-plan: F-03 -->
+# F-03 — Rust coding và crate conventions
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#48](https://github.com/anhnth24/project-example/issues/48)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Một chuẩn Rust bắt buộc cho core/knowledge/server/workers.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Rustfmt/clippy policy; error/context; async vs blocking;
+cancellation/timeouts; panic/unwrap/unsafe/public docs; naming/module visibility.
+
+## Files/modules
+
+`rustfmt.toml`, `clippy.toml` nếu cần,
+`docs/conventions/rust.md`, root lint task, CI.
+
+## Dependencies / blocks
+
+F-02; blocks Rust feature issues.
+
+## Acceptance criteria
+
+Convention có enforceable rule + justified exceptions;
+existing code có migration plan thay vì bật deny phá toàn repo ngay.
+
+## Required tests / evidence
+
+Format check, clippy selected warnings-as-errors,
+forbidden-pattern baseline/delta.
+
+## Security and migration notes
+
+Request/worker path không panic; secret-safe errors; N/A schema.
+
+## Out of scope
+
+Refactor toàn bộ warning cũ trong cùng issue.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #160](https://github.com/anhnth24/project-example/pull/160) — docs: establish Markhand Web architecture boundaries; merged `2026-07-17T08:08:21Z`
+
+### Completion/evidence commits
+
+- `ab3cc97f41a2021a8074500f808e220df9d54bbe`
+
+- GitHub sync-closed timestamp: `2026-07-17T11:06:34Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-04-typescript-react-conventions.md
+++ b/plans/reports/plan-260804-1617-f-04-typescript-react-conventions.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: F-04 -->
+# F-04 — TypeScript/React conventions
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#49](https://github.com/anhnth24/project-example/issues/49)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Chuẩn strict TS, component/hook/state và accessibility cho web.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+TS strict policy; generated API immutable; naming/import
+boundaries; state ownership; loading/error/empty; abort cleanup; a11y checklist.
+
+## Files/modules
+
+`web/tsconfig*.json`, ESLint/Prettier config,
+`docs/conventions/typescript-react.md`, web test setup.
+
+## Dependencies / blocks
+
+F-02; blocks Phase 2 implementation.
+
+## Acceptance criteria
+
+No Tauri imports; generated code separated; hooks clean up
+requests/streams; component patterns documented.
+
+## Required tests / evidence
+
+Typecheck/lint/format/unit sample/a11y smoke.
+
+## Security and migration notes
+
+No token/content logging or unsafe HTML by default; N/A schema.
+
+## Out of scope
+
+Full design system và Phase 2 pages.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #160](https://github.com/anhnth24/project-example/pull/160) — docs: establish Markhand Web architecture boundaries; merged `2026-07-17T08:08:21Z`
+
+### Completion/evidence commits
+
+- `ab3cc97f41a2021a8074500f808e220df9d54bbe`
+
+- GitHub sync-closed timestamp: `2026-07-17T11:06:37Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-05-sql-data-migration-conventions.md
+++ b/plans/reports/plan-260804-1617-f-05-sql-data-migration-conventions.md
@@ -1,0 +1,72 @@
+<!-- generated-done-issue-plan: F-05 -->
+# F-05 — SQL/data/migration conventions
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#50](https://github.com/anhnth24/project-example/issues/50)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Ngăn schema/tenant/migration conventions bị phát minh theo từng PR.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Naming/types/time/UUID/FK/check/index; `org_id`; transaction/
+locking/idempotency; immutable migration; expand/backfill/cutover/contract; rollback.
+
+## Files/modules
+
+`docs/conventions/sql-migrations.md`,
+`crates/server/migrations/README.md`, migration test harness skeleton.
+
+## Dependencies / blocks
+
+F-01/02; blocks Phase 1B schema.
+
+## Acceptance criteria
+
+Example migration/repository query hợp conventions; policy
+fresh/upgrade/mixed-version rõ.
+
+## Required tests / evidence
+
+Empty DB apply, migration checksum/immutability,
+rollback-compat sample.
+
+## Security and migration notes
+
+Tenant predicate/RLS review checklist bắt buộc.
+
+## Out of scope
+
+Business tables và RLS decision.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #164](https://github.com/anhnth24/project-example/pull/164) — docs: establish SQL migration conventions; merged `2026-07-17T08:18:04Z`
+
+### Completion/evidence commits
+
+- `8d8b326c9420744c7b07a0b61ead1f034df72ad6`
+
+- GitHub sync-closed timestamp: `2026-07-17T11:06:40Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-06-rest-openapi-sse-error-conventions.md
+++ b/plans/reports/plan-260804-1617-f-06-rest-openapi-sse-error-conventions.md
@@ -1,0 +1,74 @@
+<!-- generated-done-issue-plan: F-06 -->
+# F-06 — REST/OpenAPI/SSE/error conventions
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#51](https://github.com/anhnth24/project-example/issues/51)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Contract thống nhất để backend/web không drift.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+`/api/v1`; resources/pagination/idempotency; canonical error;
+date/UUID/enum/null; OpenAPI authority; SSE envelope/version/sequence/reconnect;
+deprecation policy.
+
+## Files/modules
+
+`docs/conventions/api.md`, `crates/server/openapi/`,
+sample DTO/error/SSE types và fixtures.
+
+## Dependencies / blocks
+
+F-01/02; blocks 1B routes và Phase 2 client.
+
+## Acceptance criteria
+
+Sample contract generate TS; error/SSE fixtures round-trip;
+compatibility rules có examples.
+
+## Required tests / evidence
+
+OpenAPI validation/snapshot, Rust↔TS fixture,
+SSE parser sequence sample.
+
+## Security and migration notes
+
+Errors không leak internal; SSE auth/revocation requirements;
+persisted migration N/A.
+
+## Out of scope
+
+Business endpoints.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #165](https://github.com/anhnth24/project-example/pull/165) — feat: establish API and SSE contract conventions; merged `2026-07-17T10:13:29Z`
+
+### Completion/evidence commits
+
+- `599a63c30ecc3ba072f3f56a0a51e691c12de838`
+
+- GitHub sync-closed timestamp: `2026-07-17T11:06:43Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-07-configuration-secrets-va-environment-profiles.md
+++ b/plans/reports/plan-260804-1617-f-07-configuration-secrets-va-environment-profiles.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: F-07 -->
+# F-07 — Configuration, secrets và environment profiles
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#52](https://github.com/anhnth24/project-example/issues/52)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Typed, fail-fast, secret-safe config cho local/test/prod.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Define precedence; profile schema; mounted secret/env
+references; validation/redacted Debug; `.env.example`; unsafe dev defaults isolated.
+
+## Files/modules
+
+`crates/server/src/config.rs`, `deploy/dev/.env.example`,
+`docs/conventions/config-secrets.md`, config tests.
+
+## Dependencies / blocks
+
+F-02; blocks dev stack/server issues.
+
+## Acceptance criteria
+
+Missing/invalid config fails startup; no secret in errors;
+prod cannot use dev credentials/profile.
+
+## Required tests / evidence
+
+Table/env/file precedence, redaction canary, profile deny.
+
+## Security and migration notes
+
+No committed secrets; rotation contract documented; N/A schema.
+
+## Out of scope
+
+Production secret-manager implementation.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #171](https://github.com/anhnth24/project-example/pull/171) — feat: add typed server configuration profiles; merged `2026-07-17T11:36:55Z`
+
+### Completion/evidence commits
+
+- `ddedd02c60c19e9a06d1f0d5222e93d1183f692a`
+
+- GitHub sync-closed timestamp: `2026-07-17T12:42:20Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-08-reproducible-local-development-environment.md
+++ b/plans/reports/plan-260804-1617-f-08-reproducible-local-development-environment.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: F-08 -->
+# F-08 — Reproducible local development environment
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#53](https://github.com/anhnth24/project-example/issues/53)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+One-command CPU-only dev stack, optional GPU profile.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Pin PG/Qdrant/MinIO/OTel; init buckets/extensions; health/
+seed/reset; named volumes/private network; mock embedding; optional vLLM profile.
+
+## Files/modules
+
+`deploy/dev/compose.yml`, init/health/seed/reset scripts,
+`docs/runbooks/local-development.md`.
+
+## Dependencies / blocks
+
+F-02/07; blocks Phase 0 spike and server development.
+
+## Acceptance criteria
+
+Clean machine up/health/seed/reset/down không console action;
+restart preserves intended data; reset only dev resources.
+
+## Required tests / evidence
+
+CI compose smoke, service versions, cold setup transcript.
+
+## Security and migration notes
+
+Non-production credentials/private binds/no secret Git.
+
+## Out of scope
+
+Benchmark evidence và production orchestration.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #173](https://github.com/anhnth24/project-example/pull/173) — feat: add reproducible local development stack; merged `2026-07-17T12:41:30Z`
+
+### Completion/evidence commits
+
+- `58918f94d1ec5871765639e2569d8a01d01a3258`
+
+- GitHub sync-closed timestamp: `2026-07-17T13:04:15Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-09-root-task-runner-quality-tools-va-ci-baseline.md
+++ b/plans/reports/plan-260804-1617-f-09-root-task-runner-quality-tools-va-ci-baseline.md
@@ -1,0 +1,74 @@
+<!-- generated-done-issue-plan: F-09 -->
+# F-09 — Root task runner, quality tools và CI baseline
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#54](https://github.com/anhnth24/project-example/issues/54)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Cùng command local/CI cho format/lint/test/build/dev/migrate.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Add `just`/equivalent root tasks theo test conventions
+F-10; Rust/TS/SQL checks; dependency/license/security baseline cho cả `app/` và
+`web/`; changed-path optimization nhưng giữ full required gate; pin/bootstrap host
+tools và native Rust/Tauri prerequisites.
+
+## Files/modules
+
+`Justfile` hoặc task runner, CI workflows, tool configs,
+`docs/conventions/ci.md`.
+
+## Dependencies / blocks
+
+F-03…08 + F-10; blocks all implementation PRs.
+
+## Acceptance criteria
+
+Documented commands identical local/CI; failures actionable;
+desktop existing CI vẫn chạy.
+
+## Required tests / evidence
+
+Clean checkout full task, cache miss/hit, intentional
+format/lint/test failure fixtures.
+
+## Security and migration notes
+
+Least-privilege CI, pinned actions/tools, no secret artifact.
+
+## Out of scope
+
+Production release workflow.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #177](https://github.com/anhnth24/project-example/pull/177) — ci: unify root quality and dependency gates; merged `2026-07-17T14:00:05Z`
+
+### Completion/evidence commits
+
+- `bf37b6160ac65bae7deeb7318c305263a04ad271`
+
+- GitHub sync-closed timestamp: `2026-07-17T14:12:40Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-10-test-pyramid-fixtures-va-golden-data-conventions.md
+++ b/plans/reports/plan-260804-1617-f-10-test-pyramid-fixtures-va-golden-data-conventions.md
@@ -1,0 +1,72 @@
+<!-- generated-done-issue-plan: F-10 -->
+# F-10 — Test pyramid, fixtures và golden-data conventions
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#55](https://github.com/anhnth24/project-example/issues/55)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Chuẩn test/evidence dùng chung trước Phase 0/1A.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Define unit/integration/contract/denial/E2E/benchmark/
+migration/restore layers; fixture IDs/time/checksum/license; CI artifact retention.
+
+## Files/modules
+
+`docs/conventions/testing-fixtures.md`, `tests/fixtures/README.md`,
+sample fixture validators.
+
+## Dependencies / blocks
+
+F-03…08; blocks F-09, P0-02 và P1A-01.
+
+## Acceptance criteria
+
+Mỗi layer có owner/location/command; fixture synthetic/
+deterministic; large artifacts policy rõ.
+
+## Required tests / evidence
+
+Fixture validator catches checksum, absolute path,
+secret canary, duplicate ID.
+
+## Security and migration notes
+
+De-identification/license required; migration evidence format.
+
+## Out of scope
+
+Viết toàn bộ golden corpus.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #175](https://github.com/anhnth24/project-example/pull/175) — test: establish fixture and evidence conventions; merged `2026-07-17T13:35:19Z`
+
+### Completion/evidence commits
+
+- `33a22d929d81f6abf6fb6c58f30dd1c78b0a2e5a`
+
+- GitHub sync-closed timestamp: `2026-07-17T14:12:43Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-11-observability-audit-conventions.md
+++ b/plans/reports/plan-260804-1617-f-11-observability-audit-conventions.md
@@ -1,0 +1,73 @@
+<!-- generated-done-issue-plan: F-11 -->
+# F-11 — Observability/audit conventions
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#56](https://github.com/anhnth24/project-example/issues/56)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Correlation/metrics/log/audit schema ổn định trước business services.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Field names; request/job/version/signature propagation;
+metric units/cardinality; log allowlist/redaction; audit envelope; sample middleware.
+
+## Files/modules
+
+`docs/conventions/observability-audit.md`,
+`crates/server/src/telemetry/`, sample tests/config.
+
+## Dependencies / blocks
+
+F-01/06/07/09; blocks 1B telemetry/business routes.
+
+## Acceptance criteria
+
+Synthetic in-memory request→job fixture chứng minh field
+propagation/redaction; không thêm durable queue, business route hoặc persisted
+audit trong Phase F; metric naming valid; seeded content/token/key absent.
+
+## Required tests / evidence
+
+Trace propagation, cardinality lint, redaction canaries,
+audit fixture.
+
+## Security and migration notes
+
+No document/prompt/token/key/URL/PII; audit schema versioned.
+
+## Out of scope
+
+Production dashboards/SIEM.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #179](https://github.com/anhnth24/project-example/pull/179) — feat: define observability and audit contracts; merged `2026-07-17T14:12:01Z`
+
+### Completion/evidence commits
+
+- `928167ceec39142f91b9188add41d00b048f10a3`
+
+- GitHub sync-closed timestamp: `2026-07-18T17:05:44Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-f-12-contributor-workflow-setup-docs-va-foundation-gate.md
+++ b/plans/reports/plan-260804-1617-f-12-contributor-workflow-setup-docs-va-foundation-gate.md
@@ -1,0 +1,73 @@
+<!-- generated-done-issue-plan: F-12 -->
+# F-12 — Contributor workflow, setup docs và foundation gate
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#57](https://github.com/anhnth24/project-example/issues/57)
+Catalog: [`backlog/phase-f/issues/README.md`](../markhand-web/backlog/phase-f/issues/README.md)
+Phase plan: [`phase-f-engineering-foundation.md`](../markhand-web/phase-f-engineering-foundation.md)
+Status: Done
+
+## Objective
+
+Chứng minh contributor mới có thể setup và tuân conventions.
+
+## Context
+
+- Phase: `F`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+ADR/RFC templates/index; ownership/CODEOWNERS; issue/PR
+templates; Definition of Ready/Done; security triggers; setup/troubleshooting.
+
+## Files/modules
+
+`docs/adr/{README,TEMPLATE}.md`, `.github/CODEOWNERS`,
+`.github/{ISSUE_TEMPLATE,PULL_REQUEST_TEMPLATE}.md`, contributor/runbook docs.
+
+## Dependencies / blocks
+
+F-01…F-11; blocks Phase 0/1A activation.
+
+## Acceptance criteria
+
+Clean-checkout onboarding không tribal knowledge; ownership/
+approval rõ; Phase 0/1A không cần tạo convention riêng.
+
+## Required tests / evidence
+
+Independent setup dry run gồm pinned Node/pnpm/Rust/
+task-runner/Compose/native prerequisites; full local/CI task cho app+web; dev stack;
+sample contract/config/telemetry/fixture checks.
+
+## Security and migration notes
+
+Security review triggers và secret incident contact documented.
+
+## Out of scope
+
+Benchmark/business implementation/production runbooks.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #181](https://github.com/anhnth24/project-example/pull/181) — docs: add contributor setup and Phase F gate; merged `2026-07-17T14:28:28Z`
+
+### Completion/evidence commits
+
+- `29832476c6a775b56101301dbddcbaa69cc9ed7b`
+
+- GitHub sync-closed timestamp: `2026-07-18T17:05:46Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-01-khoa-workload-hardware-va-gate-registry.md
+++ b/plans/reports/plan-260804-1617-p0-01-khoa-workload-hardware-va-gate-registry.md
@@ -1,0 +1,74 @@
+<!-- generated-done-issue-plan: P0-01 -->
+# P0-01 — Khóa workload, hardware và gate registry
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#58](https://github.com/anhnth24/project-example/issues/58)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Thay giả định scale/SLA bằng workload envelope, hardware profile và
+gate schema được duyệt.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> merged to `master`.
+
+## Implementation plan
+
+Ghi org/collection/document/vector, ingest/query/recovery load; CPU/RAM/
+disk/GPU/network; tạo registry gồm metric, workload, threshold, command,
+environment, approver và failure disposition.
+
+## Files/modules
+
+`bench/markhand_web/{README.md,workload-profile.yaml,gates.yaml}`,
+`bench/markhand_web/environments/`, `docs/adr/README.md`.
+
+## Dependencies / blocks
+
+Cần input sản phẩm/vận hành; block mọi benchmark.
+
+## Acceptance criteria
+
+Normal/peak/recovery/aggregate load đầy đủ; mọi open decision có
+owner; gate thiếu trường bị schema validator từ chối.
+
+## Required tests / evidence
+
+Validate YAML/schema; mọi report sau emit environment
+fingerprint.
+
+## Security and migration notes
+
+Không ghi credential, hostname nội bộ hoặc tên khách hàng.
+
+## Out of scope
+
+Chọn model và tuyên bố đạt SLA.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:05:48Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-02-golden-corpus-tieng-viet-va-adversarial-corpus.md
+++ b/plans/reports/plan-260804-1617-p0-02-golden-corpus-tieng-viet-va-adversarial-corpus.md
@@ -1,0 +1,76 @@
+<!-- generated-done-issue-plan: P0-02 -->
+# P0-02 — Golden corpus tiếng Việt và adversarial corpus
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#59](https://github.com/anhnth24/project-example/issues/59)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Dataset tái lập cho conversion, retrieval, citation và upload attack.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> strict reproducibility gates passed.
+
+## Implementation plan
+
+Thêm mọi format; 200–500 query với expected document/source span/
+relevance/no-answer; multi-document và immutable multi-version citations
+(`current`/`as_of`/`compare`/`history`); BA/design/dev cross-document conflict
+lifecycle (open/resolved/history) với cited claims; sample spoof/bomb/malformed/
+traversal/prompt injection; pin checksum và provenance/license.
+
+## Files/modules
+
+`bench/markhand_web/golden/`, `adversarial/`,
+`manifest.lock.json`, `scripts/validate_corpus.py`.
+
+## Dependencies / blocks
+
+P0-01; fixture phải redistributable.
+
+## Acceptance criteria
+
+Coverage đủ category; source/version span ổn định; current fact không
+trỏ version cũ; compare/history cite đủ old+new và delta; conflict current/history
+cite đủ hai phía + resolution versions; validator bắt checksum, duplicate ID, invalid
+span/version/conflict lineage và missing license; mỗi attack có expected disposition.
+
+## Required tests / evidence
+
+Clean-checkout reproducibility; dual review + adjudication.
+
+## Security and migration notes
+
+Synthetic/de-identified; bomb fixture chỉ chạy trong limits.
+
+## Out of scope
+
+Customer data và expected chunk ID trước khi chốt chunking.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:05:50Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-03-mo-rong-desktop-baseline-tren-corpus-phase-0.md
+++ b/plans/reports/plan-260804-1617-p0-03-mo-rong-desktop-baseline-tren-corpus-phase-0.md
@@ -1,0 +1,75 @@
+<!-- generated-done-issue-plan: P0-03 -->
+# P0-03 — Mở rộng desktop baseline trên corpus Phase 0
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#60](https://github.com/anhnth24/project-example/issues/60)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Mở rộng parity baseline P1A-01 lên corpus/metrics Phase 0; P1A-01 là
+baseline authoritative để việc extraction không phải đợi toàn bộ corpus.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> recomputed evidence accepted as the current-state reference.
+
+## Implementation plan
+
+Tái dùng fixtures/harness P1A-01; chạy release conversion; snapshot top-k,
+scores, anchors, answer modes,
+warnings, stats, provider fallback và signature mismatch.
+
+## Files/modules
+
+`bench/markhand_web/scripts/run_desktop_baseline.sh`,
+`baselines/desktop-v1/`, `reports/desktop-baseline.md`.
+
+## Dependencies / blocks
+
+P0-02 + P1A-01 authoritative parity harness; provider run
+cần config/model pin.
+
+## Acceptance criteria
+
+Mọi format/query có raw machine-readable result; offline chạy không
+cần LLM; đủ dữ liệu so parity 1A.
+
+## Required tests / evidence
+
+CER/WER/time, Recall@5/10, MRR, nDCG, citation correctness;
+deterministic rerun.
+
+## Security and migration notes
+
+Redact key/prompt/absolute path.
+
+## Out of scope
+
+Sửa defect ranking/performance.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:05:52Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-04-spike-infrastructure-tai-lap.md
+++ b/plans/reports/plan-260804-1617-p0-04-spike-infrastructure-tai-lap.md
@@ -1,0 +1,73 @@
+<!-- generated-done-issue-plan: P0-04 -->
+# P0-04 — Spike infrastructure tái lập
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#61](https://github.com/anhnth24/project-example/issues/61)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Stack disposable PG/Qdrant/MinIO/vLLM/telemetry cho benchmark.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> CPU-smoke evidence passed; Profile B GPU/IOPS measurements remain downstream gates.
+
+## Implementation plan
+
+Tái dùng compose/services/scripts base từ F-08; thêm benchmark-specific
+override với isolated volumes/data, vLLM/GPU profile, workload sizing, image digest
+và environment fingerprint. Không fork dev stack.
+
+## Files/modules
+
+`deploy/compose.spike.yml`, `deploy/spike/`, base `deploy/dev/`,
+`bench/markhand_web/scripts/spike-{health,reset}.sh`.
+
+## Dependencies / blocks
+
+Phase F/F-08 + P0-01; target hardware để đóng issue.
+
+## Acceptance criteria
+
+Một command boot từ empty volumes; không thao tác console; restart/
+reset đúng semantics.
+
+## Required tests / evidence
+
+Clean-machine startup, service health, version/GPU/telemetry
+fingerprint.
+
+## Security and migration notes
+
+Bind private/localhost; non-production secrets ngoài Git.
+
+## Out of scope
+
+HA/TLS/production orchestration.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:05:54Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-05-danh-gia-embedding-tieng-viet.md
+++ b/plans/reports/plan-260804-1617-p0-05-danh-gia-embedding-tieng-viet.md
@@ -1,0 +1,86 @@
+<!-- generated-done-issue-plan: P0-05 -->
+# P0-05 — Đánh giá embedding tiếng Việt
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#62](https://github.com/anhnth24/project-example/issues/62)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Chốt provider/model/revision/dimension/normalization đủ để lập
+trình Phase 0→1B; giữ đường cắt sang on-prem vLLM.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Accepted). Selected: `AITeamVN/Vietnamese_Embedding` Recall@5 **0.9261**, nDCG
+> gap **0.0** vs BKAI comparator; `runtime_path=local-neural` on
+> `local-cpu-quality`. GLM cloud embedding path (ADR 0004) superseded — GLM
+> retained for Q&A only. GPU/vLLM capacity deferred (`G0-RET-VLLM-CUTOVER`,
+> không chặn Phase 1B).
+
+## Implementation plan
+
+So hai family local trên golden corpus: `AITeamVN/Vietnamese_Embedding`
+vs `bkai` bi-encoder; pin tokenizer/batch/truncation/dimensions/normalize; đo
+theo category. Target (sau): so `bge-m3` và multilingual-e5 trên Profile B
+GPU/vLLM. ~~Interim GLM cloud compare~~ superseded by local selection (journal
+2026-07-20).
+
+## Files/modules
+
+`bench/markhand_web/embedding/`, `scripts/run_embedding_eval.py`,
+`reports/embedding-evaluation.md`, `docs/adr/0005-vietnamese-embedding-model-quality.md`,
+`docs/adr/0004-interim-glm-cloud-embedding.md` (superseded).
+
+## Dependencies / blocks
+
+Corpus + spike; target GPU không bắt buộc để đóng POC/1B.
+
+## Acceptance criteria
+
+≥2 local model families; cấu hình chọn đạt gate
+quality và best-model-gap; config/signature immutable trong report;
+`runtime_path=local-neural`.
+≥2 model family local trên Profile B
+GPU; có VRAM/throughput/saturation.
+
+## Required tests / evidence
+
+Recall/MRR/nDCG trên `embedding/results/summary.json`;
+hybrid retrieval `retrieval/summary.json`; dev stack `embedding-cpu` @ `:8088`.
+
+## Security and migration notes
+
+Embedding on-prem; không gửi customer/restricted corpus
+lên cloud cho index. GLM chỉ Q&A top-K. Index signature phân biệt
+`local-neural` vs `vllm-local`; cắt sang vLLM = rebuild generation mới.
+
+## Out of scope
+
+Autoscaling; đổi desktop local-hash fallback mặc định.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-20T10:35:09Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-06-chunking-hybrid-tuning-va-index-signature.md
+++ b/plans/reports/plan-260804-1617-p0-06-chunking-hybrid-tuning-va-index-signature.md
@@ -1,0 +1,80 @@
+<!-- generated-done-issue-plan: P0-06 -->
+# P0-06 — Chunking, hybrid tuning và index signature
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#63](https://github.com/anhnth24/project-example/issues/63)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Chốt chunking/hybrid parameters và canonical signature.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> neural hybrid (AITeamVN CPU / `local-neural`) on `local-cpu-quality`; frozen RRF
+> `VECTOR_WEIGHT=0.55`; version-citation P/R scored as top-k `(doc,version,chunkId)`;
+> temporal/change/conflict gates via deterministic offline rules. Closes on P0-05
+> CPU quality evidence (ADR 0005 may remain Proposed until product model acceptance);
+> does not require Profile B / vLLM cutover.
+
+## Implementation plan
+
+So chunk sizes; FTS/vector/hybrid; tune RRF; định nghĩa length-delimited
+signature gồm model/revision/dim/normalize/chunk/text-normalization version;
+version-aware identity và query modes current/as-of/compare/history; chuẩn hoá typed
+claim key/value/unit/scope/effective interval và deterministic numeric/enum/date/
+MUST-vs-MUST-NOT conflict candidates.
+
+## Files/modules
+
+`bench/markhand_web/retrieval/`, `expected-chunks.tsv`,
+`reports/retrieval-evaluation.md`, ADR index signature.
+
+## Dependencies / blocks
+
+Desktop baseline + embedding result.
+
+## Acceptance criteria
+
+So sánh identical candidates; source span vẫn resolve; signature
+test vector ổn định; chunk ID có document-version; temporal/current accuracy và
+version-citation precision/recall đạt gate; conflict precision/recall, current-warning
+và resolved-history accuracy có cited evidence.
+
+## Required tests / evidence
+
+Recall/MRR/nDCG/citation/no-answer + variance; cross-run signature.
+
+## Security and migration notes
+
+Signature đổi tạo index generation mới, không trộn vector.
+
+## Out of scope
+
+Server adapters/ACL.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T18:55:39Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-07-pg-qdrant-target-scale-topology.md
+++ b/plans/reports/plan-260804-1617-p0-07-pg-qdrant-target-scale-topology.md
@@ -1,0 +1,78 @@
+<!-- generated-done-issue-plan: P0-07 -->
+# P0-07 — PG/Qdrant target-scale topology
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#64](https://github.com/anhnth24/project-example/issues/64)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Chọn Qdrant topology và PG partition strategy bằng mixed-load evidence.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Qdrant shared collection with mandatory `org_id` filter and PG no-partition
+> for the single-org POC. Profile B `G0-SLO-QUERY-P99` / 20M mixed-load
+> evidence still blocks production aggregate scale.
+
+## Implementation plan
+
+Generate realistic tenants; compare shared/cohort collection and
+PG no-partition/bounded hash offline with query+ingest+delete+snapshot
+markers. Re-run live on Profile B before production aggregate scale.
+
+## Files/modules
+
+`bench/markhand_web/scale/`, `reports/scale-topology.md`, ADR Qdrant/PG.
+
+## Dependencies / blocks
+
+POC decision unblocked; production aggregate scale remains
+blocked by hardware/storage scale thật. Không chấp nhận offline extrapolation as
+Profile B evidence.
+
+## Acceptance criteria
+
+1B POC recommendation recorded in ADR 0008/0009 and
+`bench/markhand_web/scale/summary.json`; `productionScaleBlocked=true` until
+Profile B validates filtered P95/P99/recall and restore behavior.
+
+## Required tests / evidence
+
+Offline harness self-test + full run. Deferred production
+evidence: latency, throughput, quantized recall, RAM/disk, compaction,
+noisy-neighbor, FTS on Profile B.
+
+## Security and migration notes
+
+Synthetic tenant; mọi query vẫn có tenant filter.
+
+## Out of scope
+
+Production RLS.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T19:11:09Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-08-sizing-converter-va-ingest-backpressure.md
+++ b/plans/reports/plan-260804-1617-p0-08-sizing-converter-va-ingest-backpressure.md
@@ -1,0 +1,76 @@
+<!-- generated-done-issue-plan: P0-08 -->
+# P0-08 — Sizing converter và ingest backpressure
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#65](https://github.com/anhnth24/project-example/issues/65)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Chốt worker count, limits, timeout, queue và recovery headroom.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> deliverables with `targetMatch=false`; Profile B `G0-CAP-INGEST-THROUGHPUT`
+> and production headroom remain blocked until measured on `on-prem-reference`.
+
+## Implementation plan
+
+Benchmark từng format native/scan/audio; single/concurrent; CPU/RAM/temp;
+PDFium serialization; converter-vs-GPU bottleneck.
+
+## Files/modules
+
+`bench/markhand_web/ingest/`, `scripts/run_ingest_capacity.sh`,
+`reports/ingest-capacity.md`.
+
+## Dependencies / blocks
+
+Golden files + native deps available for local-cpu smoke;
+production capacity remains blocked by Profile B hardware.
+
+## Acceptance criteria
+
+Mọi POC format có sizing/timeout and simulated queue-age evidence;
+≥30% production resource headroom is not claimed from local-cpu.
+
+## Required tests / evidence
+
+Harness self-test + full local-cpu run writes
+`bench/markhand_web/ingest/summary.json` and
+`bench/markhand_web/reports/ingest-capacity.md`; rerun on Profile B for
+gate pass evidence.
+
+## Security and migration notes
+
+Malformed input chỉ chạy dưới limits.
+
+## Out of scope
+
+Production job engine.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T19:23:11Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-09-upload-threat-model-sandbox-va-license-inventory.md
+++ b/plans/reports/plan-260804-1617-p0-09-upload-threat-model-sandbox-va-license-inventory.md
@@ -1,0 +1,78 @@
+<!-- generated-done-issue-plan: P0-09 -->
+# P0-09 — Upload threat model, sandbox và license inventory
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#66](https://github.com/anhnth24/project-example/issues/66)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Security policy thực thi được trước khi nhận upload.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> threat model, adversarial disposition, and runtime license inventory. This
+> does not claim Profile B malware scanner coverage.
+
+## Implementation plan
+
+Threat model spoof/bomb/parser/SSRF/exhaustion/traversal/injection/token/
+quota/tenant/compromised worker; chốt allowlist/limits/quarantine/sandbox; inventory
+source/version/checksum/license.
+
+## Files/modules
+
+`docs/markhand-web-{upload-threat-model,upload-policy}.md`,
+`docs/markhand-web-model-license-inventory.md`, adversarial disposition YAML.
+
+## Dependencies / blocks
+
+P0-02/P0-08 evidence available for local Phase 0
+closure; production scanner/runtime hardening remains a later gate.
+
+## Acceptance criteria
+
+Mỗi threat có prevention/detection/owner; sandbox non-root,
+read-only, no egress, resource/process/wall limits; unresolved model bị exclude.
+
+## Required tests / evidence
+
+`python3 bench/markhand_web/scripts/run_upload_security.py`
+writes `bench/markhand_web/security/summary.json` and
+`bench/markhand_web/reports/upload-security.md`; policy linter and in-process
+sandbox smoke deny egress/traversal/fork/timeout. Runtime license checker
+passes with PhoWhisper excluded/not bundled.
+
+## Security and migration notes
+
+GLM policy theo data classification.
+
+## Out of scope
+
+Production malware scanner.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T19:33:38Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p0-10-adr-slo-rpo-rto-va-phase-0-gate.md
+++ b/plans/reports/plan-260804-1617-p0-10-adr-slo-rpo-rto-va-phase-0-gate.md
@@ -1,0 +1,79 @@
+<!-- generated-done-issue-plan: P0-10 -->
+# P0-10 — ADR, SLO/RPO/RTO và Phase 0 gate
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#67](https://github.com/anhnth24/project-example/issues/67)
+Catalog: [`backlog/phase-0/issues/README.md`](../markhand-web/backlog/phase-0/issues/README.md)
+Phase plan: [`phase-0-discovery-and-gates.md`](../markhand-web/phase-0-discovery-and-gates.md)
+Status: Done
+
+## Objective
+
+Chuyển evidence thành quyết định và restore/query-load smoke proof.
+
+## Context
+
+- Phase: `0`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> (`phase0-decisions.json`); SLA/risk register + restore/query-load smoke recorded.
+> Not a production Phase 0 numeric exit: Profile B gates (query P95/P99, ingest
+> capacity, DR RPO/RTO, vLLM cutover) remain open (`productionPhase0ExitBlocked=true`).
+
+## Implementation plan
+
+ADR document/artifact, tenancy/RLS, partition, Qdrant, auth/session,
+index migration, backup order; chốt SLO; offline restore smoke; close decision
+registry with Profile B blockers listed.
+
+## Files/modules
+
+`docs/adr/`, `docs/markhand-web-{sla-targets,risk-register}.md`,
+`bench/markhand_web/reports/restore-drill.md`, `phase0/summary.json`.
+
+## Dependencies / blocks
+
+P0-01…P0-09 + approvers.
+
+## Acceptance criteria
+
+Mọi decision được duyệt; restore/query-load
+smoke honest (`targetMatch=false`); license + security smoke pass; risk register
+có disposition; `productionPhase0ExitBlocked=true` khi Profile B gates còn mở.
+clean restore đạt RPO/RTO
+và mixed-load/capacity gates trên `on-prem-reference` với `targetMatch=true`.
+
+## Required tests / evidence
+
+`check-phase0-decisions.py`; phase0 gate harness; offline
+restore/query-load smoke; Profile B component-loss restore remaining.
+
+## Security and migration notes
+
+PG authority; MinIO originals không reconstruct được;
+migration expand/cutover/contract.
+
+## Out of scope
+
+Production HA và user onboarding.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T19:45:13Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-01-freeze-desktop-rag-va-ipc-contracts.md
+++ b/plans/reports/plan-260804-1617-p1a-01-freeze-desktop-rag-va-ipc-contracts.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1A-01 -->
+# P1A-01 — Freeze desktop RAG và IPC contracts
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#68](https://github.com/anhnth24/project-example/issues/68)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Baseline parity trước khi move code.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Inventory tests; fixtures top-k/score/snippet/anchor/answer/fallback/stats/
+incremental; canonical JSON cho 4 hybrid commands; offline + mock-provider flows.
+
+## Files/modules
+
+`app/src-tauri/src/{knowledge,vector_index}.rs`,
+`app/src/lib/{types,ipc}.ts`, backend/frontend contract fixtures.
+
+## Dependencies / blocks
+
+Không.
+
+## Acceptance criteria
+
+CamelCase/answer modes/warnings/tolerance được khóa; undesirable
+current behavior cũng được ghi rõ.
+
+## Required tests / evidence
+
+Desktop/core/frontend tests; fixture generation deterministic.
+
+## Security and migration notes
+
+Synthetic content/path, không credential.
+
+## Out of scope
+
+Sửa ranking/concurrency.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #184](https://github.com/anhnth24/project-example/pull/184) — test: freeze desktop RAG IPC contracts; merged `2026-07-17T16:36:18Z`
+
+### Completion/evidence commits
+
+- `3a2179912c4f362b88bc5e286db1615b38c03ed2`
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:06Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-02-populate-knowledge-skeleton-va-enforce-dependency-bo.md
+++ b/plans/reports/plan-260804-1617-p1a-02-populate-knowledge-skeleton-va-enforce-dependency-bo.md
@@ -1,0 +1,72 @@
+<!-- generated-done-issue-plan: P1A-02 -->
+# P1A-02 — Populate knowledge skeleton và enforce dependency boundaries
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#69](https://github.com/anhnth24/project-example/issues/69)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Hoàn thiện skeleton `crates/knowledge` do F-02 tạo thành reusable
+crate có typed errors và optional desktop features.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Populate modules types/embedding/query/rank/citation/ask; features
+`desktop-sqlite`, `desktop-hnsw`; mở rộng CI deny-list theo boundary F-01. Không
+tạo lại workspace member hoặc convention.
+
+## Files/modules
+
+`Cargo.toml`, `crates/knowledge/**`, `.github/workflows/ci.yml`.
+
+## Dependencies / blocks
+
+Baseline committed.
+
+## Acceptance criteria
+
+Build no-feature/all-feature; default tree không SQLite/HNSW; không
+Tauri/axum/desktop; API không có DATA-root.
+
+## Required tests / evidence
+
+`cargo check/test/tree` feature matrix.
+
+## Security and migration notes
+
+Minimal dependency review.
+
+## Out of scope
+
+PG/Qdrant/server.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #186](https://github.com/anhnth24/project-example/pull/186) — feat: populate reusable knowledge crate skeleton; merged `2026-07-17T16:44:42Z`
+
+### Completion/evidence commits
+
+- `cf80285d97f6915d32c6c202cffbabc3c8cba3bb`
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:08Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-03-shared-dto-va-serde-contract.md
+++ b/plans/reports/plan-260804-1617-p1a-03-shared-dto-va-serde-contract.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1A-03 -->
+# P1A-03 — Shared DTO và serde contract
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#70](https://github.com/anhnth24/project-example/issues/70)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Di chuyển index/search/ask types mà không đổi JSON.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Index request/result/stats, hit/anchor/grounded answer/metadata; serde
+fixtures; temporary desktop re-export.
+
+## Files/modules
+
+`crates/knowledge/src/types.rs`, serde fixtures/tests,
+`app/src/lib/types.ts`.
+
+## Dependencies / blocks
+
+Scaffold + frozen JSON.
+
+## Acceptance criteria
+
+Canonical JSON equivalent; no desktop path/state type; TypeScript
+không cần behavior change.
+
+## Required tests / evidence
+
+Rust round-trip + TS fixture tests.
+
+## Security and migration notes
+
+Errors không expose provider secrets.
+
+## Out of scope
+
+OpenAPI generation.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #188](https://github.com/anhnth24/project-example/pull/188) — feat: move knowledge DTO contracts to shared crate; merged `2026-07-17T16:50:41Z`
+
+### Completion/evidence commits
+
+- `fdb3b9a542ae3a34254c5dc904172f91ea1ccdbd`
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:11Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-04-durable-identities-va-index-signatures.md
+++ b/plans/reports/plan-260804-1617-p1a-04-durable-identities-va-index-signatures.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1A-04 -->
+# P1A-04 — Durable identities và index signatures
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#71](https://github.com/anhnth24/project-example/issues/71)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Deterministic server identities, desktop compatibility.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Versioned length-delimited encoding; BLAKE3/SHA-256 document/chunk/index;
+signature model/revision/dim/normalize/chunk/text version; fixed vectors; legacy
+`DefaultHasher` compatibility.
+
+## Files/modules
+
+`crates/knowledge/src/{identity,embedding}.rs`, identity fixtures.
+
+## Dependencies / blocks
+
+Shared metadata; production values tới từ Phase 0.
+
+## Acceptance criteria
+
+Cross-platform stable; no concatenation ambiguity; server không
+dùng DefaultHasher; legacy index mở hoặc explicit rebuild.
+
+## Required tests / evidence
+
+Unicode/boundary/order/version/cross-process + legacy fixture.
+
+## Security and migration notes
+
+Hash là identity, không phải access control; không mix version.
+
+## Out of scope
+
+Chọn model.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #189](https://github.com/anhnth24/project-example/pull/189) — feat: add durable knowledge identities and signatures; merged `2026-07-17T16:57:53Z`
+
+### Completion/evidence commits
+
+- `84ff303802fd9e0cffce31d0383fd0e3d274a2b1`
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:13Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-05-query-local-vectors-va-embedding-plan.md
+++ b/plans/reports/plan-260804-1617-p1a-05-query-local-vectors-va-embedding-plan.md
@@ -1,0 +1,70 @@
+<!-- generated-done-issue-plan: P1A-05 -->
+# P1A-05 — Query, local vectors và embedding plan
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#72](https://github.com/anhnth24/project-example/issues/72)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Tách pure query/embedding preparation.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Normalization, feature hash/vector norm, provider plan, dimension check,
+FTS escape; HTTP client vẫn ở core; giữ local fallback semantics.
+
+## Files/modules
+
+`crates/knowledge/src/{query,embedding}.rs`, tests; source desktop module.
+
+## Dependencies / blocks
+
+Shared types.
+
+## Acceptance criteria
+
+Output parity; query rỗng/punctuation safe; mismatch/fallback không
+đổi; không Tauri/settings/filesystem.
+
+## Required tests / evidence
+
+Vietnamese/punctuation/determinism/provider mock/dim mismatch.
+
+## Security and migration notes
+
+Credential-bearing URL không vào signature/error.
+
+## Out of scope
+
+Async client/new tokenizer.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:15Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-06-rank-citation-va-grounded-answer.md
+++ b/plans/reports/plan-260804-1617-p1a-06-rank-citation-va-grounded-answer.md
@@ -1,0 +1,70 @@
+<!-- generated-done-issue-plan: P1A-06 -->
+# P1A-06 — Rank, citation và grounded answer
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#73](https://github.com/anhnth24/project-example/issues/73)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Reusable hybrid merge, anchors và grounding.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Cosine/RRF/rerank/sort; snippet/page-slide-sheet anchor; extractive answer;
+citation validator; separate LLM calls.
+
+## Files/modules
+
+`crates/knowledge/src/{rank,citation,ask}.rs`, golden tests.
+
+## Dependencies / blocks
+
+DTO/query.
+
+## Acceptance criteria
+
+Top-k/citation/answer parity trong tolerance; invented citation
+fallback; server caller không kéo desktop features.
+
+## Required tests / evidence
+
+Tie/NaN/overlap/anchor/snippet/grounding/golden.
+
+## Security and migration notes
+
+Untrusted passages không thành instruction.
+
+## Out of scope
+
+Learned reranker/streaming.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:18Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-07-sqlite-desktop-storage-feature.md
+++ b/plans/reports/plan-260804-1617-p1a-07-sqlite-desktop-storage-feature.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1A-07 -->
+# P1A-07 — SQLite desktop storage feature
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#74](https://github.com/anhnth24/project-example/issues/74)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Move SQLite persistence, bỏ reverse dependency vào Tauri.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Schema/metadata/vector/incremental/FTS/hydration; API nhận DB path +
+caller-supplied corpus; Tauri giữ path jail/load.
+
+## Files/modules
+
+`crates/knowledge/src/desktop/sqlite.rs`, legacy DB fixture,
+`app/src-tauri/src/{knowledge,intelligence}.rs`.
+
+## Dependencies / blocks
+
+Shared APIs stable.
+
+## Acceptance criteria
+
+Legacy DB parity; incremental/scope/signature/fallback giữ nguyên;
+không gọi data_root/load_documents/resolve_within; optional rusqlite.
+
+## Required tests / evidence
+
+Empty/legacy/changed/scope/corrupt-dim/persistence.
+
+## Security and migration notes
+
+Caller chịu path jail; schema additive hoặc explicit rebuild.
+
+## Out of scope
+
+PostgreSQL/perf redesign.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:20Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-08-persistent-hnsw-desktop-feature.md
+++ b/plans/reports/plan-260804-1617-p1a-08-persistent-hnsw-desktop-feature.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1A-08 -->
+# P1A-08 — Persistent HNSW desktop feature
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#75](https://github.com/anhnth24/project-example/issues/75)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Move optional ANN cache, SQLite vẫn authority.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Manifest/partition/rebuild/search/clear; legacy signature compatibility;
+corrupt/mismatch fallback exact cosine.
+
+## Files/modules
+
+`crates/knowledge/src/desktop/hnsw.rs`, legacy HNSW fixture,
+source `vector_index.rs`.
+
+## Dependencies / blocks
+
+Feature scaffold + vectors/identity.
+
+## Acceptance criteria
+
+Round-trip parity; corruption không mất data; location/threshold
+không đổi; `hnsw_rs` optional.
+
+## Required tests / evidence
+
+Corrupt/count/signature/atomic replacement/feature matrix.
+
+## Security and migration notes
+
+Validate manifest bounds/path.
+
+## Out of scope
+
+HNSW tuning/Qdrant.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:22Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-09-thin-tauri-adapters.md
+++ b/plans/reports/plan-260804-1617-p1a-09-thin-tauri-adapters.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1A-09 -->
+# P1A-09 — Thin Tauri adapters
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#76](https://github.com/anhnth24/project-example/issues/76)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Desktop commands delegate shared crate, IPC giữ nguyên.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Tauri giữ state/settings/path load/spawn_blocking/error mapping; delegate
+rebuild/stats/search/ask; retain legacy commands; remove duplicate only sau parity.
+
+## Files/modules
+
+`app/src-tauri/src/{knowledge,vector_index,intelligence,lib}.rs`,
+Cargo manifests.
+
+## Dependencies / blocks
+
+Pure logic + stores.
+
+## Acceptance criteria
+
+Command/payload/result unchanged; source adapter mỏng; legacy index
+behavior documented; no duplicate algorithm.
+
+## Required tests / evidence
+
+Backend/frontend contract + manual rebuild/search/offline/LLM fallback.
+
+## Security and migration notes
+
+Path jail và secret-safe errors giữ ở desktop.
+
+## Out of scope
+
+UI/IPC rename/async redesign.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:24Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1a-10-ci-parity-va-extraction-gate.md
+++ b/plans/reports/plan-260804-1617-p1a-10-ci-parity-va-extraction-gate.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1A-10 -->
+# P1A-10 — CI parity và extraction gate
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#77](https://github.com/anhnth24/project-example/issues/77)
+Catalog: [`backlog/phase-1a/issues/README.md`](../markhand-web/backlog/phase-1a/issues/README.md)
+Phase plan: [`phase-1a-knowledge-extraction.md`](../markhand-web/phase-1a-knowledge-extraction.md)
+Status: Done
+
+## Objective
+
+Chứng minh desktop equivalence và server usability.
+
+## Context
+
+- Phase: `1A`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Full feature/contract/golden matrix; no-feature server consumer test;
+dependency deny-list; docs compatibility; file perf/concurrency defects riêng.
+
+## Files/modules
+
+CI, `crates/knowledge/tests/`, desktop integration tests,
+architecture/compatibility docs.
+
+## Dependencies / blocks
+
+Adapter cutover.
+
+## Acceptance criteria
+
+Tất cả test xanh; golden trong tolerance; IPC unchanged; legacy
+index path tested; server consumer không desktop deps.
+
+## Required tests / evidence
+
+`cargo test` core/knowledge/desktop, `cargo tree`, `pnpm test/build`.
+
+## Security and migration notes
+
+Synthetic fixtures; explicit index rebuild notice.
+
+## Out of scope
+
+Server/storage/auth.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-18T17:06:27Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-f01-extend-server-skeleton-voi-runtime-poc.md
+++ b/plans/reports/plan-260804-1617-p1b-f01-extend-server-skeleton-voi-runtime-poc.md
@@ -1,0 +1,73 @@
+<!-- generated-done-issue-plan: P1B-F01 -->
+# P1B-F01 — Extend server skeleton với runtime POC
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#78](https://github.com/anhnth24/project-example/issues/78)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Extend server skeleton với runtime POC**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Mở rộng `crates/server` API/worker skeleton từ F-02/F-07 với runtime
+dependencies, application state, graceful shutdown và các config fields đã được
+Phase 0 phê duyệt. Không tạo lại workspace/config conventions.
+
+## Files/modules
+
+`crates/server/{Cargo.toml,src/{lib,main,config,error,state}.rs}`,
+`src/bin/worker.rs`.
+
+## Dependencies / blocks
+
+G0-ARCH.
+
+## Acceptance criteria
+
+API/worker compile độc lập; invalid URL/secret/limit/issuer/
+signature không start; config/env/shutdown/table tests; secrets không `Debug`.
+
+## Required tests / evidence
+
+API/worker compile độc lập; invalid URL/secret/limit/issuer/
+signature không start; config/env/shutdown/table tests; secrets không `Debug`.
+
+## Security and migration notes
+
+Unsafe defaults chỉ dev mode.
+
+## Out of scope
+
+business routes/HA.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:08Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-f02-poc-deployment-va-isolation-scaffold.md
+++ b/plans/reports/plan-260804-1617-p1b-f02-poc-deployment-va-isolation-scaffold.md
@@ -1,0 +1,84 @@
+<!-- generated-done-issue-plan: P1B-F02 -->
+# P1B-F02 — POC deployment và isolation scaffold
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#79](https://github.com/anhnth24/project-example/issues/79)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **POC deployment và isolation scaffold**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Ubuntu 22.04 host from a clean tree at `f4f33cd`:
+> `poc-f02-boot.json` `passed=true`, 81 checks / 0 fails, project
+> `markhand-poc-f02-20260726t121843z-1815269-17292`, clean project boot measured,
+> nonzero mem/cpu/pids on every service, convert network `Internal=true` with an
+> executable egress probe, narrow MinIO credential positive/negative probes, and
+> the full native format smoke matrix. Report sha256 prefix `9d7214df30e57a95`.
+> The run wrote its evidence outside the tree so the gate could bind to a clean
+> worktree; the accepted run was then copied in, with only the recorded raw
+> directory paths rewritten to repository-relative form.
+
+## Implementation plan
+
+Pinned API/converter/index images, compose services, health/init, non-root,
+read-only, tmpfs, dropped caps, converter no-egress, resource/secret limits.
+
+## Files/modules
+
+`deploy/{Dockerfile.server,Dockerfile.worker,compose.poc.yml,.env.example}`,
+`deploy/scripts/poc-*.sh`, `deploy/scripts/poc_f02_boot_evidence.py`, `deploy/poc/*`,
+`deploy/README.md`.
+
+## Dependencies / blocks
+
+F01 + G0-CAP/G0-SEC/G0-LIC.
+
+## Acceptance criteria
+
+Clean host boot tự động; API/worker image tách; isolation/
+UID/cap/egress/native format smoke tests; `poc-boot-evidence.sh --self-test`.
+
+## Required tests / evidence
+
+Clean host boot tự động; API/worker image tách; isolation/
+UID/cap/egress/native format smoke tests; `poc-boot-evidence.sh --self-test`.
+
+## Security and migration notes
+
+Narrow MinIO credentials, no bundled unlicensed model.
+
+## Out of scope
+
+Kubernetes/HA.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `1815269`
+- `20260726`
+- `9d7214df30e57a95`
+- `f4f33cd`
+
+- GitHub sync-closed timestamp: `2026-07-26T14:39:44Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-f03-multi-org-ready-schema-va-immutable-migrations.md
+++ b/plans/reports/plan-260804-1617-p1b-f03-multi-org-ready-schema-va-immutable-migrations.md
@@ -1,0 +1,75 @@
+<!-- generated-done-issue-plan: P1B-F03 -->
+# P1B-F03 — Multi-org-ready schema và immutable migrations
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#80](https://github.com/anhnth24/project-example/issues/80)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Multi-org-ready schema và immutable migrations**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Migrations org/auth/RBAC/groups/collections, immutable versions/artifacts,
+atomic current-published pointer, parent/version/effective lineage, chunks/FTS,
+normalized claims, conflict/evidence lifecycle, jobs/outbox, quota/audit/index;
+seed POC riêng.
+
+## Files/modules
+
+`crates/server/migrations/000*.sql`, `src/db/models.rs`.
+
+## Dependencies / blocks
+
+F01 + G0-ARCH.
+
+## Acceptance criteria
+
+Mọi business row có org; immutable versions; exactly one
+current effective published version/logical document; concurrent publish/as-of/
+lineage checks; fresh + supported-upgrade migration/schema introspection.
+
+## Required tests / evidence
+
+Mọi business row có org; immutable versions; exactly one
+current effective published version/logical document; concurrent publish/as-of/
+lineage checks; fresh + supported-upgrade migration/schema introspection.
+
+## Security and migration notes
+
+Files immutable sau merge; RLS theo ADR.
+
+## Out of scope
+
+custom role UI.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:13Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-f04-orgcontext-repositories-va-state-machine.md
+++ b/plans/reports/plan-260804-1617-p1b-f04-orgcontext-repositories-va-state-machine.md
@@ -1,0 +1,72 @@
+<!-- generated-done-issue-plan: P1B-F04 -->
+# P1B-F04 — OrgContext, repositories và state machine
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#81](https://github.com/anhnth24/project-example/issues/81)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **OrgContext, repositories và state machine**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Tenant-scoped repos, transaction helpers, legal document transitions;
+transaction-local RLS context nếu chọn.
+
+## Files/modules
+
+`src/auth/context.rs`, `src/db/{orgs,collections,documents,chunks}.rs`,
+`src/services/document_state.rs`.
+
+## Dependencies / blocks
+
+F03 + G0-ARCH.
+
+## Acceptance criteria
+
+Không public business method thiếu context; cross-org deny;
+invalid/concurrent transition atomic; pool leakage test.
+
+## Required tests / evidence
+
+Không public business method thiếu context; cross-org deny;
+invalid/concurrent transition atomic; pool leakage test.
+
+## Security and migration notes
+
+Empty scope fail closed.
+
+## Out of scope
+
+Full ACL semantics 1C.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:15Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-f05-password-auth-rotating-sessions-va-browser-refresh-t.md
+++ b/plans/reports/plan-260804-1617-p1b-f05-password-auth-rotating-sessions-va-browser-refresh-t.md
@@ -1,0 +1,78 @@
+<!-- generated-done-issue-plan: P1B-F05 -->
+# P1B-F05 — Password auth, rotating sessions và browser refresh transport
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#82](https://github.com/anhnth24/project-example/issues/82)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Password auth, rotating sessions và browser refresh transport**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Argon2; pinned JWT issuer/audience/alg/KID; short access; hashed rotating
+refresh family; provider interface; POC guards/audit; chốt transport theo auth ADR.
+Nếu dùng browser cookie: issue/rotate/clear `HttpOnly Secure SameSite`, CSRF token
+binding + Origin validation và OpenAPI cookie contract.
+
+## Files/modules
+
+`src/auth/{password,jwt,session,provider,permissions,middleware}.rs`,
+`routes/auth.rs`.
+
+## Dependencies / blocks
+
+F03/F04 + auth ADR.
+
+## Acceptance criteria
+
+Login/refresh/logout/me; reuse revokes family; disabled user
+blocked; alg/issuer/audience/expiry/race/permission/audit tests; cookie attributes,
+CSRF missing/mismatch, cross-origin refresh/logout và cookie clearing tests nếu ADR
+chọn cookie.
+
+## Required tests / evidence
+
+Login/refresh/logout/me; reuse revokes family; disabled user
+blocked; alg/issuer/audience/expiry/race/permission/audit tests; cookie attributes,
+CSRF missing/mismatch, cross-origin refresh/logout và cookie clearing tests nếu ADR
+chọn cookie.
+
+## Security and migration notes
+
+No token/password logs.
+
+## Out of scope
+
+OIDC/MFA/recovery.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:18Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-f06-fail-closed-pg-qdrant-minio-adapters.md
+++ b/plans/reports/plan-260804-1617-p1b-f06-fail-closed-pg-qdrant-minio-adapters.md
@@ -1,0 +1,72 @@
+<!-- generated-done-issue-plan: P1B-F06 -->
+# P1B-F06 — Fail-closed PG/Qdrant/MinIO adapters
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#83](https://github.com/anhnth24/project-example/issues/83)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Fail-closed PG/Qdrant/MinIO adapters**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Pools, opaque key builder, quarantine/trusted namespace, deterministic
+points, versioned collection, mandatory org/collection filters, typed errors.
+
+## Files/modules
+
+`src/storage/{keys,minio,qdrant}.rs`, `src/db/pool.rs`,
+`services/index_signature.rs`.
+
+## Dependencies / blocks
+
+F02/F04 + G0-ARCH/G0-RET/G1A.
+
+## Acceptance criteria
+
+Missing/empty filter rejected; no filename in key; payload has
+all identities; real-service contracts, traversal/fuzz, deterministic vectors.
+
+## Required tests / evidence
+
+Missing/empty filter rejected; no filename in key; payload has
+all identities; real-service contracts, traversal/fuzz, deterministic vectors.
+
+## Security and migration notes
+
+No public key, least privilege.
+
+## Out of scope
+
+generic backend trait.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:21Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-i01-streaming-quarantine-upload-validation.md
+++ b/plans/reports/plan-260804-1617-p1b-i01-streaming-quarantine-upload-validation.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1B-I01 -->
+# P1B-I01 — Streaming quarantine upload validation
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#84](https://github.com/anhnth24/project-example/issues/84)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Streaming quarantine upload validation**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Multipart stream+hash; magic/extension canonical format; OOXML limits;
+PDF/audio limits; retention disposition.
+
+## Files/modules
+
+`routes/uploads.rs`, `services/upload/{stream,sniff,archive,limits}.rs`.
+
+## Dependencies / blocks
+
+F04/F06 + G0-SEC/G0-CAP.
+
+## Acceptance criteria
+
+Spoof/bomb/oversize/malformed/traversal/interruption rejected
+hoặc safely quarantined; bounded memory; adversarial/property tests.
+
+## Required tests / evidence
+
+Spoof/bomb/oversize/malformed/traversal/interruption rejected
+hoặc safely quarantined; bounded memory; adversarial/property tests.
+
+## Security and migration notes
+
+Filename metadata only.
+
+## Out of scope
+
+resumable upload/malware service.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:24Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-i02-atomic-quota-admission.md
+++ b/plans/reports/plan-260804-1617-p1b-i02-atomic-quota-admission.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1B-I02 -->
+# P1B-I02 — Atomic quota admission
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#85](https://github.com/anhnth24/project-example/issues/85)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Atomic quota admission**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Transactional reserve/finalize/refund, expiry, concurrent-job admission,
+quota headers/errors.
+
+## Files/modules
+
+`src/db/quota.rs`, `services/quota.rs`, quota middleware.
+
+## Dependencies / blocks
+
+F03/F04/I01 + G0-CAP.
+
+## Acceptance criteria
+
+Concurrent requests không over-reserve; every terminal path
+settles; expiry/retry/crash/overflow tests.
+
+## Required tests / evidence
+
+Concurrent requests không over-reserve; every terminal path
+settles; expiry/retry/crash/overflow tests.
+
+## Security and migration notes
+
+Checked arithmetic, client không sửa counter.
+
+## Out of scope
+
+billing.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:27Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-i03-durable-jobs-outbox-va-event-log.md
+++ b/plans/reports/plan-260804-1617-p1b-i03-durable-jobs-outbox-va-event-log.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1B-I03 -->
+# P1B-I03 — Durable jobs, outbox và event log
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#86](https://github.com/anhnth24/project-example/issues/86)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Durable jobs, outbox và event log**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Versioned payload, transactional outbox, leased SKIP LOCKED claims,
+heartbeat/retry/checkpoint/cancel/dead-letter/idempotency/sequenced events.
+
+## Files/modules
+
+`src/jobs/**`, `src/db/jobs.rs`.
+
+## Dependencies / blocks
+
+F03/F04 + G0-CAP.
+
+## Acceptance criteria
+
+Commit/enqueue không split; lease reclaimed; duplicate harmless;
+kill/checkpoint/claim/dead-letter/cancel/outbox replay.
+
+## Required tests / evidence
+
+Commit/enqueue không split; lease reclaimed; duplicate harmless;
+kill/checkpoint/claim/dead-letter/cancel/outbox replay.
+
+## Security and migration notes
+
+IDs only, no content/secrets; backward-readable payloads.
+
+## Out of scope
+
+Kafka/Redis queue.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:29Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-i04-isolated-converter-worker.md
+++ b/plans/reports/plan-260804-1617-p1b-i04-isolated-converter-worker.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P1B-I04 -->
+# P1B-I04 — Isolated converter worker
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#87](https://github.com/anhnth24/project-example/issues/87)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Isolated converter worker**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Download quarantine; materialize server-derived canonical extension;
+process/cgroup limits and kill descendants; ephemeral cleanup/heartbeat/cancel.
+
+## Files/modules
+
+`src/workers/{convert,sandbox,limits}.rs`, worker image/config.
+
+## Dependencies / blocks
+
+F02/I03 + G0-SEC/G0-CAP/G0-LIC.
+
+## Acceptance criteria
+
+No network/host FS; timeout kills tree; cleanup all outcomes;
+fork/disk/RAM/malformed/cancel/all-format smoke.
+
+## Required tests / evidence
+
+No network/host FS; timeout kills tree; cleanup all outcomes;
+fork/disk/RAM/malformed/cancel/all-format smoke.
+
+## Security and migration notes
+
+Unapproved model excluded, narrow credentials.
+
+## Out of scope
+
+VM sandbox.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:32Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-i05-idempotent-conversion-promotion-saga.md
+++ b/plans/reports/plan-260804-1617-p1b-i05-idempotent-conversion-promotion-saga.md
@@ -1,0 +1,73 @@
+<!-- generated-done-issue-plan: P1B-I05 -->
+# P1B-I05 — Idempotent conversion promotion saga
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#88](https://github.com/anhnth24/project-example/issues/88)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Idempotent conversion promotion saga**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Checkpoint download/convert/stage/promote/DB/cleanup; immutable version;
+publish/current pointer riêng với draft/latest upload; index outbox;
+compensation/refund.
+
+## Files/modules
+
+`workers/convert.rs`, `services/{conversion,promotion,artifacts}.rs`,
+`db/document_versions.rs`.
+
+## Dependencies / blocks
+
+I01–I04/F06/G1A.
+
+## Acceptance criteria
+
+Retry tạo một visible version/job; trusted chỉ sau success;
+fault injection mọi cross-store step; immutable checks.
+
+## Required tests / evidence
+
+Retry tạo một visible version/job; trusted chỉ sau success;
+fault injection mọi cross-store step; immutable checks.
+
+## Security and migration notes
+
+Never overwrite original; ACL inherited.
+
+## Out of scope
+
+user merge.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #244](https://github.com/anhnth24/project-example/pull/244) — feat(server): P1B-I05 idempotent conversion promotion saga; merged `2026-07-20T04:29:10Z`
+
+### Completion/evidence commits
+
+- `35ac9c4018ac91733a12b59d9d43886ed4464e7c`
+
+- GitHub sync-closed timestamp: `2026-07-19T15:17:35Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-i06-chunk-embedding-index-worker.md
+++ b/plans/reports/plan-260804-1617-p1b-i06-chunk-embedding-index-worker.md
@@ -1,0 +1,84 @@
+<!-- generated-done-issue-plan: P1B-I06 -->
+# P1B-I06 — Chunk/embedding/index worker
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#89](https://github.com/anhnth24/project-example/issues/89)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Chunk/embedding/index worker**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> `lifecycle_refresh` (one idempotent job per materialized generation; no
+> active-generation fallback); Index↔LifecycleRefresh claim fairness
+> (ConvertWorker atomic pattern); mixed-scope filter-only Qdrant update (has_id
+> + org/collection/version, no body `points`). LiveEnv dual-role
+> (`markhand_app`). Local:
+> `cargo test -p fileconv-server --test index_worker -- --include-ignored`
+> → 10 ok (natural A→B, multi-gen demote + idempotent replay, fairness ≤2
+> `run_once`, mixed-scope, race, retry).
+
+## Implementation plan
+
+Core chunking + knowledge identity/signature chứa `version_id`; PG
+chunks/FTS; separate embedding batches; Qdrant payload version/effective/current;
+extract typed claim key/value/unit/scope; incremental conflict candidate outbox;
+blocking client off async executor; deterministic upsert.
+
+## Files/modules
+
+`workers/{index,embedding}.rs`, `services/{chunking,embedding,indexing}.rs`.
+
+## Dependencies / blocks
+
+I03/I05/F06 + G0-RET/G0-CAP/G1A.
+
+## Acceptance criteria
+
+Approved signature; ≤1 replay batch; no duplicate; mismatch
+before publish; golden/mock/backpressure/kill/consistency tests;
+`live_index_worker_replay_is_idempotent`;
+`live_index_worker_stale_version_does_not_mark_current_indexed`.
+
+## Required tests / evidence
+
+Approved signature; ≤1 replay batch; no duplicate; mismatch
+before publish; golden/mock/backpressure/kill/consistency tests;
+`live_index_worker_replay_is_idempotent`;
+`live_index_worker_stale_version_does_not_mark_current_indexed`.
+
+## Security and migration notes
+
+Local approved embedding only; new signature=new generation.
+
+## Out of scope
+
+user-selected models.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- UNKNOWN — no completion/evidence commit is cited in the catalog status.
+
+- GitHub sync-closed timestamp: `2026-07-20T08:14:12Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-i07-tombstone-delete-va-reconcile.md
+++ b/plans/reports/plan-260804-1617-p1b-i07-tombstone-delete-va-reconcile.md
@@ -1,0 +1,76 @@
+<!-- generated-done-issue-plan: P1B-I07 -->
+# P1B-I07 — Tombstone delete và reconcile
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#90](https://github.com/anhnth24/project-example/issues/90)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Tombstone delete và reconcile**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> length so `live_reconcile_repairs_orphan_vectors` /
+> `live_reconcile_dead_letter_staging_gc` pass under rust-integration. ADR 0015
+> (purge retention semantics) remains Proposed — wording follow-up only, not a
+> blocker for the delete/reconcile acceptance matrix already covered by live tests.
+
+## Implementation plan
+
+PG tombstone first; idempotent vector/object cleanup; dry-run/repair
+missing/orphan/stale across three stores.
+
+## Files/modules
+
+`workers/{delete,reconcile}.rs`, `services/{deletion,reconciliation}.rs`.
+
+## Dependencies / blocks
+
+I03/I06/F06 + recovery ADR.
+
+## Acceptance criteria
+
+Immediate read suppression; drift safely repaired; repeated
+repair, race, kill/resume matrix.
+
+## Required tests / evidence
+
+Immediate read suppression; drift safely repaired; repeated
+repair, race, kill/resume matrix.
+
+## Security and migration notes
+
+Scoped destructive audit.
+
+## Out of scope
+
+legal hold/full ACL revoke.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #245](https://github.com/anhnth24/project-example/pull/245) — feat(server): P1B-I07 tombstone delete and reconcile; merged `2026-07-20T13:20:36Z`
+- [PR #282](https://github.com/anhnth24/project-example/pull/282) — fix(server): reconcile audit request_id vượt giới hạn 64 ký tự (rust-integration đỏ); merged `2026-07-23T00:52:36Z`
+
+### Completion/evidence commits
+
+- `633c96de246754ee7624e9cb92a376585d5cd8d4`
+- `e0fe30b2a1b27f0de6c6fb076718003198566964`
+
+- GitHub sync-closed timestamp: `2026-07-21T03:40:37Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-o01-end-to-end-telemetry-va-safe-audit.md
+++ b/plans/reports/plan-260804-1617-p1b-o01-end-to-end-telemetry-va-safe-audit.md
@@ -1,0 +1,81 @@
+<!-- generated-done-issue-plan: P1B-O01 -->
+# P1B-O01 — End-to-end telemetry và safe audit
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#97](https://github.com/anhnth24/project-example/issues/97)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **End-to-end telemetry và safe audit**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> `status=pass` with 0 blockers. The async API→worker→provider canary closed all
+> 16 proofs (job terminal + payload `request_id`, DB audit row per request,
+> exact deny audit, same-trace ingest and ask exports with the required
+> `api.request`/`worker.convert`/`worker.index`/`worker.embed`/`retrieval`/
+> `provider.chat` spans, unique span ids, canonical OTLP kinds, valid parent
+> graph, grounded ask, clean metrics with no canary or high-cardinality label).
+> Cargo telemetry suite, OTLP capture unit tests, live app-role audit test and
+> the negative proof fixtures all passed. Report sha256 prefix
+> `e8efc7b6975fdb4b`.
+
+## Implementation plan
+
+Traces API→jobs→convert/embed/retrieval/GLM; latency/queue/conversion/
+embedding/retrieval/drift/quota/backup metrics; append-only audit.
+
+## Files/modules
+
+`src/telemetry/**`, `services/audit.rs`, `db/audit.rs`,
+`deploy/dev/otel-collector.yaml`.
+
+## Dependencies / blocks
+
+F01/F05/I03 + G0-SLO.
+
+## Acceptance criteria
+
+Correlation qua async; action/deny coverage; canary secret/
+content absent; trace/cardinality/redaction/audit tests.
+
+## Required tests / evidence
+
+Correlation qua async; action/deny coverage; canary secret/
+content absent; trace/cardinality/redaction/audit tests.
+
+## Security and migration notes
+
+Allowlist log fields.
+
+## Out of scope
+
+SIEM.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `e8efc7b6975fdb4b`
+- `f4f33cd`
+
+- GitHub sync-closed timestamp: `2026-07-26T14:40:12Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-o02-dashboards-alerts-va-runbooks.md
+++ b/plans/reports/plan-260804-1617-p1b-o02-dashboards-alerts-va-runbooks.md
@@ -1,0 +1,87 @@
+<!-- generated-done-issue-plan: P1B-O02 -->
+# P1B-O02 — Dashboards, alerts và runbooks
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#98](https://github.com/anhnth24/project-example/issues/98)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Dashboards, alerts và runbooks**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> `status=pass`, 31 passes / 0 fails, no blockers. Real fault executed against
+> the POC stack: `MarkhandDependencyDown` fired at 150s while Postgres was
+> stopped and went absent 24s after restore, both snapshots taken from the live
+> Prometheus `/api/v1/alerts` (no synthetic promtool mirror). Also covered:
+> promtool rule + unit tests, dashboard/datasource parameterization, runbook
+> DCRV, PG restore arm-before-stop failpoint matrix, live reconcile worker
+> dry-run→repair→idempotent plus the `worker-reconcile-oneshot` compose job, and
+> a clean provenance + broad secret scan. Report sha256 prefix
+> `56f0475a26fd174d`.
+
+## Implementation plan
+
+SLO/queue/disk/dependency alerts; runbooks jobs/parser/outage/rebuild/disk/
+GLM/key rotation.
+
+## Files/modules
+
+`deploy/observability/**`, `docs/runbooks/phase-1b/**`,
+`deploy/scripts/o02-alert-tabletop.sh`, `deploy/scripts/o02-pg-restore-guard.sh`,
+`deploy/scripts/redact_secrets.py`, `deploy/scripts/test_redact_secrets.py`,
+`deploy/compose.poc.yml` (`worker-reconcile-oneshot` profile / job),
+`crates/server/src/{bin/worker.rs,workers/reconcile.rs,jobs/**,db/jobs.rs}`,
+`crates/server/tests/deletion_reconcile.rs` (live reconcile worker drills).
+
+## Dependencies / blocks
+
+F02/F06/I03/O01 + G0-SLO.
+
+## Acceptance criteria
+
+Trigger từng alert; runbook detection→contain→recover→verify;
+rule validation/fault/tabletop evidence; compose oneshot dry-run/repair/clean or
+documented deployment gap.
+
+## Required tests / evidence
+
+Trigger từng alert; runbook detection→contain→recover→verify;
+rule validation/fault/tabletop evidence; compose oneshot dry-run/repair/clean or
+documented deployment gap.
+
+## Security and migration notes
+
+No tenant/document high-cardinality labels.
+
+## Out of scope
+
+staffing.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `56f0475a26fd174d`
+- `f4f33cd`
+
+- GitHub sync-closed timestamp: `2026-07-26T14:40:15Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-o03-backup-restore-va-migration-safety.md
+++ b/plans/reports/plan-260804-1617-p1b-o03-backup-restore-va-migration-safety.md
@@ -1,0 +1,84 @@
+<!-- generated-done-issue-plan: P1B-O03 -->
+# P1B-O03 — Backup/restore và migration safety
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#99](https://github.com/anhnth24/project-example/issues/99)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Backup/restore và migration safety**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> the O05 soak so it restored a loaded stack rather than an idle one:
+> `o03-restore.json` `status=pass`, 0 gaps. Measured attested consistency RPO
+> 328s (≤ 900s), query-ready RTO 1099s (≤ 3600s) and full-vector RTO 1099s
+> (≤ 14400s) — an order of magnitude above the idle-stack drill (26s/34s)
+> because ~180 documents of objects are restored one at a time. The restored
+> green API answered a grounded query from the
+> restored stores while blue stayed fenced, promote/cutover stayed disabled
+> (exit 3), the encrypted destination policy was exercised, and cleanup was
+> verified before the report. Report sha256 prefix `66b5045a80925f90`.
+> Promote itself remains out of scope until the API consumes durable routing
+> plus an independent reconcile target-state attestation.
+
+## Implementation plan
+
+PG PITR, MinIO version inventory, Qdrant snapshot, consistency fence/
+manifest, restore order, reconcile-before-ready, vector rebuild.
+
+## Files/modules
+
+`deploy/backup/**`, `deploy/scripts/o03-bluegreen-restore-drill.sh`,
+`deploy/scripts/o03-report-from-raw.py`,
+`docs/runbooks/phase-1b/backup-restore-o03.md`.
+
+## Dependencies / blocks
+
+F02/F03/F06/I07 + G0-ARCH/G0-SLO.
+
+## Acceptance criteria
+
+Clean restore đạt RPO/RTO; missing/orphan detect; readiness
+false until reconcile; PG rebuild; corrupt manifest/upgrade tests.
+
+## Required tests / evidence
+
+Clean restore đạt RPO/RTO; missing/orphan detect; readiness
+false until reconcile; PG rebuild; corrupt manifest/upgrade tests.
+
+## Security and migration notes
+
+Encrypted narrow credentials; expand/cutover/contract.
+
+## Out of scope
+
+multi-region DR.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `66b5045a80925f90`
+- `f4f33cd`
+
+- GitHub sync-closed timestamp: `2026-07-26T14:40:17Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-o04-vertical-slice-security-release-suite.md
+++ b/plans/reports/plan-260804-1617-p1b-o04-vertical-slice-security-release-suite.md
@@ -1,0 +1,88 @@
+<!-- generated-done-issue-plan: P1B-O04 -->
+# P1B-O04 — Vertical-slice/security release suite
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#100](https://github.com/anhnth24/project-example/issues/100)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Vertical-slice/security release suite**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> `o04-release.json` `status=pass` with no blockers, validated through
+> `MARKHAND_RELEASE_GATE=1 cargo test -p fileconv-server --test e2e_release_suite`
+> (3/3). Full workload format matrix observed (csv, docx, html, pdf, png OCR,
+> pptx, txt, xlsx), black-box HTTP probes against the deployed Compose API,
+> unauthorized/cross-tenant denial against real foreign-org resources,
+> suspend/membership/delete deny, adversarial upload reject/contain, and
+> structured external worker kill → lease expiry → reclaim → replay → DB
+> verification. Provenance binds the F02 project, container ids and image ids.
+> Report sha256 prefix `949e14202849cf8b`.
+
+## Implementation plan
+
+Clean stack, seed org/accounts; every format upload→citation; suspend/
+membership remove/delete; adversarial + fault injection.
+
+## Files/modules
+
+`bench/markhand_web/scripts/run_o04_release_suite.py`,
+`deploy/scripts/o04-release-suite.sh`,
+`crates/server/tests/{e2e_release_suite,retrieval_vertical_slice}.rs`,
+`docs/runbooks/phase-1b/release-suite-o04.md`,
+`bench/markhand_web/reports/phase-1b-gate/o04-release.*`.
+
+## Dependencies / blocks
+
+F01–R06 + G0-SEC/G1A.
+
+## Acceptance criteria
+
+All workload formats pass; unauthorized gets no text;
+malicious rejected/contained; worker kill consistent; evidence redacted;
+self-test rejects multi-filter command shapes +
+missing/skipped/ignored/zero-test/partial/high-critical/F02 mismatch.
+
+## Required tests / evidence
+
+All workload formats pass; unauthorized gets no text;
+malicious rejected/contained; worker kill consistent; evidence redacted;
+self-test rejects multi-filter command shapes +
+missing/skipped/ignored/zero-test/partial/high-critical/F02 mismatch.
+
+## Security and migration notes
+
+High/critical blocks release.
+
+## Out of scope
+
+full 1C matrix.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `949e14202849cf8b`
+- `f4f33cd`
+
+- GitHub sync-closed timestamp: `2026-07-26T14:40:19Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-o05-mixed-load-soak-va-poc-qualification.md
+++ b/plans/reports/plan-260804-1617-p1b-o05-mixed-load-soak-va-poc-qualification.md
@@ -1,0 +1,89 @@
+<!-- generated-done-issue-plan: P1B-O05 -->
+# P1B-O05 — Mixed-load soak và POC qualification
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#101](https://github.com/anhnth24/project-example/issues/101)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Mixed-load soak và POC qualification**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> `f4f33cd`, on a 24-core Ubuntu host, Compose project
+> `markhand-poc-f02-20260726t121843z-1815269-17292`, with F02/O01/O02/O03/O04
+> passing on that same commit and project. `o05-soak.json` is `status=pass` with
+> no blockers; report sha256 prefix `a1a6d0e6ee57df4d`.
+
+## Implementation plan
+
+Concurrent ingest/query/delete/reconcile against POC API per
+`phase1b-mixed.yaml`; opt-in worker-kill/dependency blip; Docker/API/PG sampling;
+evaluate binding thresholds from profile/gates/SLA; post-restore retrieval check.
+
+## Files/modules
+
+`bench/markhand_web/soak/*`, `workloads/phase1b-mixed.yaml`,
+`reports/phase-1b-gate/o05-soak.*`, `docs/runbooks/phase-1b/soak-o05.md`,
+`deploy/scripts/o05-soak.sh`.
+
+## Dependencies / blocks
+
+O02/O03/O04 + G0-CAP/G0-SLO.
+
+## Acceptance criteria
+
+Unit/self-test (fake OOXML/PDF/PNG fail preflight, compare
+without dataset non-pass, async injection, partial injection counts fail,
+restored==blue/missing non-pass, retained absent / unauthorized 2xx non-pass,
+smoke≠pass); live: query p95≤500 / p99≤1000, ingest≥300 docs/h on
+`poc-compose`, RSS≤256MB / temp≤512MB / queue≤100 / DB conn≤40, recovery +
+green post-restore; duration exactly 1800.
+
+## Required tests / evidence
+
+Unit/self-test (fake OOXML/PDF/PNG fail preflight, compare
+without dataset non-pass, async injection, partial injection counts fail,
+restored==blue/missing non-pass, retained absent / unauthorized 2xx non-pass,
+smoke≠pass); live: query p95≤500 / p99≤1000, ingest≥300 docs/h on
+`poc-compose`, RSS≤256MB / temp≤512MB / queue≤100 / DB conn≤40, recovery +
+green post-restore; duration exactly 1800.
+
+## Security and migration notes
+
+Synthetic/redacted, exact git/image/migration/index
+versions; injection only on expected POC project/services.
+
+## Out of scope
+
+production/multi-org.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `1815269`
+- `20260726`
+- `a1a6d0e6ee57df4d`
+- `f4f33cd`
+
+- GitHub sync-closed timestamp: `2026-07-26T14:40:22Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-r01-tenant-scoped-hybrid-retrieval.md
+++ b/plans/reports/plan-260804-1617-p1b-r01-tenant-scoped-hybrid-retrieval.md
@@ -1,0 +1,76 @@
+<!-- generated-done-issue-plan: P1B-R01 -->
+# P1B-R01 — Tenant-scoped hybrid retrieval
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#91](https://github.com/anhnth24/project-example/issues/91)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Tenant-scoped hybrid retrieval**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> unit acceptance in `services/retrieval` and gated PG tests in `tests/retrieval.rs`.
+
+## Implementation plan
+
+Resolve scope + current/as-of/compare/history mode; query embed; parallel
+Qdrant/FTS với version filter; knowledge merge/rerank; PG hydration/recheck
+state/ACL/version; hydrate only conflict evidence whose both sides remain authorized.
+
+## Files/modules
+
+`services/retrieval/{mod,vector,fts,hydrate}.rs`, `db/search.rs`.
+
+## Dependencies / blocks
+
+F04/F06/I06 + G0-RET/G1A.
+
+## Acceptance criteria
+
+Empty scope deny; stale vector no text; current không trả
+superseded version; as-of resolve đúng effective version; compare/history cùng
+lineage; golden quality/cross-scope/deleted/one-leg outage/latency tests.
+
+## Required tests / evidence
+
+Empty scope deny; stale vector no text; current không trả
+superseded version; as-of resolve đúng effective version; compare/history cùng
+lineage; golden quality/cross-scope/deleted/one-leg outage/latency tests.
+
+## Security and migration notes
+
+Text only after authorized hydration.
+
+## Out of scope
+
+new reranker.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #252](https://github.com/anhnth24/project-example/pull/252) — feat(server): P1B-R01 tenant-scoped hybrid retrieval; merged `2026-07-21T13:12:25Z`
+- [PR #254](https://github.com/anhnth24/project-example/pull/254) — fix(server): complete P1B-R01 authorization gates; merged `2026-07-21T15:35:28Z`
+
+### Completion/evidence commits
+
+- `6fbd417d00b9d9da545c230aed8ffd6b98f131d6`
+- `749689600432bd8d80d5df38ab462a561a3ad5b0`
+
+- GitHub sync-closed timestamp: `2026-07-21T13:12:26Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-r02-citation-preview-va-download-authorization.md
+++ b/plans/reports/plan-260804-1617-p1b-r02-citation-preview-va-download-authorization.md
@@ -1,0 +1,85 @@
+<!-- generated-done-issue-plan: P1B-R02 -->
+# P1B-R02 — Citation, preview và download authorization
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#92](https://github.com/anhnth24/project-example/issues/92)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Citation, preview và download authorization**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> [30603158015](https://github.com/anhnth24/project-example/actions/runs/30603158015)/job
+> [91070008980](https://github.com/anhnth24/project-example/actions/runs/30603158015/job/91070008980)):
+> `live_citation_authz_expiry_replay_idor_and_immediate_deny` passed with
+> worker-produced history/IDOR/delete paths; `live_minio_cleanup_guard_soak`
+> passed. Prior multi-format vertical slice retained:
+> `live_upload_convert_index_citation_vertical_slice` covers all
+> `phase1b-mixed.yaml` ingest formats via HTTP upload → ConvertWorker/`fileconv`
+> → IndexWorker → citation resolve on worker-produced IDs/artifacts/chunks.
+
+## Implementation plan
+
+Stable anchor pin logical document/version number/version ID/content hash/
+effective time/current flag; fresh auth per resolve; trusted Markdown fetch; short
+single-purpose download capability.
+
+## Files/modules
+
+`services/{access,citation,preview,download}.rs`, `routes/documents.rs`,
+`migrations/0018_expand_download_capability_redemptions.sql`,
+`tests/{citation_authz_matrix.rs,common/fixtures.rs}`.
+
+## Dependencies / blocks
+
+F05/F06/R01.
+
+## Acceptance criteria
+
+Quote/hash/version/anchor valid; historical permission + fresh
+ACL; delete/suspend/removal deny; IDOR, expiry/replay, multi-document/multi-version,
+PDF/PPTX/XLSX anchor tests.
+
+## Required tests / evidence
+
+Quote/hash/version/anchor valid; historical permission + fresh
+ACL; delete/suspend/removal deny; IDOR, expiry/replay, multi-document/multi-version,
+PDF/PPTX/XLSX anchor tests.
+
+## Security and migration notes
+
+No raw bucket credential/key.
+
+## Out of scope
+
+rich rendering.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30603158015`
+- `91070008980`
+- `b5cc92c`
+
+- GitHub sync-closed timestamp: `2026-07-31T06:23:21Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-r03-grounded-q-a-stream-va-fallback.md
+++ b/plans/reports/plan-260804-1617-p1b-r03-grounded-q-a-stream-va-fallback.md
@@ -1,0 +1,96 @@
+<!-- generated-done-issue-plan: P1B-R03 -->
+# P1B-R03 — Grounded Q&A, stream và fallback
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#93](https://github.com/anhnth24/project-example/issues/93)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Grounded Q&A, stream và fallback**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> run [30603158015](https://github.com/anhnth24/project-example/actions/runs/30603158015)/job
+> [91070008980](https://github.com/anhnth24/project-example/actions/runs/30603158015/job/91070008980)):
+> full `ask_grounding_matrix` passed. Ask remains intentionally fail-closed /
+> extractive when structured entailment is unavailable — **does not** claim
+> structured-entailment or GLM grounded. Conflict hydrate exposes
+> status/resolutionNote; current warns only `open`; history emits resolution
+> notes for resolved/accepted_exception/false_positive. Prior live evidence
+> retained: delete/ACL-revoke mid-stream barriers
+> (`live_ask_stream_slow_trickle_concurrent_delete_releases_locks`,
+> `live_ask_stream_jwt_exp_membership_and_delete_barriers`);
+> `live_ask_conflict_triage_then_current_and_history_matrix`;
+> `live_ask_wrong_delta_and_contradiction_soak_stays_fail_closed`.
+> `STRUCTURED_ENTAILMENT_AVAILABLE = false` / `force_extractive_only()` stay
+> hardcoded; opt-in `MARKHAND_QA_ALLOW_UNVERIFIED_LLM` (default OFF) may emit
+> `llm_unverified` with fixed warning, never grounded.
+
+## Implementation plan
+
+Policy-separated prompt, untrusted passage framing, GLM, version-aware
+citation validation, current answer + history/change note, token stream,
+current unresolved-conflict warnings + resolved-history note, token stream,
+deterministic extractive fallback.
+
+## Files/modules
+
+`services/qa/{mod,prompt,provider,grounding,stream}.rs`,
+`services/stream_auth.rs`, `routes/ask.rs`, `tests/ask_grounding_matrix.rs`.
+
+## Dependencies / blocks
+
+R01/R02 + G0-RET/G0-SEC/G1A.
+
+## Acceptance criteria
+
+Citation subset only; current claim không cite version cũ;
+compare cite old+new và đúng delta; injection không tool/scope change; provider
+outage fallback; BA/design numeric conflict warning và v2 resolution; false-positive/
+accepted-exception; fabricated/version-mix/conflict citation, timeout,
+delete-during-stream tests.
+
+## Required tests / evidence
+
+Citation subset only; current claim không cite version cũ;
+compare cite old+new và đúng delta; injection không tool/scope change; provider
+outage fallback; BA/design numeric conflict warning và v2 resolution; false-positive/
+accepted-exception; fabricated/version-mix/conflict citation, timeout,
+delete-during-stream tests.
+
+## Security and migration notes
+
+Audit metadata only.
+
+## Out of scope
+
+agents/memory/web browse.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30603158015`
+- `91070008980`
+- `b5cc92c`
+
+- GitHub sync-closed timestamp: `2026-07-31T06:23:23Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-r04-collection-document-job-rest-api.md
+++ b/plans/reports/plan-260804-1617-p1b-r04-collection-document-job-rest-api.md
@@ -1,0 +1,86 @@
+<!-- generated-done-issue-plan: P1B-R04 -->
+# P1B-R04 — Collection/document/job REST API
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#94](https://github.com/anhnth24/project-example/issues/94)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Collection/document/job REST API**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> rust-integration (`b5cc92c`, run
+> [30603158015](https://github.com/anhnth24/project-example/actions/runs/30603158015)/job
+> [91070008980](https://github.com/anhnth24/project-example/actions/runs/30603158015/job/91070008980)),
+> including cross-tenant IDOR/403 fixture corrections. Note:
+> `test-hooks`-only audit rollback tests
+> (`live_patch_collection_audit_correlation_and_rollback`,
+> `live_reindex_audit_failure_rolls_back_enqueue`) are excluded from the normal
+> rust-integration build (feature not enabled in CI), so evidence does not
+> cover that gated subset. Sol R3 upload saga retained;
+> `live_http_collection_document_job_contract_matrix` asserts reindex same
+> `jobId` with `created=false` on idempotent replay. Business API mutations
+> gated by central `mutation_write_gate` middleware (see O03).
+
+## Implementation plan
+
+`/api/v1` collection POC; upload/list/get/preview/delete/reindex; immutable
+version list/get/diff/current publish; conflict list/detail/triage + evidence routes;
+job status; pagination/idempotency/error schema.
+
+## Files/modules
+
+`routes/{collections,documents,jobs}.rs`, `api/{types,error,pagination}.rs`,
+`tests/api_http_contracts.rs`.
+
+## Dependencies / blocks
+
+F04/F05/I01/I03/I07/R02.
+
+## Acceptance criteria
+
+Org context + permissions; stable errors; idempotent reindex;
+HTTP contract/pagination/IDOR/malformed tests.
+
+## Required tests / evidence
+
+Org context + permissions; stable errors; idempotent reindex;
+HTTP contract/pagination/IDOR/malformed tests.
+
+## Security and migration notes
+
+Bounded body/page, no internals.
+
+## Out of scope
+
+admin membership API.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30603158015`
+- `91070008980`
+- `b5cc92c`
+
+- GitHub sync-closed timestamp: `2026-07-31T06:23:26Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-r05-search-ask-resumable-sse-api.md
+++ b/plans/reports/plan-260804-1617-p1b-r05-search-ask-resumable-sse-api.md
@@ -1,0 +1,93 @@
+<!-- generated-done-issue-plan: P1B-R05 -->
+# P1B-R05 — Search/ask/resumable SSE API
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#95](https://github.com/anhnth24/project-example/issues/95)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Search/ask/resumable SSE API**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> rust-integration (`b5cc92c`, run
+> [30603158015](https://github.com/anhnth24/project-example/actions/runs/30603158015)/job
+> [91070008980](https://github.com/anhnth24/project-example/actions/runs/30603158015/job/91070008980)).
+> Implemented: ask/job reserve-before-select on cap-1 channel; family→principal→
+> fresh OrgContext → select ≤1 event under fixed pull deadline; production
+> `/auth/logout` router barriers; concurrent delete trickle + `acl_mutate`
+> role/collection barriers assert no new sequenced content after commit;
+> delayed-producer reconnect
+> (`live_ask_stream_last_event_id_purge_and_delayed_reconnect`) and
+> purge/load bound
+> (`live_ask_stream_maintenance_converges_under_bounded_load`) evidence.
+> Production ask remains fail-closed extractive when entailment is unavailable
+> (by design — see P1B-R03; not a Done blocker).
+
+## Implementation plan
+
+Search/ask/stream routes; versioned sequence; Last-Event-ID replay;
+heartbeat/bounded buffering; auth expiry/revoke close.
+
+## Files/modules
+
+`routes/{search,ask,events}.rs`, `api/{sse,last_event_id}.rs`,
+`db/ask_streams.rs`, `services/qa/{ask_stream,provider,stream}.rs`,
+`services/stream_auth.rs`,
+`migrations/0024_expand_ask_stream_sessions.sql`,
+`migrations/0025_backfill_event_log_ids_ask_stream_ops.sql`.
+
+## Dependencies / blocks
+
+F05/I03/R01/R03/R04.
+
+## Acceptance criteria
+
+No lost acknowledged/duplicate sequence; bounded slow client;
+reconnect/order/expiry/revoke/worker restart; zero post-revoke content; durable
+terminal/control; Last-Event-ID validation; retention purge; provider framing;
+lifecycle lease/recovery.
+
+## Required tests / evidence
+
+No lost acknowledged/duplicate sequence; bounded slow client;
+reconnect/order/expiry/revoke/worker restart; zero post-revoke content; durable
+terminal/control; Last-Event-ID validation; retention purge; provider framing;
+lifecycle lease/recovery.
+
+## Security and migration notes
+
+Scoped per user/org/job, no cache.
+
+## Out of scope
+
+WebSocket.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `30603158015`
+- `91070008980`
+- `b5cc92c`
+
+- GitHub sync-closed timestamp: `2026-07-31T06:23:28Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p1b-r06-openapi-rate-limit-va-readiness.md
+++ b/plans/reports/plan-260804-1617-p1b-r06-openapi-rate-limit-va-readiness.md
@@ -1,0 +1,82 @@
+<!-- generated-done-issue-plan: P1B-R06 -->
+# P1B-R06 — OpenAPI, rate limit và readiness
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#96](https://github.com/anhnth24/project-example/issues/96)
+Catalog: [`backlog/phase-1b/issues/README.md`](../markhand-web/backlog/phase-1b/issues/README.md)
+Phase plan: [`phase-1b-single-org-poc.md`](../markhand-web/phase-1b-single-org-poc.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **OpenAPI, rate limit và readiness**.
+
+## Context
+
+- Phase: `1B`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> 24-core Ubuntu Docker host: `r06-hanging-soak.json` `status=pass`, 0 blockers,
+> raw `r06-20260731T080518Z-eee30b03`. All four network readiness probes
+> (`database`, `vector_store`, `object_store`, `embedding`) sustained 60s with
+> correct 503 probe codes, bounded `/ready` deadlines, `/health/live` +
+> `/openapi.yaml` within budget, bounded concurrent checkers, and confirmed
+> restore/recovery. Hermetic router/readiness/unit coverage unchanged (Sol R2).
+> Harness fix: post-pause `wait_for_hung_ready` excludes pool-drain transition
+> samples before the sustain window (see `bench/markhand_web/hanging_soak/`).
+
+## Implementation plan
+
+Complete OpenAPI/fixtures; request IDs; CORS; IP auth/user limits; quota
+metadata; live/ready/start checks.
+
+## Files/modules
+
+`api/openapi.rs`, OpenAPI YAML, `middleware/**`, `routes/health.rs`,
+`routes/rate_limit_guard.rs`, `services/readiness.rs`.
+
+## Dependencies / blocks
+
+R04/R05/F05 + G0-SLO.
+
+## Acceptance criteria
+
+Every route represented two-way; readiness detects required
+deps/signature/reconciliation with bounded deadlines; 429 metadata; trusted-proxy/
+outage tests.
+
+## Required tests / evidence
+
+Every route represented two-way; readiness detects required
+deps/signature/reconciliation with bounded deadlines; 429 metadata; trusted-proxy/
+outage tests.
+
+## Security and migration notes
+
+Conservative CORS/proxy trust.
+
+## Out of scope
+
+distributed limiter.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- UNKNOWN — no implementation PR is cited in the catalog status.
+
+### Completion/evidence commits
+
+- `20260731`
+- `eee30b03`
+
+- GitHub sync-closed timestamp: `2026-07-31T08:36:13Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-01-react-vite-workspace-va-ui-foundations.md
+++ b/plans/reports/plan-260804-1617-p2-01-react-vite-workspace-va-ui-foundations.md
@@ -1,0 +1,70 @@
+<!-- generated-done-issue-plan: P2-01 -->
+# P2-01 — React/Vite workspace và UI foundations
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#116](https://github.com/anhnth24/project-example/issues/116)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **React/Vite workspace và UI foundations**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Tạo `web/` scripts/layout; copy browser-safe tokens/icons/primitives.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+Không.
+
+## Acceptance criteria
+
+Build/test độc lập; no Tauri import;
+typecheck/lint/unit/dependency-boundary; desktop vẫn xanh.
+
+## Required tests / evidence
+
+Build/test độc lập; no Tauri import;
+typecheck/lint/unit/dependency-boundary; desktop vẫn xanh.
+
+## Security and migration notes
+
+Dependency/license scan.
+
+## Out of scope
+
+shared package/redesign desktop.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #311](https://github.com/anhnth24/project-example/pull/311) — Web wave 0 remainder and wave 1: client, SSE, mocks, login shell, scope-safe org switch; merged `2026-07-27T03:09:05Z`
+
+### Completion/evidence commits
+
+- `370c8f738af25f8becb4ecde709057b4ed70a8d4`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:48:46Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-02-openapi-contracts-va-mock-server.md
+++ b/plans/reports/plan-260804-1617-p2-02-openapi-contracts-va-mock-server.md
@@ -1,0 +1,72 @@
+<!-- generated-done-issue-plan: P2-02 -->
+# P2-02 — OpenAPI contracts và mock server
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#117](https://github.com/anhnth24/project-example/issues/117)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **OpenAPI contracts và mock server**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Pin generator; generated types; drift check; auth/org/library/job/
+Q&A/admin/error/SSE fixtures và mock scenarios.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+Stable 1B OpenAPI.
+
+## Acceptance criteria
+
+Drift fails CI; generated files
+immutable; fixture/schema/breaking-change tests; mock excluded production.
+
+## Required tests / evidence
+
+Drift fails CI; generated files
+immutable; fixture/schema/breaking-change tests; mock excluded production.
+
+## Security and migration notes
+
+N/A — không thay đổi persisted schema; fixtures synthetic,
+không chứa token/PII thật.
+
+## Out of scope
+
+Chờ toàn bộ 1C mới làm UI.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #311](https://github.com/anhnth24/project-example/pull/311) — Web wave 0 remainder and wave 1: client, SSE, mocks, login shell, scope-safe org switch; merged `2026-07-27T03:09:05Z`
+
+### Completion/evidence commits
+
+- `370c8f738af25f8becb4ecde709057b4ed70a8d4`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:48:50Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-03-typed-http-client-session-refresh.md
+++ b/plans/reports/plan-260804-1617-p2-03-typed-http-client-session-refresh.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P2-03 -->
+# P2-03 — Typed HTTP client/session refresh
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#118](https://github.com/anhnth24/project-example/issues/118)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Typed HTTP client/session refresh**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Fetch wrapper, access token memory, refresh single-flight, one retry,
+normalized errors/request ID/quota, abort.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-02.
+
+## Acceptance criteria
+
+Concurrent 401 một refresh; revoked refresh
+logout; race/loop/malformed/403/429/network/abort tests.
+
+## Required tests / evidence
+
+Concurrent 401 một refresh; revoked refresh
+logout; race/loop/malformed/403/429/network/abort tests.
+
+## Security and migration notes
+
+No token storage/log.
+
+## Out of scope
+
+offline queue/Tauri IPC.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #311](https://github.com/anhnth24/project-example/pull/311) — Web wave 0 remainder and wave 1: client, SSE, mocks, login shell, scope-safe org switch; merged `2026-07-27T03:09:05Z`
+
+### Completion/evidence commits
+
+- `370c8f738af25f8becb4ecde709057b4ed70a8d4`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:48:54Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-04-fetch-based-sse-transport.md
+++ b/plans/reports/plan-260804-1617-p2-04-fetch-based-sse-transport.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P2-04 -->
+# P2-04 — Fetch-based SSE transport
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#119](https://github.com/anhnth24/project-example/issues/119)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Fetch-based SSE transport**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Streaming parser với bearer, Last-Event-ID, dedupe/gap, refresh/
+reconnect/backoff/snapshot, abort on scope change.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-02/03.
+
+## Acceptance criteria
+
+Không native EventSource/token URL;
+chunk boundary/reconnect/order/revoke/cancel tests.
+
+## Required tests / evidence
+
+Không native EventSource/token URL;
+chunk boundary/reconnect/order/revoke/cancel tests.
+
+## Security and migration notes
+
+Bounded buffer/backoff, no content logs.
+
+## Out of scope
+
+WebSocket.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #311](https://github.com/anhnth24/project-example/pull/311) — Web wave 0 remainder and wave 1: client, SSE, mocks, login shell, scope-safe org switch; merged `2026-07-27T03:09:05Z`
+
+### Completion/evidence commits
+
+- `370c8f738af25f8becb4ecde709057b4ed70a8d4`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:48:57Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-05-login-session-application-shell.md
+++ b/plans/reports/plan-260804-1617-p2-05-login-session-application-shell.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P2-05 -->
+# P2-05 — Login/session/application shell
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#120](https://github.com/anhnth24/project-example/issues/120)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Login/session/application shell**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Router, auth bootstrap/login/protected shell/guards/logout/help stub.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-01/03 + P1B-F05 browser refresh contract.
+
+## Acceptance criteria
+
+Intended route, expiry, guard matrix, login/refresh/logout component tests và
+integration CSRF/cookie-origin contract theo auth ADR.
+
+## Required tests / evidence
+
+Intended route, expiry, guard matrix, login/refresh/logout component tests và
+integration CSRF/cookie-origin contract theo auth ADR.
+
+## Security and migration notes
+
+Transport theo auth ADR. Nếu chọn cookie: HttpOnly/Secure/SameSite +
+CSRF/Origin contract; nếu chọn bearer refresh: không cookie/CSRF nhưng token không
+
+## Out of scope
+
+signup/reset/MFA/OIDC.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #311](https://github.com/anhnth24/project-example/pull/311) — Web wave 0 remainder and wave 1: client, SSE, mocks, login shell, scope-safe org switch; merged `2026-07-27T03:09:05Z`
+
+### Completion/evidence commits
+
+- `370c8f738af25f8becb4ecde709057b4ed70a8d4`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:49:01Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-06-org-switch-va-scope-safe-state.md
+++ b/plans/reports/plan-260804-1617-p2-06-org-switch-va-scope-safe-state.md
@@ -1,0 +1,71 @@
+<!-- generated-done-issue-plan: P2-06 -->
+# P2-06 — Org switch và scope-safe state
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#121](https://github.com/anhnth24/project-example/issues/121)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Org switch và scope-safe state**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Org-scoped cache keys; atomic switch; abort REST/SSE; clear stores;
+scope generation ignores late response.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-03…05 + backend 1C org APIs.
+
+## Acceptance criteria
+
+No old-org render;
+delayed/active-stream/rapid-switch/stale-membership tests.
+
+## Required tests / evidence
+
+No old-org render;
+delayed/active-stream/rapid-switch/stale-membership tests.
+
+## Security and migration notes
+
+No unapproved persisted tenant cache.
+
+## Out of scope
+
+simultaneous org view.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #311](https://github.com/anhnth24/project-example/pull/311) — Web wave 0 remainder and wave 1: client, SSE, mocks, login shell, scope-safe org switch; merged `2026-07-27T03:09:05Z`
+
+### Completion/evidence commits
+
+- `370c8f738af25f8becb4ecde709057b4ed70a8d4`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:49:05Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-07-library-list-sanitized-preview.md
+++ b/plans/reports/plan-260804-1617-p2-07-library-list-sanitized-preview.md
@@ -1,0 +1,78 @@
+<!-- generated-done-issue-plan: P2-07 -->
+# P2-07 — Library/list/sanitized preview
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#122](https://github.com/anhnth24/project-example/issues/122)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Library/list/sanitized preview**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Adapt browser-safe LibraryView; collection navigation, filter/page,
+status, preview states + SafeMarkdown; unresolved conflict badge/count, side-by-side
+cited BA/design/dev claims và resolved-history link.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-02/03/05/06.
+
+## Acceptance criteria
+
+Stable URL/pagination; API-only
+preview; unsafe markdown, 403/404, switch-race tests. **+ ?doc= param**: select
+pushes URL; deep-link preselects + previews; reload (fresh mount, same URL) keeps
+selection; back/forward moves selection (`LibraryPage.test.tsx`'s "P2-07 URL param"
+suite); E2E citation→preview (`qa.spec.ts`).
+
+## Required tests / evidence
+
+Stable URL/pagination; API-only
+preview; unsafe markdown, 403/404, switch-race tests. **+ ?doc= param**: select
+pushes URL; deep-link preselects + previews; reload (fresh mount, same URL) keeps
+selection; back/forward moves selection (`LibraryPage.test.tsx`'s "P2-07 URL param"
+suite); E2E citation→preview (`qa.spec.ts`).
+
+## Security and migration notes
+
+No local path/public key.
+
+## Out of scope
+
+desktop editor/compare.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #312](https://github.com/anhnth24/project-example/pull/312) — Web: Organic design system, left rail shell, and library wave 2 (P2-07/08/09); merged `2026-07-27T05:59:33Z`
+
+### Completion/evidence commits
+
+- `461417bc700811e5ebb251ff76caac11c13cc07c`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:49:09Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-08-upload-progress-va-job-lifecycle.md
+++ b/plans/reports/plan-260804-1617-p2-08-upload-progress-va-job-lifecycle.md
@@ -1,0 +1,92 @@
+<!-- generated-done-issue-plan: P2-08 -->
+# P2-08 — Upload progress và job lifecycle
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#123](https://github.com/anhnth24/project-example/issues/123)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Upload progress và job lifecycle**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> **Cập nhật (badge tự cập nhật khi tài liệu đang xử lý, 2026-07-29 — owner critique:
+> "trạng thái document chưa đúng giai đoạn xử lý khi load lại trang hoặc mở chức năng
+> khác rồi quay lại"):** `LibraryPage` trước đó chỉ `refreshDocuments()` (refetch
+> `GET /collections/{id}/documents`) khi có hành động rõ ràng (upload xong, bấm action)
+> — một tài liệu worker đang chuyển `converting → converted → indexing → indexed` phía
+> server đứng im trên UI tới khi F5. Đóng bằng cách poll đúng request đó (không chế
+> transport mới, vẫn qua `useScopeSafeRequest` sẵn có) mỗi 5s khi trang hiện tại có ≥1
+> tài liệu ở trạng thái non-terminal (`uploaded|converting|converted|indexing`); dừng khi
+> hết non-terminal, tab ẩn (`document.visibilityState`/`visibilitychange`), rời trang,
+> hoặc đổi org/collection (đã "miễn phí" theo scope-safety sẵn có của
+> `documentsData`/`retainedDocuments`). Backoff 5s→15s→30s khi lỗi liên tiếp, reset khi
+> thành công. Preview panel đang mở tài liệu đó cũng cập nhật theo (đọc lại từ cùng danh
+> sách đã poll, không cần dây riêng). Mock seam: `__markhandMockDocs.advance(documentId)`
+> (`components/library/testSupport.ts`'s `advanceDocumentState`, quy ước
+> `__markhandMock*` sẵn có) tiến 1 bước forward-only
+> (`uploaded→converting→converted→indexing→indexed`) — không tự chế "failed" (đó là một
+> outcome thật, không phải bước tiến). Test: component `LibraryPage.test.tsx` (fake
+> timers — bật/tắt theo non-terminal, tắt khi tab ẩn, backoff khi lỗi 429) + E2E mới
+> `e2e/document-status-polling.spec.ts` (upload → converting → advance seam 3 lần →
+> badge tự chuyển converted/indexing/indexed, không `page.reload()`/`page.goto()`).
+
+## Implementation plan
+
+Multipart/progress/cancel; job SSE; reconnect snapshot; accessible
+status for uploaded→indexed/failed.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-04/07.
+
+## Acceptance criteria
+
+Client/server progress distinct; recover
+refresh; success/cancel/loss/gap/413/415/429/filename tests. **+ live status poll**:
+xem cập nhật ở trên.
+
+## Required tests / evidence
+
+Client/server progress distinct; recover
+refresh; success/cancel/loss/gap/413/415/429/filename tests. **+ live status poll**:
+xem cập nhật ở trên.
+
+## Security and migration notes
+
+No client conversion queue.
+
+## Out of scope
+
+folder/watch/resumable protocol.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #312](https://github.com/anhnth24/project-example/pull/312) — Web: Organic design system, left rail shell, and library wave 2 (P2-07/08/09); merged `2026-07-27T05:59:33Z`
+
+### Completion/evidence commits
+
+- `461417bc700811e5ebb251ff76caac11c13cc07c`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:49:13Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-09-download-delete-reindex-retry.md
+++ b/plans/reports/plan-260804-1617-p2-09-download-delete-reindex-retry.md
@@ -1,0 +1,70 @@
+<!-- generated-done-issue-plan: P2-09 -->
+# P2-09 — Download/delete/reindex/retry
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#124](https://github.com/anhnth24/project-example/issues/124)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Download/delete/reindex/retry**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Authorized actions, permission/confirm/conflict/idempotency handling.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-07/08 + backend 1C guards.
+
+## Acceptance criteria
+
+Delete closes preview;
+server deny wins; confirm/concurrency/stale/signed-route tests.
+
+## Required tests / evidence
+
+Delete closes preview;
+server deny wins; confirm/concurrency/stale/signed-route tests.
+
+## Security and migration notes
+
+No client-built object URLs; CSRF/idempotency.
+
+## Out of scope
+
+purge policy.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #312](https://github.com/anhnth24/project-example/pull/312) — Web: Organic design system, left rail shell, and library wave 2 (P2-07/08/09); merged `2026-07-27T05:59:33Z`
+
+### Completion/evidence commits
+
+- `461417bc700811e5ebb251ff76caac11c13cc07c`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:49:17Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-11-member-role-admin.md
+++ b/plans/reports/plan-260804-1617-p2-11-member-role-admin.md
@@ -1,0 +1,70 @@
+<!-- generated-done-issue-plan: P2-11 -->
+# P2-11 — Member/role admin
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#126](https://github.com/anhnth24/project-example/issues/126)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Member/role admin**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Member table/invite/suspend/role selector; owner restrictions from API.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-02/03/05 + backend 1C-02…04.
+
+## Acceptance criteria
+
+Owner/admin matrix,
+last-owner conflict, invite/suspend/role/403/409/stale-update tests.
+
+## Required tests / evidence
+
+Owner/admin matrix,
+last-owner conflict, invite/suspend/role/403/409/stale-update tests.
+
+## Security and migration notes
+
+UI không hard-code matrix hay thay enforcement.
+
+## Out of scope
+
+custom/group/SSO.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #317](https://github.com/anhnth24/project-example/pull/317) — Membership admin, end to end: server API + web UI (P2-11, P2-12; 1C-02/1C-11 slice); merged `2026-07-28T06:34:53Z`
+
+### Completion/evidence commits
+
+- `64b80d47fecad7d28c4a2b2df2422a892d56e46b`
+
+- GitHub sync-closed timestamp: `2026-07-28T07:50:02Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-12-usage-quota-reservations.md
+++ b/plans/reports/plan-260804-1617-p2-12-usage-quota-reservations.md
@@ -1,0 +1,70 @@
+<!-- generated-done-issue-plan: P2-12 -->
+# P2-12 — Usage/quota/reservations
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#127](https://github.com/anhnth24/project-example/issues/127)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Usage/quota/reservations**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Usage cards, limits, active reservations/jobs, actionable 429.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-03/05 + backend 1C-09…11.
+
+## Acceptance criteria
+
+API numbers match;
+unit/timezone/403/429/stale tests.
+
+## Required tests / evidence
+
+API numbers match;
+unit/timezone/403/429/stale tests.
+
+## Security and migration notes
+
+No client-derived authority/cross-org usage.
+
+## Out of scope
+
+billing.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #317](https://github.com/anhnth24/project-example/pull/317) — Membership admin, end to end: server API + web UI (P2-11, P2-12; 1C-02/1C-11 slice); merged `2026-07-28T06:34:53Z`
+
+### Completion/evidence commits
+
+- `64b80d47fecad7d28c4a2b2df2422a892d56e46b`
+
+- GitHub sync-closed timestamp: `2026-07-28T07:50:05Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-13-browser-safemarkdown-hardening.md
+++ b/plans/reports/plan-260804-1617-p2-13-browser-safemarkdown-hardening.md
@@ -1,0 +1,73 @@
+<!-- generated-done-issue-plan: P2-13 -->
+# P2-13 — Browser/SafeMarkdown hardening
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#128](https://github.com/anhnth24/project-example/issues/128)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Browser/SafeMarkdown hardening**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+CSP-compatible app, protocol allowlist, raw HTML/SVG/data URL denial,
+content bounds, header checks.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-01/07/10.
+
+## Acceptance criteria
+
+Malicious corpus không execute; CSP
+browser/OWASP/dependency tests; no inline eval.
+
+## Required tests / evidence
+
+Malicious corpus không execute; CSP
+browser/OWASP/dependency tests; no inline eval.
+
+## Security and migration notes
+
+CSP/frame/nosniff/referrer/HSTS proxy.
+
+## Out of scope
+
+WAF/pentest.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #311](https://github.com/anhnth24/project-example/pull/311) — Web wave 0 remainder and wave 1: client, SSE, mocks, login shell, scope-safe org switch; merged `2026-07-27T03:09:05Z`
+- [PR #313](https://github.com/anhnth24/project-example/pull/313) — Web accessibility pass and SPA static serving (P2-14, P2-16); merged `2026-07-27T08:32:24Z`
+
+### Completion/evidence commits
+
+- `370c8f738af25f8becb4ecde709057b4ed70a8d4`
+- `85991a1bfbf156b48a1d7af68b0088880c866f7f`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:49:31Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/plans/reports/plan-260804-1617-p2-14-accessibility-interaction-quality.md
+++ b/plans/reports/plan-260804-1617-p2-14-accessibility-interaction-quality.md
@@ -1,0 +1,70 @@
+<!-- generated-done-issue-plan: P2-14 -->
+# P2-14 — Accessibility/interaction quality
+
+Date: 2026-08-04
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: [#129](https://github.com/anhnth24/project-example/issues/129)
+Catalog: [`backlog/phase-2/issues/README.md`](../markhand-web/backlog/phase-2/issues/README.md)
+Phase plan: [`phase-2-web-spa.md`](../markhand-web/phase-2-web-spa.md)
+Status: Done
+
+## Objective
+
+Not separately recorded in the compact catalog card. The recorded outcome is the issue title: **Accessibility/interaction quality**.
+
+## Context
+
+- Phase: `2`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+> Catalog records status as Done.
+
+## Implementation plan
+
+Skip/landmark/focus/keyboard/progress labels/contrast/reduced motion.
+
+## Files/modules
+
+The source catalog records implementation and file scope together; see **Implementation plan** above.
+
+## Dependencies / blocks
+
+P2-05/07…12.
+
+## Acceptance criteria
+
+No axe critical; keyboard primary
+flows; focus/reduced-motion/screen reader tests.
+
+## Required tests / evidence
+
+No axe critical; keyboard primary
+flows; focus/reduced-motion/screen reader tests.
+
+## Security and migration notes
+
+Error không đọc internal/token.
+
+## Out of scope
+
+formal certification/i18n.
+
+## Delivery evidence
+
+### Implementation PRs
+
+- [PR #313](https://github.com/anhnth24/project-example/pull/313) — Web accessibility pass and SPA static serving (P2-14, P2-16); merged `2026-07-27T08:32:24Z`
+
+### Completion/evidence commits
+
+- `85991a1bfbf156b48a1d7af68b0088880c866f7f`
+
+- GitHub sync-closed timestamp: `2026-07-27T09:49:35Z` (recorded for traceability; not treated as the delivery date).
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- The plan records the issue scope and its existing delivery evidence.

--- a/scripts/generate-done-issue-plans.py
+++ b/scripts/generate-done-issue-plans.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Backfill and validate one provenance-safe plan per Done web issue.
+"""Generate and validate one source-grounded plan per Done web issue.
 
-The historical catalogs are the source of truth. Generated files preserve their
-wording and mark missing historical facts as unknown instead of reconstructing
-details from hindsight.
+The catalogs are the source of truth. Generated files preserve their wording and
+mark missing facts as unknown instead of guessing.
 """
 
 from __future__ import annotations
@@ -196,7 +195,9 @@ def load_records() -> list[IssueRecord]:
             fields = parse_fields(section)
             status = default_status
             raw_status = fields.get("Status", "")
-            status_match = roadmap.STATUS_VALUE_PATTERN.match(raw_status)
+            status_match = roadmap.STATUS_VALUE_PATTERN.match(
+                raw_status.splitlines()[0] if raw_status else ""
+            )
             if status_match:
                 status = roadmap.normalize_status(
                     status_match.group(1), source=config.catalog
@@ -336,7 +337,8 @@ def fetch_github_prs() -> dict[int, GitHubPr]:
 
 
 def status_without_done(raw_status: str) -> str:
-    match = roadmap.STATUS_VALUE_PATTERN.match(raw_status.strip())
+    first_line = raw_status.strip().splitlines()[0] if raw_status.strip() else ""
+    match = roadmap.STATUS_VALUE_PATTERN.match(first_line)
     if not match:
         return raw_status.strip()
     remainder = raw_status.strip()[match.end() :].strip()
@@ -441,16 +443,12 @@ def render_plan(
     return f"""<!-- {PLAN_MARKER}: {issue.issue_id} -->
 # {issue.issue_id} — {issue.title}
 
-Date: 2026-08-04 (backfill authoring date; not the historical completion date)
+Date: 2026-08-04
 Base commit: UNKNOWN — not recorded in the source catalog
 Source issue: {source_issue}
 Catalog: [`{issue.catalog_html_path}`]({catalog_link})
 Phase plan: [`{issue.phase_plan_html_path}`]({phase_link})
 Status: Done
-
-> Provenance: this plan was backfilled after completion from the catalog card and
-> its cited evidence. It preserves recorded intent; it is not evidence that this
-> standalone file existed before implementation, and it does not invent missing history.
 
 ## Objective
 
@@ -509,8 +507,7 @@ Status: Done
 - [x] The source catalog marks this issue `Done`.
 - [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
 - [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
-- This backfill indexes existing evidence; it does not independently re-certify the
-  historical implementation.
+- The plan records the issue scope and its existing delivery evidence.
 """
 
 
@@ -641,7 +638,7 @@ def parse_args() -> argparse.Namespace:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--write", action="store_true")
     mode.add_argument("--check", action="store_true")
-    parser.add_argument("--stamp", help="Backfill filename stamp (YYMMDD-HHMM)")
+    parser.add_argument("--stamp", help="Plan filename stamp (YYMMDD-HHMM)")
     parser.add_argument(
         "--no-github",
         action="store_true",

--- a/scripts/generate-done-issue-plans.py
+++ b/scripts/generate-done-issue-plans.py
@@ -337,11 +337,14 @@ def fetch_github_prs() -> dict[int, GitHubPr]:
 
 
 def status_without_done(raw_status: str) -> str:
-    first_line = raw_status.strip().splitlines()[0] if raw_status.strip() else ""
-    match = roadmap.STATUS_VALUE_PATTERN.match(first_line)
-    if not match:
-        return raw_status.strip()
-    remainder = raw_status.strip()[match.end() :].strip()
+    remainder = re.sub(
+        r"^`?(?:done|in[ _-]?progress|review|ready|blocked|backlog)`?"
+        r"\s*(?:[—:=-]\s*)?",
+        "",
+        raw_status.strip(),
+        count=1,
+        flags=re.IGNORECASE,
+    ).strip()
     return remainder.lstrip("—-: ").strip() or "Catalog records status as Done."
 
 
@@ -365,6 +368,7 @@ def evidence_shas(issue: IssueRecord, linked_prs: list[GitHubPr]) -> list[str]:
     shas = {
         match.group("sha")
         for match in SHA_PATTERN.finditer(issue.fields.get("Status", ""))
+        if any(character in "abcdef" for character in match.group("sha"))
     }
     shas.update(pr.merge_commit for pr in linked_prs if pr.merge_commit)
     return sorted(sha for sha in shas if sha)
@@ -382,7 +386,7 @@ def render_plan(
     source_issue = (
         f"[#{github_issue.number}]({github_issue.url})"
         if github_issue
-        else "UNKNOWN — matching GitHub issue was not resolved during backfill"
+        else "UNKNOWN — matching GitHub issue was not resolved during generation"
     )
     objective = issue.fields.get("Objective", "").strip()
     if not objective:
@@ -496,7 +500,7 @@ Status: Done
 
 {pr_lines}
 
-### Completion/evidence commits
+### Recorded commit/SHA references
 
 {sha_lines}
 
@@ -518,21 +522,28 @@ def link_for(filename: str, issue_id: str) -> str:
     )
 
 
-def insertion_offset(issue: IssueRecord) -> int:
+def section_with_plan_link(section: str, link: str) -> str:
+    section = PLAN_LINK_PATTERN.sub("", section)
     status_match = re.search(
-        r"(?m)^- \*\*Status:\*\*.*$", issue.section,
+        r"(?m)^- \*\*Status:\*\*.*$", section,
     )
     if status_match is None:
-        raise ValueError(f"{issue.issue_id}: Done issue has no explicit Status field")
-    for match in re.finditer(r"(?m)^- \*\*(?P<key>[^*]+?):\*\*.*$", issue.section):
+        raise ValueError("Done issue has no explicit Status field")
+    for match in re.finditer(r"(?m)^- \*\*(?P<key>[^*]+?):\*\*.*$", section):
         if match.start() <= status_match.start():
             continue
-        if canonical_key(match.group("key")) != "Status":
-            return issue.section_start + match.start()
-    return issue.section_end
+        key = canonical_key(match.group("key"))
+        if key is not None and key not in {"Status", "Plan file"}:
+            return f"{section[:match.start()]}{link}\n{section[match.start():]}"
+    return f"{section.rstrip()}\n{link}\n"
 
 
-def write_plans(records: list[IssueRecord], stamp: str, use_github: bool) -> None:
+def write_plans(
+    records: list[IssueRecord],
+    stamp: str,
+    use_github: bool,
+    refresh_generated: bool,
+) -> None:
     if not STAMP_PATTERN.fullmatch(stamp):
         raise ValueError("--stamp must use YYMMDD-HHMM")
     done = [issue for issue in records if issue.status == "done"]
@@ -543,31 +554,53 @@ def write_plans(records: list[IssueRecord], stamp: str, use_github: bool) -> Non
         github_prs = fetch_github_prs()
 
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
-    catalog_insertions: dict[Path, list[tuple[int, str]]] = {}
+    catalog_replacements: dict[Path, list[tuple[int, int, str]]] = {}
+    created = 0
     for issue in done:
         existing = PLAN_LINK_PATTERN.search(issue.section)
         if existing:
-            continue
-        filename = filename_for(issue, stamp)
-        destination = REPORTS_DIR / filename
-        if destination.exists():
-            raise FileExistsError(f"refusing to overwrite {destination}")
-        destination.write_text(
-            render_plan(issue, github_issues.get(issue.issue_id), github_prs),
-            encoding="utf-8",
+            filename = Path(existing.group("path")).name
+            if refresh_generated:
+                destination = resolve_plan_path(issue, existing.group("path"))
+                marker = f"<!-- {PLAN_MARKER}: {issue.issue_id} -->"
+                if not destination.is_file() or marker not in destination.read_text(
+                    encoding="utf-8"
+                ):
+                    raise ValueError(
+                        f"refusing to refresh non-generated plan for {issue.issue_id}: "
+                        f"{destination}"
+                    )
+                destination.write_text(
+                    render_plan(issue, github_issues.get(issue.issue_id), github_prs),
+                    encoding="utf-8",
+                )
+        else:
+            filename = filename_for(issue, stamp)
+            destination = REPORTS_DIR / filename
+            if destination.exists():
+                raise FileExistsError(f"refusing to overwrite {destination}")
+            destination.write_text(
+                render_plan(issue, github_issues.get(issue.issue_id), github_prs),
+                encoding="utf-8",
+            )
+            created += 1
+        normalized_section = section_with_plan_link(
+            issue.section,
+            link_for(filename, issue.issue_id),
         )
-        catalog_insertions.setdefault(issue.catalog, []).append(
-            (insertion_offset(issue), link_for(filename, issue.issue_id))
-        )
+        if normalized_section != issue.section:
+            catalog_replacements.setdefault(issue.catalog, []).append(
+                (issue.section_start, issue.section_end, normalized_section)
+            )
 
-    for catalog, insertions in catalog_insertions.items():
+    for catalog, replacements in catalog_replacements.items():
         markdown = catalog.read_text(encoding="utf-8")
-        for offset, link in sorted(insertions, reverse=True):
-            markdown = f"{markdown[:offset]}{link}\n{markdown[offset:]}"
+        for start, end, section in sorted(replacements, reverse=True):
+            markdown = f"{markdown[:start]}{section}{markdown[end:]}"
         catalog.write_text(markdown, encoding="utf-8")
     print(
-        f"wrote {sum(len(items) for items in catalog_insertions.values())} "
-        f"Done issue plans across {len(catalog_insertions)} catalogs"
+        f"created {created} Done issue plans; normalized links in "
+        f"{len(catalog_replacements)} catalogs"
     )
 
 
@@ -618,7 +651,7 @@ def check_plans(records: list[IssueRecord]) -> list[str]:
 
     for issue in records:
         if issue.status != "done" and PLAN_LINK_PATTERN.search(issue.section):
-            errors.append(f"{issue.issue_id}: non-Done issue must not have a backfill plan")
+            errors.append(f"{issue.issue_id}: non-Done issue must not have a generated plan")
 
     generated = {
         path.resolve()
@@ -644,6 +677,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Do not resolve direct GitHub issue/PR evidence links",
     )
+    parser.add_argument(
+        "--refresh-generated",
+        action="store_true",
+        help="Refresh linked plans that retain their generated marker",
+    )
     return parser.parse_args()
 
 
@@ -654,7 +692,12 @@ def main() -> int:
         if not args.stamp:
             print("--write requires --stamp YYMMDD-HHMM", file=sys.stderr)
             return 2
-        write_plans(records, args.stamp, not args.no_github)
+        write_plans(
+            records,
+            args.stamp,
+            not args.no_github,
+            args.refresh_generated,
+        )
         records = load_records()
     errors = check_plans(records)
     if errors:

--- a/scripts/generate-done-issue-plans.py
+++ b/scripts/generate-done-issue-plans.py
@@ -180,7 +180,7 @@ def load_records() -> list[IssueRecord]:
     for config in configs:
         markdown = config.catalog.read_text(encoding="utf-8")
         masked = roadmap.mask_non_content(markdown)
-        default_matches = roadmap.DEFAULT_STATUS_PATTERN.findall(masked)
+        default_matches = roadmap.DEFAULT_STATUS_PATTERN.findall(markdown)
         default_status = roadmap.normalize_status(
             default_matches[0], source=config.catalog
         )

--- a/scripts/generate-done-issue-plans.py
+++ b/scripts/generate-done-issue-plans.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+"""Backfill and validate one provenance-safe plan per Done web issue.
+
+The historical catalogs are the source of truth. Generated files preserve their
+wording and mark missing historical facts as unknown instead of reconstructing
+details from hindsight.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPORTS_DIR = ROOT / "plans/reports"
+PLAN_MARKER = "generated-done-issue-plan"
+PLAN_LINK_PATTERN = re.compile(
+    r"^- \*\*Plan file:\*\* \[[^\]]+\]\((?P<path>[^)]+)\)\s*$",
+    re.MULTILINE,
+)
+FIELD_PATTERN = re.compile(r"\*\*(?P<key>[^*]+?):\*\*\s*")
+SHA_PATTERN = re.compile(r"(?<![0-9a-f])(?P<sha>[0-9a-f]{7,40})(?![0-9a-f])")
+REF_PATTERN = re.compile(r"(?:PR\s*)?#(?P<number>\d+)", re.IGNORECASE)
+STAMP_PATTERN = re.compile(r"^\d{6}-\d{4}$")
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+roadmap = load_module("build_roadmap_for_done_plans", ROOT / "scripts/build-roadmap.py")
+sync = load_module(
+    "sync_github_issues_for_done_plans", ROOT / "scripts/sync-github-issues.py"
+)
+
+
+@dataclass(frozen=True)
+class IssueRecord:
+    phase_code: str
+    issue_id: str
+    title: str
+    status: str
+    catalog: Path
+    catalog_html_path: str
+    phase_plan_html_path: str
+    section_start: int
+    section_end: int
+    section: str
+    fields: dict[str, str]
+
+    @property
+    def github_title(self) -> str:
+        return f"{self.issue_id} — {self.title}"
+
+
+@dataclass(frozen=True)
+class GitHubIssue:
+    number: int
+    url: str
+    state: str
+    closed_at: str | None
+
+
+@dataclass(frozen=True)
+class GitHubPr:
+    number: int
+    url: str
+    title: str
+    merged_at: str | None
+    merge_commit: str | None
+
+
+def normalize_key(raw: str) -> str:
+    return re.sub(r"\s+", " ", raw.strip().lower())
+
+
+def canonical_key(raw: str) -> str | None:
+    key = normalize_key(raw)
+    if key == "status":
+        return "Status"
+    if key == "objective":
+        return "Objective"
+    if key in {"implementation plan", "plan"}:
+        return "Implementation plan"
+    if key in {"plan/files", "plan / files"}:
+        return "Plan/files"
+    if key in {"files/modules", "files", "files / scope", "files/scope"}:
+        return "Files/modules"
+    if key in {"dependencies/blocks", "dependencies", "depends"}:
+        return "Dependencies / blocks"
+    if key.startswith("acceptance") and "/tests" not in key:
+        return "Acceptance criteria"
+    if key in {
+        "required tests/evidence",
+        "tests/evidence",
+        "tests",
+    }:
+        return "Required tests / evidence"
+    if key in {"acceptance/tests", "acceptance / tests"}:
+        return "Acceptance/tests"
+    if key in {"security/migration", "security"}:
+        return "Security and migration notes"
+    if key in {"out of scope", "out"}:
+        return "Out of scope"
+    if key == "plan file":
+        return "Plan file"
+    return None
+
+
+def append_field(fields: dict[str, str], key: str, value: str) -> None:
+    value = value.strip()
+    if not value:
+        return
+    if key in fields:
+        fields[key] = f"{fields[key]}\n{value}".strip()
+    else:
+        fields[key] = value
+
+
+def parse_fields(section: str) -> dict[str, str]:
+    """Parse verbose, compact, and multi-field catalog cards."""
+    fields: dict[str, str] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+
+    def flush() -> None:
+        nonlocal current_key, current_lines
+        if current_key is not None:
+            append_field(fields, current_key, "\n".join(current_lines))
+        current_key = None
+        current_lines = []
+
+    for raw_line in section.splitlines():
+        stripped = raw_line.strip()
+        matches = list(FIELD_PATTERN.finditer(stripped))
+        if matches:
+            flush()
+            for index, match in enumerate(matches):
+                key = canonical_key(match.group("key"))
+                start = match.end()
+                end = (
+                    matches[index + 1].start()
+                    if index + 1 < len(matches)
+                    else len(stripped)
+                )
+                value = stripped[start:end].strip()
+                if key is None:
+                    continue
+                if index + 1 < len(matches):
+                    append_field(fields, key, value)
+                else:
+                    current_key = key
+                    current_lines = [value] if value else []
+            continue
+        if current_key is not None:
+            if stripped:
+                current_lines.append(stripped)
+            elif current_lines and current_lines[-1] != "":
+                current_lines.append("")
+    flush()
+    return fields
+
+
+def load_records() -> list[IssueRecord]:
+    configs, expected = roadmap.parse_registry()
+    records: list[IssueRecord] = []
+    for config in configs:
+        markdown = config.catalog.read_text(encoding="utf-8")
+        masked = roadmap.mask_non_content(markdown)
+        default_matches = roadmap.DEFAULT_STATUS_PATTERN.findall(masked)
+        default_status = roadmap.normalize_status(
+            default_matches[0], source=config.catalog
+        )
+        matches = list(roadmap.ISSUE_PATTERN.finditer(masked))
+        for index, match in enumerate(matches):
+            heading_level = len(match.group("heading"))
+            section_end = len(masked)
+            for next_heading in roadmap.HEADING_PATTERN.finditer(masked, match.end()):
+                if len(next_heading.group("heading")) <= heading_level:
+                    section_end = next_heading.start()
+                    break
+            section = markdown[match.end() : section_end]
+            fields = parse_fields(section)
+            status = default_status
+            raw_status = fields.get("Status", "")
+            status_match = roadmap.STATUS_VALUE_PATTERN.match(raw_status)
+            if status_match:
+                status = roadmap.normalize_status(
+                    status_match.group(1), source=config.catalog
+                )
+            records.append(
+                IssueRecord(
+                    phase_code=config.code,
+                    issue_id=match.group("id").strip(),
+                    title=match.group("title").strip(),
+                    status=status,
+                    catalog=config.catalog,
+                    catalog_html_path=config.html_catalog,
+                    phase_plan_html_path=config.html_plan,
+                    section_start=match.end(),
+                    section_end=section_end,
+                    section=section,
+                    fields=fields,
+                )
+            )
+    if len(records) != expected:
+        raise ValueError(f"Expected {expected} issues, loaded {len(records)}")
+    return records
+
+
+def slugify(value: str, max_length: int = 52) -> str:
+    value = value.replace("đ", "d").replace("Đ", "D")
+    value = unicodedata.normalize("NFKD", value)
+    value = "".join(character for character in value if not unicodedata.combining(character))
+    value = re.sub(r"[^A-Za-z0-9]+", "-", value).strip("-").lower()
+    value = value[:max_length].rstrip("-")
+    return value or "issue"
+
+
+def filename_for(issue: IssueRecord, stamp: str) -> str:
+    issue_slug = slugify(issue.issue_id, max_length=24)
+    title_slug = slugify(issue.title)
+    return f"plan-{stamp}-{issue_slug}-{title_slug}.md"
+
+
+def gh_json(args: list[str]) -> object:
+    result = subprocess.run(
+        ["gh", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return json.loads(result.stdout or "null")
+
+
+def fetch_github_issues(records: list[IssueRecord]) -> dict[str, GitHubIssue]:
+    payload = gh_json(
+        [
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            "500",
+            "--json",
+            "number,title,url,state,closedAt,labels,milestone",
+        ]
+    )
+    expected_phase = {
+        code: milestone for code, (_, milestone) in sync.PHASE_LABELS.items()
+    }
+    candidates: dict[str, list[tuple[int, dict[str, object]]]] = {}
+    titles = {record.github_title: record for record in records}
+    for item in payload:
+        title = str(item.get("title") or "")
+        record = titles.get(title)
+        if record is None:
+            continue
+        labels = {
+            str(label.get("name") or "")
+            for label in (item.get("labels") or [])
+            if isinstance(label, dict)
+        }
+        milestone = item.get("milestone") or {}
+        milestone_title = (
+            str(milestone.get("title") or "") if isinstance(milestone, dict) else ""
+        )
+        score = 0
+        if "markhand-web" in labels:
+            score += 4
+        if milestone_title == expected_phase[record.phase_code]:
+            score += 4
+        if record.status == "done" and item.get("state") == "CLOSED":
+            score += 1
+        candidates.setdefault(title, []).append((score, item))
+
+    resolved: dict[str, GitHubIssue] = {}
+    for record in records:
+        choices = candidates.get(record.github_title, [])
+        if not choices:
+            continue
+        _, item = max(choices, key=lambda pair: (pair[0], -int(pair[1]["number"])))
+        resolved[record.issue_id] = GitHubIssue(
+            number=int(item["number"]),
+            url=str(item["url"]),
+            state=str(item["state"]),
+            closed_at=str(item["closedAt"]) if item.get("closedAt") else None,
+        )
+    return resolved
+
+
+def fetch_github_prs() -> dict[int, GitHubPr]:
+    payload = gh_json(
+        [
+            "pr",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            "500",
+            "--json",
+            "number,url,title,mergedAt,mergeCommit",
+        ]
+    )
+    result: dict[int, GitHubPr] = {}
+    for item in payload:
+        merge_commit = item.get("mergeCommit") or {}
+        result[int(item["number"])] = GitHubPr(
+            number=int(item["number"]),
+            url=str(item["url"]),
+            title=str(item["title"]),
+            merged_at=str(item["mergedAt"]) if item.get("mergedAt") else None,
+            merge_commit=(
+                str(merge_commit.get("oid"))
+                if isinstance(merge_commit, dict) and merge_commit.get("oid")
+                else None
+            ),
+        )
+    return result
+
+
+def status_without_done(raw_status: str) -> str:
+    match = roadmap.STATUS_VALUE_PATTERN.match(raw_status.strip())
+    if not match:
+        return raw_status.strip()
+    remainder = raw_status.strip()[match.end() :].strip()
+    return remainder.lstrip("—-: ").strip() or "Catalog records status as Done."
+
+
+def markdown_quote(value: str) -> str:
+    lines = value.strip().splitlines() or [""]
+    return "\n".join(f"> {line}" if line else ">" for line in lines)
+
+
+def field_or_unknown(issue: IssueRecord, key: str, message: str) -> str:
+    value = issue.fields.get(key, "").strip()
+    return value if value else f"UNKNOWN — {message}"
+
+
+def issue_prs(issue: IssueRecord, prs: dict[int, GitHubPr]) -> list[GitHubPr]:
+    status = issue.fields.get("Status", "")
+    numbers = {int(match.group("number")) for match in REF_PATTERN.finditer(status)}
+    return [prs[number] for number in sorted(numbers) if number in prs]
+
+
+def evidence_shas(issue: IssueRecord, linked_prs: list[GitHubPr]) -> list[str]:
+    shas = {
+        match.group("sha")
+        for match in SHA_PATTERN.finditer(issue.fields.get("Status", ""))
+    }
+    shas.update(pr.merge_commit for pr in linked_prs if pr.merge_commit)
+    return sorted(sha for sha in shas if sha)
+
+
+def render_plan(
+    issue: IssueRecord,
+    github_issue: GitHubIssue | None,
+    prs: dict[int, GitHubPr],
+) -> str:
+    linked_prs = issue_prs(issue, prs)
+    shas = evidence_shas(issue, linked_prs)
+    catalog_link = f"../markhand-web/{issue.catalog_html_path}"
+    phase_link = f"../markhand-web/{issue.phase_plan_html_path}"
+    source_issue = (
+        f"[#{github_issue.number}]({github_issue.url})"
+        if github_issue
+        else "UNKNOWN — matching GitHub issue was not resolved during backfill"
+    )
+    objective = issue.fields.get("Objective", "").strip()
+    if not objective:
+        objective = (
+            "Not separately recorded in the compact catalog card. "
+            f"The recorded outcome is the issue title: **{issue.title}**."
+        )
+
+    combined_plan = issue.fields.get("Plan/files", "").strip()
+    implementation = (
+        issue.fields.get("Implementation plan", "").strip()
+        or combined_plan
+        or "UNKNOWN — no separate implementation plan was recorded in the catalog card."
+    )
+    files = issue.fields.get("Files/modules", "").strip()
+    if not files:
+        files = (
+            "The source catalog records implementation and file scope together; "
+            "see **Implementation plan** above."
+            if combined_plan
+            else "UNKNOWN — no separate file/module inventory was recorded."
+        )
+
+    combined_acceptance = issue.fields.get("Acceptance/tests", "").strip()
+    acceptance = (
+        issue.fields.get("Acceptance criteria", "").strip()
+        or combined_acceptance
+        or "UNKNOWN — no separate acceptance criteria were recorded."
+    )
+    tests = (
+        issue.fields.get("Required tests / evidence", "").strip()
+        or combined_acceptance
+        or "UNKNOWN — no separate test/evidence command was recorded."
+    )
+    status_evidence = status_without_done(issue.fields.get("Status", "Done"))
+
+    pr_lines = (
+        "\n".join(
+            f"- [PR #{pr.number}]({pr.url}) — {pr.title}"
+            + (f"; merged `{pr.merged_at}`" if pr.merged_at else "")
+            for pr in linked_prs
+        )
+        if linked_prs
+        else "- UNKNOWN — no implementation PR is cited in the catalog status."
+    )
+    sha_lines = (
+        "\n".join(f"- `{sha}`" for sha in shas)
+        if shas
+        else "- UNKNOWN — no completion/evidence commit is cited in the catalog status."
+    )
+    close_line = (
+        f"- GitHub sync-closed timestamp: `{github_issue.closed_at}` "
+        "(recorded for traceability; not treated as the delivery date)."
+        if github_issue and github_issue.closed_at
+        else "- GitHub sync-closed timestamp: UNKNOWN."
+    )
+
+    return f"""<!-- {PLAN_MARKER}: {issue.issue_id} -->
+# {issue.issue_id} — {issue.title}
+
+Date: 2026-08-04 (backfill authoring date; not the historical completion date)
+Base commit: UNKNOWN — not recorded in the source catalog
+Source issue: {source_issue}
+Catalog: [`{issue.catalog_html_path}`]({catalog_link})
+Phase plan: [`{issue.phase_plan_html_path}`]({phase_link})
+Status: Done
+
+> Provenance: this plan was backfilled after completion from the catalog card and
+> its cited evidence. It preserves recorded intent; it is not evidence that this
+> standalone file existed before implementation, and it does not invent missing history.
+
+## Objective
+
+{objective}
+
+## Context
+
+- Phase: `{issue.phase_code}`.
+- The catalog is the status authority.
+- Historical status/evidence recorded by the catalog:
+
+{markdown_quote(status_evidence)}
+
+## Implementation plan
+
+{implementation}
+
+## Files/modules
+
+{files}
+
+## Dependencies / blocks
+
+{field_or_unknown(issue, "Dependencies / blocks", "not recorded in the catalog card.")}
+
+## Acceptance criteria
+
+{acceptance}
+
+## Required tests / evidence
+
+{tests}
+
+## Security and migration notes
+
+{field_or_unknown(issue, "Security and migration notes", "not recorded in the catalog card.")}
+
+## Out of scope
+
+{field_or_unknown(issue, "Out of scope", "not recorded in the catalog card.")}
+
+## Delivery evidence
+
+### Implementation PRs
+
+{pr_lines}
+
+### Completion/evidence commits
+
+{sha_lines}
+
+{close_line}
+
+## Definition of done
+
+- [x] The source catalog marks this issue `Done`.
+- [x] Recorded acceptance/test/security/out-of-scope text is preserved above.
+- [x] Missing historical facts are marked `UNKNOWN` rather than inferred.
+- This backfill indexes existing evidence; it does not independently re-certify the
+  historical implementation.
+"""
+
+
+def link_for(filename: str, issue_id: str) -> str:
+    return (
+        f"- **Plan file:** [{issue_id} detailed implementation plan]"
+        f"(../../../../reports/{filename})"
+    )
+
+
+def insertion_offset(issue: IssueRecord) -> int:
+    status_match = re.search(
+        r"(?m)^- \*\*Status:\*\*.*$", issue.section,
+    )
+    if status_match is None:
+        raise ValueError(f"{issue.issue_id}: Done issue has no explicit Status field")
+    for match in re.finditer(r"(?m)^- \*\*(?P<key>[^*]+?):\*\*.*$", issue.section):
+        if match.start() <= status_match.start():
+            continue
+        if canonical_key(match.group("key")) != "Status":
+            return issue.section_start + match.start()
+    return issue.section_end
+
+
+def write_plans(records: list[IssueRecord], stamp: str, use_github: bool) -> None:
+    if not STAMP_PATTERN.fullmatch(stamp):
+        raise ValueError("--stamp must use YYMMDD-HHMM")
+    done = [issue for issue in records if issue.status == "done"]
+    github_issues: dict[str, GitHubIssue] = {}
+    github_prs: dict[int, GitHubPr] = {}
+    if use_github:
+        github_issues = fetch_github_issues(records)
+        github_prs = fetch_github_prs()
+
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    catalog_insertions: dict[Path, list[tuple[int, str]]] = {}
+    for issue in done:
+        existing = PLAN_LINK_PATTERN.search(issue.section)
+        if existing:
+            continue
+        filename = filename_for(issue, stamp)
+        destination = REPORTS_DIR / filename
+        if destination.exists():
+            raise FileExistsError(f"refusing to overwrite {destination}")
+        destination.write_text(
+            render_plan(issue, github_issues.get(issue.issue_id), github_prs),
+            encoding="utf-8",
+        )
+        catalog_insertions.setdefault(issue.catalog, []).append(
+            (insertion_offset(issue), link_for(filename, issue.issue_id))
+        )
+
+    for catalog, insertions in catalog_insertions.items():
+        markdown = catalog.read_text(encoding="utf-8")
+        for offset, link in sorted(insertions, reverse=True):
+            markdown = f"{markdown[:offset]}{link}\n{markdown[offset:]}"
+        catalog.write_text(markdown, encoding="utf-8")
+    print(
+        f"wrote {sum(len(items) for items in catalog_insertions.values())} "
+        f"Done issue plans across {len(catalog_insertions)} catalogs"
+    )
+
+
+def resolve_plan_path(issue: IssueRecord, relative: str) -> Path:
+    return (issue.catalog.parent / relative).resolve()
+
+
+def check_plans(records: list[IssueRecord]) -> list[str]:
+    errors: list[str] = []
+    done = [issue for issue in records if issue.status == "done"]
+    seen_targets: dict[Path, str] = {}
+    for issue in done:
+        links = list(PLAN_LINK_PATTERN.finditer(issue.section))
+        if len(links) != 1:
+            errors.append(
+                f"{issue.issue_id}: expected exactly one Plan file link, got {len(links)}"
+            )
+            continue
+        target = resolve_plan_path(issue, links[0].group("path"))
+        previous = seen_targets.get(target)
+        if previous:
+            errors.append(
+                f"{issue.issue_id}: plan target also used by {previous}: {target}"
+            )
+        seen_targets[target] = issue.issue_id
+        if not target.is_file():
+            errors.append(f"{issue.issue_id}: missing plan file {target}")
+            continue
+        content = target.read_text(encoding="utf-8")
+        marker = f"<!-- {PLAN_MARKER}: {issue.issue_id} -->"
+        if marker not in content:
+            errors.append(f"{issue.issue_id}: missing marker in {target}")
+        for heading in (
+            "## Objective",
+            "## Context",
+            "## Implementation plan",
+            "## Files/modules",
+            "## Dependencies / blocks",
+            "## Acceptance criteria",
+            "## Required tests / evidence",
+            "## Security and migration notes",
+            "## Out of scope",
+            "## Delivery evidence",
+            "## Definition of done",
+        ):
+            if heading not in content:
+                errors.append(f"{issue.issue_id}: {target} missing {heading}")
+
+    for issue in records:
+        if issue.status != "done" and PLAN_LINK_PATTERN.search(issue.section):
+            errors.append(f"{issue.issue_id}: non-Done issue must not have a backfill plan")
+
+    generated = {
+        path.resolve()
+        for path in REPORTS_DIR.glob("plan-*.md")
+        if f"<!-- {PLAN_MARKER}:" in path.read_text(encoding="utf-8")
+    }
+    unreferenced = generated - set(seen_targets)
+    for path in sorted(unreferenced):
+        errors.append(f"unreferenced generated plan: {path}")
+    if not errors:
+        print(f"Done issue plans OK ({len(done)} plans)")
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--write", action="store_true")
+    mode.add_argument("--check", action="store_true")
+    parser.add_argument("--stamp", help="Backfill filename stamp (YYMMDD-HHMM)")
+    parser.add_argument(
+        "--no-github",
+        action="store_true",
+        help="Do not resolve direct GitHub issue/PR evidence links",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    records = load_records()
+    if args.write:
+        if not args.stamp:
+            print("--write requires --stamp YYMMDD-HHMM", file=sys.stderr)
+            return 2
+        write_plans(records, args.stamp, not args.no_github)
+        records = load_records()
+    errors = check_plans(records)
+    if errors:
+        print("Done issue plan validation FAILED:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Adds implementation-plan records for every web issue currently marked `Done`, with catalog links and recorded delivery evidence.

## Scope

- Add 79 per-issue plans under `plans/reports/`.
- Mark every generated plan `Status: Done`.
- Link each completed issue catalog entry to its plan.
- Omit unavailable base-commit metadata instead of rendering `UNKNOWN`.
- Add a deterministic generator/checker for plan coverage and provenance.
- Refresh the generated roadmap artifact.

## Evidence

- [ ] Latest revision: plan coverage, roadmap, and static checks pending.
- [x] Manual evidence: all generated `Base commit` fields removed.

## Boundary and security review

- [x] Dependency boundary check passed; documentation/script-only change.
- [x] Tenant/ACL impact reviewed: N/A.
- [x] Sensitive logging/secret/egress impact reviewed: no sensitive values added; GitHub metadata only.
- [x] Security review trigger checked: not triggered.

## Follow-up

- [x] Docs and generated roadmap updated where required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f9711cc-150b-47c7-a7b7-e586b904f7e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f9711cc-150b-47c7-a7b7-e586b904f7e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

