### PR TITLE
Re-point open issue catalog and phase plans at the Qwen/OpenRouter flow

### DIFF
--- a/plans/markhand-web/backlog/phase-1b/issues/README.md
+++ b/plans/markhand-web/backlog/phase-1b/issues/README.md
@@ -23,7 +23,7 @@ ghi trong issue đã `Done`.
 |---|---|
 | G0-ARCH | ADR document/artifact, tenancy/RLS, partition, Qdrant, auth, migration, recovery |
 | G0-RET | Model/dimension/normalize/chunk/signature/hybrid thresholds |
-| G0-SEC | Upload allowlist/limits/quarantine/sandbox/GLM policy |
+| G0-SEC | Upload allowlist/limits/quarantine/sandbox/LLM-provider policy (thời 1B là GLM; nay OpenRouter Qwen — ADR 0016) |
 | G0-CAP | Worker/queue/concurrency/timeout/headroom |
 | G0-SLO | Latency/throughput/RPO/RTO/soak numeric gates |
 | G0-LIC | Model/native license inventory |

--- a/plans/markhand-web/backlog/phase-3/issues/README.md
+++ b/plans/markhand-web/backlog/phase-3/issues/README.md
@@ -85,7 +85,11 @@ P3-03..13 → P3-14
   derived version/export, full audit.
 - **Depends:** P3-02/03 + RBAC. **Acceptance/tests:** Original hash unchanged; findings
   authorized; precision/recall/completeness/overlap/Unicode/permission tests.
-- **Security:** No PII logs; prohibited data no GLM. **Out:** legal completeness guarantee.
+- **Security:** No PII logs; prohibited-classification data never leaves for any
+  external LLM/embedding provider (hiện tại OpenRouter Qwen — chat/OCR/embedding,
+  ADR 0016; tương lai self-host local model khi có GPU). Cover cả đường cloud
+  embedding: index build gửi toàn bộ chunk text, không chỉ Q&A top-K.
+  **Out:** legal completeness guarantee.
 
 ## P3-09 — Schema/table edit và safe CSV
 

--- a/plans/markhand-web/backlog/phase-4/issues/README.md
+++ b/plans/markhand-web/backlog/phase-4/issues/README.md
@@ -71,7 +71,8 @@ P4-01..12 → P4-13 ────────────────────
 ## P4-07 — HA/degraded modes/distributed limiting
 
 - **Plan/files:** Stateless replicas, worker fairness, PG/MinIO/Qdrant HA;
-  circuit breaker cho provider ngoài (OpenRouter OCR/embedding, GLM) với
+  circuit breaker cho provider ngoài (OpenRouter — OCR/embedding/chat Qwen,
+  ADR 0016; hoặc endpoint self-host cùng contract khi có GPU) với
   retry/backoff và extractive/lexical degraded mode; pause ingest; shared
   global limiter.
 - **Depends:** SLA/deployment ADR. **Acceptance/tests:** Aggregate limits survive

--- a/plans/markhand-web/phase-0-discovery-and-gates.md
+++ b/plans/markhand-web/phase-0-discovery-and-gates.md
@@ -58,8 +58,11 @@ Hai tầng runtime (ADR 0005; ADR 0004 superseded):
    `G0-RET-VLLM-CUTOVER` đã gỡ khỏi registry. Pin mặc định đổi sau khi model
    mới qua gate Recall@5/nDCG trên golden corpus (DKP-02).
 
-**GLM cloud** is **not** the Markhand Web server embedding runtime. GLM remains
-approved for grounded Q&A / summarize (top-K citation handoff only).
+~~**GLM cloud** is **not** the Markhand Web server embedding runtime. GLM remains
+approved for grounded Q&A / summarize (top-K citation handoff only).~~ —
+**superseded 2026-08:** theo ADR 0016 + chuyển hướng Q&A, chat/OCR/embedding đều
+dùng Qwen qua OpenRouter (`MARKHAND_CHAT_*`/`MARKHAND_OCR_*`/`provider-cloud`);
+GLM chỉ còn alias legacy deprecated.
 
 Đo trên golden corpus:
 
@@ -82,9 +85,12 @@ Kết quả chốt:
 - index signature canonical (không trộn generation giữa hai runtime);
 - hybrid weights/rerank baseline.
 
-Không chọn model chỉ theo latency. Chất lượng tiếng Việt là ưu tiên. Markhand Web
+Không chọn model chỉ theo latency. Chất lượng tiếng Việt là ưu tiên. ~~Markhand Web
 server không gửi corpus chunk lên cloud cho embedding; GLM chỉ nhận top-K citation
-cho Q&A.
+cho Q&A.~~ — **superseded 2026-08-10 (ADR 0016):** cloud embedding
+(`provider-cloud` + `MARKHAND_ALLOW_CLOUD_EMBEDDINGS=true`) gửi toàn bộ chunk
+text tới OpenRouter khi build index; profile air-gapped giữ `local-neural`
+không egress.
 
 ## P0.4 — Qdrant/PG scale spike
 
@@ -139,7 +145,8 @@ Chốt:
 - quarantine lifecycle;
 - sandbox profile: unprivileged UID, read-only root, no egress mặc định, giới hạn
   CPU/RAM/file/process/wall-clock, process-group kill;
-- policy GLM cloud theo phân loại dữ liệu.
+- policy LLM-provider cloud theo phân loại dữ liệu (thời Phase 0 là GLM; nay
+  OpenRouter Qwen — ADR 0016).
 
 Lập inventory model/native dependency gồm nguồn, version, checksum, license và
 redistribution constraints. Model chưa rõ license, gồm PhoWhisper, không được bundle

--- a/plans/markhand-web/phase-3-intelligence.md
+++ b/plans/markhand-web/phase-3-intelligence.md
@@ -90,7 +90,9 @@ Invariant:
 - Original immutable.
 - UI buộc review trước publish/export.
 
-Không gửi tài liệu có classification cấm ra GLM cloud.
+Không gửi tài liệu có classification cấm ra bất kỳ LLM/embedding provider ngoài
+nào (hiện tại OpenRouter Qwen — ADR 0016; kể cả đường cloud embedding gửi toàn
+bộ chunk text khi build index).
 
 ## P3.7 — Schema, tables và versions
 

--- a/plans/markhand-web/phase-4-production-hardening.md
+++ b/plans/markhand-web/phase-4-production-hardening.md
@@ -37,7 +37,8 @@ UI:
 - SSRF/egress allowlist.
 - Parser sandbox escape review.
 - Audit tamper evidence, retention và export.
-- Privacy/data-classification review cho GLM cloud.
+- Privacy/data-classification review cho các provider cloud (OpenRouter Qwen —
+  chat/OCR/embedding, ADR 0016).
 
 Không go-live nếu còn high/critical finding chưa được giải quyết. Risk được chấp
 nhận chính thức phải có approver, compensating controls, expiry và retest date mới
@@ -56,7 +57,7 @@ Theo SLA/ADR đã chốt:
   query hạ xuống lexical FTS;
 - vision OCR provider outage (OpenRouter): convert job retry/backoff, không mất
   dữ liệu;
-- GLM outage fallback (extractive);
+- chat provider outage fallback (extractive);
 - query vẫn phục vụ khi ingest tạm pause.
 
 Mỗi dependency có readiness và circuit breaker phù hợp. Không trả stale unauthorized
@@ -109,7 +110,7 @@ Diễn tập thêm:
 - Qdrant index versioned, shadow query, alias switch và giữ bản trước để rollback.
 - Worker khai báo schema/job payload compatibility.
 - API và worker canary độc lập.
-- Feature flag cho format, cloud GLM, intelligence và index signature.
+- Feature flag cho format, cloud LLM provider, intelligence và index signature.
 
 Rollout:
 
@@ -138,7 +139,7 @@ Runbook bắt buộc:
 
 - stuck jobs/dead letters;
 - parser outbreak;
-- PG/Qdrant/MinIO/OpenRouter/GLM outage;
+- PG/Qdrant/MinIO/OpenRouter (chat/OCR/embedding) outage;
 - rebuild/rollback model;
 - quota discrepancy;
 - credential rotation;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Outcome

Fix the root source of old-flow drift in the roadmap: open issues in the authoritative catalog (`plans/markhand-web/backlog/`) and the phase plan docs still named GLM as the LLM provider and carried pre-ADR-0016 embedding-egress policy statements. New issues decomposed from these docs would inherit the stale flow. After this PR the catalog and plans match the current direction: Qwen via OpenRouter for chat/OCR/embedding today, self-hosted local models over the same contract once GPU capacity exists.

Audit basis: scan of all 62 open GitHub issues + full catalog for `tesseract/tessdata/aiteamvn/glm/vllm/local-neural/embedding-cpu/paddle`.

## Scope

- **Backlog P3-08 (open, [#139](https://github.com/anhnth24/project-example/issues/139)):** "prohibited data no GLM" → provider-agnostic rule (OpenRouter Qwen today, self-host later) that now also explicitly covers the cloud-embedding path, which sends full chunk text at index build (a gap in the old top-K-only wording).
- **Backlog P4-07 (open, [#152](https://github.com/anhnth24/project-example/issues/152)):** circuit-breaker scope "OpenRouter OCR/embedding, GLM" → "OpenRouter — OCR/embedding/chat Qwen (or same-contract self-hosted endpoint)".
- **Backlog phase-1b gate table:** G0-SEC label "GLM policy" → "LLM-provider policy" with a historical note (1B ran on GLM).
- **Phase plans:** `phase-3-intelligence.md` (classification egress rule), `phase-4-production-hardening.md` (privacy review, outage fallback, feature flag, outage list), `phase-0-discovery-and-gates.md` (strike-through + superseded-by-ADR-0016 notes on the two embedding-egress policy sentences; gate wording note).

Untouched by design: Done-issue records mentioning GLM/AITeamVN/vLLM (P0-05, P1B-R03/O01/O02, F-08 …) — historical evidence; `gates.yaml` notes already carry retired-markers. GitHub issue **bodies** for #139/#152 and the Tesseract-based intern issue [#357](https://github.com/anhnth24/project-example/issues/357) still need a GitHub-side edit (my tooling is read-only for issues) — the catalog here is the authority, and `scripts/sync-github-issues.py` can push the updated bodies.

## Evidence

- [x] Tests: `python3 scripts/build-roadmap.py` + `--check` pass (120 issues, status counts unchanged); `python3 scripts/sync-github-issues.py --dry-run` parses the full catalog cleanly.
- [x] Manual/benchmark/migration evidence: N/A — documentation/catalog wording only; no status, dependency, or count changes.

## Boundary and security review

- [x] Dependency boundary check passed (no code/dependency changes).
- [x] Tenant/ACL impact reviewed: N/A.
- [x] Sensitive logging/secret/egress impact reviewed: wording tightens the egress policy statements (cloud embedding sends full chunk text) rather than weakening them.
- [x] Security review trigger checked: LLM-policy wording — flagged for reviewer attention, no behavior change.

## Follow-up

- [x] Roadmap/catalog validation run as required by `docs/conventions/issues-and-plans.md`.
- [ ] After merge: run `scripts/sync-github-issues.py` (non-dry-run) or manually update GitHub bodies for #139/#152 so they match the catalog.
- [ ] Decide fate of intern issue #357 (rewrite as vision-OCR deep-dive or close) — comment draft already provided to the owner.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff0fe-396e-79c9-8938-69a438e4b84d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff0fe-396e-79c9-8938-69a438e4b84d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

