### PR TITLE
docs(intern-22): speed benchmark multi-format (#360)

### DIFF
--- a/bench/INTERN22_SPEED.md
+++ b/bench/INTERN22_SPEED.md
@@ -1,0 +1,95 @@
+# Báo cáo TỐC ĐỘ — fileconv-core backend
+
+## Chi tiết từng file
+
+| File | Loại | KB | Pages | Thời gian (ms) | ms/page | KB/s | Ký tự MD | OK |
+|---|---|--:|--:|--:|--:|--:|--:|:-:|
+| csv/airtravel.csv | csv | 0 | — | 10.95 | — | 29 | 375 | ✓ |
+| csv/biostats.csv | csv | 1 | — | 0.21 | — | 3955 | 647 | ✓ |
+| csv/cities.csv | csv | 8 | — | 0.70 | — | 11757 | 8177 | ✓ |
+| csv/grades.csv | csv | 2 | — | 0.17 | — | 8943 | 1421 | ✓ |
+| csv/homes.csv | csv | 2 | — | 0.24 | — | 8832 | 2668 | ✓ |
+| docx/blk-containing-table.docx | docx | 25 | — | 30.72 | — | 799 | 31 | ✓ |
+| docx/calibre-demo.docx | docx | 1281 | — | 19.56 | — | 65486 | 10643 | ✓ |
+| docx/doc-default.docx | docx | 21 | — | 1.67 | — | 12510 | 0 | ✓ |
+| docx/hdr-header-footer.docx | docx | 18 | — | 2.36 | — | 7493 | 57 | ✓ |
+| docx/par-known-paragraphs.docx | docx | 27 | — | 2.63 | — | 10389 | 39 | ✓ |
+| html/example.html | html | 1 | — | 6.39 | — | 85 | 183 | ✓ |
+| html/gpl3.html | html | 49 | — | 6.07 | — | 8083 | 38952 | ✓ |
+| html/httpbin.html | html | 0 | — | 0.30 | — | 526 | 74 | ✓ |
+| html/rust-book.html | html | 22 | — | 1.50 | — | 14673 | 1697 | ✓ |
+| html/wiki-vn.html | html | 2294 | — | 208.30 | — | 11014 | 843131 | ✓ |
+| image_png/vn_diachi.gt.txt | text | 0 | — | 0.10 | — | 1044 | 86 | ✓ |
+| image_png/vn_hopdong.gt.txt | text | 0 | — | 0.02 | — | 6486 | 106 | ✓ |
+| image_png/vn_quyet.gt.txt | text | 0 | — | 0.02 | — | 8475 | 116 | ✓ |
+| image_png/vn_thongbao.gt.txt | text | 0 | — | 0.01 | — | 7526 | 93 | ✓ |
+| image_png/vn_thongke.gt.txt | text | 0 | — | 0.01 | — | 7595 | 84 | ✓ |
+| pdf/arxiv-1301.3781.pdf | pdf | 223 | 12 | 274.45 | 22.87 | 814 | 38990 | ✓ |
+| pdf/arxiv-1409.1556.pdf | pdf | 195 | 14 | 253.36 | 18.10 | 771 | 54705 | ✓ |
+| pdf/arxiv-1512.03385.pdf | pdf | 800 | 12 | 232.90 | 19.41 | 3436 | 59749 | ✓ |
+| pdf/arxiv-1706.03762.pdf | pdf | 2163 | 15 | 445.55 | 29.70 | 4855 | 39892 | ✓ |
+| pdf/arxiv-1810.04805.pdf | pdf | 757 | 16 | 323.86 | 20.24 | 2337 | 65376 | ✓ |
+| pptx/cht-charts.pptx | pptx | 76 | 1 | 0.17 | 0.17 | 448680 | 0 | ✓ |
+| pptx/lyt-shapes.pptx | pptx | 23 | 0 | 0.08 | — | 282863 | 0 | ✓ |
+| pptx/mst-placeholders.pptx | pptx | 25 | 0 | 0.08 | — | 301181 | 0 | ✓ |
+| pptx/shp-groupshape.pptx | pptx | 23 | 1 | 0.14 | 0.14 | 163126 | 0 | ✓ |
+| pptx/shp-shapes.pptx | pptx | 122 | 2 | 0.38 | 0.19 | 325861 | 64 | ✓ |
+| xls/phpspreadsheet-sample.xls | xlsx | 5 | — | 0.27 | — | 18388 | 689 | ✓ |
+| xlsx/21d_FitToHeightPdf.xlsx | xlsx | 13 | — | 1.17 | — | 10968 | 3681 | ✓ |
+| xlsx/26template.xlsx | xlsx | 9 | — | 0.37 | — | 24165 | 891 | ✓ |
+| xlsx/28iterators.xlsx | xlsx | 8 | — | 0.24 | — | 34422 | 148 | ✓ |
+| xlsx/31docproperties.xlsx | xlsx | 9 | — | 0.20 | — | 43189 | 48 | ✓ |
+| xlsx/32chartreadwrite.xlsx | xlsx | 26 | — | 0.41 | — | 64160 | 1097 | ✓ |
+
+## Tổng hợp theo định dạng
+
+| Loại | Số file | Thành công | Σ KB | Σ pages | Σ ms | ms/file (TB) | ms/page (TB) | KB/s (TB) |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|
+| csv | 5 | 5 | 13 | — | 12.3 | 2.45 | — | 1055 |
+| docx | 5 | 5 | 1372 | — | 56.9 | 11.39 | — | 24090 |
+| html | 5 | 5 | 2366 | — | 222.6 | 44.51 | — | 10630 |
+| pdf | 5 | 5 | 4139 | 69 | 1530.1 | 306.02 | 22.18 | 2705 |
+| pptx | 5 | 5 | 269 | 4 | 0.8 | 0.17 | 0.21 | 316609 |
+| text | 5 | 5 | 1 | — | 0.2 | 0.03 | — | 3579 |
+| xlsx | 6 | 6 | 70 | — | 2.7 | 0.44 | — | 26305 |
+
+---
+
+## Phân tích intern-22 (#360)
+
+**Corpus:** Option `bench/sample10/` (36 files; PNG/audio generation skipped — `gtts` missing, no `.png` in `image_png/`).
+
+**Môi trường:** commit `07784a21`, PDFium yes, Tesseract 5.5.0 (`vie+eng`), `pdfinfo` (poppler-utils), release build `-p fileconv-cli`.
+
+### So sánh định dạng (ms/file TB)
+
+| Loại | ms/file (TB) | Nhận xét |
+|------|-------------:|----------|
+| pptx | 0.17 | Nhanh nhất — parse ZIP/XML, ít nội dung text |
+| xlsx | 0.44 | calamine, sub-ms đến vài ms |
+| csv | 2.45 | Parser thuần; `airtravel.csv` outlier ~11 ms (cold?) |
+| docx | 11.39 | ZIP + duyệt XML/run |
+| html | 44.51 | `wiki-vn.html` ~208 ms (2.3 MB HTML) |
+| pdf | 306.02 | Chậm nhất — pdf-inspector ~22 ms/page TB; OCR trên trang `needs_ocr` |
+
+**Thứ tự tương đối:** pdf ≫ html > docx > csv > xlsx ≈ pptx — khớp kỳ vọng: PDF tốn pdf-inspector (+ OCR khi cần); CSV/HTML/DOCX chủ yếu CPU parse.
+
+**PDF vs CSV:** PDF ~306 ms/file vs CSV ~2.5 ms/file (~120×) — PDF chậm vì xử lý từng trang (pdf-inspector) và có thể OCR.
+
+### Regression check
+
+So với baseline repo [`bench/REPORT_SAMPLE10_SPEED.md`](REPORT_SAMPLE10_SPEED.md) (cùng corpus, máy/commit khác):
+
+| Loại | Lần này | Baseline repo | Δ |
+|------|--------:|--------------:|---|
+| csv | 2.45 | 0.26 | +843% (outlier file; tổng Σ ms 12 vs 1.3) |
+| docx | 11.39 | 5.92 | +92% |
+| html | 44.51 | 38.07 | +17% |
+| pdf | 306.02 | 252.48 | +21% |
+| pptx | 0.17 | 0.39 | −56% (nhanh hơn) |
+| xlsx | 0.44 | 0.30 | +47% |
+
+**Kết luận:** Thứ tự định dạng giữ nguyên (pdf chậm nhất). Chênh số tuyệt đối có thể do máy/WSL, lần chạy đầu (cache PDFium), và corpus thiếu ảnh (baseline có `image` ~777 ms/file). Không có thay đổi code → không regression do commit; chênh ±20–90% trên sub-second paths là bình thường giữa máy.
+
+**Lệnh:** `./target/release/fileconv speed bench/sample10 bench/INTERN22_SPEED.md` — exit 0, 36/36 OK.
+


### PR DESCRIPTION
## Summary

- Chạy speed benchmark intern-22 trên corpus `bench/sample10/`, 36 file.
- Báo cáo [`bench/INTERN22_SPEED.md`](bench/INTERN22_SPEED.md): bảng ms/file, ms/page + mục **Phân tích intern-22**.
- Harness nằm trong [`crates/cli/src/main.rs`](crates/cli/src/main.rs) (`cmd_speed`, `render_speed_report`) — không có `commands/speed.rs`.

## Given / When / Then

- **Given:** release CLI (`cargo build --release -p fileconv-cli`), PDFium + Tesseract 5.5 trên WSL.
- **When:** `./target/release/fileconv speed bench/sample10 bench/INTERN22_SPEED.md`
- **Then:** 36/36 OK; summary theo định dạng; so sánh ≥2 format trong report.

## Format comparison (ms/file TB)

| Loại | ms/file | Observation |
|------|--------:|-------------|
| pptx | 0.17 | Nhanh nhất |
| xlsx | 0.44 | calamine |
| csv | 2.45 | parser thuần |
| docx | 11.39 | ZIP + XML |
| html | 44.51 | wiki-vn.html nặng |
| pdf | 306.02 | pdf-inspector + OCR trang cần |

## Regression

So với [`bench/REPORT_SAMPLE10_SPEED.md`](bench/REPORT_SAMPLE10_SPEED.md): thứ tự pdf ≫ html > docx giữ nguyên; chênh số tuyệt đối ~17–90% trên vài format (máy khác, không đổi code). Không regression do commit.

**Lưu ý:** `make_sample10.sh` thiếu PNG (`gtts` not installed) — không đo được image OCR lần này.

Closes #360

## Test plan

- [x] `cargo build --release -p fileconv-cli`
- [x] `bash bench/make_sample10.sh` (partial — no images/audio)
- [x] `./target/release/fileconv speed bench/sample10 bench/INTERN22_SPEED.md`
