### PR TITLE
docs: refresh living codebase documentation

### DIFF
--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -103,7 +103,7 @@ Không đo lại = không claims "nhanh/đúng hơn". Quy tắc Fail loud: báo 
 
 - `default = []` — core build tinh gọn, offline.
 - feature `audio` (opt-in) → `whisper-rs`/`symphonia`/`rubato`, mở transcribe. TẮT mặc định: whisper.cpp
-  phải compile C++ qua cmake (~1–2 phút), chỉ cli/desktop cần — server/knowledge dùng lõi text-only
+  phải compile C++ qua cmake (~1–2 phút), chỉ CLI/desktop/MCP cần — server/knowledge dùng lõi text-only
   không gánh chi phí này.
 - `cuda` / `metal` / `vulkan` / `hipblas` / `openblas` / `openmp` → **kéo theo feature `audio`** (proxy
   sang `whisper-rs` để tăng tốc GPU/BLAS), không bật độc lập được.

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -16,6 +16,7 @@
 | `pdf-extract` | `=0.8.2` | 0.12 **panic** trên một số PDF mà 0.8.2 xử lý được |
 | `symphonia` | `0.5` | 0.6 cấu trúc lại module, đổi API |
 | `time` (app) | `=0.3.51` | tương thích cookie 0.18.1 |
+| `sha2` (workspace, `sha2 = "=0.11.0"`) | `=0.11.0` | contract durable intelligence ID `sha256-v1` (ADR 0013): `DefaultHasher` không ổn định qua version Rust nên ID SQLite/HNSW/handoff sẽ trôi; pin để cùng họ crate với ADR 0006 (server digest) — đừng nâng ngoài quy trình ADR |
 
 Crate chính (không pin cứng nhưng cố ý giữ ổn định): `pdfium-render 0.9.2`, `pdf-inspector 0.1.3`,
 `docx-rust 0.1.11`, `whisper-rs 0.16`, `htmd 0.5`, `calamine 0.35`, `quick-xml 0.37`, `zip 2.2`,
@@ -25,7 +26,7 @@ Crate chính (không pin cứng nhưng cố ý giữ ổn định): `pdfium-rend
 
 PDF và whisper **đắt** → phải giữ pattern cache. Đừng "dọn" thành gọi thẳng mỗi lần.
 
-- **PDFium thread_local + PDFIUM_CALL lock** (`crates/core/src/conv/pdf.rs`): `thread_local! { static PDFIUM: Option<Pdfium> = load_pdfium() }`.
+- **PDFium thread_local + PDFIUM_CALL lock** (`crates/core/src/conv/pdf/pdfium.rs`): `thread_local! { static PDFIUM: Option<Pdfium> = load_pdfium() }`.
   Mỗi thread 1 instance, init 1 lần/tiến trình. Chỉ load khi thực sự cần OCR (`need_pdfium` gate).
   **libpdfium KHÔNG thread-safe**: mỗi region dùng PDFium (cả render+OCR) phải acquire `PDFIUM_CALL: Mutex<()>` trước.
   Concurrent scanned-PDF conversions sẽ queue tại lock (trade-off vs throughput).
@@ -39,7 +40,8 @@ PDF và whisper **đắt** → phải giữ pattern cache. Đừng "dọn" thàn
   (`audio_threads`, `audio_no_speech_threshold`) stay on `AudioEngine` and are **not** part of the
   cache key. Resample to 16 kHz uses `rubato` FFT with partial/flush + `output_delay` trim;
   returns `Result` (never invents silence on failure). Trả `Unsupported` nếu chưa có model.
-- **Tesseract**: spawn mỗi lần qua `crate::proc::background_command()` (không cache process). Temp PNG dùng bộ đếm `AtomicU64`.
+- **Tesseract**: spawn mỗi lần qua `crate::proc::background_command()` (không cache process). Temp PNG ghi qua
+  `tempfile::NamedTempFile` (exclusive `O_EXCL`/tên random) — tránh path đoán được trong `/tmp`.
 
 ## Subprocess spawning — MUST dùng `crate::proc::background_command`
 
@@ -74,7 +76,7 @@ và cách app/CLI gom file.
 
 ## Khi đổi OCR / PDF — MUST đo lại
 
-Sau bất kỳ thay đổi nào ở `image_ocr.rs`, `audio.rs`, `conv/pdf.rs`: **đo lại** bằng CLI trên corpus
+Sau bất kỳ thay đổi nào ở `image_ocr.rs`, `audio.rs`, `conv/pdf/`: **đo lại** bằng CLI trên corpus
 (tái tạo qua `bench/*.sh`):
 
 ```bash
@@ -100,7 +102,11 @@ Không đo lại = không claims "nhanh/đúng hơn". Quy tắc Fail loud: báo 
 ## Tính năng (feature gates)
 
 - `default = []` — core build tinh gọn, offline.
-- `cuda` / `metal` / `vulkan` / `hipblas` / `openblas` / `openmp` → proxy sang `whisper-rs` để tăng tốc GPU.
+- feature `audio` (opt-in) → `whisper-rs`/`symphonia`/`rubato`, mở transcribe. TẮT mặc định: whisper.cpp
+  phải compile C++ qua cmake (~1–2 phút), chỉ cli/desktop cần — server/knowledge dùng lõi text-only
+  không gánh chi phí này.
+- `cuda` / `metal` / `vulkan` / `hipblas` / `openblas` / `openmp` → **kéo theo feature `audio`** (proxy
+  sang `whisper-rs` để tăng tốc GPU/BLAS), không bật độc lập được.
 - `llm` → `reqwest` (blocking, rustls-tls) + `base64`, mở `pub mod llm`. **MCP crate luôn build với `llm`.**
 
 ## Build native (yêu cầu môi trường)
@@ -117,7 +123,6 @@ Override đường dẫn qua env: `FILECONV_PDFIUM_LIB`, `FILECONV_TESSDATA`, `F
 
 - `pdf-extract` và `pdf-inspector` đều bọc `catch_unwind(AssertUnwindSafe)` — lopdf/pdf-extract panic trên PDF malformed. Giữ wrapper.
 - `tables.rs` CSV path dùng `String::from_utf8_lossy` và **không** decode TCVN3 như `csv_conv.rs` — bất nhất đã biết.
-- CLI `count_pages` cho PPTX shell ra `python3` trong khi `probe.rs` đếm native Rust — logic trùng, 2 implementation.
 
 ## Tham chiếu chéo
 - Map code: [`codebase-summary.md`](codebase-summary.md)

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -107,7 +107,9 @@ Không đo lại = không claims "nhanh/đúng hơn". Quy tắc Fail loud: báo 
   không gánh chi phí này.
 - `cuda` / `metal` / `vulkan` / `hipblas` / `openblas` / `openmp` → **kéo theo feature `audio`** (proxy
   sang `whisper-rs` để tăng tốc GPU/BLAS), không bật độc lập được.
-- `llm` → `reqwest` (blocking, rustls-tls) + `base64`, mở `pub mod llm`. **MCP crate luôn build với `llm`.**
+- `llm` → `reqwest` (blocking, rustls-tls) + `httpdate`, mở `pub mod llm`. `base64` là dependency
+  **không điều kiện** (dùng cả ngoài `llm`, ví dụ `pptx_preview.rs`), không phải feature dep của `llm`.
+  **MCP crate luôn build với `llm`.**
 
 ## Build native (yêu cầu môi trường)
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -66,7 +66,7 @@ Tám subcommand đăng ký ở `registered_commands()` (`crates/cli/src/main.rs`
 | `accuracy` | CER/WER (Levenshtein, `normalize()` bỏ markdown) theo manifest |
 | `audio` | (feature `audio`) WER/RTF/load mỗi model GGML |
 | `handoff` | đóng gói handoff (BRD/PRD) từ nhiều file nguồn → ZIP |
-| `pptx-preview` | JSON preview meta/slides/shapes; metadata PPTX lấy qua `fileconv_core::pptx_preview`/`probe` (đường Rust thuần, không còn nhánh shell Python riêng) |
+| `pptx-preview` | JSON preview meta/slides/shapes qua `fileconv_core::pptx_preview::preview_meta`/`preview_slide` |
 | `info` | danh sách định dạng hỗ trợ + trạng thái PDFium/tessdata/model whisper |
 
 ## `crates/mcp/` — binary `fileconv-mcp`

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -30,8 +30,9 @@ Q&A) đi qua contract `fileconv-knowledge` (`crates/knowledge`) — `types`, `qu
 `locate_chunk_text`) và **embedding runtime** (suy luận/parse runtime path) đều bắt
 nguồn từ `fileconv-core` (`src/chunk.rs`, `src/embedding_runtime.rs`): server path-dep
 thẳng vào `fileconv-core` để chunk (`services/chunking.rs`, `services/citation.rs`),
-còn `fileconv-knowledge` chỉ tái dùng/re-export phần embedding runtime khi cần
-(ví dụ `infer_runtime_path` re-export `fileconv_core::embedding_runtime::infer_embedding_runtime_path`)
+còn `fileconv-knowledge` tái dùng/re-export phần embedding runtime và `normalize_search_text`
+khi cần (ví dụ `infer_runtime_path` re-export `fileconv_core::embedding_runtime::infer_embedding_runtime_path`;
+`rank.rs`/`query.rs`/`citation.rs` gọi trực tiếp `fileconv_core::intelligence::normalize_search_text`)
 chứ không tự định nghĩa lại.
 
 ## `crates/core/` — fileconv-core (engine)

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -5,17 +5,17 @@
 ## Bức tranh tổng thể
 
 ```text
-crates/core/       shared conversion engine and detailed diagnostics
-crates/cli/        conversion CLI, handoff and benchmark commands
-crates/mcp/        stdio MCP surface, deterministic and optional LLM tools
-crates/knowledge/  framework-free retrieval/grounding contracts plus opt-in desktop adapters
-crates/server/     Markhand Web API, auth, storage adapters and workers
-app/               Markhand Tauri desktop
-web/               browser-only React/Vite SPA over HTTP/SSE
-deploy/            local and POC infrastructure, scripts and observability
-bench/             reproducible converter/Web evaluation assets and reports
-plans/             authoritative Markhand Web issue catalog and evidence
-vendor/            reference-only markitdown-rs, excluded from the workspace
+crates/core/       engine convert dùng chung + diagnostics chi tiết
+crates/cli/        CLI convert, lệnh handoff và benchmark
+crates/mcp/        stdio MCP surface, tool deterministic và LLM opt-in
+crates/knowledge/  contract retrieval/grounding framework-free + adapter desktop opt-in
+crates/server/     Markhand Web API, auth, storage adapter và worker
+app/               desktop "Markhand" (Tauri)
+web/               SPA React/Vite chỉ chạy browser, qua HTTP/SSE
+deploy/            hạ tầng local và POC, script và observability
+bench/             tài sản đánh giá converter/Web tái tạo được + báo cáo
+plans/             danh mục issue Markhand Web chính thức + evidence
+vendor/            markitdown-rs tham khảo, đã loại khỏi workspace
 ```
 
 **CLI, desktop và MCP dùng chung `fileconv-core`**: cả ba path-dep thẳng vào
@@ -23,9 +23,16 @@ vendor/            reference-only markitdown-rs, excluded from the workspace
 khác. **Markhand Web đi theo boundary riêng**: `web/` (browser SPA) chỉ nói
 HTTP/SSE với `fileconv-server` (`crates/server`) — server sở hữu auth/services/
 repositories/storage adapters và các worker; phần retrieval/grounding (search,
-Q&A, chunk/embedding contract) đi qua `fileconv-knowledge` (`crates/knowledge`)
-dùng chung giữa server và các adapter desktop opt-in (SQLite/HNSW), không phải
-`fileconv-core`.
+Q&A) đi qua contract `fileconv-knowledge` (`crates/knowledge`) — `types`, `query`,
+`rank`, `citation`, `ask`, `identity`, và phần **kế hoạch embedding** (mode/dimension,
+`embedding.rs`) — dùng chung giữa server và các adapter desktop opt-in (SQLite/HNSW).
+**Chunk primitive** (`chunk_markdown`/`normalize_newlines`/`locate_chunk_span`/
+`locate_chunk_text`) và **embedding runtime** (suy luận/parse runtime path) đều bắt
+nguồn từ `fileconv-core` (`src/chunk.rs`, `src/embedding_runtime.rs`): server path-dep
+thẳng vào `fileconv-core` để chunk (`services/chunking.rs`, `services/citation.rs`),
+còn `fileconv-knowledge` chỉ tái dùng/re-export phần embedding runtime khi cần
+(ví dụ `infer_runtime_path` re-export `fileconv_core::embedding_runtime::infer_embedding_runtime_path`)
+chứ không tự định nghĩa lại.
 
 ## `crates/core/` — fileconv-core (engine)
 
@@ -96,14 +103,14 @@ thể). Desktop-only adapter nằm sau feature riêng:
 |---|---|
 | `src/desktop/sqlite.rs` | (feature `desktop-sqlite`) SQLite FTS5 — index/tra cứu chunk local |
 | `src/desktop/hnsw.rs` | (feature `desktop-hnsw`) persistent HNSW ANN cache cho vector local |
-| `src/desktop/service.rs` | ghép SQLite + HNSW thành service hybrid-search/ask cho desktop |
+| `src/desktop/service.rs` | (yêu cầu **cả hai** feature `desktop-sqlite` VÀ `desktop-hnsw`) ghép SQLite + HNSW thành service hybrid-search/ask cho desktop |
 
 ## `crates/server/` — fileconv-server (Markhand Web API)
 
 | Vùng | File chính | Trách nhiệm |
 |---|---|---|
 | routes | `src/routes/*.rs` | HTTP handler theo tài nguyên: `health`, `auth`, `uploads`, `collections`, `documents`, `jobs`, `members`, `orgs`, `projects`, `audit`, `search`, `ask`, `chat_sessions`, `events`, `graph` — ghép ở `src/http.rs::router` |
-| services | `src/services/*.rs` | logic domain: upload saga/sniff/limits, conversion, indexing/chunking, embedding, citation, access/ACL, quota, deletion, graph |
+| services | `src/services/*.rs` + `src/services/{upload,qa,retrieval}/` | logic domain: upload saga/sniff/limits, conversion, indexing/chunking, embedding, citation, access/ACL, quota, deletion, graph |
 | repositories | `src/db/*.rs` | truy vấn PostgreSQL theo bảng/nghiệp vụ (jobs, documents, collections, chunks, orgs, members, audit, acl_sql, ...) |
 | storage adapters | `src/storage/*.rs` | `minio.rs` (object store), `qdrant.rs` (vector index), `keys.rs`/`url_safety.rs` |
 | workers | `src/workers/*.rs` | `convert.rs`, `index.rs`, `embedding.rs`, `delete.rs`, `reconcile.rs`, `sandbox.rs`, `fairness.rs`, `limits.rs` — chạy qua `src/bin/worker.rs`, tách khỏi tiến trình API |

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -66,7 +66,7 @@ Tám subcommand đăng ký ở `registered_commands()` (`crates/cli/src/main.rs`
 | `accuracy` | CER/WER (Levenshtein, `normalize()` bỏ markdown) theo manifest |
 | `audio` | (feature `audio`) WER/RTF/load mỗi model GGML |
 | `handoff` | đóng gói handoff (BRD/PRD) từ nhiều file nguồn → ZIP |
-| `pptx-preview` | JSON preview meta/slides/shapes; metadata PPTX lấy qua `fileconv_core::pptx_preview`/`probe`, không còn shell `python3` |
+| `pptx-preview` | JSON preview meta/slides/shapes; metadata PPTX lấy qua `fileconv_core::pptx_preview`/`probe` (đường Rust thuần, không còn nhánh shell Python riêng) |
 | `info` | danh sách định dạng hỗ trợ + trạng thái PDFium/tessdata/model whisper |
 
 ## `crates/mcp/` — binary `fileconv-mcp`

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,86 +1,149 @@
 # Tóm tắt codebase & Bản đồ điều hướng
 
-> Đâu để tìm cái gì, khi cần sửa thì đụng file nào. Số liệu LOC tính trên file được git track.
+> Đâu để tìm cái gì, khi cần sửa thì đụng file nào.
 
 ## Bức tranh tổng thể
 
+```text
+crates/core/       shared conversion engine and detailed diagnostics
+crates/cli/        conversion CLI, handoff and benchmark commands
+crates/mcp/        stdio MCP surface, deterministic and optional LLM tools
+crates/knowledge/  framework-free retrieval/grounding contracts plus opt-in desktop adapters
+crates/server/     Markhand Web API, auth, storage adapters and workers
+app/               Markhand Tauri desktop
+web/               browser-only React/Vite SPA over HTTP/SSE
+deploy/            local and POC infrastructure, scripts and observability
+bench/             reproducible converter/Web evaluation assets and reports
+plans/             authoritative Markhand Web issue catalog and evidence
+vendor/            reference-only markitdown-rs, excluded from the workspace
 ```
-project-example/
-├── crates/
-│   ├── core/    # fileconv-core: LỎI convert (gọi crate gốc), dùng chung bởi CLI + app + MCP
-│   ├── cli/     # fileconv: binary CLI + bench harness (đo tốc độ/CER/WER)
-│   └── mcp/     # fileconv-mcp: MCP server cho Claude Code (stdio/rmcp)
-├── app/         # Markhand: desktop app Tauri 2 + React 19 (GUI)
-├── bench/       # script tải corpus + sinh dữ liệu VN + các REPORT*.md (số liệu đo thực)
-├── vendor/      # markitdown-rs — CHỈ tham khảo (MIT, đã exclude khỏi workspace)
-├── docs/        # tài liệu này
-└── CLAUDE.md    # hướng dẫn nhanh cho agent
-```
 
-**Một lõi, ba giao diện**: `fileconv-core` là engine duy nhất. CLI, app desktop, và MCP server
-đều phụ thuộc/path-dep vào nó — không re-implement logic convert ở đâu khác.
-
-## Quy mô (file được git track)
-
-| Ngôn ngữ | LOC | Files | Nơi chính |
-|---|---:|---:|---|
-| Rust `.rs` | ~5 669 | 43 | `crates/` + `app/src-tauri/` |
-| TypeScript `.tsx` | ~1 140 | 9 | `app/src/components/` |
-| TypeScript `.ts` | ~184 | 5 | `app/src/{lib,state}/` |
-| Python `.py` | ~2 171 | 8 | `bench/` (sinh corpus + thí nghiệm OCR) |
-| CSS | ~1 108 | 1 | `app/src/styles.css` |
-| Shell `.sh` | ~391 | 8 | `bench/` (tải corpus/model/pdfium/tessdata) |
+**CLI, desktop và MCP dùng chung `fileconv-core`**: cả ba path-dep thẳng vào
+`crates/core` (`Converter`/`FormatKind`) — không re-implement logic convert ở đâu
+khác. **Markhand Web đi theo boundary riêng**: `web/` (browser SPA) chỉ nói
+HTTP/SSE với `fileconv-server` (`crates/server`) — server sở hữu auth/services/
+repositories/storage adapters và các worker; phần retrieval/grounding (search,
+Q&A, chunk/embedding contract) đi qua `fileconv-knowledge` (`crates/knowledge`)
+dùng chung giữa server và các adapter desktop opt-in (SQLite/HNSW), không phải
+`fileconv-core`.
 
 ## `crates/core/` — fileconv-core (engine)
 
 | File | Trách nhiệm |
 |---|---|
-| `src/lib.rs` | `Converter`, `convert_path()` (định tuyến), `FormatKind`, `ConverterOptions`, NFC + cắt output |
+| `src/lib.rs` | `Converter`, `FormatKind` (Pdf, Docx, Pptx, Xlsx, Csv, Html, **Text**, Image, Audio, Unknown), `ConverterOptions`; `convert_path_detailed()` là API chính (NFC + cắt output + soft warnings + derive title); `convert_path()` là lớp compatibility mỏng gọi `convert_path_detailed()` rồi bỏ warnings |
 | `src/conv/mod.rs` | khai báo module convert theo format |
-| `src/conv/pdf.rs` | **3-tier**: pdf-inspector (cấu trúc) → pdfium-render → pdf-extract; render trang quét 300DPI + OCR; `PDFIUM_CALL` lock |
+| `src/conv/pdf/` | pipeline PDF **3-tier**, chia module: `mod.rs` (điều phối), `inspector.rs` (pdf-inspector — cấu trúc + `needs_ocr`), `pdfium.rs` (bind libpdfium, cache `thread_local`, khóa `PDFIUM_CALL`), `native_text.rs`, `ocr.rs` (render 300DPI + Tesseract), `fallback.rs` (pdf-extract), `recovery.rs`, `postprocess.rs` |
 | `src/conv/docx.rs` | docx-rust: heading theo style, gom run theo (bold,italic), xử lý `<w:br>/<w:tab>` |
 | `src/conv/xlsx.rs` | calamine: đọc MỌI sheet (xls/xlsb/ods) |
 | `src/conv/pptx.rs` | zip + quick-xml: slide sort theo số thứ tự |
 | `src/conv/html.rs` | htmd (skip script/style/noscript) |
 | `src/conv/csv_conv.rs` | csv: strip BOM, TCVN3 fallback, sniff delimiter, chứa `rows_to_md_table` chung |
+| `src/conv/text.rs` | txt/log/md/markdown: strip BOM UTF-8 + decode qua `viet_legacy` |
 | `src/proc.rs` | `background_command()`: CREATE_NO_WINDOW trên Windows (tránh flash console) |
 | `src/image_ocr.rs` | Tesseract CLI + tiền xử lý ảnh (grayscale/upscale/unsharpen/normalize); dùng `proc::background_command` |
-| `src/audio.rs` | AudioEngine (cache Whisper), decode symphonia + resample 16k, lang "vi" |
+| `src/audio.rs` | (feature `audio`) AudioEngine — cache Whisper **process-wide** (bounded LRU), decode symphonia + resample 16k, lang "vi" |
 | `src/chunk.rs` | tách chunk RAG theo heading-path |
 | `src/viet_legacy.rs` | decode TCVN3/VNI/VPS; opt-in `Tcvn3CaseHint` (TCVN3/ABC all-capital H-font) — TXT/CSV không suy hoa |
+| `src/diagnostics.rs` | `ConversionReport`/`ConversionWarning`/`ConversionOutcome`/`DetailedConvertError` — soft warnings và outcome (FullSuccess/PartialSuccess) trả về từ `convert_path_detailed`, tách khỏi lỗi cứng `ConvertError` |
+| `src/embedding_runtime.rs` | helper runtime-path embedding luôn bật (không gate `llm`, ADR 0006) — dùng chung giữa `llm.rs` và `fileconv-knowledge` để tránh cycle phụ thuộc |
+| `src/intelligence.rs` | document intelligence trên Markdown sidecar: handoff pack, cited search/Q&A, quality, PII, table/schema, version — baseline tất định, LLM chỉ tăng cường (feature `llm`) |
 | `src/llm.rs` | (feature `llm`) chat/summarize/extract_json/vision_ocr qua env `FILECONV_LLM_*` |
+| `src/llm_cli.rs` | (feature `llm`) transport CLI subscription Cursor/Codex chính thức (không phải Claude consumer OAuth) |
 | `src/probe.rs` | `probe()` → FileInfo{format,bytes,pages,sheets} |
 | `src/tables.rs` | `tables_json` (xlsx/csv → JSON rows) — LƯU Ý: không decode TCVN3 như csv_conv.rs |
+| `src/pptx_preview.rs` | metadata + preview slide/shape cho desktop SVG, cũng là nguồn PPTX metadata cho CLI `pptx-preview` |
 
 ## `crates/cli/` — binary `fileconv`
 
-| File | Trách nhiệm |
+Tám subcommand đăng ký ở `registered_commands()` (`crates/cli/src/main.rs`):
+
+| Lệnh | Mục đích |
 |---|---|
-| `src/main.rs` | dispatch 4 subcommand: `one` / `speed` / `accuracy` / `audio`; panic hook |
-| `src/metrics.rs` | CER/WER Levenshtein + `normalize()` (bỏ markdown để đo NỘI DUNG) |
+| `one` | convert 1 file → stdout (markdown thuần, legacy) |
+| `one-detailed` | convert + JSON `{markdown,title,format,outcome,warnings}` hoặc lỗi `{message,kind}` |
+| `speed` | bench tốc độ ms/file, ms/page, KB/s theo format trên một thư mục |
+| `accuracy` | CER/WER (Levenshtein, `normalize()` bỏ markdown) theo manifest |
+| `audio` | (feature `audio`) WER/RTF/load mỗi model GGML |
+| `handoff` | đóng gói handoff (BRD/PRD) từ nhiều file nguồn → ZIP |
+| `pptx-preview` | JSON preview meta/slides/shapes; metadata PPTX lấy qua `fileconv_core::pptx_preview`/`probe`, không còn shell `python3` |
+| `info` | danh sách định dạng hỗ trợ + trạng thái PDFium/tessdata/model whisper |
 
 ## `crates/mcp/` — binary `fileconv-mcp`
 
+Chín MCP tool (stdio/rmcp) — năm deterministic (không cần API key) và bốn LLM
+(cần `FILECONV_LLM_*`):
+
+| Tool | Loại | Mục đích |
+|---|---|---|
+| `detect_format` | deterministic | `probe()` → format/bytes/pages/sheets, không convert |
+| `convert_to_markdown` | deterministic | convert → markdown thuần (legacy) |
+| `convert_to_markdown_detailed` | deterministic | convert → JSON có `outcome`/`warnings` (partial success) |
+| `extract_tables_json` | deterministic | xlsx/csv → JSON rows |
+| `convert_chunks` | deterministic | convert + chia chunk RAG theo heading |
+| `summarize` | LLM | tóm tắt tài liệu |
+| `extract_json` | LLM | trích JSON theo hướng dẫn ngôn ngữ tự nhiên |
+| `translate` | LLM | dịch sang ngôn ngữ đích |
+| `ocr_hard` | LLM (vision) | OCR ảnh khó (đa cột, IN HOA, viết tay, con dấu) |
+
+## `crates/knowledge/` — fileconv-knowledge (contracts)
+
+Framework-free: `types`, `query`, `rank`, `embedding`, `citation`, `ask`,
+`identity`, `error` là contract thuần (không phụ thuộc storage/transport cụ
+thể). Desktop-only adapter nằm sau feature riêng:
+
 | File | Trách nhiệm |
 |---|---|
-| `src/main.rs` | server stdio (rmcp); 8 tool (4 all-deterministic + 4 LLM) |
-| `README.md` | cách đăng ký `claude mcp add fileconv ...` |
+| `src/desktop/sqlite.rs` | (feature `desktop-sqlite`) SQLite FTS5 — index/tra cứu chunk local |
+| `src/desktop/hnsw.rs` | (feature `desktop-hnsw`) persistent HNSW ANN cache cho vector local |
+| `src/desktop/service.rs` | ghép SQLite + HNSW thành service hybrid-search/ask cho desktop |
+
+## `crates/server/` — fileconv-server (Markhand Web API)
+
+| Vùng | File chính | Trách nhiệm |
+|---|---|---|
+| routes | `src/routes/*.rs` | HTTP handler theo tài nguyên: `health`, `auth`, `uploads`, `collections`, `documents`, `jobs`, `members`, `orgs`, `projects`, `audit`, `search`, `ask`, `chat_sessions`, `events`, `graph` — ghép ở `src/http.rs::router` |
+| services | `src/services/*.rs` | logic domain: upload saga/sniff/limits, conversion, indexing/chunking, embedding, citation, access/ACL, quota, deletion, graph |
+| repositories | `src/db/*.rs` | truy vấn PostgreSQL theo bảng/nghiệp vụ (jobs, documents, collections, chunks, orgs, members, audit, acl_sql, ...) |
+| storage adapters | `src/storage/*.rs` | `minio.rs` (object store), `qdrant.rs` (vector index), `keys.rs`/`url_safety.rs` |
+| workers | `src/workers/*.rs` | `convert.rs`, `index.rs`, `embedding.rs`, `delete.rs`, `reconcile.rs`, `sandbox.rs`, `fairness.rs`, `limits.rs` — chạy qua `src/bin/worker.rs`, tách khỏi tiến trình API |
 
 ## `app/` — desktop "Markhand" (Tauri 2)
 
 | Vùng | File chính | Trách nhiệm |
 |---|---|---|
 | entry | `src/main.tsx`, `src/App.tsx` | root + drag-drop toàn cửa sổ + toast lỗi |
-| components | `Sidebar.tsx`, `Tree.tsx` | cây file, toolbar upload/tạo, đổi DATA root |
-| | `DocView.tsx` | workspace 3 tab (split/md/source), Save/Copy/Reconvert |
-| | `MarkdownEditor.tsx` | CodeMirror (Soạn) + react-markdown (Xem trước) |
-| | `SourcePreview.tsx` | dispatch theo format: Pdf/Docx/Excel/Text/Image/Audio + size-gate |
-| | `Settings.tsx` | modal cài OCR lang, PDF OCR, audio lang/threads, model whisper |
+| Home | `components/HomeView.tsx`, `IconRail.tsx` | điều hướng vùng chính, tổng quan project |
+| Library | `components/LibraryView.tsx`, `Sidebar.tsx`, `Tree.tsx` | cây file, toolbar upload/tạo, đổi DATA root |
+| Document | `components/DocView.tsx`, `DocumentTabs.tsx`, `MarkdownEditor.tsx`, `SourcePreview.tsx`, `CompareView.tsx` | workspace tab split/md/source, Soạn/Xem trước, đối chiếu version |
+| Intelligence | `components/IntelligenceView.tsx` | handoff, quality, cited search/Q&A, PII, schema/table, versions |
+| conversion queue | `components/ConvertQueue.tsx` | hàng đợi reconvert tuần tự chạy background |
+| project | `src-tauri/src/projects.rs` | list/create/adopt/remove project, import đệ quy folder local |
+| Settings | `components/Settings.tsx` | modal cài OCR lang, PDF OCR, audio lang/threads, model whisper, LLM/embedding |
 | state | `state/store.ts` | Zustand store duy nhất (không persist — Rust là nguồn sự thật) |
 | lib | `lib/ipc.ts`, `lib/types.ts` | wrap `invoke` + type `FsNode`/`Settings` mirror Rust serde |
-| Tauri bridge | `src-tauri/src/lib.rs` | 18 `#[tauri::command]`, AppState, `convert_and_write_md` |
-| | `src-tauri/src/main.rs` | shim 6 dòng gọi `run()` |
+| Tauri bridge | `src-tauri/src/lib.rs` | `AppState`, `convert_and_write_md`/`convert_and_write_md_detailed`; đăng ký toàn bộ command qua `tauri::generate_handler!` — registry là macro đó, không phải một con số cố định |
+| | `src-tauri/src/main.rs` | shim gọi `run()` |
 | config | `src-tauri/tauri.conf.json`, `capabilities/default.json` | identity Markhand, permission tối thiểu |
+
+`generate_handler!` gom các nhóm lệnh: cây/file DATA (`read_tree`, `create_folder`,
+`create_markdown`, `rename_node`, `delete_node`, `read/write_text_file`, ...),
+import/convert (`import_file_only`, `import_file`, `reconvert` và bản song song
+`reconvert_detailed` — cùng side effect, thêm `outcome`/`warnings`), settings/
+watch, preview PPTX, nhóm Intelligence (handoff, quality, cited search/Q&A, PII,
+schema/table, version, watch rules), nhóm knowledge RAG (`rebuild_knowledge_index`,
+`knowledge_index_stats`, `hybrid_search`, `hybrid_ask`) và nhóm project.
+
+## `web/` — browser SPA (`web/src/pages/`)
+
+| Trang | File | Vùng |
+|---|---|---|
+| Login | `LoginPage.tsx` | đăng nhập/khởi tạo session |
+| Library | `LibraryPage.tsx` | library/upload tài liệu qua HTTP |
+| Q&A | `QaPage.tsx` | hỏi-đáp/tìm kiếm có trích dẫn qua SSE |
+| Graph | `GraphPage.tsx` | xem quan hệ tài liệu/collection |
+| Admin | `AdminMembersPage.tsx`, `AdminProjectsPage.tsx`, `AdminUsagePage.tsx` | quản trị member/project/usage |
+| Help | `HelpPage.tsx` | hướng dẫn sử dụng |
 
 ## `bench/` — đo lường & tái tạo dữ liệu
 
@@ -98,14 +161,18 @@ project-example/
 
 | Muốn... | Đụng file |
 |---|---|
-| Thêm / sửa định dạng | `crates/core/src/conv/<fmt>.rs` + định tuyến ở `lib.rs` |
+| Thêm / sửa định dạng | `crates/core/src/conv/<fmt>.rs` (hoặc `conv/pdf/` cho PDF) + định tuyến ở `lib.rs` |
 | Đổi tiền xử lý OCR | `crates/core/src/image_ocr.rs` |
+| Đổi PDFium cache/lock | `crates/core/src/conv/pdf/pdfium.rs` |
 | Đổi phụ thuộc native OCR (Tesseract/whisper) | `image_ocr.rs` / `audio.rs` |
 | Spawn subprocess (CLI, OCR, LLM) | dùng `crate::proc::background_command` chứ không `Command::new` (tránh console flash Windows) |
 | Thêm CLI flag | `crates/cli/src/main.rs` |
 | Thêm MCP tool | `crates/mcp/src/main.rs` (+ `crates/core/src/llm.rs` nếu cần LLM) |
-| Sửa GUI | `app/src/components/*.tsx` |
+| Sửa GUI desktop | `app/src/components/*.tsx` |
 | Sửa cầu nối Tauri | `app/src-tauri/src/lib.rs` |
+| Sửa Markhand Web API | `crates/server/src/routes/`, `services/`, `db/`, `workers/` |
+| Sửa retrieval/grounding contract | `crates/knowledge/src/` |
+| Sửa web SPA | `web/src/pages/` |
 | Đo lại sau đổi | `bench/` + `fileconv speed`/`accuracy` |
 
 ## Tham chiếu chéo

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -10,10 +10,19 @@ tối ưu cho **nội dung tiếng Việt**. Code do dự án làm chủ hoàn t
 gốc thay vì bọc công cụ có sẵn. Mục tiêu cuối: đóng gói thành **desktop app (Tauri)** chạy
 offline cho Win / Mac / Ubuntu.
 
-Hai giao diện cùng dùng một lõi `fileconv-core`:
+Các mặt sản phẩm hiện có, chia theo hai nhóm ranh giới (xem
+[`system-architecture.md`](system-architecture.md)):
+
+**Offline-first, gọi thẳng `fileconv-core` trong tiến trình** (mặc định của dự án):
 - **CLI** (`fileconv`) — convert từng file + đo tốc độ / độ chính xác (CER/WER).
 - **Desktop app "Markhand"** (Tauri + React) — GUI kéo-thả, soạn thảo Markdown, xem trước nguồn.
 - **MCP server** (`fileconv-mcp`) — tool cho Claude Code: convert, rút bảng, tách chunk RAG, OCR nặng qua vision-LLM.
+
+**Markhand Web — track on-prem multi-org riêng**, không offline (cần Postgres/Qdrant/MinIO):
+- **API/workers** (`fileconv-server`, `fileconv-worker` — `crates/server`) — auth, upload,
+  job convert/index/embedding; worker gọi lại `fileconv` CLI/`fileconv-core`.
+- **Browser SPA** (`web/`) — nói HTTP/SSE với `fileconv-server`, không import trực tiếp
+  `fileconv-core`.
 
 `vendor/markitdown-rs/` **chỉ là tài liệu tham khảo (MIT)** — đã `exclude` khỏi workspace,
 không phải dependency. Đừng dùng lại hay phụ thuộc nó.
@@ -39,20 +48,23 @@ tiền xử lý ảnh trước OCR.
 | RAG | SQLite FTS5 + neural/local vectors + persistent HNSW | ✅ |
 | Bảng mã cũ | Decode TCVN3, VNI-Windows và VPS | ✅ |
 | OCR khó | Vision-LLM (cột nhiều, IN HOA, chữ viết tay, con dấu) qua MCP `ocr_hard` | ✅ (cần key LLM) |
-| Desktop GUI | PPTX preview, merged tables, live watch, intelligence | ✅ (`.deb`; Win/Mac chờ credentials ký) |
+| Desktop GUI | PPTX preview, merged tables, live watch, intelligence, theme dark LumiBase | ✅ (Linux `.deb` có build evidence; Windows/macOS còn cần xác minh artifact + credentials ký/notarization) |
 | NFC | Chuẩn hoá mọi output (tài liệu NFD từ macOS/PDF cũ) | ✅ |
 
 ### Yêu cầu phi chức năng
-- **Offline-first**: lõi + CLI + desktop chạy không cần mạng. LLM/vision chỉ là tier tuỳ chọn.
+- **Offline-first (mặc định converter/desktop)**: lõi + CLI + desktop chạy không cần mạng. LLM/vision
+  chỉ là tier tuỳ chọn. Markhand Web nằm ngoài mặc định này — track on-prem multi-org riêng, cần
+  Postgres/Qdrant/MinIO (xem [`runbooks/local-development.md`](runbooks/local-development.md)).
 - **Hiệu năng**: tài liệu văn bản < 1ms/file; PDF ~5.7ms/trang (xem số liệu ở [`bench/REPORT.md`](../bench/REPORT.md)).
 - **Đóng gói được**: chạy được trên Win/Mac/Linux chỉ với các phụ thuộc native tối thiểu.
 - **Tái kiểm chứng được**: mọi thay đổi OCR/PDF phải đo lại bằng CLI trên corpus (`accuracy` / `speed`).
 
-### Ngoài phạm vi (hiện tại)
-- Đóng gói installer distributable (`.msi`/`.dmg`/`.deb`) — chưa làm.
+### Ngoài phạm vi / giới hạn hiện tại
+- Installer Windows (`.msi`) / macOS (`.dmg`) đạt release thật: CI có bundle metadata cho cả
+  matrix, nhưng còn cần xác minh artifact trên từng platform và credentials ký/notarization.
+  Linux `.deb` đã có build evidence.
 - Nhận dạng giọng nói (ASR) streaming real-time.
 - OCR chữ viết tay độ cao (giới hạn Tesseract; tier vision-LLM mới giải quyết từng phần).
-- Hỗ trợ dark mode desktop (hiện ép light — xem [`system-architecture.md`](system-architecture.md#theme)).
 
 ## Động lực & vị thế thị trường
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -7,8 +7,10 @@
 
 `fileconv` là **backend Rust** chuyển đổi tài liệu / ảnh / âm thanh sang **Markdown**,
 tối ưu cho **nội dung tiếng Việt**. Code do dự án làm chủ hoàn toàn — gọi thẳng các crate
-gốc thay vì bọc công cụ có sẵn. Mục tiêu cuối: đóng gói thành **desktop app (Tauri)** chạy
-offline cho Win / Mac / Ubuntu.
+gốc thay vì bọc công cụ có sẵn. Ở track **offline-first** (mặc định của dự án), mục tiêu
+cuối là đóng gói thành **desktop app (Tauri)** chạy offline cho Win / Mac / Ubuntu, cùng
+CLI và MCP server; bên cạnh đó có track **Markhand Web** on-prem multi-org riêng (xem
+danh sách mặt sản phẩm ngay dưới).
 
 Các mặt sản phẩm hiện có, chia theo hai nhóm ranh giới (xem
 [`system-architecture.md`](system-architecture.md)):

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -323,7 +323,10 @@ curl -sS -N http://127.0.0.1:8787/api/v1/jobs/$JOB_ID/events \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-   Convert worker hoàn tất → job `convert` completed và tạo job `index`; index worker tạo job
+   Convert worker hoàn tất → promotion (chốt version/markdown artifact hiện tại) ghi outbox
+   event `document.index_requested`; chính index worker tự relay outbox này thành job `index`
+   trong claim-loop của nó (không phải convert worker tạo job `index` trực tiếp — nếu index
+   worker không chạy, event outbox nằm chờ, chưa có job `index`) → job `index` hoàn tất tạo job
    `embedding_batch`; embedding worker upsert Qdrant (chi tiết ở mục Workers).
 
 5. Verify khả năng tìm kiếm sau khi index/embedding xong: `POST /api/v1/search` (mục Verify).

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -329,8 +329,8 @@ embedding.
    (không phải convert worker tạo job `index` trực tiếp — nếu index worker không chạy,
    event outbox nằm chờ, chưa có job `index`) → job `index` hoàn tất tạo job
    `embedding_batch`; embedding worker upsert Qdrant (chi tiết ở mục Workers). Delete worker
-   và reconcile worker dùng chung cơ chế relay outbox này (cùng `IndexingOutboxSink`) cho
-   event của riêng chúng, nhưng nằm ngoài walkthrough convert/index/embedding này.
+   và reconcile worker dùng chung relay/sink này (`IndexingOutboxSink`/`OutboxJobSink`) để
+   relay cả event `index` và `delete`, nằm ngoài walkthrough convert/index/embedding này.
 
 5. Verify khả năng tìm kiếm sau khi index/embedding xong: `POST /api/v1/search` (mục Verify).
 6. Verify hỏi-đáp: `POST /api/v1/ask` (mục Verify) — mặc định trả lời extractive

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -17,8 +17,8 @@ lần đầu chậm vì tải model HuggingFace.
 | Auth, upload quarantine, jobs (API) | ✅ (cần bật auth nếu gọi route bảo vệ) |
 | `fileconv-worker` convert (Linux/WSL) | ✅ sandbox thật; Windows native fail-closed |
 | Index/embedding worker | ✅ (AITeamVN CPU @ `:8088`) |
-| Upload → convert → index qua HTTP | ⏳ upload quarantine OK; enqueue document/job API chưa đủ |
-| Search/Q&A/web SPA | ⏳ Phase 1B R* / Phase 2 |
+| Upload → convert → index qua HTTP | ✅ accepted upload tạo job `convert` durable trong cùng transaction (saga); cần convert + index + embedding worker chạy riêng để pipeline hoàn tất |
+| Search (`/api/v1/search`), Ask (`/api/v1/ask`, `/ask/stream`), web SPA | ✅ có trên `master`; câu trả lời sinh bởi LLM (ngoài extractive fallback mặc định) và production qualification vẫn phụ thuộc runtime/evidence đã cấu hình |
 
 Desktop Tauri (`pnpm --dir app tauri dev`) và CLI `fileconv` vẫn chạy độc lập — xem
 [`CLAUDE.md`](../../CLAUDE.md).
@@ -290,7 +290,8 @@ cargo run --release -p fileconv-server --bin fileconv-worker
 ```
 
 Index worker tạo job `embedding_batch`; embedding worker upsert Qdrant. Không có hash fallback —
-runtime lỗi → job failed, lexical search vẫn độc lập (khi có R*).
+runtime lỗi → job failed; lexical search (`/api/v1/search`, FTS) vẫn hoạt động độc lập với
+embedding.
 
 ## E2E checklist
 
@@ -304,20 +305,46 @@ runtime lỗi → job failed, lexical search vẫn độc lập (khi có R*).
 ### B. Pipeline workers (Linux/WSL)
 
 1. Hoàn thành A + `curl http://127.0.0.1:8088/health` (embedding-cpu ready)
-2. Terminal: convert worker
-3. Terminal: index worker (`MARKHAND_WORKER_KIND=index`)
-4. Terminal: embedding worker (`MARKHAND_WORKER_KIND=embedding`)
-5. Upload file qua curl (quarantine object trên MinIO)
-6. **Lưu ý:** trên `master`, HTTP upload chưa enqueue job `convert`/`index` tự động — pipeline
-   end-to-end qua API đang chờ issue document/job API (Phase 1B). Kiểm tra worker + indexing
-   logic:
+2. Terminal riêng cho từng worker — convert, index (`MARKHAND_WORKER_KIND=index`), embedding
+   (`MARKHAND_WORKER_KIND=embedding`) — xem mục Workers (`fileconv-worker`) để lấy env đầy đủ.
+3. Upload một file **accepted** qua HTTP (curl mục Verify) hoặc qua Web SPA (`web/`). Upload
+   accepted tạo job `convert` durable ngay trong transaction đăng ký document/version (saga
+   `run_upload_saga`) — không cần enqueue thủ công.
+4. Theo dõi job bằng `jobId` trong response upload:
 
 ```bash
-# Integration (cần stack + MARKHAND_TEST_* — xem crates/server/README.md)
+JOB_ID=<jobId lấy từ response upload>
+
+curl -sS http://127.0.0.1:8787/api/v1/jobs/$JOB_ID \
+  -H "Authorization: Bearer $TOKEN"
+
+# hoặc theo dõi realtime qua SSE
+curl -sS -N http://127.0.0.1:8787/api/v1/jobs/$JOB_ID/events \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+   Convert worker hoàn tất → job `convert` completed và tạo job `index`; index worker tạo job
+   `embedding_batch`; embedding worker upsert Qdrant (chi tiết ở mục Workers).
+
+5. Verify khả năng tìm kiếm sau khi index/embedding xong: `POST /api/v1/search` (mục Verify).
+6. Verify hỏi-đáp: `POST /api/v1/ask` (mục Verify) — mặc định trả lời extractive
+   (`offline_extractive`/`fallback_extractive`), không cần provider LLM nào. Chỉ cần cấu hình
+   provider (`MARKHAND_CHAT_BASE_URL`/`MARKHAND_CHAT_API_KEY`/`MARKHAND_CHAT_MODEL`, hoặc
+   `MARKHAND_GLM_*` tương ứng) khi muốn bật sinh câu trả lời bằng LLM thay cho extractive.
+
+**Lưu ý:** quarantined/rejected upload **không** theo path convert accepted ở trên — upload
+quarantined vẫn đăng ký document/version nhưng job `convert` chỉ được tạo khi có
+`doc.quarantine.review` approve (`approve_quarantined_upload`); upload rejected không lưu
+document/job nào.
+
+7. (Tuỳ chọn) Integration test worker/indexing thay vì chạy worker thủ công:
+
+```bash
+# Cần stack + MARKHAND_TEST_* — xem crates/server/README.md
 cargo test -p fileconv-server --test index_worker -- --ignored
 ```
 
-7. Theo dõi job trong DB (khi có job):
+8. Theo dõi job trong DB:
 
 ```bash
 docker compose -f deploy/dev/compose.yml exec -T postgres psql \
@@ -404,9 +431,30 @@ curl -sS -X POST http://127.0.0.1:8787/api/v1/uploads \
   -F 'collectionId=55555555-5555-5555-5555-555555555501'
 ```
 
-### Route chưa có
+Response accepted trả về `jobId` — theo dõi qua `GET /api/v1/jobs/{jobId}` hoặc
+`GET /api/v1/jobs/{jobId}/events` (xem mục E2E checklist B).
 
-Search/Q&A (`/api/v1/search`, `/api/v1/ask`) — Phase 1B R*.
+### Search & Ask
+
+Cần convert/index/embedding worker đã xử lý xong file upload (mục E2E checklist B) để có kết
+quả khớp:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8787/api/v1/search \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"hello markhand","collectionIds":["55555555-5555-5555-5555-555555555501"]}'
+
+curl -sS -X POST http://127.0.0.1:8787/api/v1/ask \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"question":"Tài liệu nói gì?","collectionIds":["55555555-5555-5555-5555-555555555501"]}'
+```
+
+`ask` mặc định trả lời extractive (`mode: offline_extractive`/`fallback_extractive`) khi chưa
+cấu hình chat provider; cấu hình provider (`MARKHAND_CHAT_BASE_URL`/`MARKHAND_CHAT_API_KEY`/
+`MARKHAND_CHAT_MODEL`, hoặc `MARKHAND_GLM_*` tương ứng) chỉ cần khi muốn bật sinh câu trả lời
+bằng LLM.
 
 ## Failure and reset
 

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -312,22 +312,25 @@ embedding.
    `run_upload_saga`) — không cần enqueue thủ công.
 4. Theo dõi job bằng `jobId` trong response upload:
 
-```bash
-JOB_ID=<jobId lấy từ response upload>
+   ```bash
+   JOB_ID=<jobId lấy từ response upload>
 
-curl -sS http://127.0.0.1:8787/api/v1/jobs/$JOB_ID \
-  -H "Authorization: Bearer $TOKEN"
+   curl -sS http://127.0.0.1:8787/api/v1/jobs/$JOB_ID \
+     -H "Authorization: Bearer $TOKEN"
 
-# hoặc theo dõi realtime qua SSE
-curl -sS -N http://127.0.0.1:8787/api/v1/jobs/$JOB_ID/events \
-  -H "Authorization: Bearer $TOKEN"
-```
+   # hoặc theo dõi realtime qua SSE
+   curl -sS -N http://127.0.0.1:8787/api/v1/jobs/$JOB_ID/events \
+     -H "Authorization: Bearer $TOKEN"
+   ```
 
    Convert worker hoàn tất → promotion (chốt version/markdown artifact hiện tại) ghi outbox
-   event `document.index_requested`; chính index worker tự relay outbox này thành job `index`
-   trong claim-loop của nó (không phải convert worker tạo job `index` trực tiếp — nếu index
-   worker không chạy, event outbox nằm chờ, chưa có job `index`) → job `index` hoàn tất tạo job
-   `embedding_batch`; embedding worker upsert Qdrant (chi tiết ở mục Workers).
+   event `document.index_requested`; trong setup convert/index/embedding đang mô tả ở đây,
+   chính **index worker** tự relay outbox này thành job `index` trong claim-loop của nó
+   (không phải convert worker tạo job `index` trực tiếp — nếu index worker không chạy,
+   event outbox nằm chờ, chưa có job `index`) → job `index` hoàn tất tạo job
+   `embedding_batch`; embedding worker upsert Qdrant (chi tiết ở mục Workers). Delete worker
+   và reconcile worker dùng chung cơ chế relay outbox này (cùng `IndexingOutboxSink`) cho
+   event của riêng chúng, nhưng nằm ngoài walkthrough convert/index/embedding này.
 
 5. Verify khả năng tìm kiếm sau khi index/embedding xong: `POST /api/v1/search` (mục Verify).
 6. Verify hỏi-đáp: `POST /api/v1/ask` (mục Verify) — mặc định trả lời extractive

--- a/docs/superpowers/plans/2026-08-04-codebase-docs-refresh.md
+++ b/docs/superpowers/plans/2026-08-04-codebase-docs-refresh.md
@@ -1,0 +1,397 @@
+# Codebase Documentation Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh the five living codebase documents so they accurately describe the current workspace, architecture, product surfaces, conventions, and local Web workflow.
+
+**Architecture:** Treat manifests, source registries, OpenAPI, Make targets, scripts, and tests as evidence. Update the codebase map and architecture first, then align product/convention wording, and finally repair the local-development flow. Preserve historical records and avoid volatile LOC/file counts.
+
+**Tech Stack:** Markdown, Rust workspace manifests and source, Tauri 2, React/Vite, Axum HTTP/SSE, OpenAPI, PostgreSQL/Qdrant/MinIO development stack.
+
+## Global Constraints
+
+- Modify only `docs/codebase-summary.md`, `docs/system-architecture.md`, `docs/project-overview-pdr.md`, `docs/code-standards.md`, and `docs/runbooks/local-development.md`.
+- Do not modify roadmap, issue catalogs, ADRs, journals, historical specs/plans, benchmark reports, generated roadmap, or PostgreSQL ERD.
+- Preserve project-owned converter boundaries, intentional pins/fallbacks, GNU native linking, thread-local PDFium, and bounded process-wide Whisper caches.
+- Distinguish code present on `master`, runtime dependencies, and production/release evidence.
+- Do not add LOC or tracked-file counts.
+- Do not introduce new benchmark, production-readiness, or release claims.
+
+---
+
+### Task 1: Refresh the codebase map and system architecture
+
+**Files:**
+- Modify: `docs/codebase-summary.md`
+- Modify: `docs/system-architecture.md`
+
+**Interfaces:**
+- Consumes: workspace membership from `Cargo.toml`; converter contracts from `crates/core/src/lib.rs`; CLI registry from `crates/cli/src/main.rs::registered_commands`; MCP tool handlers from `crates/mcp/src/main.rs`; Tauri handler registry from `app/src-tauri/src/lib.rs`; server routes from `crates/server/src/http.rs`; Web pages from `web/src/pages/`.
+- Produces: the canonical navigation map and high-level architecture used by Tasks 2 and 3.
+
+- [ ] **Step 1: Record the stale inventory before editing**
+
+Run:
+
+```bash
+rg -n 'Một lõi, ba giao diện|~5 669|18 IPC|56 command|8 tool|title: None|python3' \
+  docs/codebase-summary.md docs/system-architecture.md
+```
+
+Expected: matches for the obsolete three-surface description, LOC table, IPC/MCP
+counts, fixed-empty title, or PPTX Python path.
+
+- [ ] **Step 2: Replace the top-level codebase map**
+
+In `docs/codebase-summary.md`, replace the tree and “Một lõi, ba giao diện” text with
+a stable map containing these responsibilities:
+
+```text
+crates/core/       shared conversion engine and detailed diagnostics
+crates/cli/        conversion CLI, handoff and benchmark commands
+crates/mcp/        stdio MCP surface, deterministic and optional LLM tools
+crates/knowledge/  framework-free retrieval/grounding contracts plus opt-in desktop adapters
+crates/server/     Markhand Web API, auth, storage adapters and workers
+app/               Markhand Tauri desktop
+web/               browser-only React/Vite SPA over HTTP/SSE
+deploy/            local and POC infrastructure, scripts and observability
+bench/             reproducible converter/Web evaluation assets and reports
+plans/             authoritative Markhand Web issue catalog and evidence
+vendor/            reference-only markitdown-rs, excluded from the workspace
+```
+
+State explicitly that CLI, desktop and MCP share `fileconv-core`, while Markhand Web
+uses the server/worker boundary and shared `fileconv-knowledge` contracts. Remove the
+entire LOC/files table.
+
+- [ ] **Step 3: Update module navigation tables**
+
+Rewrite the tables in `docs/codebase-summary.md` to include:
+
+- core routing and detailed conversion in `src/lib.rs`;
+- split PDF implementation under `src/conv/pdf/`;
+- `text.rs`, `diagnostics.rs`, `embedding_runtime.rs`, `intelligence.rs` and
+  `llm_cli.rs`;
+- all eight CLI commands from `registered_commands()`:
+  `speed`, `accuracy`, `audio`, `one`, `one-detailed`, `handoff`,
+  `pptx-preview`, `info`;
+- all nine MCP tools, including `convert_to_markdown_detailed`;
+- knowledge contracts and `desktop/{sqlite,hnsw,service}.rs`;
+- server route/service/repository-storage/worker boundaries;
+- desktop Home, Library, Document, Intelligence, project and conversion queue areas;
+- Web login, library/upload, Q&A, graph and admin areas.
+
+Do not state numeric IPC totals. Describe command groups and point to
+`tauri::generate_handler!` as the registry.
+
+- [ ] **Step 4: Replace the architecture overview**
+
+In `docs/system-architecture.md`, replace the three-layer diagram with two connected
+paths:
+
+```text
+CLI / Desktop / MCP
+        │
+        ▼
+fileconv-core ───────► native PDF/OCR/audio runtimes
+
+Browser SPA ──HTTP/SSE──► fileconv-server
+                              ├── auth/services/repositories
+                              ├── PostgreSQL/Qdrant/MinIO
+                              ├── fileconv-knowledge
+                              └── workers ──► fileconv CLI/core
+```
+
+Clarify that Compose is needed for Markhand Web development but not for standalone
+CLI/desktop work.
+
+- [ ] **Step 5: Synchronize core, CLI, MCP and desktop facts**
+
+Apply these exact corrections in `docs/system-architecture.md`:
+
+- add `Text` to `FormatKind`;
+- describe `convert_path()` as the compatibility API over
+  `convert_path_detailed()`;
+- describe title derivation as first Markdown heading, falling back to file stem;
+- point PDFium cache/lock details to `crates/core/src/conv/pdf/pdfium.rs`;
+- list the eight CLI commands from Step 3 and state that PPTX metadata comes from
+  `fileconv_core::probe`;
+- list nine MCP tools by adding `convert_to_markdown_detailed` to the deterministic
+  group;
+- remove the `18`, `56`, or other brittle Tauri command count and describe the command
+  groups registered by `generate_handler!`;
+- add `opener:allow-open-path` to the capability list;
+- mention `reconvert_detailed` alongside legacy `reconvert`.
+
+- [ ] **Step 6: Verify Task 1 and commit**
+
+Run:
+
+```bash
+rg -n 'Một lõi, ba giao diện|~5 669|18 IPC|56 command|8 tool|title: None|python3' \
+  docs/codebase-summary.md docs/system-architecture.md
+git diff --check
+```
+
+Expected: no stale-claim matches; `git diff --check` exits 0.
+
+Then:
+
+```bash
+git add docs/codebase-summary.md docs/system-architecture.md
+git commit -m "docs: refresh codebase map and architecture"
+```
+
+### Task 2: Align product scope and code conventions
+
+**Files:**
+- Modify: `docs/project-overview-pdr.md`
+- Modify: `docs/code-standards.md`
+
+**Interfaces:**
+- Consumes: architecture terms established in Task 1; feature definitions in
+  `crates/core/Cargo.toml`; workspace `sha2` pin in `Cargo.toml`; OCR temp handling in
+  `crates/core/src/image_ocr.rs`.
+- Produces: current product boundaries and contributor constraints referenced by the
+  local-development runbook.
+
+- [ ] **Step 1: Record contradictory and resolved claims**
+
+Run:
+
+```bash
+rg -n 'Hai giao diện|installer distributable|ép light|AtomicU64|conv/pdf\.rs|shell ra `python3`' \
+  docs/project-overview-pdr.md docs/code-standards.md
+```
+
+Expected: matches for obsolete product scope, installer/theme status, PDF path, OCR
+temp mechanism, or resolved PPTX pitfall.
+
+- [ ] **Step 2: Update product surfaces and boundaries**
+
+In `docs/project-overview-pdr.md`:
+
+- replace “Hai giao diện” with a product-surface section covering CLI, desktop, MCP,
+  Markhand Web API/workers, and browser SPA;
+- keep offline-first as the converter/desktop default, while describing Markhand Web
+  as a separate on-prem multi-org track;
+- replace the installer out-of-scope item with: Linux `.deb` has build evidence;
+  Windows/macOS release still requires platform artifact verification and
+  signing/notarization credentials;
+- remove the light-theme claim and state that desktop currently ships the dark
+  LumiBase theme;
+- keep ASR streaming and high-quality handwriting OCR as out of scope/current
+  limitations.
+
+- [ ] **Step 3: Update contributor constraints**
+
+In `docs/code-standards.md`:
+
+- change PDF references from `crates/core/src/conv/pdf.rs` to
+  `crates/core/src/conv/pdf/`, naming `pdfium.rs` for the cache/lock;
+- replace the `AtomicU64` temp PNG statement with exclusive temporary files through
+  `tempfile::NamedTempFile`;
+- document `audio` as an opt-in feature and state that GPU/BLAS features imply it;
+- add the exact workspace pin `sha2 = "=0.11.0"` and its durable-ID contract rationale;
+- remove the resolved CLI PPTX/Python pitfall;
+- preserve `pdf-extract = "=0.8.2"`, Symphonia 0.5, `time = "=0.3.51"`,
+  `background_command`, NFC, extension-only routing, native prerequisites, and cache
+  constraints unchanged.
+
+- [ ] **Step 4: Verify Task 2 and commit**
+
+Run:
+
+```bash
+rg -n 'Hai giao diện|installer distributable.*chưa làm|ép light|AtomicU64|conv/pdf\.rs|shell ra `python3`' \
+  docs/project-overview-pdr.md docs/code-standards.md
+rg -n 'Markhand Web|dark LumiBase|NamedTempFile|sha2 = \"=0\.11\.0\"|feature `audio`' \
+  docs/project-overview-pdr.md docs/code-standards.md
+git diff --check
+```
+
+Expected: first search has no matches; second search finds each new fact;
+`git diff --check` exits 0.
+
+Then:
+
+```bash
+git add docs/project-overview-pdr.md docs/code-standards.md
+git commit -m "docs: align product scope and code conventions"
+```
+
+### Task 3: Repair the local Markhand Web development flow
+
+**Files:**
+- Modify: `docs/runbooks/local-development.md`
+
+**Interfaces:**
+- Consumes: accepted-upload enqueue behavior from
+  `crates/server/src/services/upload/saga.rs`; API paths from
+  `crates/server/src/api/openapi.rs`; worker kinds from `crates/server/src/workers/`;
+  current Compose and seed commands already documented in the runbook.
+- Produces: an executable local flow for upload, conversion, indexing, retrieval, and
+  browser use.
+
+- [ ] **Step 1: Record obsolete local status**
+
+Run:
+
+```bash
+rg -n 'enqueue document/job API chưa đủ|Search/Q&A/web SPA.*⏳|chưa enqueue job|Route chưa có' \
+  docs/runbooks/local-development.md
+```
+
+Expected: matches in the master-status table, E2E checklist and curl verification.
+
+- [ ] **Step 2: Correct the master-status table**
+
+Update the table to state:
+
+- accepted upload creates a durable convert job;
+- separate convert, index and embedding workers are required for pipeline completion;
+- search, JSON ask, streaming ask and the browser SPA exist on `master`;
+- external LLM-backed answer generation and production qualification still depend on
+  their configured runtime/evidence.
+
+Do not alter the currently accurate Compose image, port, profile, auth seed or
+embedding signature tables.
+
+- [ ] **Step 3: Rewrite the E2E pipeline checklist**
+
+Replace the “upload does not enqueue” note with this sequence:
+
+1. start dependencies, migrate and seed;
+2. run convert, index and embedding workers with the documented environment;
+3. upload an accepted file through HTTP or Web SPA;
+4. inspect `GET /api/v1/jobs/{jobId}` or
+   `GET /api/v1/jobs/{jobId}/events`;
+5. verify retrieval through `POST /api/v1/search`;
+6. verify grounded/extractive behavior through `POST /api/v1/ask`, with provider
+   configuration called out only when LLM generation is enabled.
+
+Explain that quarantined/rejected uploads do not follow the accepted conversion path.
+
+- [ ] **Step 4: Replace the missing-route section with current curl examples**
+
+Add request examples using the existing `$TOKEN`, organization and collection scope:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8787/api/v1/search \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"hello markhand","collectionIds":["55555555-5555-5555-5555-555555555501"]}'
+
+curl -sS -X POST http://127.0.0.1:8787/api/v1/ask \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"question":"Tài liệu nói gì?","collectionIds":["55555555-5555-5555-5555-555555555501"]}'
+```
+
+Before committing, compare field names against
+`crates/server/openapi/openapi.yaml`; adjust only if the schema uses different exact
+property names.
+
+- [ ] **Step 5: Verify Task 3 and commit**
+
+Run:
+
+```bash
+rg -n 'enqueue document/job API chưa đủ|Search/Q&A/web SPA.*⏳|chưa enqueue job|Route chưa có' \
+  docs/runbooks/local-development.md
+rg -n '/api/v1/search|/api/v1/ask|/api/v1/jobs/\{jobId\}|accepted' \
+  docs/runbooks/local-development.md
+git diff --check
+```
+
+Expected: first search has no matches; second search finds the corrected flow and
+current routes; `git diff --check` exits 0.
+
+Then:
+
+```bash
+git add docs/runbooks/local-development.md
+git commit -m "docs: update local web development flow"
+```
+
+### Task 4: Cross-document verification and delivery
+
+**Files:**
+- Verify: `docs/codebase-summary.md`
+- Verify: `docs/system-architecture.md`
+- Verify: `docs/project-overview-pdr.md`
+- Verify: `docs/code-standards.md`
+- Verify: `docs/runbooks/local-development.md`
+
+**Interfaces:**
+- Consumes: all documentation produced by Tasks 1–3.
+- Produces: a reviewed, evidence-backed documentation-only change ready for PR review.
+
+- [ ] **Step 1: Check scope and stale claims**
+
+Run:
+
+```bash
+git diff master...HEAD --name-only
+rg -n '18 IPC|56 command|8 tool|title: None|~5 669|ép light|Route chưa có|chưa enqueue job|shell ra `python3`' \
+  docs/codebase-summary.md docs/system-architecture.md docs/project-overview-pdr.md \
+  docs/code-standards.md docs/runbooks/local-development.md
+```
+
+Expected: changed files are the approved spec/plan plus the five living docs; stale
+claim search returns no matches.
+
+- [ ] **Step 2: Verify repository policy and generated roadmap stability**
+
+Run:
+
+```bash
+python3 scripts/check-architecture-boundaries.py
+python3 scripts/check-dependency-policy.py
+python3 scripts/build-roadmap.py --check
+git diff --check
+```
+
+Expected: all commands exit 0 and generated roadmap remains unchanged.
+
+- [ ] **Step 3: Review factual evidence**
+
+For every newly named command, tool, route, feature and path, use `rg` or the
+corresponding manifest/OpenAPI registry to confirm it exists. Specifically confirm:
+
+```text
+8 CLI commands
+9 MCP tools
+FormatKind::Text
+convert_path_detailed / reconvert_detailed
+opener:allow-open-path
+/api/v1/search, /api/v1/ask, /api/v1/ask/stream
+accepted upload enqueues JobType::Convert
+```
+
+Expected: every item has a current source or contract definition; remove any claim
+that cannot be verified.
+
+- [ ] **Step 4: Commit verification fixes if needed**
+
+If Step 1–3 required documentation corrections:
+
+```bash
+git add docs/codebase-summary.md docs/system-architecture.md \
+  docs/project-overview-pdr.md docs/code-standards.md \
+  docs/runbooks/local-development.md
+git commit -m "docs: fix documentation verification findings"
+```
+
+Expected: a commit is created only when verification changed files.
+
+- [ ] **Step 5: Push and update the pull request**
+
+Run:
+
+```bash
+git push -u origin cursor/refresh-codebase-docs-37df
+git status --short --branch
+```
+
+Expected: push succeeds; working tree is clean and branch tracks its origin.

--- a/docs/superpowers/specs/2026-08-04-codebase-docs-refresh-design.md
+++ b/docs/superpowers/specs/2026-08-04-codebase-docs-refresh-design.md
@@ -1,0 +1,112 @@
+# Thiết kế cập nhật tài liệu codebase
+
+## Mục tiêu
+
+Cập nhật các tài liệu sống mô tả codebase để phản ánh đúng `master` hiện tại, giúp
+contributor tìm đúng module, hiểu đúng các surface sản phẩm và chạy đúng luồng local.
+Mọi khẳng định về trạng thái hoặc hành vi phải có bằng chứng từ manifest, source,
+OpenAPI, Makefile, script hoặc test hiện hành.
+
+## Phạm vi
+
+Các tài liệu chính:
+
+- `docs/codebase-summary.md`
+- `docs/system-architecture.md`
+- `docs/project-overview-pdr.md`
+- `docs/code-standards.md`
+- `docs/runbooks/local-development.md`
+
+Runbook sống khác chỉ được sửa nếu nội dung liên kết trực tiếp tới các luồng trên và
+có bằng chứng rõ ràng rằng câu lệnh hoặc trạng thái đã sai.
+
+Ngoài phạm vi:
+
+- roadmap và issue catalog;
+- ADR, journal, design spec và implementation plan đã đóng vai trò lịch sử;
+- báo cáo benchmark và evidence đã chốt;
+- tài liệu ngoài `docs/`;
+- PostgreSQL ERD, vì đây là một outcome riêng cần regenerate và validate schema.
+
+## Nguồn sự thật
+
+Ưu tiên đối chiếu theo thứ tự:
+
+1. Workspace/package manifests và lockfiles.
+2. Source đăng ký command, route, tool, feature và adapter.
+3. OpenAPI, migrations và script vận hành.
+4. Makefile, CI workflow và test hiện hành.
+5. Issue catalog chỉ để giải thích maturity; không dùng thay bằng chứng code.
+
+Không suy trạng thái triển khai chỉ từ roadmap hoặc tài liệu cũ.
+
+## Thay đổi thiết kế
+
+### Bản đồ codebase
+
+`codebase-summary.md` sẽ mô tả đầy đủ `fileconv-core`, CLI, MCP,
+`fileconv-knowledge`, `fileconv-server`, desktop Tauri, Web SPA và deployment
+surface. Bảng LOC dễ lỗi thời sẽ bị bỏ hoặc thay bằng mô tả định tính. Các bảng module
+sẽ dùng đường dẫn và trách nhiệm hiện tại, gồm PDF module phân tách, detailed
+conversion, knowledge adapters, server routes/workers và các vùng chính của Web SPA.
+
+### Kiến trúc hệ thống
+
+`system-architecture.md` sẽ mở rộng từ mô hình ba giao diện sang hai nhánh:
+
+- converter surfaces: CLI, desktop và MCP dùng `fileconv-core`;
+- Markhand Web: browser SPA → HTTP/SSE API → service/repository/storage/workers,
+  dùng contracts từ `fileconv-knowledge` và converter qua worker.
+
+Các inventory cụ thể sẽ được đồng bộ với code: format `Text`, detailed conversion,
+title derivation, CLI commands, MCP tools, Tauri IPC và capability. Số đếm dễ drift
+chỉ giữ khi code có một registry rõ ràng; nếu không sẽ dùng mô tả nhóm.
+
+### PDR
+
+`project-overview-pdr.md` sẽ bổ sung Markhand Web như một product track riêng thay vì
+ngụ ý dự án chỉ có desktop/CLI/MCP. Các mâu thuẫn về installer và dark theme sẽ được
+sửa; giới hạn còn lại được diễn đạt chính xác là signing/notarization và evidence phát
+hành phù hợp, không phải chưa có bundle.
+
+### Quy ước code
+
+`code-standards.md` sẽ cập nhật đường dẫn PDF module, cơ chế temp file OCR, feature
+`audio`, pin digest ở workspace và xóa cạm bẫy PPTX/Python đã được giải quyết. Các pin
+có chủ đích, cache bounded/thread-local, GNU linking và converter boundary phải được
+giữ nguyên.
+
+### Local development
+
+`runbooks/local-development.md` sẽ phản ánh API upload/jobs, search/ask và Web SPA đã
+có trên `master`. E2E flow sẽ mô tả upload accepted enqueue convert, các worker cần
+chạy để hoàn tất convert/index/embedding và cách quan sát job. Phần “route chưa có”
+sẽ được thay bằng ví dụ kiểm tra route hiện hành. Các bảng port, image pin, auth seed
+và embedding profile đang đúng sẽ được giữ nguyên.
+
+## Nguyên tắc chống drift
+
+- Tránh số LOC và số lượng file.
+- Với command/tool/route, ưu tiên liệt kê từ registry hoặc OpenAPI.
+- Tách rõ “đã có trong code”, “cần runtime ngoài” và “đã có evidence production”.
+- Không đổi status roadmap chỉ vì code đã tồn tại.
+- Giữ liên kết tới tài liệu chuyên sâu thay vì lặp cấu hình dài ở nhiều nơi.
+
+## Kiểm chứng
+
+- Đối chiếu lại mọi đường dẫn và symbol được thêm.
+- Tìm các claim cũ đã xác định: `18 IPC`, `56 command`, `8 tool`,
+  `title: None`, PPTX qua Python, route search/ask chưa có và upload chưa enqueue.
+- Chạy Markdown/link checks hiện có nếu repository cung cấp.
+- Chạy quality gate tĩnh liên quan tới docs và roadmap; không sửa generated roadmap.
+- Xem diff cuối để bảo đảm không thay đổi tài liệu lịch sử hoặc mở rộng sang outcome
+  ERD.
+
+## Tiêu chí hoàn thành
+
+- Năm tài liệu trong phạm vi không còn các discrepancy đã audit.
+- Contributor có thể lần từ tài liệu tới đúng crate/module/route hiện tại.
+- Luồng local upload → worker → retrieval được mô tả đúng maturity và dependency.
+- Không có claim benchmark, production readiness hoặc release evidence mới khi chưa có
+  bằng chứng.
+- Các kiểm tra tài liệu liên quan vượt qua.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -17,18 +17,24 @@ Browser SPA ──HTTP/SSE──► fileconv-server
                               └── workers ──► fileconv CLI/core
 ```
 
-Hai luồng độc lập, không đi qua nhau:
+Hai ranh giới sản phẩm, không phải hai luồng tách biệt hoàn toàn — `fileconv-core`
+có giao điểm ở cả hai bên:
 
 - **CLI (`fileconv`) / Desktop "Markhand" / MCP (`fileconv-mcp`)** gọi thẳng
   `fileconv-core` trong tiến trình (path-dep, không HTTP) — `Converter::convert_path`/
   `convert_path_detailed` định tuyến theo `FormatKind` rồi chạm các native runtime
   PDF/OCR/audio (PDFium, Tesseract, Whisper) có cache. Nhóm này chạy **offline**,
   không cần Docker/Compose.
-- **Browser SPA (`web/`)** chỉ nói HTTP/SSE với **`fileconv-server`**
-  (`crates/server`): route/service/repository sở hữu auth, PostgreSQL, Qdrant
-  (vector), MinIO (object store); retrieval/grounding đi qua contract
-  `fileconv-knowledge`; các job nặng (convert/index/embedding) chạy trong
-  **worker** riêng, worker gọi lại `fileconv` CLI/`fileconv-core` để convert.
+- **Browser SPA (`web/`)** không bao giờ link `fileconv-core` — chỉ nói HTTP/SSE với
+  **`fileconv-server`** (`crates/server`): route/service/repository sở hữu auth,
+  PostgreSQL, Qdrant (vector), MinIO (object store); retrieval/grounding đi qua
+  contract `fileconv-knowledge`. Ngược lại, **`fileconv-server` có path-dependency
+  thẳng vào `fileconv-core`** (`crates/server/Cargo.toml`) để dùng chung các
+  primitive chunk/normalize/runtime — `chunk::{chunk_markdown, normalize_newlines,
+  locate_chunk_span, locate_chunk_text}`, `intelligence::normalize_search_text`,
+  `embedding_runtime` — không qua HTTP; **riêng job nặng (convert/index/embedding)**
+  chạy trong **worker** riêng, worker gọi converter path bằng cách spawn subprocess
+  `fileconv` CLI (mà CLI đó path-dep `fileconv-core` để convert).
   Luồng Markhand Web này **cần Compose** (`deploy/dev/compose.yml`, xem
   [`runbooks/local-development.md`](runbooks/local-development.md)) để
   dựng PostgreSQL/Qdrant/MinIO cho phát triển local; phát triển CLI/desktop

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -30,7 +30,7 @@ Hai luồng độc lập, không đi qua nhau:
   `fileconv-knowledge`; các job nặng (convert/index/embedding) chạy trong
   **worker** riêng, worker gọi lại `fileconv` CLI/`fileconv-core` để convert.
   Luồng Markhand Web này **cần Compose** (`deploy/dev/compose.yml`, xem
-  [`../runbooks/local-development.md`](../runbooks/local-development.md)) để
+  [`runbooks/local-development.md`](runbooks/local-development.md)) để
   dựng PostgreSQL/Qdrant/MinIO cho phát triển local; phát triển CLI/desktop
   độc lập không cần Compose.
 
@@ -138,7 +138,7 @@ Tám subcommand đăng ký ở `registered_commands()`:
 | `accuracy` | `<manifest.tsv> [report.md]` | CER/WER (Levenshtein, `normalize()` bỏ markdown) theo nhãn |
 | `audio` | `<models.csv> <manifest.tsv> [report.md]` | (feature `audio`) WER/RTF/load mỗi model GGML |
 | `handoff` | `<product> <output.zip> <sources...>` | đóng gói handoff pack (BRD/PRD) từ nhiều file nguồn |
-| `pptx-preview` | `<file.pptx>` | JSON preview meta/slides/shapes; metadata lấy qua `fileconv_core::pptx_preview`/`probe` |
+| `pptx-preview` | `<file.pptx>` | JSON preview meta/slides/shapes qua `fileconv_core::pptx_preview::preview_meta`/`preview_slide` |
 | `info` | (không đối số) | danh sách định dạng hỗ trợ + trạng thái PDFium/tessdata/model whisper |
 
 Panic hook in `file:line`. Manifest: mỗi dòng `<file>\t<ground_truth.txt>\t<nhãn>`, `#` = comment.

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -2,49 +2,63 @@
 
 > Luồng dữ liệu, định tuyến, và các ranh giới hệ thống. Số liệu đo thực trích [`../bench/`](../bench/).
 
-## Tổng quan 3 lớp
+## Tổng quan: hai luồng kết nối
 
+```text
+CLI / Desktop / MCP
+        │
+        ▼
+fileconv-core ───────► native PDF/OCR/audio runtimes
+
+Browser SPA ──HTTP/SSE──► fileconv-server
+                              ├── auth/services/repositories
+                              ├── PostgreSQL/Qdrant/MinIO
+                              ├── fileconv-knowledge
+                              └── workers ──► fileconv CLI/core
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│  GIAO DIỆN                                                          │
-│  ┌──────────────┐   ┌─────────────────────┐   ┌──────────────────┐  │
-│  │ CLI (fileconv)│   │ Desktop "Markhand"  │   │ MCP (fileconv-mcp)│  │
-│  │ one/speed/   │   │ Tauri 2 + React 19  │   │ stdio / rmcp     │  │
-│  │ accuracy/audio│   │ 18 IPC commands     │   │ 8 tools          │  │
-│  └──────┬───────┘   └─────────┬───────────┘   └────────┬─────────┘  │
-└─────────┼─────────────────────┼────────────────────────┼────────────┘
-          │                     │                        │
-          └─────────────────────┼────────────────────────┘
-                                ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│  LÕI: fileconv-core  (Converter::convert_path)                      │
-│  định tuyến theo FormatKind (extension) → conv::* / image_ocr / audio│
-│  → NFC + cắt → ConversionResult                                      │
-└─────────────────────────────────────────────────────────────────────┘
-                                ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│  PHỤ THUỘC NATIVE (đắt, có cache)                                   │
-│  PDFium (thread_local) · Tesseract (per-call) · Whisper (process cache) │
-└─────────────────────────────────────────────────────────────────────┘
-```
+
+Hai luồng độc lập, không đi qua nhau:
+
+- **CLI (`fileconv`) / Desktop "Markhand" / MCP (`fileconv-mcp`)** gọi thẳng
+  `fileconv-core` trong tiến trình (path-dep, không HTTP) — `Converter::convert_path`/
+  `convert_path_detailed` định tuyến theo `FormatKind` rồi chạm các native runtime
+  PDF/OCR/audio (PDFium, Tesseract, Whisper) có cache. Nhóm này chạy **offline**,
+  không cần Docker/Compose.
+- **Browser SPA (`web/`)** chỉ nói HTTP/SSE với **`fileconv-server`**
+  (`crates/server`): route/service/repository sở hữu auth, PostgreSQL, Qdrant
+  (vector), MinIO (object store); retrieval/grounding đi qua contract
+  `fileconv-knowledge`; các job nặng (convert/index/embedding) chạy trong
+  **worker** riêng, worker gọi lại `fileconv` CLI/`fileconv-core` để convert.
+  Luồng Markhand Web này **cần Compose** (`deploy/dev/compose.yml`, xem
+  [`../runbooks/local-development.md`](../runbooks/local-development.md)) để
+  dựng PostgreSQL/Qdrant/MinIO cho phát triển local; phát triển CLI/desktop
+  độc lập không cần Compose.
 
 ## Lõi `fileconv-core`
 
 ### Định tuyến (`crates/core/src/lib.rs`)
 
 ```rust
-pub enum FormatKind { Pdf, Docx, Pptx, Xlsx, Csv, Html, Image, Audio, Unknown }
+pub enum FormatKind { Pdf, Docx, Pptx, Xlsx, Csv, Html, Text, Image, Audio, Unknown }
 // FormatKind::from_path(&Path) -> Self   // match extension lowercase, KHÔNG sniff magic-byte
 
-pub fn convert_path(&self, path: &Path) -> Result<ConversionResult, ConvertError>
+pub fn convert_path_detailed(&self, path: &Path)
+    -> Result<ConversionReport, DetailedConvertError>
 //   1. FormatKind::from_path(path)
-//   2. match → conv::{pdf,docx,pptx,xlsx,csv_conv,html}::to_markdown
-//                | image_ocr::ocr_image | self.engine()?.transcribe_file
+//   2. match → conv::{pdf,docx,pptx,xlsx,csv_conv,html,text}::to_markdown
+//                | image_ocr::ocr_image_detailed | self.engine()?.transcribe_file
 //   3. NFC chuẩn hoá (is_nfc_quick guard) + optional max_chars cắt
-//   4. ConversionResult { markdown, title: None, format }
+//   4. title = heading Markdown đầu tiên tìm được, fallback file stem nếu không có
+//   5. ConversionReport { result: ConversionResult{markdown,title,format}, warnings }
+
+pub fn convert_path(&self, path: &Path) -> Result<ConversionResult, ConvertError>
+//   Lớp compatibility mỏng: gọi convert_path_detailed() rồi bỏ warnings/outcome.
 ```
 
 `Unknown` → `ConvertError::Unsupported`. Lỗi `ConvertError` (thiserror): `BadPath`, `Unsupported(&str)`, `Failed(String)`.
+Diagnostics bổ sung (`ConversionOutcome`, `ConversionWarning`, `DetailedConvertError` —
+`crates/core/src/diagnostics.rs`) chỉ trả về từ `convert_path_detailed`, không đổi shape
+`ConvertError`/`ConversionResult` legacy.
 
 ### Chuỗi fallback PDF (3 tier)
 
@@ -66,8 +80,9 @@ convert pdf
  pdf_ocr_images (mặc định tắt) → OCR thêm ảnh nhúng ≥200×200px
 ```
 
-**Thread-safety lock**: libpdfium KHÔNG thread-safe. Mỗi region dùng PDFium được 
-serialized qua `PDFIUM_CALL: Mutex<()>` trong `pdf.rs`, gồm cả render+OCR các trang quét. 
+**Thread-safety lock**: libpdfium KHÔNG thread-safe. Mỗi region dùng PDFium được
+serialized qua `PDFIUM_CALL: Mutex<()>` trong `crates/core/src/conv/pdf/pdfium.rs`
+(cùng file giữ cache PDFium `thread_local`), gồm cả render+OCR các trang quét.
 Trade-off: concurrent scanned-PDF conversions queue tại lock (move Tesseract ngoài nếu cần throughput cao).
 
 Đánh đổi (đo thực): corpus cũ pdf-inspector **~18ms/trang** (có cấu trúc + đa cột)
@@ -86,7 +101,8 @@ Chi tiết: [`../bench/REPORT_CASAN_PDF.md`](../bench/REPORT_CASAN_PDF.md).
 | xlsx | calamine 0.35 | mọi sheet; xls/xlsb/ods; merge/multiline → rowspan/colspan |
 | pptx | zip + quick-xml | text Markdown + structured preview text/image/shape |
 | html | htmd 0.5 | skip script/style/noscript; thay html2md (cũ phình output) |
-| csv/text | csv + legacy maps | UTF-8/TCVN3/VNI/VPS; delimiter sniff; plain `.txt/.log` (TCVN3/ABC H-font hoa chỉ qua opt-in hint, không suy từ TXT/CSV) |
+| csv | csv + legacy maps | UTF-8/TCVN3/VNI/VPS; delimiter sniff; strip BOM |
+| text (txt/log/md/markdown) | `viet_legacy` | strip BOM UTF-8, decode legacy Việt (TCVN3/ABC H-font hoa chỉ qua opt-in hint, không suy từ TXT/CSV) |
 | image | Tesseract/Paddle | preprocess, split scan columns, PSM retry; Paddle opt-in/fallback |
 | audio | whisper-rs 0.16 + symphonia 0.5 | 16k mono; tự tìm PhoWhisper; lọc segment no-speech/marker nhạc |
 
@@ -100,21 +116,30 @@ Mọi output: NFC (bắt buộc) → optional cắt tại `max_chars` kèm `<!--
 `xlsx_sheet: Option<String>`, `max_chars: Option<usize>`.
 
 ### Module công khai
-`audio` (AudioEngine, Transcript, decode_to_pcm16k_mono) · `image_ocr` (ocr_image, ocr_dynimage, tesseract_available) ·
+`audio` (feature `audio`; AudioEngine, Transcript, decode_to_pcm16k_mono) ·
+`image_ocr` (ocr_image, ocr_dynimage, tesseract_available) ·
 `chunk` · `probe` · `pptx_preview` · `tables` · `viet_legacy`
 (TCVN3/VNI/VPS detect/decode; `Tcvn3CaseHint` opt-in cho font hoa) ·
-`llm`/`llm_cli` (HTTP chat/vision, neural embeddings, Cursor/Codex subscription transport).
-`conv::*` **private** — chỉ qua `convert_path`.
+`diagnostics` (ConversionReport/ConversionWarning/ConversionOutcome/DetailedConvertError) ·
+`embedding_runtime` (runtime-path helper luôn bật, dùng chung với `fileconv-knowledge`) ·
+`intelligence` (handoff/cited search/PII/table/version baseline tất định) ·
+`llm`/`llm_cli` (feature `llm`; HTTP chat/vision, neural embeddings, Cursor/Codex subscription transport).
+`conv::*` **private** — chỉ qua `convert_path`/`convert_path_detailed`.
 
 ## CLI `fileconv` (`crates/cli`)
 
+Tám subcommand đăng ký ở `registered_commands()`:
+
 | Subcommand | Args | Mục đích |
 |---|---|---|
-| `one` | `<file> [--ocr-images --lang vie+eng --pages 1,2,3 --sheet NAME --max-chars N]` | convert 1 file → stdout |
-| `speed` | `<dir> [report.md]` | ms/file, ms/page, KB/s theo format (`count_pages` gọi pdfinfo/python3) |
+| `one` | `<file> [--ocr-images --lang vie+eng --pages 1,2,3 --sheet NAME --max-chars N]` | convert 1 file → stdout (markdown thuần) |
+| `one-detailed` | cùng cờ như `one` (+ `--no-pdf-ocr`) | convert → JSON `{markdown,title,format,outcome,warnings}` hoặc lỗi `{message,kind}` |
+| `speed` | `<dir> [report.md]` | ms/file, ms/page, KB/s theo format (`count_pages`: pdfinfo cho PDF, `fileconv_core::probe` cho PPTX — không còn shell `python3`) |
 | `accuracy` | `<manifest.tsv> [report.md]` | CER/WER (Levenshtein, `normalize()` bỏ markdown) theo nhãn |
-| `audio` | `<models.csv> <manifest.tsv> [report.md]` | WER/RTF/load mỗi model GGML |
-| `pptx-preview` | `<file.pptx>` | JSON preview meta/slides/shapes cho QA |
+| `audio` | `<models.csv> <manifest.tsv> [report.md]` | (feature `audio`) WER/RTF/load mỗi model GGML |
+| `handoff` | `<product> <output.zip> <sources...>` | đóng gói handoff pack (BRD/PRD) từ nhiều file nguồn |
+| `pptx-preview` | `<file.pptx>` | JSON preview meta/slides/shapes; metadata lấy qua `fileconv_core::pptx_preview`/`probe` |
+| `info` | (không đối số) | danh sách định dạng hỗ trợ + trạng thái PDFium/tessdata/model whisper |
 
 Panic hook in `file:line`. Manifest: mỗi dòng `<file>\t<ground_truth.txt>\t<nhãn>`, `#` = comment.
 
@@ -124,10 +149,13 @@ Transport **stdio** qua `rmcp 0.16`, tokio multi-thread, build với feature `ll
 `spawn_blocking` (convert là blocking I/O). Lỗi dạng `Result<String,String>`. Đăng ký:
 `claude mcp add fileconv -- .../fileconv-mcp`.
 
+Chín tool — năm deterministic (không cần API key) và bốn LLM (`FILECONV_LLM_*`):
+
 | Tool | Loại | Mục đích |
 |---|---|---|
 | `detect_format` | deterministic | `probe()` → format/bytes/pages/sheets JSON, không convert |
-| `convert_to_markdown` | deterministic | convert đầy đủ (đọc `FILECONV_WHISPER_MODEL`) |
+| `convert_to_markdown` | deterministic | convert đầy đủ (đọc `FILECONV_WHISPER_MODEL`) → markdown thuần |
+| `convert_to_markdown_detailed` | deterministic | cùng convert nhưng trả JSON `{markdown,title,format,outcome,warnings}` (partial success) |
 | `extract_tables_json` | deterministic | xlsx/csv → JSON rows (`tables::tables_json`) |
 | `convert_chunks` | deterministic | convert + `chunk::chunk_markdown` → JSON `[{index,heading,text,chars}]` |
 | `summarize` | LLM (`FILECONV_LLM_*`) | tóm tắt (cap 40 000 ký tự) |
@@ -155,8 +183,10 @@ pdfjs-dist 6.1, docx-preview,
 
 **Identity** (`tauri.conf.json`): productName/binary `Markhand`/`markhand`,
 identifier `com.anhnth24.markhand`, v0.1.0 (đây là source-of-truth cho version),
-cửa sổ 1440×900 (min 900×600). Permission tối thiểu: `core:default`, `dialog:default`, `opener:default`,
-`updater:default`, `process:default` — **không** fs scope (mọi FS qua custom command). 
+cửa sổ 1440×900 (min 900×600). Permission tối thiểu (`capabilities/default.json`):
+`core:default`, `dialog:default`, `opener:default`, `opener:allow-open-path`
+("Mở ngoài" cho `resolve_path`), `updater:default`, `process:default` — **không**
+fs scope (mọi FS qua custom command).
 Rust crate `fileconv-desktop`. Bundle có icon đa nền tảng, metadata deb/AppImage/MSI/DMG 
 và CI release matrix; `.deb` Linux đã build thực tế.
 
@@ -190,23 +220,33 @@ sinh qua `createUpdaterArtifacts: true` từ CI. Desktop khởi động backgrou
 ### Cầu nối Tauri (`app/src-tauri/src/lib.rs`)
 - **AppState**: config/DATA/settings + `WatchService` notify thread.
 - **Path safety**: `resolve_within` chặn `..`, tuyệt đối, root-relative.
-- **56 command**: `supported_extensions`, `get/set_data_root` (persist `config.json`; mặc định `app_data_dir()/DATA`),
-  `read_tree` (ghép cặp `report.pdf`↔`report.pdf.md` 1-1, ẩn phía `.md`, đánh dấu `standaloneMd`),
-  `create_folder`, `create_markdown`, `rename_node` (rename cả `.md` ghép cặp), `delete_node` (từ chối xóa DATA root),
-  `import_file_only` (copy, chưa convert), `import_file` (compat: copy + convert), `reconvert`,
-  `read/write_text_file`, `read_text_preview` (head + truncated),
-  `file_size`, `resolve_path`, `read_bytes` (ArrayBuffer — webview `fetch(asset://)` trả 403 nên phải dùng command này),
-  `get/set_settings`; cộng nhóm Intelligence: handoff BRD/PRD, quality, cited search/Q&A,
-  PII/redaction, schema/tables/CSV, versions/diff/merge, watch rules, hard OCR và ZIP pack.
-  RAG mới gồm `rebuild_knowledge_index`, `knowledge_index_stats`, `hybrid_search`,
-  `hybrid_ask`: SQLite FTS5 + local hash 256D hoặc neural embeddings
-  OpenAI-compatible/Gemini, model signature/dimension guard, incremental content
-  hash, persistent HNSW (>1.000 chunks), exact fallback, RRF rerank, anchors và
-  FTS/LLM fallback có validation citation.
-  Bốn command cấu hình mới: subscription status/login và embedding presets/test.
-  PPTX meta/slide preview và live-watch status là ba command còn lại.
-  Nhóm Project: list/create/adopt/remove project và import đệ quy folder local.
-- `convert_and_write_md` map `Settings`→`ConverterOptions`→`Converter::convert_path`→ghi `.md`.
+- **Registry**: `tauri::generate_handler![...]` ở cuối `lib.rs` là nguồn sự thật duy
+  nhất cho danh sách command — không có tổng số cố định trong tài liệu này (dễ lệch
+  khi thêm command). Nhóm theo chức năng:
+  - **DATA tree/file**: `supported_extensions`, `get/set_data_root` (persist
+    `config.json`; mặc định `app_data_dir()/DATA`), `read_tree` (ghép cặp
+    `report.pdf`↔`report.pdf.md` 1-1, ẩn phía `.md`, đánh dấu `standaloneMd`),
+    `create_folder`, `create_markdown`, `rename_node` (rename cả `.md` ghép cặp),
+    `delete_node` (từ chối xóa DATA root), `read/write_text_file`, `read_text_preview`
+    (head + truncated), `file_size`, `resolve_path`, `read_bytes` (ArrayBuffer —
+    webview `fetch(asset://)` trả 403 nên phải dùng command này).
+  - **Import/convert**: `import_file_only` (copy, chưa convert), `import_file`
+    (compat: copy + convert), `reconvert` (legacy, markdown-only) và
+    **`reconvert_detailed`** (song song, cùng side effect + snapshot version,
+    thêm `outcome`/`warnings` — cả hai vẫn đăng ký, không thay thế nhau).
+  - **Settings/watch**: `get/set_settings`, `get_live_watch_status`.
+  - **Preview PPTX**: `preview_pptx_meta`, `preview_pptx_slide`.
+  - **Intelligence**: handoff BRD/PRD, quality, cited search/Q&A, PII/redaction,
+    schema/tables/CSV, versions/diff/merge, watch rules, hard OCR, ZIP pack,
+    subscription status/login, embedding presets/test.
+  - **Knowledge RAG**: `rebuild_knowledge_index`, `knowledge_index_stats`,
+    `hybrid_search`, `hybrid_ask` — SQLite FTS5 + local hash 256D hoặc neural
+    embeddings OpenAI-compatible/Gemini, model signature/dimension guard,
+    incremental content hash, persistent HNSW (>1.000 chunks), exact fallback,
+    RRF rerank, anchors và FTS/LLM fallback có validation citation.
+  - **Project**: list/create/adopt/remove project và import đệ quy folder local.
+- `convert_and_write_md`/`convert_and_write_md_detailed` map `Settings`→`ConverterOptions`→
+  `Converter::convert_path`/`convert_path_detailed`→ghi `.md`.
 
 ### State (Zustand, `app/src/state/store.ts`)
 Store duy nhất, **không persist nội dung** (Rust/filesystem là nguồn sự thật). Ngoài DATA tree/settings, store giữ

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -134,7 +134,7 @@ Tám subcommand đăng ký ở `registered_commands()`:
 |---|---|---|
 | `one` | `<file> [--ocr-images --lang vie+eng --pages 1,2,3 --sheet NAME --max-chars N]` | convert 1 file → stdout (markdown thuần) |
 | `one-detailed` | cùng cờ như `one` (+ `--no-pdf-ocr`) | convert → JSON `{markdown,title,format,outcome,warnings}` hoặc lỗi `{message,kind}` |
-| `speed` | `<dir> [report.md]` | ms/file, ms/page, KB/s theo format (`count_pages`: pdfinfo cho PDF, `fileconv_core::probe` cho PPTX — không còn shell `python3`) |
+| `speed` | `<dir> [report.md]` | ms/file, ms/page, KB/s theo format (`count_pages`: pdfinfo cho PDF, `fileconv_core::probe` cho PPTX — đường Rust thuần, không còn nhánh shell Python riêng) |
 | `accuracy` | `<manifest.tsv> [report.md]` | CER/WER (Levenshtein, `normalize()` bỏ markdown) theo nhãn |
 | `audio` | `<models.csv> <manifest.tsv> [report.md]` | (feature `audio`) WER/RTF/load mỗi model GGML |
 | `handoff` | `<product> <output.zip> <sources...>` | đóng gói handoff pack (BRD/PRD) từ nhiều file nguồn |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Define and deliver an evidence-based refresh of the living codebase documentation so it matches the current workspace, architecture, product surfaces, and local development flow.

## Scope

- Refresh the codebase map, architecture, PDR, code conventions, and local-development runbook.
- Preserve roadmap, ADRs, journals, historical plans/specs, benchmark evidence, and PostgreSQL ERD as separate outcomes.
- Avoid brittle counts and distinguish code availability from runtime and production evidence.
- Approved design and task-by-task implementation plan are committed.

## Evidence

- [x] Tests: `git diff --check`; stale-claim sweep; independent task and whole-branch reviews
- [x] Manual/benchmark/migration evidence: source/OpenAPI/manifests cross-checked; benchmark and migration evidence N/A for documentation-only changes
- [x] `python3 scripts/check-architecture-boundaries.py`
- [x] `python3 scripts/check-dependency-policy.py`
- [x] `python3 scripts/build-roadmap.py --check`

## Boundary and security review

- [x] Dependency boundary check passed.
- [x] Tenant/ACL impact reviewed, or N/A — documentation-only changes; existing boundaries are described, not modified.
- [x] Sensitive logging/secret/egress impact reviewed, or N/A — no sensitive data added.
- [x] Security review trigger checked — no runtime or security boundary change.

## Follow-up

- [x] Living codebase docs and local-development runbook updated where required.
- [ ] Separate scoped follow-up may refresh excluded roadmap inventory and `CLAUDE.md` module paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcddd-f4b8-73f7-8271-ede4f93937df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcddd-f4b8-73f7-8271-ede4f93937df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

