### PR TITLE
Align code, docs and deploy configs with the Qwen-via-OpenRouter flow (ADR 0016)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ vendor/         # markitdown-rs — CHỈ tham khảo (MIT, đã exclude khỏi 
 
 ## Định dạng hỗ trợ
 
-pdf, docx, pptx, xlsx/xls/xlsb/ods, csv, html + **ảnh OCR tiếng Việt** (Tesseract `vie+eng`) +
-**audio tiếng Việt** (whisper-rs + symphonia). PDF quét → render 300 DPI + OCR.
+pdf, docx, pptx, xlsx/xls/xlsb/ods, csv, html + **ảnh OCR tiếng Việt** (vision-LLM
+qua OpenRouter mặc định — `FILECONV_OCR_*`; Tesseract/Paddle local đã loại bỏ, ADR 0016) +
+**audio tiếng Việt** (whisper-rs + symphonia). PDF quét → render 300 DPI + OCR vision.
 
 ## Kết quả tóm tắt (Intel Xeon 2.8GHz, release)
 
 - **Tốc độ** (60-file corpus): pptx/csv/xlsx/docx < 1ms/file; pdf **~5.7ms/trang**; html ~15ms/file. 100% convert.
-- **Độ chính xác VN**: docx/csv 100%, html 99.2%, xlsx 98.5%, pptx 98.0%; ảnh in OCR ~99% (sau tiền xử lý); low-res 81→99%.
+- **Độ chính xác VN**: docx/csv 100%, html 99.2%, xlsx 98.5%, pptx 98.0%; ảnh in OCR ~99%
+  (số liệu lịch sử đo trên stack Tesseract cũ — OCR hiện qua vision-LLM, ADR 0016).
 - **Audio vi** (gTTS): tiny 86.8% / base 94.5% / small 97.0% (RTF 0.15 / 0.30 / 0.99).
 - **PhoWhisper** (clip vi thật): **90.8%** vs whisper-small 77.3% (**+13.5 điểm**, cùng cỡ model).
 
@@ -58,8 +60,11 @@ Chi tiết: [`bench/REPORT.md`](bench/REPORT.md) + [`docs/system-architecture.md
 
 ## Chạy thử
 
-Yêu cầu: Rust, `tesseract-ocr` + `tesseract-ocr-vie`, `poppler-utils`, `imagemagick`, `python3`.
+Yêu cầu: Rust, `poppler-utils`, `imagemagick` (bench), `python3`.
 Build whisper-rs cần cmake + C/C++ + clang.
+OCR ảnh/PDF scan cần key vision-LLM: `export FILECONV_OCR_API_KEY=...`
+(mặc định OpenRouter; endpoint self-host vLLM/Ollama vision dùng
+`FILECONV_OCR_BASE_URL` khi có GPU).
 
 ```bash
 # 1) Build
@@ -67,9 +72,6 @@ cargo build --release
 
 # 1b) PDFium (thiếu → tự fallback pdf-extract)
 bash bench/download_pdfium.sh
-
-# 1c) tessdata_best (khuyến nghị cho tài liệu thật / IN HOA)
-bash bench/download_tessdata.sh
 
 # 2) Convert 1 file → stdout
 ./target/release/fileconv one duong-dan/file.docx

--- a/bench/download_tessdata.sh
+++ b/bench/download_tessdata.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Tải model OCR chất lượng cao tessdata_best (vie + eng) để tăng độ chính xác
-# tiếng Việt với tài liệu thật (đặc biệt chữ IN HOA). Đặt ở ./tessdata_best —
-# backend tự dùng nếu có (hoặc trỏ FILECONV_TESSDATA). Thiếu thì dùng model nhẹ hệ thống.
+# [LỊCH SỬ — ADR 0016] Tesseract đã bị loại bỏ khỏi pipeline OCR (2026-08-10);
+# backend không còn đọc tessdata/FILECONV_TESSDATA. Script này chỉ giữ để tái
+# tạo thí nghiệm OCR cũ (bench/REPORT_ACCURACY.md, ocr_experiment.py).
+# Tải model tessdata_best (vie + eng) vào ./tessdata_best.
 set -eu
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DST="$ROOT/tessdata_best"

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -1,12 +1,15 @@
 # fileconv-mcp
 
-MCP server (stdio) để AI/agent chuyển file → Markdown **offline, không cần API key**.
-Tái dùng `fileconv-core`. Giúp agent đọc file không-phải-md (pdf/docx/pptx/xlsx/csv/html/ảnh/audio)
-mà **đỡ tốn token**: trích xuất ngoài context + chỉ lấy phần cần.
+MCP server (stdio) để AI/agent chuyển file → Markdown, chạy local và **đỡ tốn
+token**: trích xuất ngoài context + chỉ lấy phần cần. Tái dùng `fileconv-core`.
+Văn bản số (pdf text-layer/docx/pptx/xlsx/csv/html) convert tất định không cần
+API key; riêng **ảnh và PDF scan cần OCR đi qua vision-LLM** (`FILECONV_OCR_*`,
+ADR 0016 — Tesseract local đã bị loại bỏ), thiếu key sẽ báo `DependencyMissing`
+rõ ràng.
 
 ## Tool
 
-**Không cần API key (tất định, offline):**
+**Không cần API key (tất định — trừ ảnh/PDF scan cần `FILECONV_OCR_*`):**
 
 | Tool | Mô tả |
 |---|---|
@@ -47,8 +50,10 @@ claude mcp add fileconv -- /đường/dẫn/target/release/fileconv-mcp
 ```
 
 Tài nguyên native (tuỳ chọn) trỏ qua env khi đăng ký:
-`FILECONV_PDFIUM_LIB` (PDF), `FILECONV_TESSDATA` (OCR chất lượng cao), `FILECONV_WHISPER_MODEL` (audio).
-Thiếu thì tự fallback / báo lỗi rõ.
+`FILECONV_PDFIUM_LIB` (PDF render), `FILECONV_WHISPER_MODEL` (audio).
+OCR ảnh/scan cấu hình qua `FILECONV_OCR_API_KEY`/`FILECONV_OCR_BASE_URL`/
+`FILECONV_OCR_MODEL` (mặc định OpenRouter `qwen/qwen3.7-flash`; endpoint vision
+self-host dùng được khi có GPU). Thiếu thì tự fallback / báo lỗi rõ.
 
 ## Ví dụ luồng agent (tiết kiệm token)
 

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -1,12 +1,14 @@
 //! fileconv-mcp — MCP server (stdio) cho fileconv-core.
 //!
-//! Cho AI/agent chuyển file → Markdown NGOÀI context (đỡ tốn token). Tất định, offline,
-//! không cần API key. Tool:
+//! Cho AI/agent chuyển file → Markdown NGOÀI context (đỡ tốn token). Tất định,
+//! chạy local — riêng ảnh/PDF scan cần OCR đi qua vision-LLM (`FILECONV_OCR_*`,
+//! ADR 0016; thiếu key → lỗi `DependencyMissing` rõ ràng). Tool:
 //!   - `detect_format(path)`       — xem loại/kích thước/số trang/sheet (không convert).
 //!   - `convert_to_markdown(path)` — convert; hỗ trợ chọn trang (pages), sheet, max_chars.
 //!   - `convert_to_markdown_detailed(path)` — cùng convert + outcome/warnings (JSON).
 //!
-//! Đường dẫn tài nguyên qua env: FILECONV_PDFIUM_LIB, FILECONV_TESSDATA, FILECONV_WHISPER_MODEL.
+//! Đường dẫn tài nguyên qua env: FILECONV_PDFIUM_LIB, FILECONV_WHISPER_MODEL;
+//! OCR qua FILECONV_OCR_* (fallback FILECONV_LLM_API_KEY).
 
 use std::path::PathBuf;
 
@@ -123,7 +125,7 @@ impl Fileconv {
     }
 
     #[tool(
-        description = "Chuyển file sang Markdown (pdf/docx/pptx/xlsx/csv/html + ảnh OCR + audio). Chạy offline. Dùng `pages` (PDF, 1-indexed), `sheet` (Excel) hoặc `max_chars` để chỉ lấy phần cần — tiết kiệm token."
+        description = "Chuyển file sang Markdown (pdf/docx/pptx/xlsx/csv/html + ảnh OCR + audio). Chạy local; riêng ảnh/PDF scan cần OCR vision-LLM (FILECONV_OCR_*). Dùng `pages` (PDF, 1-indexed), `sheet` (Excel) hoặc `max_chars` để chỉ lấy phần cần — tiết kiệm token."
     )]
     async fn convert_to_markdown(
         &self,
@@ -329,7 +331,8 @@ impl ServerHandler for Fileconv {
                 ..Default::default()
             },
             instructions: Some(
-                "Chuyển file sang Markdown offline (pdf/docx/pptx/xlsx/csv/html/ảnh OCR/audio). \
+                "Chuyển file sang Markdown local (pdf/docx/pptx/xlsx/csv/html/ảnh OCR/audio; \
+                 ảnh/PDF scan cần OCR vision-LLM qua FILECONV_OCR_*). \
                  Gọi detect_format để xem trước (số trang/sheet), rồi convert_to_markdown; \
                  truyền pages/sheet/max_chars để chỉ lấy phần cần, tiết kiệm token."
                     .into(),

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -55,10 +55,11 @@ export MARKHAND_EMBEDDING_RUNTIME_PATH=vllm-local
 export MARKHAND_INDEX_SIGNATURE=<64-lowercase-hex>
 ```
 
-Production and test profiles accept only local runtime paths (`vllm-local` or
-`local-neural`). A cloud runtime is permitted solely for development when
-`MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true` is set explicitly; production rejects it
-even if that flag is present.
+Local runtime paths (`vllm-local`, `local-neural`) are always accepted. A cloud
+runtime (`provider-cloud`, e.g. OpenRouter `qwen/qwen3-embedding-8b`) is
+permitted on **any** profile, but only when the deployment sets the explicit
+egress opt-in `MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true` (ADR 0016 — index builds
+send full chunk text to the provider). Without the flag it is rejected.
 
 ### CI test strategy
 

--- a/crates/server/src/services/qa/mod.rs
+++ b/crates/server/src/services/qa/mod.rs
@@ -154,7 +154,7 @@ pub(crate) fn resolve_llm_answer(
                 .into(),
             );
             // UAT-only: surface the discarded draft so operators can inspect
-            // what GLM said without promoting it to the primary answer.
+            // what the model said without promoting it to the primary answer.
             if allow_unverified_llm() {
                 warnings.push(discarded_llm_draft_warning(&llm_answer));
             }
@@ -172,7 +172,7 @@ pub(crate) fn resolve_llm_answer(
 // The only real token consumer on the ask path is the configured chat
 // provider (`ChatProvider::complete` / `stream_tokens`); when no provider is
 // configured (extractive-only MVP deployment) nothing is reserved. Neither
-// the OpenAI-compatible non-streaming response nor GLM streaming chunks are
+// the OpenAI-compatible non-streaming response nor provider streaming chunks are
 // guaranteed to carry a `usage` block, so both admission and settlement use
 // the same character heuristic (~4 chars/token) — reserve an upper bound
 // (prompt + MAX_ANSWER_CHARS allowance), settle measured characters.
@@ -373,7 +373,7 @@ pub(crate) fn hits_to_hybrid(hits: &[RetrievalHit]) -> Vec<HybridSearchHit> {
         .collect()
 }
 
-/// Grounded ask: retrieve → optional GLM → citation validate → extractive fallback.
+/// Grounded ask: retrieve → optional chat LLM → citation validate → extractive fallback.
 pub async fn ask(
     pool: &Pool,
     qdrant: &QdrantClient,
@@ -481,7 +481,7 @@ pub async fn ask(
     let extractive = extractive_answer(&request.question, &hybrid);
     let valid_ids = valid_citation_ids(hybrid.len());
 
-    // Provider may be attempted for outage/timeout observability, but GLM answers are
+    // Provider may be attempted for outage/timeout observability, but LLM answers are
     // never claimed grounded unless structured entailment is available AND validation passes.
     let (answer, mode) = match provider {
         Some(chat) if !hybrid.is_empty() => {
@@ -767,7 +767,7 @@ mod tests {
     /// End-to-end through the real `ChatProvider::complete` call (not just the
     /// pure policy function), same wiring `ask()` uses — a hermetic stand-in
     /// for an HTTP-mocked `OpenAiCompatibleChat` run, since `ChatProvider::Static`
-    /// exercises the identical call path without a live GLM endpoint.
+    /// exercises the identical call path without a live provider endpoint.
     /// Plain `#[test]` + `block_on` (not `#[tokio::test]`) so the env-var mutex
     /// guard is never held across an actual `.await` suspension point.
     #[test]

--- a/crates/server/src/services/qa/provider.rs
+++ b/crates/server/src/services/qa/provider.rs
@@ -1,4 +1,5 @@
-//! Optional OpenAI-compatible chat provider for grounded Q&A (GLM / local).
+//! Optional OpenAI-compatible chat provider for grounded Q&A (OpenRouter /
+//! self-hosted local endpoint).
 //!
 //! Supports non-streaming `complete` and incremental `stream_tokens` with
 //! cooperative cancel (P1B-R05). Extractive fallback may chunk locally; the
@@ -17,6 +18,12 @@ use tokio::sync::mpsc;
 
 use crate::services::qa::prompt::GroundedMessages;
 use crate::services::qa::stream::tokenize_answer;
+
+/// Current product direction (ADR 0016 / owner 2026-08-11): Qwen via
+/// OpenRouter for grounded Q&A; a self-hosted local model becomes the target
+/// once GPU capacity exists (same OpenAI-compatible contract, only the base
+/// URL/model change).
+const DEFAULT_CHAT_MODEL: &str = "qwen/qwen3.7-flash";
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const BODY_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
@@ -197,16 +204,19 @@ impl std::fmt::Debug for OpenAiCompatibleChat {
 }
 
 impl OpenAiCompatibleChat {
+    /// Reads `MARKHAND_CHAT_*` (canonical). `MARKHAND_GLM_*` is a deprecated
+    /// legacy alias from the interim GLM deployment (ADR 0004 era) kept only
+    /// so existing deployments keep working; new configs must use `CHAT_*`.
     pub fn from_env() -> Result<Self, ProviderError> {
-        let base = env::var("MARKHAND_GLM_BASE_URL")
-            .or_else(|_| env::var("MARKHAND_CHAT_BASE_URL"))
+        let base = env::var("MARKHAND_CHAT_BASE_URL")
+            .or_else(|_| env::var("MARKHAND_GLM_BASE_URL"))
             .map_err(|_| ProviderError::NotConfigured)?;
-        let api_key = env::var("MARKHAND_GLM_API_KEY")
-            .or_else(|_| env::var("MARKHAND_CHAT_API_KEY"))
+        let api_key = env::var("MARKHAND_CHAT_API_KEY")
+            .or_else(|_| env::var("MARKHAND_GLM_API_KEY"))
             .unwrap_or_default();
-        let model = env::var("MARKHAND_GLM_MODEL")
-            .or_else(|_| env::var("MARKHAND_CHAT_MODEL"))
-            .unwrap_or_else(|_| "glm-4-flash".into());
+        let model = env::var("MARKHAND_CHAT_MODEL")
+            .or_else(|_| env::var("MARKHAND_GLM_MODEL"))
+            .unwrap_or_else(|_| DEFAULT_CHAT_MODEL.into());
         let mode = if base.contains("127.0.0.1") || base.contains("localhost") {
             AnswerMode::LocalLlm
         } else {
@@ -641,7 +651,7 @@ mod tests {
         let provider = OpenAiCompatibleChat::new(
             "https://example.invalid/v1".into(),
             "super-secret-key".into(),
-            "glm-4-flash".into(),
+            "test-chat-model".into(),
             AnswerMode::CloudLlm,
         )
         .unwrap();

--- a/crates/server/src/telemetry/metrics.rs
+++ b/crates/server/src/telemetry/metrics.rs
@@ -2,7 +2,7 @@
 
 use super::validate_metric;
 
-/// Canonical metric names used across API → jobs → convert/embed/retrieval/GLM.
+/// Canonical metric names used across API → jobs → convert/embed/retrieval/chat provider.
 pub const METRIC_REQUEST_LATENCY: &str = "markhand_http_request_duration_seconds";
 pub const METRIC_QUEUE_DEPTH: &str = "markhand_job_queue_depth";
 pub const METRIC_QUEUE_AGE: &str = "markhand_job_queue_age_seconds";

--- a/crates/server/tests/ask_grounding_matrix.rs
+++ b/crates/server/tests/ask_grounding_matrix.rs
@@ -36,7 +36,7 @@ use common::{
 fn production_ask_path_is_extractive_while_entailment_unavailable() {
     assert!(
         !structured_entailment_available(),
-        "must not claim GLM grounded answers without verified entailment"
+        "must not claim LLM grounded answers without verified entailment"
     );
 }
 
@@ -274,7 +274,7 @@ async fn live_ask_is_extractive_and_delete_during_stream_closes() {
     assert!(!response
         .answer
         .to_ascii_lowercase()
-        .contains("glm grounded"));
+        .contains("llm grounded"));
 
     // P2-10 gap close: `CitationPin` (`services::citation`) must carry the
     // exact seeded document/version/collection identity end-to-end through
@@ -402,7 +402,7 @@ async fn live_ask_is_extractive_and_delete_during_stream_closes() {
     );
 
     // HTTP ask route also stays extractive-only.
-    // Document is tombstoned; ask may return empty extractive but must not 500 claiming grounded GLM.
+    // Document is tombstoned; ask may return empty extractive but must not 500 claiming LLM grounding.
     let response = router
         .oneshot(
             Request::builder()
@@ -422,7 +422,7 @@ async fn live_ask_is_extractive_and_delete_during_stream_closes() {
         )
         .await
         .unwrap();
-    // May be 200 with empty hits or an auth/not-found style response; never claim grounded GLM.
+    // May be 200 with empty hits or an auth/not-found style response; never claim LLM grounding.
     let status = response.status();
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let text = String::from_utf8_lossy(&body);

--- a/crates/server/worker.env.example
+++ b/crates/server/worker.env.example
@@ -15,7 +15,15 @@ MARKHAND_WORKER_ALLOW_APP_DB_FALLBACK=1
 
 # Generic sandboxed converter argv. The worker replaces "{input}" with the
 # server-materialized file path named by canonical extension.
-MARKHAND_CONVERTER_ARGV_JSON=["/usr/local/bin/fileconv","one","{input}"]
+# `--ocr-defer-dir .` is required for scan/image inputs (ADR 0016 deferred OCR):
+# the sandbox renders page JPEGs + placeholders, the worker then calls the
+# vision provider via MARKHAND_OCR_* outside the sandbox.
+MARKHAND_CONVERTER_ARGV_JSON=["/usr/local/bin/fileconv","one","--ocr-defer-dir",".","{input}"]
+
+# Vision OCR provider for the deferred-OCR worker stage (required for scans).
+# MARKHAND_OCR_API_KEY=<openrouter-key>
+# MARKHAND_OCR_BASE_URL=https://openrouter.ai/api
+# MARKHAND_OCR_MODEL=qwen/qwen3.7-flash
 
 MARKHAND_WORKER_CLAIM_LIMIT=1
 MARKHAND_WORKER_HEARTBEAT_INTERVAL_SECS=5

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -79,7 +79,30 @@ MARKHAND_EMBEDDING_RUNTIME_PATH=local-neural
 MARKHAND_INDEX_SIGNATURE=72dda20007ffb7fbe293612091103321eb9e4e0e4a0517a5f3413e31a2978874
 MARKHAND_MOCK_EMBEDDING_DIMENSIONS=8
 
-# --- AITeamVN CPU (COMPOSE_PROFILES=aiteamvn) — replace mock block above with: ---
+# --- OpenRouter cloud embedding (ADR 0016 — hướng hiện tại) ---
+# Replace the mock block above with the values below. Requires the explicit
+# egress opt-in; every value is pinned into the index signature (ADR 0006).
+# MARKHAND_EMBEDDING_BASE_URL=https://openrouter.ai/api/v1
+# MARKHAND_EMBEDDING_API_KEY=<openrouter-key>
+# MARKHAND_EMBEDDING_PROVIDER=openrouter
+# MARKHAND_EMBEDDING_MODEL=qwen/qwen3-embedding-8b
+# MARKHAND_EMBEDDING_REVISION=qwen3-embedding-8b-20251028
+# MARKHAND_EMBEDDING_DIMENSIONS=1024
+# MARKHAND_EMBEDDING_RUNTIME_PATH=provider-cloud
+# MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true
+# MARKHAND_EMBEDDING_NORMALIZE=client
+# MARKHAND_EMBEDDING_SEND_DIMENSIONS=true
+# MARKHAND_INDEX_SIGNATURE=<print-index-signature.py output>
+# Signature:
+#   python deploy/scripts/print-index-signature.py \
+#     --base-url https://openrouter.ai/api/v1 \
+#     --model qwen/qwen3-embedding-8b \
+#     --revision qwen3-embedding-8b-20251028 --dimensions 1024
+
+# --- AITeamVN CPU (COMPOSE_PROFILES=aiteamvn) — air-gapped / self-host ---
+# Không phải mặc định nữa: giữ cho deployment không egress, và là đường
+# self-host tương lai khi có GPU (ADR 0016 exception lifecycle).
+# Replace mock block above with:
 # MARKHAND_EMBEDDING_BASE_URL=http://embedding-cpu:8080/v1
 # MARKHAND_EMBEDDING_API_KEY=poc-embedding-key
 # MARKHAND_EMBEDDING_MODEL=AITeamVN/Vietnamese_Embedding
@@ -99,18 +122,30 @@ MARKHAND_MOCK_EMBEDDING_DIMENSIONS=8
 MARKHAND_CHAT_BASE_URL=http://mock-embedding:8080/v1
 MARKHAND_CHAT_API_KEY=poc-chat-key
 MARKHAND_CHAT_MODEL=markhand-mock-chat
-# UAT with GLM: replace all three values above. Prefer the full endpoint so no
-# provider-specific path is guessed:
-# MARKHAND_CHAT_BASE_URL=https://open.bigmodel.cn/api/paas/v4/chat/completions
-# MARKHAND_CHAT_API_KEY=
-# MARKHAND_CHAT_MODEL=glm-4-flash
+# UAT/prod hiện tại: Qwen qua OpenRouter (cùng key với OCR/embedding được).
+# Tương lai có GPU: trỏ BASE_URL sang endpoint OpenAI-compatible self-host
+# (vLLM/Ollama) — không cần đổi code.
+# MARKHAND_CHAT_BASE_URL=https://openrouter.ai/api/v1
+# MARKHAND_CHAT_API_KEY=<openrouter-key>
+# MARKHAND_CHAT_MODEL=qwen/qwen3.7-flash
+# (Legacy GLM deployment cũ vẫn chạy qua alias MARKHAND_GLM_* — deprecated.)
 # Optional IPv4 pin when the chat host publishes AAAA but the Docker bridge has
-# no working IPv6 (compose extra_hosts for api.z.ai). Resolve with:
-#   dig +short A api.z.ai
+# no working IPv6 (compose extra_hosts; hostname mặc định api.z.ai là legacy —
+# override bằng MARKHAND_CHAT_PIN_HOSTNAME). Resolve with: dig +short A <host>
+# MARKHAND_CHAT_PIN_HOSTNAME=api.z.ai
 # MARKHAND_CHAT_HOST_IPV4=128.14.21.40
 # Dev/UAT only: opt in to showing citation-valid provider output as
 # mode=llm_unverified with a warning. Default 0 keeps fail-closed extractive output.
 # MARKHAND_QA_ALLOW_UNVERIFIED_LLM=1
+
+# --- Vision OCR (worker stage — bắt buộc cho ảnh/PDF scan, ADR 0016) ---
+# Sandbox converter không có network/key; worker thu artifact JPEG rồi gọi
+# provider. Thiếu key → job scan fail "vision OCR not configured" (fail-closed).
+# MARKHAND_OCR_API_KEY=<openrouter-key>
+# MARKHAND_OCR_BASE_URL=https://openrouter.ai/api   # mặc định OpenRouter
+# MARKHAND_OCR_MODEL=qwen/qwen3.7-flash             # mặc định
+# MARKHAND_OCR_TIMEOUT_SECS=180
+# MARKHAND_OCR_BATCH_PAGES=1
 
 # --- Worker tenant context (seed org; F03 seed scripts align with these UUIDs) ---
 MARKHAND_WORKER_ORG_ID=11111111-1111-1111-1111-111111111111

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -36,7 +36,15 @@ Defaults:
 - API on `http://127.0.0.1:8788` (`/api/v1/health/ready`)
 - Host ports are loopback-only and offset from `deploy/dev` to avoid clashes
 
-AITeamVN CPU embedding (not GLM):
+OpenRouter cloud embedding (`qwen/qwen3-embedding-8b`, ADR 0016 — hướng hiện tại):
+
+```bash
+# edit deploy/.env: bật block "OpenRouter cloud embedding" (provider-cloud,
+# MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true) + signature từ print-index-signature.py
+deploy/scripts/poc-up.sh
+```
+
+AITeamVN CPU embedding (air-gapped / self-host tương lai khi có GPU):
 
 ```bash
 # edit deploy/.env: COMPOSE_PROFILES=aiteamvn + AITeamVN signature/URL block

--- a/deploy/compose.poc.yml
+++ b/deploy/compose.poc.yml
@@ -426,9 +426,11 @@ services:
     ports:
       - "${MARKHAND_API_BIND_HOST:-127.0.0.1}:${MARKHAND_API_PORT:-8788}:8787"
     # Optional IPv4 pin for cloud chat hosts whose AAAA records are unreachable
-    # from the bridge (common on IPv4-only Docker hosts). Mock profile ignores it.
+    # from the bridge (common on IPv4-only Docker hosts). Hostname is
+    # configurable (legacy default api.z.ai from the interim GLM deployment);
+    # OpenRouter normally needs no pin. Mock profile ignores it.
     extra_hosts:
-      - "api.z.ai:${MARKHAND_CHAT_HOST_IPV4:-127.0.0.1}"
+      - "${MARKHAND_CHAT_PIN_HOSTNAME:-api.z.ai}:${MARKHAND_CHAT_HOST_IPV4:-127.0.0.1}"
     networks: [edge, private]
     tmpfs:
       - /tmp:rw,noexec,nosuid,nodev,size=256m

--- a/deploy/dev/.env.example
+++ b/deploy/dev/.env.example
@@ -26,7 +26,10 @@ MARKHAND_AUTH_AUDIENCE=markhand-dev
 MARKHAND_AUTH_SIGNING_KEY=dev-only-signing-key-at-least-32-bytes
 MARKHAND_AUTH_KID=dev-key-1
 
-# --- AITeamVN CPU embedding (Compose embedding-cpu :8088, same path as on-prem CPU prod) ---
+# --- AITeamVN CPU embedding (Compose embedding-cpu :8088) ---
+# Dev default vì không cần key/egress. Hướng deployment hiện tại là OpenRouter
+# qwen3-embedding-8b (ADR 0016 — xem worker.env.example); AITeamVN giữ cho
+# air-gapped và là đường self-host tương lai khi có GPU.
 MARKHAND_EMBEDDING_PORT=8088
 MARKHAND_EMBEDDING_BASE_URL=http://127.0.0.1:8088/v1
 MARKHAND_EMBEDDING_API_KEY=dev-embedding-key
@@ -72,11 +75,13 @@ MARKHAND_MINIO_PASSWORD=markhand_dev_only
 # MARKHAND_VLLM_PORT=8000
 # MARKHAND_DEV_PASSWORD=markhand-dev
 
-# --- Optional: grounded ask GLM/OpenAI-compatible chat provider (see README "bật LLM cho dev") ---
+# --- Optional: grounded ask chat provider (OpenAI-compatible; see README "bật LLM cho dev") ---
 # Unset by default: /api/v1/ask stays extractive-only (no provider configured).
-# MARKHAND_GLM_BASE_URL=http://127.0.0.1:8089/v1
-# MARKHAND_GLM_API_KEY=dev-only-placeholder-not-a-real-key
-# MARKHAND_GLM_MODEL=glm-4-flash
+# Hiện tại: Qwen qua OpenRouter. Tương lai có GPU: trỏ BASE_URL sang endpoint
+# self-host (vLLM/Ollama). Alias legacy MARKHAND_GLM_* vẫn đọc được (deprecated).
+# MARKHAND_CHAT_BASE_URL=https://openrouter.ai/api/v1
+# MARKHAND_CHAT_API_KEY=dev-only-placeholder-not-a-real-key
+# MARKHAND_CHAT_MODEL=qwen/qwen3.7-flash
 # Dev-gate (default OFF): even with a provider configured above, ask() stays
 # extractive-only unless this is also set to 1/true. When ON + provider answers
 # pass citation/claim validation, ask returns mode=llm_unverified with a fixed

--- a/deploy/dev/README.md
+++ b/deploy/dev/README.md
@@ -1,7 +1,8 @@
 # Local development stack
 
-PostgreSQL, Qdrant, MinIO, telemetry and **AITeamVN CPU embedding** (same runtime as
-on-prem CPU production).
+PostgreSQL, Qdrant, MinIO, telemetry and **AITeamVN CPU embedding** (dev default
+— không cần key/egress; deployment hiện tại dùng OpenRouter `qwen3-embedding-8b`
+theo ADR 0016, AITeamVN giữ cho air-gapped / self-host tương lai khi có GPU).
 
 **Runbook:** [`../../docs/runbooks/local-development.md`](../../docs/runbooks/local-development.md)
 
@@ -26,14 +27,16 @@ Compose: [`compose.yml`](compose.yml) · Dockerfile: [`Dockerfile.embedding-cpu`
 ## Bật LLM cho dev (grounded ask, opt-in)
 
 Mặc định `/api/v1/ask` là extractive-only (fail-closed vì chưa có structured
-entailment verifier — xem `services/qa/mod.rs`). Để thử một provider GLM/
-OpenAI-compatible thật trong dev:
+entailment verifier — xem `services/qa/mod.rs`). Để thử một provider
+OpenAI-compatible thật trong dev (hiện tại: Qwen qua OpenRouter; local
+self-host vLLM/Ollama dùng cùng contract):
 
 ```bash
 # .env (không commit key thật):
-MARKHAND_GLM_BASE_URL=http://127.0.0.1:8089/v1   # hoặc MARKHAND_CHAT_BASE_URL
-MARKHAND_GLM_API_KEY=...                          # hoặc MARKHAND_CHAT_API_KEY; để trống nếu local không cần key
-MARKHAND_GLM_MODEL=glm-4-flash                    # hoặc MARKHAND_CHAT_MODEL
+MARKHAND_CHAT_BASE_URL=https://openrouter.ai/api/v1   # hoặc endpoint local :8089/v1
+MARKHAND_CHAT_API_KEY=...                              # để trống nếu local không cần key
+MARKHAND_CHAT_MODEL=qwen/qwen3.7-flash
+# (alias legacy MARKHAND_GLM_* vẫn được đọc — deprecated)
 
 # Dev-gate riêng — mặc định TẮT. Bật để answer LLM (sau khi qua citation/claim
 # validation) được trả về thay vì luôn rớt extractive:

--- a/deploy/observability/alerts/README.md
+++ b/deploy/observability/alerts/README.md
@@ -22,7 +22,7 @@ Dashboard: [`../dashboards/markhand-phase1b.json`](../dashboards/markhand-phase1
 | `MarkhandQueueAgeHigh` | `markhand_job_queue_age_seconds` | stuck-jobs |
 | `MarkhandDiskLow` | `node_filesystem_*` (instance/device/mountpoint) | disk-exhaustion |
 | `MarkhandDependencyDown` | `up{job=markhand-api}` or `probe_success{job=~markhand-(postgres\|qdrant\|minio\|embedding)}` | dependency-outage |
-| `MarkhandProviderErrors` | `markhand_provider_duration_seconds` | glm-fallback |
+| `MarkhandProviderErrors` | `markhand_provider_duration_seconds` | chat-provider-fallback |
 | `MarkhandEmbeddingErrors` | `markhand_embedding_batch_duration_seconds` | dependency-outage |
 | `MarkhandConversionFailures` | `markhand_conversion_duration_seconds` | converter-outbreak |
 | `MarkhandReconcileDrift` | `markhand_reconcile_drift_total` | reconcile-drift |

--- a/deploy/observability/prometheus/markhand-rules-test.yml
+++ b/deploy/observability/prometheus/markhand-rules-test.yml
@@ -145,9 +145,11 @@ tests:
   - name: MarkhandProviderErrors fire then resolve
     interval: 1m
     input_series:
-      - series: 'markhand_provider_duration_seconds_count{provider="glm",outcome="error"}'
+      # Label matches what the server records for the chat path
+      # (`services/qa/provider.rs` uses provider="chat"/"chat_stream").
+      - series: 'markhand_provider_duration_seconds_count{provider="chat",outcome="error"}'
         values: "0+20x12 240+0x10"
-      - series: 'markhand_provider_duration_seconds_count{provider="glm",outcome="ok"}'
+      - series: 'markhand_provider_duration_seconds_count{provider="chat",outcome="ok"}'
         values: "0+2x12 24+20x10"
     alert_rule_test:
       - eval_time: 10m
@@ -155,10 +157,10 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
-              provider: glm
+              provider: chat
             exp_annotations:
-              summary: Chat/GLM provider error rate above 50%
-              runbook: docs/runbooks/phase-1b/glm-fallback.md
+              summary: Chat provider error rate above 50%
+              runbook: docs/runbooks/phase-1b/chat-provider-fallback.md
       - eval_time: 21m
         alertname: MarkhandProviderErrors
         exp_alerts: []

--- a/deploy/observability/prometheus/markhand-rules.yml
+++ b/deploy/observability/prometheus/markhand-rules.yml
@@ -73,8 +73,8 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: Chat/GLM provider error rate above 50%
-          runbook: docs/runbooks/phase-1b/glm-fallback.md
+          summary: Chat provider error rate above 50%
+          runbook: docs/runbooks/phase-1b/chat-provider-fallback.md
 
       - alert: MarkhandEmbeddingErrors
         expr: |

--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -50,7 +50,7 @@ deploy/scripts/download-aiteamvn-embedding.sh
 
 | Profile | Service | Use |
 |---|---|---|
-| **`aiteamvn`** (default) | `embedding-cpu` | AITeamVN @ `:8088` — **dev + on-prem CPU prod path** |
+| **`aiteamvn`** (default) | `embedding-cpu` | AITeamVN @ `:8088` — **dev mặc định (không cần key) + air-gapped**; deployment hiện tại dùng OpenRouter `qwen3-embedding-8b` (ADR 0016), self-host lại khi có GPU |
 | `mock` | `mock-embedding` | 8-dim stub — **CI** (`COMPOSE_PROFILES=mock`) |
 | `gpu` | `vllm` | Optional GPU inference |
 

--- a/deploy/scripts/poc-boot-evidence.sh
+++ b/deploy/scripts/poc-boot-evidence.sh
@@ -842,7 +842,7 @@ def stroke(points, radius):
                 if math.hypot(x - (x0 + t * dx), y - (y0 + t * dy)) <= radius:
                     black(x, y)
 
-# Large, conventional sans-serif shapes that Tesseract reads consistently.
+# Large, conventional sans-serif shapes that OCR engines read consistently.
 rectangle(55, 30, 78, 190)
 rectangle(55, 30, 170, 53)
 rectangle(55, 95, 150, 118)

--- a/deploy/scripts/print-dev-defaults.sh
+++ b/deploy/scripts/print-dev-defaults.sh
@@ -45,7 +45,7 @@ POC UUIDs (migration 0011)
   Admin user      22222222-2222-2222-2222-222222222201
   Collection      55555555-5555-5555-5555-555555555501  (slug: poc-library)
 
-Embedding (AITeamVN CPU — chậm lần đầu, cùng runtime on-prem CPU)
+Embedding (AITeamVN CPU — chậm lần đầu; dev/air-gapped — prod hiện dùng OpenRouter, ADR 0016)
   MARKHAND_EMBEDDING_BASE_URL=${MARKHAND_EMBEDDING_BASE_URL:-http://127.0.0.1:8088/v1}
   MARKHAND_EMBEDDING_MODEL=${MARKHAND_EMBEDDING_MODEL:-AITeamVN/Vietnamese_Embedding}
   MARKHAND_EMBEDDING_DIMENSIONS=${MARKHAND_EMBEDDING_DIMENSIONS:-1024}

--- a/docs/adr/0005-vietnamese-embedding-model-quality.md
+++ b/docs/adr/0005-vietnamese-embedding-model-quality.md
@@ -1,6 +1,10 @@
 # ADR 0005: Vietnamese embedding — AITeamVN local for POC/1B
 
-- Status: Accepted
+- Status: Superseded by [ADR 0016](0016-openrouter-qwen-ocr-embedding.md) for
+  cloud-allowed Markhand Web deployments (OpenRouter `qwen/qwen3-embedding-8b`,
+  benchmark PASS 2026-08-10). AITeamVN local (`local-neural`) remains the
+  supported air-gapped profile and the future self-host path once GPU capacity
+  exists (ADR 0016 exception lifecycle).
 - Date: 2026-07-18
 - Accepted: 2026-07-20
 - Owners: retrieval-owner

--- a/docs/adr/0016-openrouter-qwen-ocr-embedding.md
+++ b/docs/adr/0016-openrouter-qwen-ocr-embedding.md
@@ -1,12 +1,13 @@
 # ADR 0016: OpenRouter Qwen cho OCR và embedding của Markhand Web
 
 - Status: Accepted (phần OCR — quyết định trực tiếp của product owner
-  2026-08-10, đã implement); phần embedding cutover vẫn gated theo điều kiện
-  bên dưới
+  2026-08-10, đã implement); phần embedding: benchmark DKP-02 **PASS**
+  (2026-08-10), cutover còn chờ chốt dimension + security review theo điều
+  kiện bên dưới
 - Date: 2026-08-10
 - Owners: retrieval-owner, worker-owner
-- Approver: product-owner (OCR: approved 2026-08-10; embedding: pending
-  benchmark evidence)
+- Approver: product-owner (OCR: approved 2026-08-10; embedding: benchmark PASS,
+  pending dimension decision + security review)
 - Supersedes: [ADR 0005](0005-vietnamese-embedding-model-quality.md) (embedding
   runtime selection cho Markhand Web — khi phần embedding được kích hoạt)
 - Related issues/PRs: draft DKP-01…DKP-07 trong

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ native, security/egress và migration strategy.
 | [0002](0002-version-aware-citations.md) | Accepted | Version-aware retrieval and citations |
 | [0003](0003-cross-document-conflict-lifecycle.md) | Proposed | Cross-document claim/conflict lifecycle |
 | [0004](0004-interim-glm-cloud-embedding.md) | Superseded by 0005 | GLM cloud embedding interim (historical; superseded 2026-07-20) |
-| [0005](0005-vietnamese-embedding-model-quality.md) | Accepted | AITeamVN local embedding for POC/1B; GLM chat-only |
+| [0005](0005-vietnamese-embedding-model-quality.md) | Superseded by 0016 (cloud-allowed); giữ cho air-gapped | AITeamVN local embedding for POC/1B (nay là profile air-gapped / self-host tương lai) |
 | [0006](0006-index-signature.md) | Accepted | Canonical index signature and chunk identity (P0-06) |
 | [0007](0007-tenant-isolation-rls.md) | Accepted | Tenant isolation and RLS boundary |
 | [0008](0008-pg-partition-strategy.md) | Accepted | PG partition strategy for Phase 1B POC and Profile B revalidation |
@@ -33,7 +33,7 @@ native, security/egress và migration strategy.
 | [0013](0013-intelligence-durable-ids.md) | Accepted | Durable intelligence IDs (`sha256-v1`) and desktop rebuild |
 | [0014](0014-vietnamese-word-segmentation-fts.md) | Proposed | Vietnamese word segmentation for FTS lexical retrieval (P1B-R01) |
 | [0015](0015-purge-content-retention-semantics.md) | Proposed | Immutable-content retention semantics for document purge (P1B-I07) |
-| [0016](0016-openrouter-qwen-ocr-embedding.md) | Accepted (OCR) / gated (embedding) | Vision OCR OpenRouter thay thế hoàn toàn Tesseract; `qwen3-embedding-8b` cutover chờ benchmark (supersedes 0005 khi kích hoạt) |
+| [0016](0016-openrouter-qwen-ocr-embedding.md) | Accepted (OCR) / benchmark PASS, chờ chốt dimension + security review (embedding) | Vision OCR OpenRouter thay thế hoàn toàn Tesseract; `qwen3-embedding-8b` supersedes 0005 cho deployment cloud-allowed |
 | [0017](0017-spa-api-image-delivery.md) | Proposed | Bundle the matching web SPA in the API image |
 
 Phase 0 numeric/benchmark decisions use the machine-readable

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -40,24 +40,24 @@ PDF và whisper **đắt** → phải giữ pattern cache. Đừng "dọn" thàn
   (`audio_threads`, `audio_no_speech_threshold`) stay on `AudioEngine` and are **not** part of the
   cache key. Resample to 16 kHz uses `rubato` FFT with partial/flush + `output_delay` trim;
   returns `Result` (never invents silence on failure). Trả `Unsupported` nếu chưa có model.
-- **Tesseract**: spawn mỗi lần qua `crate::proc::background_command()` (không cache process). Temp PNG ghi qua
-  `tempfile::NamedTempFile` (exclusive `O_EXCL`/tên random) — tránh path đoán được trong `/tmp`.
+- **Temp file**: file tạm (ảnh render, artifact) ghi qua `tempfile::NamedTempFile`
+  (exclusive `O_EXCL`/tên random) — tránh path đoán được trong `/tmp`.
 
 ## Subprocess spawning — MUST dùng `crate::proc::background_command`
 
-GUI app (Tauri) không nên hiển thị console window khi spawn CLI subprocess (tesseract, python, LLM CLI).
+GUI app (Tauri) không nên hiển thị console window khi spawn CLI subprocess (python, LLM CLI…).
 Luôn dùng `crate::proc::background_command()` thay vì `Command::new()` trực tiếp:
 
 ```rust
 // ✅ Đúng
-let output = crate::proc::background_command("tesseract")
-    .arg(&image_path)
+let output = crate::proc::background_command("some-cli")
+    .arg(&input_path)
     .arg(out_path)
     .output()?;
 
 // ❌ Sai
-let output = std::process::Command::new("tesseract")
-    .arg(&image_path)
+let output = std::process::Command::new("some-cli")
+    .arg(&input_path)
     .arg(out_path)
     .output()?;
 ```
@@ -115,11 +115,11 @@ Không đo lại = không claims "nhanh/đúng hơn". Quy tắc Fail loud: báo 
 
 - Build whisper-rs cần **cmake + C/C++ + clang** (bindgen). Lần đầu compile whisper.cpp ~1–2 phút.
 - PDFium: `bash bench/download_pdfium.sh` → `./pdfium/lib`. Thiếu → PDF tự fallback pdf-extract.
-- tessdata_best (khuyến nghị, tài liệu thật/IN HOA): `bash bench/download_tessdata.sh` → `./tessdata_best`.
 - Whisper model: `bash bench/download_models.sh` → `./models/ggml-{tiny,base,small}.bin` + **PhoWhisper-small**.
-- Tesseract: cài `tesseract-ocr` + `tesseract-ocr-vie` (CLI).
+- OCR ảnh/scan: vision-LLM (`FILECONV_OCR_API_KEY`, mặc định OpenRouter; ADR 0016 —
+  Tesseract/Paddle local đã loại bỏ; self-host vision endpoint qua `FILECONV_OCR_BASE_URL`).
 
-Override đường dẫn qua env: `FILECONV_PDFIUM_LIB`, `FILECONV_TESSDATA`, `FILECONV_WHISPER_MODEL`.
+Override đường dẫn qua env: `FILECONV_PDFIUM_LIB`, `FILECONV_WHISPER_MODEL`.
 
 ## Cạm bẫy đã biết (tránh lặp)
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -75,7 +75,7 @@ Tám subcommand đăng ký ở `registered_commands()` (`crates/cli/src/main.rs`
 | `audio` | (feature `audio`) WER/RTF/load mỗi model GGML |
 | `handoff` | đóng gói handoff (BRD/PRD) từ nhiều file nguồn → ZIP |
 | `pptx-preview` | JSON preview meta/slides/shapes qua `fileconv_core::pptx_preview::preview_meta`/`preview_slide` |
-| `info` | danh sách định dạng hỗ trợ + trạng thái PDFium/tessdata/model whisper |
+| `info` | danh sách định dạng hỗ trợ + trạng thái PDFium/model whisper |
 
 ## `crates/mcp/` — binary `fileconv-mcp`
 
@@ -159,10 +159,12 @@ schema/table, version, watch rules), nhóm knowledge RAG (`rebuild_knowledge_ind
   `REPORT_AUDIO.md`, `REPORT_PHOWHISPER.md`, `REPORT_EDGE.md`, `REPORT_SAMPLE10*.md`, `REPORT_XL.md`,
   `RESEARCH_COMPETITORS.md`.
 - **Shell**: `download_corpus*.sh`, `download_models.sh`, `download_pdfium.sh`,
-  `download_tessdata.sh`, `make_sample10.sh`, `make_vn_images.sh`, `make_xl_images.sh`.
-- **Python**: `make_vn_corpus.py`, `make_vn_audio.py`, `ocr_experiment.py`, `paddle_test.py`.
+  `make_sample10.sh`, `make_vn_images.sh`, `make_xl_images.sh`
+  (`download_tessdata.sh` chỉ còn giá trị lịch sử — Tesseract đã loại bỏ, ADR 0016).
+- **Python**: `make_vn_corpus.py`, `make_vn_audio.py` (`ocr_experiment.py`,
+  `paddle_test.py` là tư liệu thí nghiệm stack OCR cũ).
 
-> Các thư mục `pdfium/`, `tessdata_best/`, `models/`, `bench/corpus*`, `bench/edge` đều **gitignore**
+> Các thư mục `pdfium/`, `models/`, `bench/corpus*`, `bench/edge` đều **gitignore**
 > — phải chạy script `bench/*.sh` để tái tạo.
 
 ## Khi cần sửa — tìm đâu

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,9 +3,12 @@
 ## Platform
 
 Self-hosted Linux/amd64 Docker Compose. The UAT image serves the React SPA and
-Rust API from one origin; five workers use PostgreSQL, Qdrant, MinIO, and the
-local AITeamVN CPU embedding service. Grounded chat uses a server-side GLM
-OpenAI-compatible endpoint.
+Rust API from one origin; five workers use PostgreSQL, Qdrant, MinIO, and —
+per ADR 0016 — OpenRouter Qwen for vision OCR (`qwen/qwen3.7-flash`), cloud
+embedding (`qwen/qwen3-embedding-8b`, explicit egress opt-in), and grounded
+chat (OpenAI-compatible `MARKHAND_CHAT_*`). The local AITeamVN CPU embedding
+service remains the air-gapped profile and the future self-host path once GPU
+capacity exists.
 
 This is a `dev`-profile, private-network test deployment. Direct HTTP is allowed
 only for sanitized UAT documents and test identities. Add a reviewed TLS edge
@@ -27,18 +30,25 @@ Create `deploy/.env` from `deploy/.env.example`, keep it mode `0600`, and set:
 
 - `MARKHAND_COMPOSE_PROJECT=markhand-test`
 - `MARKHAND_PROFILE=dev`
-- `COMPOSE_PROFILES=aiteamvn`
 - `MARKHAND_API_BIND_HOST=<private-interface-ip>`
 - matching `MARKHAND_AUTH_ISSUER`
 - unique PostgreSQL, MinIO, JWT, and embedding credentials
-- the pinned AITeamVN URL/model/revision/dimensions/signature block
-- `MARKHAND_CHAT_BASE_URL` (full `/chat/completions` URL),
-  `MARKHAND_CHAT_API_KEY`, and `MARKHAND_CHAT_MODEL` for GLM
-- `MARKHAND_CHAT_HOST_IPV4` when `api.z.ai` (or the chosen chat host) resolves
-  to unreachable AAAA records from the Docker bridge; pin the A record so the
-  API container can reach GLM over IPv4
+- the OpenRouter cloud-embedding block (`qwen/qwen3-embedding-8b`,
+  `MARKHAND_EMBEDDING_RUNTIME_PATH=provider-cloud`,
+  `MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true`, `MARKHAND_EMBEDDING_NORMALIZE=client`,
+  `MARKHAND_EMBEDDING_SEND_DIMENSIONS=true`, pinned revision/dimensions and the
+  matching `MARKHAND_INDEX_SIGNATURE`) — air-gapped deployments use
+  `COMPOSE_PROFILES=aiteamvn` with the pinned AITeamVN block instead
+- `MARKHAND_OCR_API_KEY` (vision OCR worker stage; base URL/model default to
+  OpenRouter `qwen/qwen3.7-flash`)
+- `MARKHAND_CHAT_BASE_URL`, `MARKHAND_CHAT_API_KEY`, and `MARKHAND_CHAT_MODEL`
+  for grounded chat (currently Qwen via OpenRouter; a self-hosted
+  OpenAI-compatible endpoint slots in unchanged once GPU capacity exists;
+  legacy `MARKHAND_GLM_*` aliases are still read but deprecated)
+- `MARKHAND_CHAT_PIN_HOSTNAME`/`MARKHAND_CHAT_HOST_IPV4` only when the chosen
+  chat host resolves to unreachable AAAA records from the Docker bridge
 - optionally `MARKHAND_QA_ALLOW_UNVERIFIED_LLM=1` only while UAT explicitly
-  evaluates GLM output; responses remain labelled `llm_unverified` with a
+  evaluates provider output; responses remain labelled `llm_unverified` with a
   warning because structured entailment is unavailable
 - `MARKHAND_POC_MAX_STORAGE_BYTES=32212254720`
 - `MARKHAND_QDRANT_MEM_LIMIT=6g`
@@ -46,9 +56,9 @@ Create `deploy/.env` from `deploy/.env.example`, keep it mode `0600`, and set:
 Never commit the environment file, model weights, credentials, customer
 documents, or secret-bearing logs.
 
-Keep AITeamVN at batch size 16 initially. During a measured backlog ingest,
-`MARKHAND_EMBEDDING_CPUS` may be raised as high as `8.0` on the 24-CPU test
-host, then returned to the normal limit after the queue drains.
+Air-gapped only: keep AITeamVN at batch size 16 initially. During a measured
+backlog ingest, `MARKHAND_EMBEDDING_CPUS` may be raised as high as `8.0` on the
+24-CPU test host, then returned to the normal limit after the queue drains.
 
 ## Deploy
 
@@ -64,8 +74,8 @@ deploy/scripts/poc-health.sh
 
 `poc-up.sh` builds the API/SPA and worker images, runs migrations, applies the
 optional seeded-org quota override, starts dependencies and workers, and checks
-readiness. The first AITeamVN boot downloads the pinned model into the persistent
-embedding cache volume.
+readiness. (Air-gapped profile: the first AITeamVN boot downloads the pinned
+model into the persistent embedding cache volume.)
 
 Migration 0011 creates `admin@poc.example` without a password. Generate a random
 test password on a trusted workstation, store it in the team password manager,

--- a/docs/licenses/tesseract-runtime-evidence.md
+++ b/docs/licenses/tesseract-runtime-evidence.md
@@ -1,5 +1,10 @@
 # Tesseract runtime license evidence
 
+> **Historical (ADR 0016):** Tesseract was removed from the OCR pipeline on
+> 2026-08-10 — image/scan OCR now runs through a vision LLM. This evidence is
+> retained for past releases that shipped the Tesseract runtime; do not treat
+> it as a current runtime prerequisite.
+
 - Inventory id: `tesseract-ocr-system`
 - Kind: native-library
 - Source: Ubuntu package `tesseract-ocr`

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -133,36 +133,44 @@ export FILECONV_LLM_API_KEY=...
 Baseline luôn là FTS5 + local feature hashing 256D. Người dùng có thể bật neural
 embeddings riêng với chat provider:
 
-- **Markhand Web server (POC/1B):** on-prem `AITeamVN/Vietnamese_Embedding`
-  (`local-neural`, Compose `embedding-cpu` @ `:8088`) — ADR 0005.
+- **Markhand Web server (hướng hiện tại — ADR 0016):** OpenRouter
+  `qwen/qwen3-embedding-8b` (`provider-cloud`, cần `MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true`).
+- **Markhand Web air-gapped / self-host tương lai (khi có GPU):** on-prem
+  `AITeamVN/Vietnamese_Embedding` (`local-neural`, Compose `embedding-cpu` @ `:8088`)
+  — ADR 0005 (superseded bởi 0016 cho deployment cloud-allowed; giữ như generation riêng).
 - Local desktop/server presets: Ollama (`nomic-embed-text`, `mxbai-embed-large`,
   `bge-m3`), LM Studio, vLLM.
-- Cloud (desktop optional only; **not** Markhand Web server default): GLM/Zhipu
-  (`embedding-3`, `embedding-2`), OpenAI (`text-embedding-3-*`), Gemini
-  (`gemini-embedding-001`) — xem ADR 0004 (superseded for web server).
+- Cloud khác (desktop optional only): GLM/Zhipu (`embedding-3`, `embedding-2`),
+  OpenAI (`text-embedding-3-*`), Gemini (`gemini-embedding-001`) — xem ADR 0004
+  (superseded for web server).
 
 ### Markhand Web — OCR, embedding vs Q&A
 
 | Path | Runtime | Egress |
 |---|---|---|
 | OCR ảnh/trang scan | Vision LLM qua worker stage (OpenRouter mặc định, `MARKHAND_OCR_*`); sandbox chỉ render JPEG (deferred), không network/key | Ảnh trang scan → provider |
-| Index / hybrid search | AITeamVN local (`local-neural`) **hoặc** OpenRouter `qwen/qwen3-embedding-8b` (`provider-cloud`, cần `MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true`) | Local: không; cloud: toàn bộ chunk text |
-| Grounded Q&A | GLM cloud (hoặc local LLM) | Chỉ top-K citation |
+| Index / hybrid search | OpenRouter `qwen/qwen3-embedding-8b` (`provider-cloud`, cần `MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true`) — hướng hiện tại; AITeamVN local (`local-neural`) cho air-gapped / self-host khi có GPU | Local: không; cloud: toàn bộ chunk text |
+| Grounded Q&A | Qwen qua OpenRouter (`MARKHAND_CHAT_*`; alias legacy `MARKHAND_GLM_*` deprecated) hoặc local LLM self-host | Chỉ top-K citation |
 
 ```bash
-# Server embedding local (dev/POC) — see deploy/dev/.env.example
-MARKHAND_EMBEDDING_BASE_URL=http://127.0.0.1:8088/v1
-MARKHAND_EMBEDDING_MODEL=AITeamVN/Vietnamese_Embedding
-
-# Server embedding OpenRouter (ADR 0016) — xem deploy/dev/worker.env.example:
+# Server embedding OpenRouter (ADR 0016 — hướng hiện tại), xem deploy/dev/worker.env.example:
 # BASE_URL=https://openrouter.ai/api/v1, MODEL=qwen/qwen3-embedding-8b,
 # RUNTIME_PATH=provider-cloud, ALLOW_CLOUD_EMBEDDINGS=true, NORMALIZE=client,
 # SEND_DIMENSIONS=true (MRL 4096→1024). Đổi config = index generation mới.
 
+# Server embedding local (dev mặc định / air-gapped / self-host tương lai khi có GPU)
+MARKHAND_EMBEDDING_BASE_URL=http://127.0.0.1:8088/v1
+MARKHAND_EMBEDDING_MODEL=AITeamVN/Vietnamese_Embedding
+
 # Server vision OCR (worker stage, bắt buộc cho ảnh/PDF scan)
 MARKHAND_OCR_API_KEY=...
 
-# Q&A only (cloud)
+# Server grounded Q&A (hiện tại: Qwen qua OpenRouter; self-host cùng contract)
+MARKHAND_CHAT_BASE_URL=https://openrouter.ai/api/v1
+MARKHAND_CHAT_API_KEY=...
+MARKHAND_CHAT_MODEL=qwen/qwen3.7-flash
+
+# Desktop Q&A (cloud)
 export FILECONV_LLM_API_KEY=...
 ```
 

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -43,7 +43,7 @@ tiền xử lý ảnh trước OCR.
 | Nhóm | Yêu cầu | Trạng thái |
 |---|---|---|
 | Văn bản | pdf / docx / pptx / xlsx(xls/xlsb/ods) / csv / html → Markdown | ✅ |
-| Ảnh | OCR tiếng Việt (Tesseract `vie+eng` + tiền xử lý ảnh) | ✅ |
+| Ảnh | OCR tiếng Việt (vision-LLM qua OpenRouter mặc định, `FILECONV_OCR_*` — ADR 0016) | ✅ (cần key vision) |
 | Âm thanh | Phản âm tiếng Việt (whisper-rs + symphonia, ưu tiên PhoWhisper) | ✅ |
 | PDF quét | Render 300 DPI + OCR từng trang `needs_ocr` | ✅ |
 | Cấu trúc | PDF có heading/bảng/đa cột (pdf-inspector) | ✅ |
@@ -54,8 +54,10 @@ tiền xử lý ảnh trước OCR.
 | NFC | Chuẩn hoá mọi output (tài liệu NFD từ macOS/PDF cũ) | ✅ |
 
 ### Yêu cầu phi chức năng
-- **Offline-first (mặc định converter/desktop)**: lõi + CLI + desktop chạy không cần mạng. LLM/vision
-  chỉ là tier tuỳ chọn. Markhand Web nằm ngoài mặc định này — track on-prem multi-org riêng, cần
+- **Offline-first (văn bản số)**: convert pdf text-layer/docx/pptx/xlsx/csv/html + audio chạy
+  không cần mạng. **Ảnh/PDF scan cần OCR là ngoại lệ**: đi qua vision-LLM (ADR 0016 — hiện tại
+  OpenRouter, tương lai có GPU thì self-host endpoint vision local để trở lại không-egress).
+  Markhand Web nằm ngoài mặc định này — track on-prem multi-org riêng, cần
   Postgres/Qdrant/MinIO (xem [`runbooks/local-development.md`](runbooks/local-development.md)).
 - **Hiệu năng**: tài liệu văn bản < 1ms/file; PDF ~5.7ms/trang (xem số liệu ở [`bench/REPORT.md`](../bench/REPORT.md)).
 - **Đóng gói được**: chạy được trên Win/Mac/Linux chỉ với các phụ thuộc native tối thiểu.
@@ -66,7 +68,7 @@ tiền xử lý ảnh trước OCR.
   matrix, nhưng còn cần xác minh artifact trên từng platform và credentials ký/notarization.
   Linux `.deb` đã có build evidence.
 - Nhận dạng giọng nói (ASR) streaming real-time.
-- OCR chữ viết tay độ cao (giới hạn Tesseract; tier vision-LLM mới giải quyết từng phần).
+- OCR chữ viết tay độ cao (vision-LLM giải quyết từng phần; cần đo lại baseline trên corpus scan).
 
 ## Động lực & vị thế thị trường
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -70,8 +70,8 @@ Issue catalog: [`../plans/markhand-web/backlog/`](../plans/markhand-web/backlog/
 ## Backlog
 
 ### Độ chính xác tiếng Việt
-- [ ] **Phục hồi dấu IN HOA đầy đủ**: đã thêm retry PSM 6 khi output sparse/lỗi/
-      dính chuỗi IN HOA và chọn output theo quality score; phục hồi bằng VLM vẫn cần corpus thật.
+- [ ] **Phục hồi dấu IN HOA đầy đủ**: cơ chế retry PSM 6 thời Tesseract đã retired
+      cùng engine (ADR 0016); cần đo lại IN HOA trên vision OCR với corpus thật.
 - [x] **Tách cột trước OCR** bằng vertical projection, OCR từng cột và score fallback.
 - [x] **Decode VNI / VPS** đầy đủ từ bảng tham chiếu VietUnicode.
 - [x] **Lọc ảo giác whisper** bằng `no_speech_probability` + marker nhạc/im lặng.

--- a/docs/runbooks/contributor-setup.md
+++ b/docs/runbooks/contributor-setup.md
@@ -37,8 +37,9 @@ CI runs these same Make targets in parallel and adds Linux bundle validation.
 - `whisper-rs` native build stale: verify C/C++/cmake, then
   `cargo clean -p whisper-rs-sys`.
 - pnpm mismatch/nested lock: install pnpm 10.33.3; use only root lock.
-- scan PDF runtime missing: run `bench/download_pdfium.sh`; install Tesseract `vie+eng`
-  or use bundled desktop runtime.
+- scan PDF runtime missing: run `bench/download_pdfium.sh` (render); OCR needs a
+  vision-LLM key — `export FILECONV_OCR_API_KEY=...` (OpenRouter default) or a
+  self-hosted vision endpoint via `FILECONV_OCR_BASE_URL` (ADR 0016 — Tesseract removed).
 - Compose health fail: inspect `docker compose -f deploy/dev/compose.yml ps` and logs;
   scripts already retry stable PostgreSQL/Qdrant startup.
 - generated roadmap/API drift: run `python3 scripts/build-roadmap.py` or

--- a/docs/runbooks/local-development.md
+++ b/docs/runbooks/local-development.md
@@ -5,8 +5,9 @@ và quality gate xem [`contributor-setup.md`](contributor-setup.md).
 
 F-08 cung cấp stack CPU-only cho development — **không** dùng làm bằng chứng benchmark hay
 production throughput. Stack gồm PostgreSQL, Qdrant, MinIO, OpenTelemetry Collector và
-**embedding-cpu (AITeamVN trên CPU)** — cùng runtime dự kiến cho on-prem CPU production;
-lần đầu chậm vì tải model HuggingFace.
+**embedding-cpu (AITeamVN trên CPU)** — dev mặc định (không cần key/egress); deployment
+hiện tại dùng OpenRouter `qwen3-embedding-8b` (ADR 0016), AITeamVN giữ cho air-gapped và
+là đường self-host khi có GPU; lần đầu chậm vì tải model HuggingFace.
 
 ## Trên `master` hiện chạy được gì?
 
@@ -206,9 +207,11 @@ Volume `embedding_model_cache` giữ weights HuggingFace giữa các lần resta
 
 ### Embedding runtime (index + embedding workers)
 
-**Mặc định — AITeamVN CPU (dev = on-prem CPU prod path):** Compose `embedding-cpu` @
-`:8088`. Pin P0-05 trong `.env.example` (1024-d, revision `dea33aa1…`). Worker và server
-dùng cùng `MARKHAND_EMBEDDING_*`.
+**Mặc định dev — AITeamVN CPU (air-gapped / self-host tương lai):** Compose
+`embedding-cpu` @ `:8088`. Pin P0-05 trong `.env.example` (1024-d, revision `dea33aa1…`).
+Worker và server dùng cùng `MARKHAND_EMBEDDING_*`. Deployment cloud-allowed hiện dùng
+OpenRouter `qwen/qwen3-embedding-8b` (`provider-cloud` + `MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true`,
+ADR 0016 — xem `deploy/dev/worker.env.example`).
 
 **Profile `mock`:** stub 8-dim cho CI — set `COMPOSE_PROFILES=mock` và uncomment block mock
 trong `.env.example`.
@@ -335,8 +338,9 @@ embedding.
 5. Verify khả năng tìm kiếm sau khi index/embedding xong: `POST /api/v1/search` (mục Verify).
 6. Verify hỏi-đáp: `POST /api/v1/ask` (mục Verify) — mặc định trả lời extractive
    (`offline_extractive`/`fallback_extractive`), không cần provider LLM nào. Chỉ cần cấu hình
-   provider (`MARKHAND_CHAT_BASE_URL`/`MARKHAND_CHAT_API_KEY`/`MARKHAND_CHAT_MODEL`, hoặc
-   `MARKHAND_GLM_*` tương ứng) khi muốn bật sinh câu trả lời bằng LLM thay cho extractive.
+   provider (`MARKHAND_CHAT_BASE_URL`/`MARKHAND_CHAT_API_KEY`/`MARKHAND_CHAT_MODEL` —
+   hiện tại Qwen qua OpenRouter; alias legacy `MARKHAND_GLM_*` deprecated) khi muốn bật
+   sinh câu trả lời bằng LLM thay cho extractive.
 
 **Lưu ý:** quarantined/rejected upload **không** theo path convert accepted ở trên — upload
 quarantined vẫn đăng ký document/version nhưng job `convert` chỉ được tạo khi có
@@ -459,8 +463,8 @@ curl -sS -X POST http://127.0.0.1:8787/api/v1/ask \
 
 `ask` mặc định trả lời extractive (`mode: offline_extractive`/`fallback_extractive`) khi chưa
 cấu hình chat provider; cấu hình provider (`MARKHAND_CHAT_BASE_URL`/`MARKHAND_CHAT_API_KEY`/
-`MARKHAND_CHAT_MODEL`, hoặc `MARKHAND_GLM_*` tương ứng) chỉ cần khi muốn bật sinh câu trả lời
-bằng LLM.
+`MARKHAND_CHAT_MODEL` — hiện tại Qwen qua OpenRouter; alias legacy `MARKHAND_GLM_*`
+deprecated) chỉ cần khi muốn bật sinh câu trả lời bằng LLM.
 
 ## Failure and reset
 

--- a/docs/runbooks/phase-1b/README.md
+++ b/docs/runbooks/phase-1b/README.md
@@ -10,7 +10,7 @@ bodies, prompts, or embeddings into tickets.
 | Stuck / dead-letter / quota | `MarkhandQueueGrowth`, `MarkhandQueueAgeHigh`, `MarkhandQuotaExceeded` | [stuck-jobs.md](stuck-jobs.md) |
 | Converter outbreak | `MarkhandConversionFailures` | [converter-outbreak.md](converter-outbreak.md) |
 | Dependency / embed outage | `MarkhandDependencyDown`, `MarkhandEmbeddingErrors` | [dependency-outage.md](dependency-outage.md) |
-| GLM / chat fallback | `MarkhandProviderErrors` | [glm-fallback.md](glm-fallback.md) |
+| Chat provider fallback | `MarkhandProviderErrors` | [chat-provider-fallback.md](chat-provider-fallback.md) |
 | Disk exhaustion | `MarkhandDiskLow` | [disk-exhaustion.md](disk-exhaustion.md) |
 | Reconcile drift | `MarkhandReconcileDrift` | [reconcile-drift.md](reconcile-drift.md) |
 | Backup / restore | `MarkhandBackupStale` | [backup-restore.md](backup-restore.md) |

--- a/docs/runbooks/phase-1b/chat-provider-fallback.md
+++ b/docs/runbooks/phase-1b/chat-provider-fallback.md
@@ -1,4 +1,4 @@
-# GLM / chat provider fallback
+# Chat provider fallback (OpenRouter Qwen / self-hosted local)
 
 ## Detect
 
@@ -23,7 +23,7 @@ clamp_min(sum(rate(markhand_provider_duration_seconds_count[5m])) by (provider),
 
 ```bash
 # Endpoint reachability only — do not print Authorization headers
-curl -sS -o /dev/null -w '%{http_code}\n' "${MARKHAND_GLM_BASE_URL:-http://127.0.0.1:9}/health" || true
+curl -sS -o /dev/null -w '%{http_code}\n' "${MARKHAND_CHAT_BASE_URL:-${MARKHAND_GLM_BASE_URL:-http://127.0.0.1:9}}/health" || true
 docker compose -f deploy/compose.poc.yml --env-file deploy/.env logs --tail=80 api \
   2>&1 | python3 deploy/scripts/redact_secrets.py
 ```
@@ -35,4 +35,4 @@ docker compose -f deploy/compose.poc.yml --env-file deploy/.env logs --tail=80 a
 ## Verify
 
 - Provider error ratio `< 0.5` for ≥5m; alert inactive.
-- Ask returns cited extractive or validated GLM answers; audit has no prompts.
+- Ask returns cited extractive or validated LLM answers; audit has no prompts.

--- a/docs/runbooks/phase-1b/dependency-outage.md
+++ b/docs/runbooks/phase-1b/dependency-outage.md
@@ -47,7 +47,7 @@ docker compose -f deploy/compose.poc.yml --env-file deploy/.env exec -T postgres
 
 1. Restore the failed dependency; wait healthy.
 2. Qdrant-only loss → rebuild from PG chunks (ADR 0012) via [vector-rebuild](vector-rebuild.md).
-3. Embedding/provider errors → restore mock/vLLM/GLM; leave extractive ask online.
+3. Embedding/provider errors → restore mock/OpenRouter/self-hosted endpoint; leave extractive ask online.
 
 ## Verify
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -146,7 +146,7 @@ Tám subcommand đăng ký ở `registered_commands()`:
 | `audio` | `<models.csv> <manifest.tsv> [report.md]` | (feature `audio`) WER/RTF/load mỗi model GGML |
 | `handoff` | `<product> <output.zip> <sources...>` | đóng gói handoff pack (BRD/PRD) từ nhiều file nguồn |
 | `pptx-preview` | `<file.pptx>` | JSON preview meta/slides/shapes qua `fileconv_core::pptx_preview::preview_meta`/`preview_slide` |
-| `info` | (không đối số) | danh sách định dạng hỗ trợ + trạng thái PDFium/tessdata/model whisper |
+| `info` | (không đối số) | danh sách định dạng hỗ trợ + trạng thái PDFium/model whisper |
 
 Panic hook in `file:line`. Manifest: mỗi dòng `<file>\t<ground_truth.txt>\t<nhãn>`, `#` = comment.
 
@@ -168,7 +168,7 @@ Chín tool — năm deterministic (không cần API key) và bốn LLM (`FILECON
 | `summarize` | LLM (`FILECONV_LLM_*`) | tóm tắt (cap 40 000 ký tự) |
 | `extract_json` | LLM | trích JSON theo hướng dẫn ngôn ngữ tự nhiên |
 | `translate` | LLM | dịch sang ngôn ngữ đích |
-| `ocr_hard` | LLM (vision) | OCR ảnh khó (đa cột, IN HOA, viết tay, con dấu) — chất lượng hơn Tesseract |
+| `ocr_hard` | LLM (vision) | OCR ảnh khó (đa cột, IN HOA, viết tay, con dấu) với provider/model tuỳ chọn (`FILECONV_LLM_*`) |
 
 `ocr_hard` (`llm.rs::vision_ocr`): base64 ảnh → POST vision endpoint của provider (OpenAI/Anthropic/Gemini),
 system prompt yêu cầu phiên âm Markdown tiếng Việt trung thực, timeout 180s.

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -133,7 +133,7 @@ Bảng này là nguồn dữ liệu cho tab **Tech stack** trong
 | Vector retrieval | Qdrant | Vector candidates; kết quả luôn được hydrate và kiểm ACL lại | Phase 1B |
 | Object storage | MinIO | File gốc, quarantine, Markdown và derived artifacts | Phase 1B |
 | Embeddings | AITeamVN local / OpenRouter `qwen3-embedding-8b` | POC/1B baseline: AITeamVN on-prem CPU (`local-neural`, Compose `:8088`, Recall@5 0.9261). ADR 0016 thay target vLLM GPU bằng OpenRouter `provider-cloud` (egress opt-in `MARKHAND_ALLOW_CLOUD_EMBEDDINGS`); thành pin mặc định sau benchmark golden corpus (DKP-02); đổi runtime = rebuild index generation | Phase 0 → 1B (local); OpenRouter option delivered 2026-08-10 |
-| Chat and extraction | GLM via LLM client | Grounded Q&A, summarize và structured extraction theo policy (**không** dùng cho embedding/index) | Phase 1B → 3 |
+| Chat and extraction | OpenRouter Qwen via OpenAI-compatible client (`MARKHAND_CHAT_*`) | Grounded Q&A, summarize và structured extraction theo policy (**không** dùng cho embedding/index); self-host local model khi có GPU — cùng contract; alias legacy `MARKHAND_GLM_*` deprecated | Phase 1B → 3 |
 | Identity | JWT + rotating refresh + OIDC | Session cho POC; SSO/OIDC và key rotation cho production | Phase 1B → 4 |
 | Observability | OpenTelemetry + structured logs | Trace, metrics, audit correlation và redacted diagnostics | Phase F → 4 |
 | Runtime | Docker Compose → production orchestrator | Local/POC reproducible; Kubernetes hoặc nền tảng on-prem tương đương được chốt ở Phase 4 | Phase F → 4 |
@@ -167,7 +167,8 @@ Bảng này là nguồn dữ liệu cho tab **Tech stack** trong
 Đã chốt 2026-08-10 (ADR 0016) và loại khỏi danh sách: GPU/VRAM/throughput vLLM
 cutover (bỏ — thay bằng OpenRouter, gate `G0-RET-VLLM-CUTOVER` retired); chính
 sách cloud embedding (được phép sau egress opt-in tường minh
-`MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true`; GLM vẫn chỉ Q&A).
+`MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true`). Q&A chuyển hướng sang Qwen qua
+OpenRouter (2026-08-11), thay GLM interim; self-host local model khi có GPU.
 
 Còn mở:
 

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -1659,8 +1659,8 @@
       },
       {
         "layer": "Chat and extraction",
-        "technology": "GLM via LLM client",
-        "responsibility": "Grounded Q&A, summarize và structured extraction theo policy (**không** dùng cho embedding/index)",
+        "technology": "OpenRouter Qwen via OpenAI-compatible client (MARKHAND_CHAT_*)",
+        "responsibility": "Grounded Q&A, summarize và structured extraction theo policy (**không** dùng cho embedding/index); self-host local model khi có GPU — cùng contract; alias legacy MARKHAND_GLM_* deprecated",
         "delivery": "Phase 1B → 3"
       },
       {

--- a/web/src/components/qa/TurnAnswerMeta.tsx
+++ b/web/src/components/qa/TurnAnswerMeta.tsx
@@ -1,5 +1,5 @@
 // Shared post-answer chrome for live + historical chat turns: mode badge,
-// Vietnamese warning summary, optional discarded GLM draft, technical details.
+// Vietnamese warning summary, optional discarded LLM draft, technical details.
 import { Notice } from '../ui';
 import { describeAnswerMode } from './answerMode';
 import { presentWarnings } from './warningPresentation';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Remove stale old-flow information so code, docs and deploy configs consistently describe the current direction (owner 2026-08-11): **Qwen via OpenRouter for OCR, embedding and grounded Q&A today; self-hosted local models over the same OpenAI-compatible contract once GPU capacity exists**. Local Tesseract is gone (ADR 0016) and AITeamVN embedding is an air-gapped/self-host profile, not the default narrative.

## Scope

**Q&A provider (functional, backward compatible):**
- `crates/server/src/services/qa/provider.rs`: canonical env is now `MARKHAND_CHAT_BASE_URL/API_KEY/MODEL`; `MARKHAND_GLM_*` kept as a deprecated legacy alias so existing deployments keep working; default model is now `qwen/qwen3.7-flash` (was `glm-4-flash`; deployments that set the model explicitly are unaffected).
- `deploy/compose.poc.yml`: the chat-host IPv4 pin hostname is configurable via `MARKHAND_CHAT_PIN_HOSTNAME` (legacy default `api.z.ai` preserved).
- GLM-specific comments/assertion strings neutralized in `qa/mod.rs`, `telemetry/metrics.rs`, `ask_grounding_matrix.rs`, `web/.../TurnAnswerMeta.tsx`.

**Deploy/config gaps:**
- `deploy/.env.example`: added the missing `MARKHAND_OCR_*` block, an OpenRouter cloud-embedding recipe, and an OpenRouter chat recipe; AITeamVN block relabelled air-gapped/self-host.
- `crates/server/worker.env.example`: converter argv now includes the required `--ocr-defer-dir "."` (deferred-OCR contract) plus the `MARKHAND_OCR_*` vars.
- Prometheus: `MarkhandProviderErrors` summary/runbook de-GLM'd; rules-test fixture label `provider="glm"` → `"chat"` (matches what `provider.rs` actually records); runbook renamed `glm-fallback.md` → `chat-provider-fallback.md` with references updated.

**Docs:**
- Onboarding no longer teaches Tesseract/tessdata: root `README.md`, `docs/code-standards.md`, `docs/project-overview-pdr.md`, `docs/runbooks/contributor-setup.md`, `crates/mcp/README.md` + MCP tool descriptions (image/scan OCR requires `FILECONV_OCR_*`, no longer claimed fully offline).
- Current-path framing: `docs/llm-providers.md`, `docs/deployment.md`, `docs/runbooks/local-development.md`, `deploy/*/README.md`, `crates/server/README.md` (cloud embedding policy corrected: allowed on any profile with the explicit egress flag), `plans/markhand-web/README.md` (+ regenerated `roadmap.html`).
- ADR hygiene: ADR 0005 marked superseded-by-0016 for cloud-allowed deployments (air-gapped kept); ADR 0016 header and index reflect embedding benchmark PASS (remaining gate: dimension decision + security review); Tesseract license evidence and `bench/download_tessdata.sh` marked historical.

**Deliberately out of scope (needs its own reviewed PR):** removing Tesseract from desktop packaging/CI (`scripts/prepare-desktop-runtime.py`, `tauri.macos.conf.json` tessdata resources, `release-desktop.yml`, `ci.yml` apt installs, `validate_desktop_baseline.py`) — native-runtime/CI changes require the dedicated review per repository policy. Desktop optional GLM embedding presets and `glm-cloud-interim` allowlist entries are intentional and untouched.

## Evidence

- [x] Tests: `cargo fmt --all -- --check`; `cargo clippy --no-deps -p fileconv-knowledge -p fileconv-server --all-targets -- -D warnings`; `cargo metadata --locked`; `scripts/check-dependency-policy.py`; `scripts/check-rust-lint-baseline.py` (full workspace, no new warnings); `cargo test -p fileconv-server --lib qa` (37 pass) and `--lib embedding` (12 pass); `promtool check rules` + `promtool test rules` (SUCCESS); web `format:check`/`lint`/`vitest` (560 pass).
- [x] Manual/benchmark/migration evidence: no runtime data/migration change; env alias fallback keeps existing GLM UAT deployments working unchanged.

## Boundary and security review

- [x] Dependency boundary check passed (no dependency changes; `cargo metadata --locked` clean).
- [x] Tenant/ACL impact reviewed: N/A (no auth/ACL paths touched).
- [x] Sensitive logging/secret/egress impact reviewed: no new egress paths; documented recipes only describe the already-implemented ADR 0016 opt-ins; `redact_secrets.py` GLM pattern still valid while aliases exist.
- [x] Security review trigger checked: LLM policy/docs wording changes only; chat default-model change flagged for reviewer attention.

## Follow-up

- [x] Docs, ADR, OpenAPI, roadmap or runbook updated where required (this PR is that update; `roadmap.html` regenerated via `scripts/build-roadmap.py`).
- [ ] Separate PR: strip Tesseract from desktop packaging + CI/release workflows (native-runtime review required).
- [ ] When GPU capacity lands: point `MARKHAND_CHAT_*`/`MARKHAND_OCR_*`/embedding env at the self-hosted endpoint (no code change expected).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff0fe-396e-79c9-8938-69a438e4b84d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff0fe-396e-79c9-8938-69a438e4b84d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

