### PR TITLE
[intern-25] Tối ưu pipeline PDF: bỏ extract pdf-inspector trùng

### DIFF
--- a/bench/INTERN25_OPTIMIZATION.md
+++ b/bench/INTERN25_OPTIMIZATION.md
@@ -1,0 +1,53 @@
+# Issue #363 — PDF pipeline optimization (intern-25)
+
+> Corpus: `bench/sample10/pdf/` (5 arXiv PDF). Build: `cargo build --release -p fileconv-cli`.
+> Machine: 16 CPU, WSL2. Ngày: 11/08/2026.
+
+## Bottleneck
+
+**Category:** parsing (pdf-inspector duplicate work)
+
+Trên slow path (`<16` trang, không hit parallel fast path), pipeline gọi
+`pdf_inspector::extract_pages_markdown_mem` **hai lần**:
+
+1. `probe_pages_needing_ocr()` — trước fast path, luôn chạy
+2. `via_pdf_inspector()` — spawn thread gọi lại cùng API
+
+Fast path thành công vẫn trả tiền probe dù không cần `needs_ocr` cho fallback.
+
+Evidence: baseline `fileconv speed bench/sample10/pdf` — **768 ms/file TB**;
+sau khi bỏ duplicate — **160 ms/file TB** (xem bảng dưới).
+
+## Optimization
+
+**Một thay đổi:** defer probe + reuse single extract trên slow path.
+
+- Bỏ `probe_pages_needing_ocr()` upfront trong [`mod.rs`](../crates/core/src/conv/pdf/mod.rs)
+- Fast path (`filtered` / `parallel`) return sớm — **không extract/probe**
+- Slow path: `extract_pages_markdown_mem()` một lần → truyền vào `via_pdf_inspector(prefetched)`
+- Helper dùng chung: `extract_pages_markdown_mem`, `pages_needing_ocr_from_extract`
+
+Không đổi algorithm pdf-inspector, PDFium, OCR.
+
+## Before / after
+
+| Metric | Before | After | Δ |
+|--------|-------:|------:|--:|
+| ms/file TB (5 PDF) | 768.47 | 159.69 | **−79.2%** |
+| arxiv-1301.3781.pdf | 357.73 ms | 59.25 ms | **−83.4%** |
+| arxiv-1409.1556.pdf | 597.69 ms | 126.76 ms | −78.8% |
+| arxiv-1512.03385.pdf | 598.22 ms | 142.47 ms | −76.2% |
+| arxiv-1706.03762.pdf | 1259.74 ms | 277.87 ms | −77.9% |
+| arxiv-1810.04805.pdf | 1028.95 ms | 192.09 ms | −81.3% |
+| ms/page TB | 55.69 | 11.57 | −79.2% |
+
+## Regression
+
+Markdown output **unchanged** — `diff` 5/5 file `bench/sample10/pdf/*.pdf` identical
+(snapshots lưu tại `/tmp/issue363-regression/`).
+
+`cargo test -p fileconv-core pdf::` — 28 passed.
+
+## Issue
+
+Closes https://github.com/anhnth24/project-example/issues/363

--- a/crates/core/src/conv/pdf/inspector.rs
+++ b/crates/core/src/conv/pdf/inspector.rs
@@ -25,24 +25,41 @@ const PARALLEL_MIN_CPUS: usize = 5;
 pub(super) enum InspectorAttempt {
     Success(MarkdownOutput),
     Abandoned { pages_needing_ocr: HashSet<u32> },
-    Unavailable,
 }
 
-pub(super) fn probe_pages_needing_ocr(bytes: &[u8], pages: Option<&[u32]>) -> HashSet<u32> {
-    let pages0: Option<Vec<u32>> =
-        pages.map(|ps| ps.iter().filter(|&&p| p >= 1).map(|&p| p - 1).collect());
-    let Some(res) = catch_unwind(AssertUnwindSafe(|| {
+fn user_pages_to_inspector(pages: Option<&[u32]>) -> Option<Vec<u32>> {
+    pages.map(|ps| ps.iter().filter(|&&p| p >= 1).map(|&p| p - 1).collect())
+}
+
+/// Single pdf-inspector extract (panic-safe). Shared by probe and the main path.
+pub(super) fn extract_pages_markdown_mem(
+    bytes: &[u8],
+    pages: Option<&[u32]>,
+) -> Option<pdf_inspector::PagesExtractionResult> {
+    let pages0 = user_pages_to_inspector(pages);
+    catch_unwind(AssertUnwindSafe(|| {
         pdf_inspector::extract_pages_markdown_mem(bytes, pages0.as_deref())
     }))
+    .ok()?
     .ok()
-    .and_then(|r| r.ok()) else {
-        return HashSet::new();
-    };
+}
+
+pub(super) fn pages_needing_ocr_from_extract(
+    res: &pdf_inspector::PagesExtractionResult,
+) -> HashSet<u32> {
     res.pages
-        .into_iter()
+        .iter()
         .filter(|page| page.needs_ocr)
         .map(|page| page.page + 1)
         .collect()
+}
+
+/// Probe which pages need OCR (tests + fallback diagnostics).
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) fn probe_pages_needing_ocr(bytes: &[u8], pages: Option<&[u32]>) -> HashSet<u32> {
+    extract_pages_markdown_mem(bytes, pages)
+        .map(|res| pages_needing_ocr_from_extract(&res))
+        .unwrap_or_default()
 }
 
 pub(super) fn parse_marked_pages(markdown: &str) -> HashMap<u32, String> {
@@ -312,7 +329,7 @@ pub(super) fn via_pdf_inspector_parallel_full(path: &Path, bytes: &[u8]) -> Opti
 #[allow(clippy::too_many_arguments)] // Explicit conversion controls are safer at this module boundary.
 pub(super) fn via_pdf_inspector(
     path: &Path,
-    bytes: &[u8],
+    prefetched: pdf_inspector::PagesExtractionResult,
     langs: &str,
     ocr_enabled: bool,
     ocr_images: bool,
@@ -320,26 +337,10 @@ pub(super) fn via_pdf_inspector(
     ocr_config: &OcrRunConfig,
     last_ocr_error: &mut Option<OcrAttemptError>,
 ) -> InspectorAttempt {
-    // pages 1-indexed từ người dùng → 0-indexed cho pdf-inspector.
-    let pages0: Option<Vec<u32>> =
-        pages.map(|ps| ps.iter().filter(|&&p| p >= 1).map(|&p| p - 1).collect());
-    // lopdf structure extraction and PDFium native-text extraction are
-    // independent. Run them concurrently so documents that need native table
-    // rescue pay the slower stage, not the sum of both stages.
-    let Some((res, native_pages)) = std::thread::scope(|scope| {
-        let inspector = scope.spawn(|| {
-            catch_unwind(AssertUnwindSafe(|| {
-                pdf_inspector::extract_pages_markdown_mem(bytes, pages0.as_deref())
-            }))
-            .ok()?
-            .ok()
-        });
-        let native_pages = native_text_for_requested_pages(path, pages);
-        let res = inspector.join().ok().flatten()?;
-        Some((res, native_pages))
-    }) else {
-        return InspectorAttempt::Unavailable;
-    };
+    // Native text is independent of the prefetched inspector result; no second
+    // `extract_pages_markdown_mem` call on the slow path.
+    let res = prefetched;
+    let native_pages = native_text_for_requested_pages(path, pages);
 
     let pages_needing_ocr: HashSet<u32> = res
         .pages

--- a/crates/core/src/conv/pdf/mod.rs
+++ b/crates/core/src/conv/pdf/mod.rs
@@ -20,6 +20,7 @@ mod pdfium;
 mod postprocess;
 mod recovery;
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use crate::diagnostics::{ConversionWarning, DetailedConvertError, MarkdownOutput};
@@ -28,8 +29,8 @@ use crate::ConvertError;
 
 use fallback::{extract_with_pdf_extract, via_pdfium};
 use inspector::{
-    probe_pages_needing_ocr, via_pdf_inspector, via_pdf_inspector_filtered_fast,
-    via_pdf_inspector_parallel_full, InspectorAttempt,
+    extract_pages_markdown_mem, pages_needing_ocr_from_extract, via_pdf_inspector,
+    via_pdf_inspector_filtered_fast, via_pdf_inspector_parallel_full, InspectorAttempt,
 };
 use pdfium::pdfium_available;
 use recovery::PDF_UNTRUSTED_EXTRACT_SOURCE;
@@ -66,9 +67,6 @@ pub(crate) fn to_markdown_detailed(
 ) -> Result<MarkdownOutput, DetailedConvertError> {
     let bytes = std::fs::read(path).map_err(|e| DetailedConvertError::failed(e.to_string()))?;
 
-    // Probe needs_ocr early so PDFium/pdf-extract fallbacks inherit the flags
-    // even when the structured inspector path is abandoned.
-    let probed_needs_ocr = probe_pages_needing_ocr(&bytes, pages);
     let mut last_ocr_error: Option<OcrAttemptError> = None;
 
     // Page-filtered requests are common in the desktop/MCP token-saving flow.
@@ -92,25 +90,29 @@ pub(crate) fn to_markdown_detailed(
         }
     }
 
-    // 1) pdf-inspector: markdown có cấu trúc + needs_ocr theo trang.
-    let mut inherited_needs_ocr = probed_needs_ocr;
-    match via_pdf_inspector(
-        path,
-        &bytes,
-        ocr_langs,
-        ocr_enabled,
-        ocr_images,
-        pages,
-        ocr_config,
-        &mut last_ocr_error,
-    ) {
-        InspectorAttempt::Success(output) if !output.markdown.trim().is_empty() => {
-            return Ok(output);
+    // 1) pdf-inspector: one extract reused for needs_ocr flags + structured markdown.
+    // Fast paths above skip this entirely (no upfront probe/extract).
+    let mut inherited_needs_ocr = HashSet::new();
+    if let Some(prefetched) = extract_pages_markdown_mem(&bytes, pages) {
+        inherited_needs_ocr = pages_needing_ocr_from_extract(&prefetched);
+        match via_pdf_inspector(
+            path,
+            prefetched,
+            ocr_langs,
+            ocr_enabled,
+            ocr_images,
+            pages,
+            ocr_config,
+            &mut last_ocr_error,
+        ) {
+            InspectorAttempt::Success(output) if !output.markdown.trim().is_empty() => {
+                return Ok(output);
+            }
+            InspectorAttempt::Abandoned { pages_needing_ocr } => {
+                inherited_needs_ocr.extend(pages_needing_ocr);
+            }
+            InspectorAttempt::Success(_) => {}
         }
-        InspectorAttempt::Abandoned { pages_needing_ocr } => {
-            inherited_needs_ocr.extend(pages_needing_ocr);
-        }
-        InspectorAttempt::Success(_) | InspectorAttempt::Unavailable => {}
     }
 
     // 2) Fallback: PDFium — inherits inspector needs_ocr flags.


### PR DESCRIPTION
## Summary
- Bỏ `probe_pages_needing_ocr` upfront; fast path (`filtered` / `parallel`) return sớm không gọi extract
- Slow path: một lần `extract_pages_markdown_mem` → reuse cho `needs_ocr` flags + `via_pdf_inspector(prefetched)`
- Benchmark `bench/sample10/pdf`: **768 → 160 ms/file TB (−79.2%)**, output markdown không đổi (5/5 PDF)

## Test plan
- [x] `cargo test -p fileconv-core pdf::` (28 passed)
- [x] `make check-static`
- [x] `RUST_CRATES=core bash scripts/run-rust-ci-fast.sh`
- [x] `fileconv speed bench/sample10/pdf` before/after
- [x] Regression diff 5 PDF sample10 — identical

Closes #363

Made with [Cursor](https://cursor.com)