### PR TITLE
docs: add issue creator and delivery planning skills

### DIFF
--- a/.cursor/skills/issue-creation/SKILL.md
+++ b/.cursor/skills/issue-creation/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: issue-creation
+description: Create or revise a Markhand roadmap issue in the authoritative catalog, validate Definition of Ready, and safely synchronize the canonical format to GitHub.
+---
+
+# Issue creation
+
+Use this workflow when decomposing a phase into issues or adding one roadmap issue. The
+Markdown phase catalog is authoritative; GitHub issues are synchronized representations.
+Do not create a remote issue, milestone, or label unless the user explicitly requests it.
+
+1. **Locate the roadmap authority.** Read `plans/markhand-web/README.md`, the phase plan,
+   and `plans/markhand-web/backlog/<phase>/issues/README.md`. Check existing IDs, phase
+   issue count, dependency graph, default status, milestone, and similarly scoped issues.
+   Never reuse an ID or create a second issue for the same independently reviewable outcome.
+2. **Choose one outcome and status.** The title must be `ID — concise outcome`, where the
+   ID follows that phase's existing convention. Use only `Backlog`, `Blocked`, `Ready`,
+   `In progress`, `Review`, or `Done`. New work is normally `Backlog` or `Blocked`; use
+   `Ready` only after every Definition of Ready check below passes. Never create a new
+   issue directly as `Done`.
+3. **Write the catalog entry first.** Use these canonical field names so
+   `scripts/sync-github-issues.py` can generate the GitHub body:
+
+   ```markdown
+   ## <ID> — <concise outcome>
+
+   - **Status:** <Backlog | Blocked — exact blocker | Ready>
+   - **Objective:** <one observable, independently reviewable outcome>
+   - **Implementation plan:** <ordered technical approach and failure/degraded behavior>
+   - **Files/modules:** <owner plus module boundaries and likely files>
+   - **Dependencies/blocks:** <issue IDs/external gates and what evidence unblocks them>
+   - **Acceptance criteria:** <observable pass/fail behaviors, including negative paths>
+   - **Required tests/evidence:** <named commands, fixtures, environments, and artifacts>
+   - **Security/migration:** <data/API/tenant impact; review trigger; migration/rollback,
+     or reasoned N/A>
+   - **Out of scope:** <explicit exclusions that prevent scope growth>
+   ```
+
+   Keep acceptance criteria separate from implementation tasks. Do not invent approvals,
+   owners, dependency completion, benchmark results, or security evidence. Record unknown
+   material facts as blockers instead.
+4. **Apply Definition of Ready.** Before using `Ready`, confirm: one outcome; explicit
+   scope and acceptance criteria; owner and module boundary; dependencies completed with
+   evidence; data/API/tenant impact stated; named test/evidence commands or fixtures;
+   security trigger assessed; and out-of-scope boundaries recorded. Otherwise retain
+   `Backlog`/`Blocked` and state the exact gap.
+5. **Maintain roadmap consistency.** Add the issue to the phase dependency graph and
+   summary where applicable. When adding a new ID, update the phase issue count and the
+   `Issue-level backlog (... issues)` total in `plans/markhand-web/README.md`. Do not add a
+   `Plan file` placeholder: `issue-delivery` creates and links the real plan before code.
+6. **Validate before synchronization.** Run:
+
+   ```bash
+   python3 scripts/build-roadmap.py
+   python3 scripts/build-roadmap.py --check
+   python3 scripts/sync-github-issues.py --dry-run
+   ```
+
+   Review the generated title, phase, status, and issue count. Fix catalog/parser errors;
+   do not bypass them.
+7. **Synchronize only when authorized.** With explicit permission, use the repository
+   synchronizer rather than manually duplicating the body:
+
+   ```bash
+   python3 scripts/sync-github-issues.py --create
+   # Use --update when an existing catalog issue changed.
+   ```
+
+   Confirm the GitHub title is `ID — title`, and that milestone, phase/status labels,
+   source paths, and rendered sections match the catalog. If remote write access is
+   unavailable, deliver the catalog change and report that synchronization remains.
+8. **Hand off to delivery.** Report the issue ID, status, catalog/phase links, blockers,
+   and validation evidence. Invoke `issue-delivery` only after the issue is `Ready`; that
+   workflow creates the detailed plan, branch, implementation, review, and Done evidence.

--- a/.cursor/skills/issue-creator/SKILL.md
+++ b/.cursor/skills/issue-creator/SKILL.md
@@ -5,70 +5,33 @@ description: Create or revise a Markhand roadmap issue in the authoritative cata
 
 # Issue creator
 
-Use this workflow when decomposing a phase into issues or adding one roadmap issue. The
-Markdown phase catalog is authoritative; GitHub issues are synchronized representations.
-Do not create a remote issue, milestone, or label unless the user explicitly requests it.
+Use this workflow when decomposing a phase or creating/revising one issue. The user prompt
+only needs the outcome, special product constraints, and remote-write permission.
 
-1. **Locate the roadmap authority.** Read `plans/markhand-web/README.md`, the phase plan,
-   and `plans/markhand-web/backlog/<phase>/issues/README.md`. Check existing IDs, phase
-   issue count, dependency graph, default status, milestone, and similarly scoped issues.
-   Never reuse an ID or create a second issue for the same independently reviewable outcome.
-2. **Choose one outcome and status.** The title must be `ID — concise outcome`, where the
-   ID follows that phase's existing convention. Use only `Backlog`, `Blocked`, `Ready`,
-   `In progress`, `Review`, or `Done`. New work is normally `Backlog` or `Blocked`; use
-   `Ready` only after every Definition of Ready check below passes. Never create a new
-   issue directly as `Done`.
-3. **Write the catalog entry first.** Use these canonical field names so
-   `scripts/sync-github-issues.py` can generate the GitHub body:
-
-   ```markdown
-   ## <ID> — <concise outcome>
-
-   - **Status:** <Backlog | Blocked — exact blocker | Ready>
-   - **Objective:** <one observable, independently reviewable outcome>
-   - **Implementation plan:** <ordered technical approach and failure/degraded behavior>
-   - **Files/modules:** <owner plus module boundaries and likely files>
-   - **Dependencies/blocks:** <issue IDs/external gates and what evidence unblocks them>
-   - **Acceptance criteria:** <observable pass/fail behaviors, including negative paths>
-   - **Required tests/evidence:** <named commands, fixtures, environments, and artifacts>
-   - **Security/migration:** <data/API/tenant impact; review trigger; migration/rollback,
-     or reasoned N/A>
-   - **Out of scope:** <explicit exclusions that prevent scope growth>
-   ```
-
-   Keep acceptance criteria separate from implementation tasks. Do not invent approvals,
-   owners, dependency completion, benchmark results, or security evidence. Record unknown
-   material facts as blockers instead.
-4. **Apply Definition of Ready.** Before using `Ready`, confirm: one outcome; explicit
-   scope and acceptance criteria; owner and module boundary; dependencies completed with
-   evidence; data/API/tenant impact stated; named test/evidence commands or fixtures;
-   security trigger assessed; and out-of-scope boundaries recorded. Otherwise retain
-   `Backlog`/`Blocked` and state the exact gap.
-5. **Maintain roadmap consistency.** Add the issue to the phase dependency graph and
-   summary where applicable. When adding a new ID, update the phase issue count and the
-   `Issue-level backlog (... issues)` total in `plans/markhand-web/README.md`. Do not add a
-   `Plan file` placeholder: `issue-delivery` creates and links the real plan before code.
-6. **Validate before synchronization.** Run:
-
-   ```bash
-   python3 scripts/build-roadmap.py
-   python3 scripts/build-roadmap.py --check
-   python3 scripts/sync-github-issues.py --dry-run
-   ```
-
-   Review the generated title, phase, status, and issue count. Fix catalog/parser errors;
-   do not bypass them.
-7. **Synchronize only when authorized.** With explicit permission, use the repository
-   synchronizer rather than manually duplicating the body:
-
-   ```bash
-   python3 scripts/sync-github-issues.py --create
-   # Use --update when an existing catalog issue changed.
-   ```
-
-   Confirm the GitHub title is `ID — title`, and that milestone, phase/status labels,
-   source paths, and rendered sections match the catalog. If remote write access is
-   unavailable, deliver the catalog change and report that synchronization remains.
-8. **Hand off to delivery.** Report the issue ID, status, catalog/phase links, blockers,
-   and validation evidence. Invoke `issue-delivery` only after the issue is `Ready`; that
-   workflow creates the detailed plan, branch, implementation, review, and Done evidence.
+1. **Load the mandatory contract.** Read and follow:
+   - `docs/conventions/issues-and-plans.md` for canonical issue format, authority, status,
+     roadmap consistency, synchronization, and prompt contract;
+   - `docs/conventions/delivery.md` for Definition of Ready/Done and security triggers;
+   - the owning roadmap/catalog and phase plan;
+   - `CLAUDE.md` for repository architecture constraints.
+   These documents supply mandatory requirements even when the prompt omits them.
+2. **Verify the gap and owner.** Inspect current code/docs and existing issues before
+   drafting. Do not create a duplicate for behavior already supported. Convert a broad
+   request into one independently reviewable outcome. Do not force core/desktop/CLI work
+   into a Web phase; if no owning catalog exists, obtain the owner's tracking decision.
+3. **Create the authoritative record.** Write the catalog entry first using the exact
+   fields and status rules in `issues-and-plans.md`. Record concrete blockers instead of
+   inventing owner, approval, dependency completion, benchmark, or security evidence.
+   Use `Ready` only when every Definition of Ready condition passes.
+4. **Keep the roadmap consistent.** Update dependency graph, phase summary, phase count,
+   total count, and generated roadmap as required by the owning catalog. Do not create a
+   placeholder plan link; `issue-delivery` creates and links the real file.
+5. **Validate the rendered issue.** For Markhand Web run the roadmap build/check and
+   `python3 scripts/sync-github-issues.py --dry-run` commands required by
+   `issues-and-plans.md`. Run relevant repository static checks and fix parser/count drift.
+6. **Mutate remote state only when authorized.** Use the repository synchronizer for
+   create/update; do not manually diverge the GitHub body from the catalog. If permission
+   or authentication is unavailable, deliver the authoritative local change and report the
+   remaining sync action.
+7. **Hand off concisely.** Return the issue ID, title, status, authority links, blockers,
+   and validation evidence. `issue-delivery` may start only when the issue is `Ready`.

--- a/.cursor/skills/issue-creator/SKILL.md
+++ b/.cursor/skills/issue-creator/SKILL.md
@@ -5,8 +5,9 @@ description: Create or revise a Markhand roadmap issue in the authoritative cata
 
 # Issue creator
 
-Use this workflow when decomposing a phase or creating/revising one issue. The user prompt
-only needs the outcome, special product constraints, and remote-write permission.
+Use this workflow when decomposing a phase or creating/revising one issue. A draft prompt
+only needs the outcome and special product constraints. Drafting never mutates GitHub;
+the canonical approval phrase defined below authorizes automatic synchronization.
 
 1. **Load the mandatory contract.** Read and follow:
    - `docs/conventions/issues-and-plans.md` for canonical issue format, authority, status,
@@ -29,9 +30,15 @@ only needs the outcome, special product constraints, and remote-write permission
 5. **Validate the rendered issue.** For Markhand Web run the roadmap build/check and
    `python3 scripts/sync-github-issues.py --dry-run` commands required by
    `issues-and-plans.md`. Run relevant repository static checks and fix parser/count drift.
-6. **Mutate remote state only when authorized.** Use the repository synchronizer for
-   create/update; do not manually diverge the GitHub body from the catalog. If permission
-   or authentication is unavailable, deliver the authoritative local change and report the
-   remaining sync action.
-7. **Hand off concisely.** Return the issue ID, title, status, authority links, blockers,
+6. **Treat draft approval as the sync trigger.** When the user says `Tôi duyệt draft.`,
+   revalidate the current draft against Definition of Ready. If it passes, change the
+   catalog status to `Ready`, update and validate roadmap metadata, then automatically
+   create the missing GitHub issue or update the existing one with the repository
+   synchronizer. The user does not need to request GitHub sync separately. Verify title,
+   milestone, labels, body, and source links, then return the issue URL.
+7. **Fail closed.** Approval does not waive readiness. If a required fact/evidence is
+   missing, do not mark `Ready` or create the GitHub issue; report the exact gap. Do not
+   manually diverge the GitHub body from the catalog. If authentication or authorization
+   fails, preserve the catalog as authority and report the remaining sync action.
+8. **Hand off concisely.** Return the issue ID, title, status, authority links, blockers,
    and validation evidence. `issue-delivery` may start only when the issue is `Ready`.

--- a/.cursor/skills/issue-creator/SKILL.md
+++ b/.cursor/skills/issue-creator/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: issue-creation
+name: issue-creator
 description: Create or revise a Markhand roadmap issue in the authoritative catalog, validate Definition of Ready, and safely synchronize the canonical format to GitHub.
 ---
 
-# Issue creation
+# Issue creator
 
 Use this workflow when decomposing a phase into issues or adding one roadmap issue. The
 Markdown phase catalog is authoritative; GitHub issues are synchronized representations.

--- a/.cursor/skills/issue-delivery/SKILL.md
+++ b/.cursor/skills/issue-delivery/SKILL.md
@@ -13,7 +13,7 @@ documents and the issue itself as authoritative; do not infer missing approval o
    dependencies/external-gate evidence, data/API/tenant impact (or reasoned `N/A`), named
    test commands or fixtures, and a security-trigger assessment. If a material item is
    missing, report the exact gap and keep the issue `Blocked`/`Backlog`; do not invent it.
-   Use `issue-creation` to repair an incomplete catalog issue before delivery.
+   Use `issue-creator` to repair an incomplete catalog issue before delivery.
 2. **Create or reuse the persisted plan before editing code.** Search the issue catalog's
    `Plan file` field and `plans/reports/`; update one existing plan instead of duplicating
    it. For an open issue, use the plan creation date:

--- a/.cursor/skills/issue-delivery/SKILL.md
+++ b/.cursor/skills/issue-delivery/SKILL.md
@@ -5,92 +5,44 @@ description: Deliver one repository issue through readiness checks, scoped imple
 
 # Issue delivery
 
-Use this workflow when implementing a roadmap or GitHub issue. Treat repository delivery
-documents and the issue itself as authoritative; do not infer missing approval or evidence.
+Use this workflow to deliver one Ready issue. The user prompt only needs the issue ID and
+special constraints; this skill owns plan creation, implementation discipline, review,
+evidence, and status transitions.
 
-1. **Validate Definition of Ready.** Confirm the issue has one independently reviewable
-   outcome, explicit scope and acceptance criteria, an owner and module boundary, completed
-   dependencies/external-gate evidence, data/API/tenant impact (or reasoned `N/A`), named
-   test commands or fixtures, and a security-trigger assessment. If a material item is
-   missing, report the exact gap and keep the issue `Blocked`/`Backlog`; do not invent it.
-   Use `issue-creator` to repair an incomplete catalog issue before delivery.
-2. **Create or reuse the persisted plan before editing code.** Search the issue catalog's
-   `Plan file` field and `plans/reports/`; update one existing plan instead of duplicating
-   it. For an open issue, use the plan creation date:
-   `plans/reports/plan-YYYY-MM-DD-<lowercase-id>-<slug>.md` and `Created: YYYY-MM-DD`.
-   For a historical issue already closed, use its verified GitHub close date in both the
-   filename and `Issue closed: YYYY-MM-DD`. Never use today's date merely because a
-   generator runs, and omit unavailable metadata instead of writing `Base commit: UNKNOWN`.
-   Link the real file directly below the catalog `Status` field.
-3. **Use the canonical plan structure.** Set `Status: Planned` before implementation,
-   `In progress` while coding, `Blocked` with the exact blocker, and `Done` only after the
-   repository Definition of Done passes. The file must contain:
-
-   ```markdown
-   # <ID> — <title>
-
-   <Created: YYYY-MM-DD for open work, or Issue closed: YYYY-MM-DD for historical work>
-   Source issue: <verified GitHub link, or state that catalog sync is pending>
-   Catalog: <relative Markdown link>
-   Phase plan: <relative Markdown link>
-   Status: Planned
-
-   ## Objective
-   ## Context
-   ## Implementation plan
-   ## Files/modules
-   ## Dependencies / blocks
-   ## Acceptance criteria
-   ## Required tests / evidence
-   ## Security and migration notes
-   ## Out of scope
-   ## Delivery evidence
-   ### Implementation PRs
-   ### Recorded commit/SHA references
-   ## Definition of done
-   ```
-
-   Fill every section from repository evidence. Use `N/A` with a reason where appropriate;
-   use `UNKNOWN` only for a material historical fact that cannot be recovered. Do not
-   fabricate links, commits, approvals, dates, tests, or delivery evidence.
-4. **Build an acceptance map in the plan.** For every acceptance criterion, record the
-   implementation location, automated or manual verification, fixture/environment, and
-   expected evidence. Include compatibility, degraded/error behavior, migration/rollback,
-   performance, docs, and deployed evidence when applicable. Preserve explicit
-   out-of-scope boundaries.
-5. **Plan the technical sequence.** Inspect current contracts and invariants, then order
-   changes by dependency. Identify files, state/data/API transitions, failure/cancellation/
-   idempotency behavior, observability without sensitive content, documentation, and
-   rollback needs. Escalate unclear product or destructive choices instead of guessing.
-6. **Implement one issue per branch and logical PR.** Keep changes limited to the mapped
-   outcome; reference the roadmap issue ID in the PR title. Do not bundle opportunistic
-   cleanup, reuse `vendor/markitdown-rs`, or change intentional dependency pins without
-   issue-backed justification. Include `Cargo.lock` for dependency-manifest changes.
-7. **Apply security controls.** Require security review for auth/session, org/RBAC/ACL,
-   upload/converter sandbox, object storage/signed URLs, SQL/RLS/migrations, secrets/egress,
-   LLM content policy, audit/logging, dependencies/native binaries, or CI permissions.
-   Never self-approve security/ADR exceptions. Never commit or expose credentials, tokens,
-   keys, signed URLs, customer documents, model binaries, benchmark hostnames, prompts, PII,
-   or document content in logs/evidence. Report suspected exposure privately.
-8. **Test proportionately.** Run focused unit, integration/contract, denial/security,
-   migration/rollback, performance, and manual checks selected by the acceptance map.
-   Use `make check-foundation` before review; for server/local-service work also run
-   `make dev-up`, `make dev-health`, and `make dev-down`. For every Rust PR push run:
-   `cargo fmt --all -- --check`,
-   `cargo metadata --locked --format-version 1 --no-deps`, and
-   `python3 scripts/check-dependency-policy.py`, plus relevant Rust tests. Follow
-   `docs/runbooks/contributor-setup.md` for subsystem gates and test preconditions.
-9. **Obtain independent verification.** Have a reviewer or independent verification pass
-   check the issue, persisted plan, acceptance map, diff, negative paths, security/ADR
-   triggers, and evidence. The author must not be the sole verifier. Remediate high/critical
-   findings or document their owner, compensating control, expiry, and retest date.
-10. **Record evidence, then update status.** Capture commands, fixture/workload,
-    environment/tool versions, final commit, PR links, and artifact/report locations in the
-    plan without secret- or corpus-bearing logs. Update plan status, Markdown issue status,
-    blockers, and generated roadmap only after criteria and evidence pass; let repository
-    synchronization manage GitHub state.
-11. **Distinguish merge from Done.** A merged PR is not `Done` when deployment, benchmark,
-    external gate, migration, or other post-merge evidence remains. State what is proven and
-    what remains. Do not blindly create milestones/issues, deploy, release, or change remote
-    tracking state; perform those actions only when the issue and explicit authorization
-    require them.
+1. **Load the mandatory contract.** Read and follow:
+   - `docs/conventions/issues-and-plans.md` for plan naming, metadata, sections, acceptance
+     mapping, evidence, lifecycle, and catalog linking;
+   - `docs/conventions/delivery.md` for Definition of Ready/Done and security triggers;
+   - `CONTRIBUTING.md` and `docs/runbooks/contributor-setup.md` for workflow/quality gates;
+   - `CLAUDE.md` and relevant ADRs for architecture constraints.
+   These requirements apply even when the prompt does not repeat them.
+2. **Gate on readiness.** Verify the authoritative issue and dependencies. If any material
+   Ready condition is absent, state the exact gap, retain `Backlog`/`Blocked`, and use
+   `issue-creator` to repair the record. Do not infer approval or evidence.
+3. **Persist the plan before code.** Create or reuse exactly one plan under
+   `plans/reports/`, using the canonical date semantics, format, status, and catalog link
+   from `issues-and-plans.md`. Populate every section from repository facts and map every
+   acceptance criterion to implementation location, verification, fixture/environment,
+   and expected evidence. Never fabricate metadata or create a duplicate plan.
+4. **Plan the technical sequence.** Inspect current contracts and invariants; identify
+   files, dependencies, state/data/API transitions, negative/degraded behavior,
+   cancellation/idempotency, security/migration/rollback, observability, docs, and tests.
+   Escalate unclear product or destructive choices instead of guessing.
+5. **Implement one issue per branch and logical PR.** Keep changes limited to the mapped
+   outcome. Do not bundle opportunistic cleanup, depend on `vendor/markitdown-rs`, change
+   intentional pins without issue-backed justification, or omit lockfile updates.
+6. **Apply mandatory security controls.** Trigger the required review for the areas named
+   in `delivery.md`. Never self-approve exceptions or expose credentials, signed URLs,
+   customer documents, model artifacts, prompts, PII, content, or secret-bearing logs.
+7. **Verify proportionately.** Run focused unit, integration/contract, denial/security,
+   migration/rollback, performance, and manual checks from the acceptance map, plus every
+   applicable repository preflight in the contributor runbook.
+8. **Obtain independent review.** A reviewer other than the implementer checks the issue,
+   plan, diff, negative paths, security/ADR triggers, and evidence. Remediate high/critical
+   findings or record the required owner, control, expiry, and retest date.
+9. **Record evidence and transition status.** Keep plan, catalog, roadmap, PR, commit,
+   commands, environment, artifacts, blockers, and GitHub representation consistent.
+   Mark `Done` only when the documented Definition of Done passes; merge alone is not Done.
+10. **Mutate external state only when authorized.** Do not create issues/milestones,
+    deploy, release, or change remote tracking state unless the issue and user authorization
+    require it. Report what is proven and what remains.

--- a/.cursor/skills/issue-delivery/SKILL.md
+++ b/.cursor/skills/issue-delivery/SKILL.md
@@ -13,25 +13,66 @@ documents and the issue itself as authoritative; do not infer missing approval o
    dependencies/external-gate evidence, data/API/tenant impact (or reasoned `N/A`), named
    test commands or fixtures, and a security-trigger assessment. If a material item is
    missing, report the exact gap and keep the issue `Blocked`/`Backlog`; do not invent it.
-2. **Build an acceptance map.** For every acceptance criterion, record the implementation
-   location, automated or manual verification, fixture/environment, and expected evidence.
-   Include compatibility, degraded/error behavior, migration/rollback, performance, docs,
-   and deployed evidence when applicable. Preserve explicit out-of-scope boundaries.
-3. **Plan before editing.** Inspect current contracts and invariants, then order changes by
-   dependency. Identify files, state/data/API transitions, failure/cancellation/idempotency
-   behavior, observability without sensitive content, documentation, and rollback needs.
-   Escalate unclear product or destructive choices instead of guessing.
-4. **Implement one issue per branch and logical PR.** Keep changes limited to the mapped
+   Use `issue-creation` to repair an incomplete catalog issue before delivery.
+2. **Create or reuse the persisted plan before editing code.** Search the issue catalog's
+   `Plan file` field and `plans/reports/`; update one existing plan instead of duplicating
+   it. For an open issue, use the plan creation date:
+   `plans/reports/plan-YYYY-MM-DD-<lowercase-id>-<slug>.md` and `Created: YYYY-MM-DD`.
+   For a historical issue already closed, use its verified GitHub close date in both the
+   filename and `Issue closed: YYYY-MM-DD`. Never use today's date merely because a
+   generator runs, and omit unavailable metadata instead of writing `Base commit: UNKNOWN`.
+   Link the real file directly below the catalog `Status` field.
+3. **Use the canonical plan structure.** Set `Status: Planned` before implementation,
+   `In progress` while coding, `Blocked` with the exact blocker, and `Done` only after the
+   repository Definition of Done passes. The file must contain:
+
+   ```markdown
+   # <ID> — <title>
+
+   <Created: YYYY-MM-DD for open work, or Issue closed: YYYY-MM-DD for historical work>
+   Source issue: <verified GitHub link, or state that catalog sync is pending>
+   Catalog: <relative Markdown link>
+   Phase plan: <relative Markdown link>
+   Status: Planned
+
+   ## Objective
+   ## Context
+   ## Implementation plan
+   ## Files/modules
+   ## Dependencies / blocks
+   ## Acceptance criteria
+   ## Required tests / evidence
+   ## Security and migration notes
+   ## Out of scope
+   ## Delivery evidence
+   ### Implementation PRs
+   ### Recorded commit/SHA references
+   ## Definition of done
+   ```
+
+   Fill every section from repository evidence. Use `N/A` with a reason where appropriate;
+   use `UNKNOWN` only for a material historical fact that cannot be recovered. Do not
+   fabricate links, commits, approvals, dates, tests, or delivery evidence.
+4. **Build an acceptance map in the plan.** For every acceptance criterion, record the
+   implementation location, automated or manual verification, fixture/environment, and
+   expected evidence. Include compatibility, degraded/error behavior, migration/rollback,
+   performance, docs, and deployed evidence when applicable. Preserve explicit
+   out-of-scope boundaries.
+5. **Plan the technical sequence.** Inspect current contracts and invariants, then order
+   changes by dependency. Identify files, state/data/API transitions, failure/cancellation/
+   idempotency behavior, observability without sensitive content, documentation, and
+   rollback needs. Escalate unclear product or destructive choices instead of guessing.
+6. **Implement one issue per branch and logical PR.** Keep changes limited to the mapped
    outcome; reference the roadmap issue ID in the PR title. Do not bundle opportunistic
    cleanup, reuse `vendor/markitdown-rs`, or change intentional dependency pins without
    issue-backed justification. Include `Cargo.lock` for dependency-manifest changes.
-5. **Apply security controls.** Require security review for auth/session, org/RBAC/ACL,
+7. **Apply security controls.** Require security review for auth/session, org/RBAC/ACL,
    upload/converter sandbox, object storage/signed URLs, SQL/RLS/migrations, secrets/egress,
    LLM content policy, audit/logging, dependencies/native binaries, or CI permissions.
    Never self-approve security/ADR exceptions. Never commit or expose credentials, tokens,
    keys, signed URLs, customer documents, model binaries, benchmark hostnames, prompts, PII,
    or document content in logs/evidence. Report suspected exposure privately.
-6. **Test proportionately.** Run focused unit, integration/contract, denial/security,
+8. **Test proportionately.** Run focused unit, integration/contract, denial/security,
    migration/rollback, performance, and manual checks selected by the acceptance map.
    Use `make check-foundation` before review; for server/local-service work also run
    `make dev-up`, `make dev-health`, and `make dev-down`. For every Rust PR push run:
@@ -39,16 +80,17 @@ documents and the issue itself as authoritative; do not infer missing approval o
    `cargo metadata --locked --format-version 1 --no-deps`, and
    `python3 scripts/check-dependency-policy.py`, plus relevant Rust tests. Follow
    `docs/runbooks/contributor-setup.md` for subsystem gates and test preconditions.
-7. **Obtain independent verification.** Have a reviewer or independent verification pass
-   check the acceptance map, diff, negative paths, security/ADR triggers, and evidence.
-   The author must not be the sole verifier. Remediate high/critical findings or document
-   their owner, compensating control, expiry, and retest date.
-8. **Record evidence, then update status.** Capture commands, fixture/workload,
-   environment/tool versions, final commit, and artifact/report locations without secret
-   or corpus-bearing logs. Update the Markdown issue, blockers, and generated roadmap only
-   after criteria and evidence pass; let repository synchronization manage GitHub state.
-9. **Distinguish merge from Done.** A merged PR is not `Done` when deployment, benchmark,
-   external gate, migration, or other post-merge evidence remains. State what is proven and
-   what remains. Do not blindly create milestones/issues, deploy, release, or change remote
-   tracking state; perform those actions only when the issue and explicit authorization
-   require them.
+9. **Obtain independent verification.** Have a reviewer or independent verification pass
+   check the issue, persisted plan, acceptance map, diff, negative paths, security/ADR
+   triggers, and evidence. The author must not be the sole verifier. Remediate high/critical
+   findings or document their owner, compensating control, expiry, and retest date.
+10. **Record evidence, then update status.** Capture commands, fixture/workload,
+    environment/tool versions, final commit, PR links, and artifact/report locations in the
+    plan without secret- or corpus-bearing logs. Update plan status, Markdown issue status,
+    blockers, and generated roadmap only after criteria and evidence pass; let repository
+    synchronization manage GitHub state.
+11. **Distinguish merge from Done.** A merged PR is not `Done` when deployment, benchmark,
+    external gate, migration, or other post-merge evidence remains. State what is proven and
+    what remains. Do not blindly create milestones/issues, deploy, release, or change remote
+    tracking state; perform those actions only when the issue and explicit authorization
+    require them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,9 @@ Start with:
 1. [`CLAUDE.md`](CLAUDE.md) for project priorities/native dependencies.
 2. [`docs/adr/0001-web-boundaries.md`](docs/adr/0001-web-boundaries.md).
 3. [`docs/conventions/delivery.md`](docs/conventions/delivery.md) for Ready/Done.
-4. [`docs/runbooks/contributor-setup.md`](docs/runbooks/contributor-setup.md).
+4. [`docs/conventions/issues-and-plans.md`](docs/conventions/issues-and-plans.md) for the
+   canonical issue and implementation-plan formats.
+5. [`docs/runbooks/contributor-setup.md`](docs/runbooks/contributor-setup.md).
 
 ## Workflow
 

--- a/docs/conventions/issues-and-plans.md
+++ b/docs/conventions/issues-and-plans.md
@@ -14,8 +14,8 @@ trigger nằm tại [`delivery.md`](delivery.md); quality gate nằm tại
   tracking location/milestone với owner trước khi tạo remote issue.
 - Một issue chỉ có một outcome có thể review độc lập. Không tạo issue mới nếu code hoặc issue
   hiện có đã đáp ứng outcome; khi đó phải thu hẹp thành gap hoặc enhancement thực sự.
-- Không tự tạo GitHub issue, milestone, label hay thay đổi trạng thái remote nếu user chưa
-  cho phép rõ ràng.
+- Draft không tạo GitHub issue. Câu xác nhận `Tôi duyệt draft.` là quyền rõ ràng để chuyển
+  draft đủ điều kiện sang `Ready` và đồng bộ GitHub theo quy trình bên dưới.
 
 ## Format issue
 
@@ -89,7 +89,23 @@ Khi thêm issue vào Markhand Web:
    python3 scripts/sync-github-issues.py --dry-run
    ```
 
-Chỉ khi được cho phép mới chạy `--create` hoặc `--update`.
+### Duyệt draft và tự động đồng bộ
+
+`Tôi duyệt draft.` là approval trigger canonical. Khi nhận trigger này, `issue-creator`
+phải tự thực hiện toàn bộ các bước sau, user không cần yêu cầu sync riêng:
+
+1. kiểm tra lại Definition of Ready trên nội dung draft hiện tại;
+2. nếu đạt, đổi catalog status sang `Ready`, cập nhật roadmap/count liên quan và chạy lại
+   validation;
+3. tạo GitHub issue nếu chưa tồn tại, hoặc cập nhật issue đã tồn tại, bằng repository
+   synchronizer;
+4. xác nhận title, milestone, labels, body và source paths khớp catalog;
+5. trả về issue ID/URL và validation evidence.
+
+Approval không miễn bất kỳ điều kiện Ready nào. Nếu draft còn thiếu owner, acceptance,
+dependency evidence, security assessment hoặc dữ kiện bắt buộc khác, không chuyển `Ready`
+và không tạo GitHub issue; báo chính xác phần còn thiếu. Nếu authentication/authorization
+thất bại, giữ catalog đã duyệt làm authority và báo sync action chưa hoàn thành.
 
 ## Format implementation plan
 
@@ -170,16 +186,21 @@ sử quan trọng đã cố gắng truy tìm nhưng không thể phục hồi.
 
 ## Prompt contract cho Cursor
 
-Skill chịu trách nhiệm đọc và thực thi toàn bộ chuẩn trên. Prompt của user chỉ cần nêu:
+Skill chịu trách nhiệm đọc và thực thi toàn bộ chuẩn trên. Prompt tạo draft chỉ cần nêu:
 
 1. mục tiêu hoặc issue ID;
-2. constraint kinh doanh đặc biệt nếu có;
-3. có hay không quyền tạo/sửa resource remote.
+2. constraint kinh doanh đặc biệt nếu có.
 
 Ví dụ:
 
 ```text
-Dùng issue-creator tạo draft issue cho hỗ trợ TXT UTF-16 trong core; chưa sync GitHub.
+Dùng issue-creator tạo draft issue cho hỗ trợ TXT UTF-16 trong core.
+```
+
+Sau khi review draft:
+
+```text
+Tôi duyệt draft.
 ```
 
 ```text

--- a/docs/conventions/issues-and-plans.md
+++ b/docs/conventions/issues-and-plans.md
@@ -1,0 +1,190 @@
+# Chuẩn issue và implementation plan
+
+Tài liệu này là nguồn chuẩn cho format issue và plan. Definition of Ready/Done và security
+trigger nằm tại [`delivery.md`](delivery.md); quality gate nằm tại
+[`../runbooks/contributor-setup.md`](../runbooks/contributor-setup.md).
+
+## Nguồn dữ liệu authoritative
+
+- Với Markhand Web, phase catalog trong
+  `plans/markhand-web/backlog/<phase>/issues/README.md` là authority. GitHub issue được
+  render/synchronize từ catalog bằng `scripts/sync-github-issues.py`.
+- Với subsystem khác, dùng catalog/milestone hiện có của subsystem đó. Không đưa issue core,
+  desktop hoặc CLI vào phase Web chỉ để lấy ID. Nếu chưa có catalog phù hợp, phải xác nhận
+  tracking location/milestone với owner trước khi tạo remote issue.
+- Một issue chỉ có một outcome có thể review độc lập. Không tạo issue mới nếu code hoặc issue
+  hiện có đã đáp ứng outcome; khi đó phải thu hẹp thành gap hoặc enhancement thực sự.
+- Không tự tạo GitHub issue, milestone, label hay thay đổi trạng thái remote nếu user chưa
+  cho phép rõ ràng.
+
+## Format issue
+
+### Tiêu đề và trạng thái
+
+Tiêu đề canonical:
+
+```text
+<ID> — <outcome ngắn gọn>
+```
+
+ID phải theo convention của catalog/milestone sở hữu. Trạng thái hợp lệ:
+
+- `Backlog`: scope đã ghi nhưng chưa đủ điều kiện bắt đầu;
+- `Blocked — <lý do chính xác>`: thiếu dependency, quyết định hoặc external evidence;
+- `Ready`: vượt qua toàn bộ Definition of Ready;
+- `In progress`: đang triển khai;
+- `Review`: implementation/evidence đang được review;
+- `Done`: vượt qua Definition of Done, không chỉ vì PR đã merge.
+
+Issue mới không được tạo trực tiếp ở trạng thái `Done`.
+
+### Catalog entry canonical
+
+```markdown
+## <ID> — <outcome ngắn gọn>
+
+- **Status:** <Backlog | Blocked — exact blocker | Ready>
+- **Objective:** <một outcome quan sát và review độc lập được>
+- **Implementation plan:** <hướng kỹ thuật theo thứ tự; failure/degraded behavior>
+- **Files/modules:** <owner; module boundary; file dự kiến>
+- **Dependencies/blocks:** <issue ID/external gate; evidence cần để unblock>
+- **Acceptance criteria:** <hành vi pass/fail quan sát được, gồm negative path>
+- **Required tests/evidence:** <command, fixture, environment và artifact cụ thể>
+- **Security/migration:** <data/API/tenant impact; security trigger; migration/rollback,
+  hoặc N/A có lý do>
+- **Out of scope:** <giới hạn rõ để tránh scope creep>
+```
+
+Các tên field trên là canonical vì `scripts/sync-github-issues.py` dùng chúng để tạo GitHub
+body. Acceptance criteria mô tả hành vi cần chứng minh; implementation plan mô tả cách dự
+kiến thực hiện. Không trộn hai loại nội dung.
+
+Chỉ dùng `Ready` khi đã có:
+
+1. một outcome và scope rõ;
+2. acceptance criteria quan sát được;
+3. owner và module boundary;
+4. dependency/external gate đã hoàn tất với evidence;
+5. data/API/tenant impact hoặc `N/A` có lý do;
+6. test command/fixture/evidence được chỉ định;
+7. security trigger được đánh giá;
+8. out-of-scope rõ ràng.
+
+Thiếu dữ kiện quan trọng phải dùng `Backlog`/`Blocked`; không tự suy đoán owner, approval,
+dependency completion, benchmark hoặc security evidence.
+
+### Roadmap consistency
+
+Khi thêm issue vào Markhand Web:
+
+1. thêm issue vào phase dependency graph và summary nếu áp dụng;
+2. cập nhật issue count của phase và tổng `Issue-level backlog (... issues)` tại
+   `plans/markhand-web/README.md`;
+3. không thêm `Plan file` placeholder; chỉ liên kết sau khi file plan thật đã được tạo;
+4. chạy:
+
+   ```bash
+   python3 scripts/build-roadmap.py
+   python3 scripts/build-roadmap.py --check
+   python3 scripts/sync-github-issues.py --dry-run
+   ```
+
+Chỉ khi được cho phép mới chạy `--create` hoặc `--update`.
+
+## Format implementation plan
+
+### Vị trí và tên file
+
+Plan được lưu tại:
+
+```text
+plans/reports/plan-YYYY-MM-DD-<lowercase-id>-<slug>.md
+```
+
+- Issue đang mở: ngày trong filename là ngày plan được tạo; metadata dùng
+  `Created: YYYY-MM-DD`.
+- Hồ sơ lịch sử cho issue đã đóng: ngày trong filename và `Issue closed: YYYY-MM-DD` phải
+  lấy từ verified GitHub close timestamp.
+- Không dùng ngày chạy generator thay cho ngày có ý nghĩa.
+- Không ghi metadata không có giá trị như `Base commit: UNKNOWN`.
+- Một issue chỉ có một linked plan; cập nhật file hiện có thay vì tạo bản trùng.
+
+### Metadata và section canonical
+
+```markdown
+# <ID> — <title>
+
+Created: <YYYY-MM-DD>
+Source issue: <verified GitHub link, hoặc ghi catalog sync đang pending>
+Catalog: <relative Markdown link>
+Phase plan: <relative Markdown link, hoặc N/A có lý do>
+Status: Planned
+
+## Objective
+
+## Context
+
+## Implementation plan
+
+## Files/modules
+
+## Dependencies / blocks
+
+## Acceptance criteria
+
+## Required tests / evidence
+
+## Security and migration notes
+
+## Out of scope
+
+## Delivery evidence
+
+### Implementation PRs
+
+### Recorded commit/SHA references
+
+## Definition of done
+```
+
+Với hồ sơ lịch sử, thay `Created` bằng `Issue closed`. Không tạo link, commit, approval,
+date, test result hoặc evidence giả. `N/A` phải có lý do. Chỉ dùng `UNKNOWN` cho fact lịch
+sử quan trọng đã cố gắng truy tìm nhưng không thể phục hồi.
+
+### Lifecycle
+
+- Tạo plan trước khi sửa code và link trực tiếp dưới field `Status` của catalog:
+
+  ```markdown
+  - **Plan file:** [<ID> detailed implementation plan](<relative-path>)
+  ```
+
+- Plan bắt đầu ở `Status: Planned`, chuyển `In progress` khi code bắt đầu, `Blocked` khi có
+  blocker cụ thể, và `Done` chỉ sau khi Definition of Done đạt.
+- Mỗi acceptance criterion phải map tới implementation location, test/manual verification,
+  fixture/environment và expected evidence.
+- Trong quá trình delivery, cập nhật plan bằng PR, final commit, command, environment và
+  artifact thực tế; không ghi secret, token, customer content, PII hoặc corpus-bearing log.
+- Reviewer độc lập phải kiểm tra issue, plan, diff, negative paths, security/ADR trigger và
+  evidence. Author không phải verifier duy nhất.
+
+## Prompt contract cho Cursor
+
+Skill chịu trách nhiệm đọc và thực thi toàn bộ chuẩn trên. Prompt của user chỉ cần nêu:
+
+1. mục tiêu hoặc issue ID;
+2. constraint kinh doanh đặc biệt nếu có;
+3. có hay không quyền tạo/sửa resource remote.
+
+Ví dụ:
+
+```text
+Dùng issue-creator tạo draft issue cho hỗ trợ TXT UTF-16 trong core; chưa sync GitHub.
+```
+
+```text
+Dùng issue-delivery triển khai P1A-11.
+```
+
+User không cần lặp lại format issue, format plan, quality gate, security review, reviewer
+độc lập hay điều kiện `Done`; đó là trách nhiệm bắt buộc của skill.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Adds `issue-creator`, extends `issue-delivery`, and centralizes mandatory issue/plan requirements so user prompts remain minimal.

## Scope

- Add `.cursor/skills/issue-creator/SKILL.md` for authoritative issue creation and readiness validation.
- Define `Tôi duyệt draft.` as the canonical trigger to revalidate Ready, update the catalog/roadmap, and automatically create or update the GitHub issue.
- Fail closed when approval is given but Definition of Ready remains incomplete.
- Require `issue-delivery` to create/reuse and maintain a persisted plan before code.
- Add `docs/conventions/issues-and-plans.md` as the canonical issue/plan format, lifecycle, and prompt contract.
- Reference existing Ready/Done, contributor, runbook, architecture, and roadmap authorities from both skills.
- Link the convention from `CONTRIBUTING.md`.

## Evidence

- [x] Approval-trigger contract appears in both the skill and canonical convention.
- [x] Approval revalidates Definition of Ready and fails closed before any Ready/remote transition.
- [x] No prompt example requires a separate GitHub synchronization request.
- [x] `git diff --check` and `make check-static` pass.

## Boundary and security review

- [x] Dependency boundary check passed; documentation-only change.
- [x] Tenant/ACL impact reviewed: N/A.
- [x] Sensitive logging/secret/egress impact reviewed: no sensitive values added.
- [x] Security review trigger checked: not triggered.

## Follow-up

- [x] Users no longer need to request GitHub synchronization separately after approving a valid draft.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f9711cc-150b-47c7-a7b7-e586b904f7e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f9711cc-150b-47c7-a7b7-e586b904f7e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

