### PR TITLE
feat(cli): add convert timeout for one/one-detailed (#366)

### DIFF
--- a/crates/cli/src/convert_timeout.rs
+++ b/crates/cli/src/convert_timeout.rs
@@ -1,0 +1,198 @@
+//! Wall-clock timeout for `fileconv one` / `one-detailed`.
+//!
+//! macOS often lacks GNU `timeout`; this wraps convert in a worker thread and
+//! waits with `mpsc::recv_timeout` (same idea as `fileconv_core::llm_cli`).
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use fileconv_core::{
+    ConversionReport, ConversionResult, ConvertError, Converter, DetailedConvertError,
+};
+
+pub const TIMEOUT_ENV: &str = "FILECONV_CONVERT_TIMEOUT_SEC";
+
+/// Parse `30`, `30s`, `30sec`, or `30seconds` into a positive second count.
+pub fn parse_timeout_secs(raw: &str) -> Result<u64> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        bail!("--timeout / {TIMEOUT_ENV} rỗng — dùng số giây > 0 (vd: 30 hoặc 30s)");
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    let digits = lower
+        .strip_suffix("seconds")
+        .or_else(|| lower.strip_suffix("secs"))
+        .or_else(|| lower.strip_suffix("sec"))
+        .or_else(|| lower.strip_suffix('s'))
+        .unwrap_or(lower.as_str())
+        .trim();
+    let secs: u64 = digits
+        .parse()
+        .with_context(|| format!("giá trị timeout không hợp lệ: {raw:?}"))?;
+    if secs == 0 {
+        bail!("timeout phải > 0 giây (nhận được 0)");
+    }
+    Ok(secs)
+}
+
+/// Flag `--timeout` wins over `{TIMEOUT_ENV}`; neither set → no timeout.
+pub fn resolve_timeout_from_args(rest: &[String]) -> Result<Option<Duration>> {
+    if let Some(index) = rest.iter().position(|argument| argument == "--timeout") {
+        let raw = rest
+            .get(index + 1)
+            .context("thiếu giá trị sau --timeout (vd: --timeout 30s)")?;
+        return Ok(Some(Duration::from_secs(parse_timeout_secs(raw)?)));
+    }
+    match std::env::var(TIMEOUT_ENV) {
+        Ok(value) if !value.trim().is_empty() => {
+            Ok(Some(Duration::from_secs(parse_timeout_secs(&value)?)))
+        }
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(error).context(format!("đọc {TIMEOUT_ENV}"))?,
+    }
+}
+
+fn timeout_message(timeout: Duration) -> String {
+    format!("convert timeout sau {}s", timeout.as_secs().max(1))
+}
+
+/// Run `work` on a helper thread; abandon the join if `timeout` elapses.
+pub fn run_with_timeout<T, E, F>(timeout: Duration, work: F) -> Result<T, E>
+where
+    T: Send + 'static,
+    E: Send + 'static + FromTimeout,
+    F: FnOnce() -> Result<T, E> + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = tx.send(work());
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(timeout_error(timeout)),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err(E::from_timeout("convert worker ended unexpectedly".into()))
+        }
+    }
+}
+
+fn timeout_error<E>(timeout: Duration) -> E
+where
+    E: FromTimeout,
+{
+    E::from_timeout(timeout_message(timeout))
+}
+
+pub trait FromTimeout {
+    fn from_timeout(message: String) -> Self;
+}
+
+impl FromTimeout for ConvertError {
+    fn from_timeout(message: String) -> Self {
+        ConvertError::Failed(message)
+    }
+}
+
+impl FromTimeout for DetailedConvertError {
+    fn from_timeout(message: String) -> Self {
+        DetailedConvertError::failed(message)
+    }
+}
+
+pub fn convert_path_with_timeout(
+    conv: Converter,
+    path: &Path,
+    timeout: Duration,
+) -> Result<ConversionResult, ConvertError> {
+    let path = PathBuf::from(path);
+    run_with_timeout(timeout, move || conv.convert_path(&path))
+}
+
+pub fn convert_path_detailed_with_timeout(
+    conv: Converter,
+    path: &Path,
+    timeout: Duration,
+) -> Result<ConversionReport, DetailedConvertError> {
+    let path = PathBuf::from(path);
+    run_with_timeout(timeout, move || conv.convert_path_detailed(&path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    fn parse_timeout_secs_accepts_plain_and_suffix() {
+        assert_eq!(parse_timeout_secs("30").unwrap(), 30);
+        assert_eq!(parse_timeout_secs("30s").unwrap(), 30);
+        assert_eq!(parse_timeout_secs("30sec").unwrap(), 30);
+        assert_eq!(parse_timeout_secs(" 45Seconds ").unwrap(), 45);
+    }
+
+    #[test]
+    fn parse_timeout_secs_rejects_zero_and_garbage() {
+        assert!(parse_timeout_secs("0").is_err());
+        assert!(parse_timeout_secs("abc").is_err());
+        assert!(parse_timeout_secs("").is_err());
+    }
+
+    #[test]
+    fn resolve_timeout_prefers_flag_over_env() {
+        let rest = vec!["--timeout".into(), "12s".into()];
+        // Even if env is set, flag wins (set env then restore).
+        let previous = std::env::var_os(TIMEOUT_ENV);
+        std::env::set_var(TIMEOUT_ENV, "99");
+        let got = resolve_timeout_from_args(&rest).unwrap();
+        match previous {
+            Some(value) => std::env::set_var(TIMEOUT_ENV, value),
+            None => std::env::remove_var(TIMEOUT_ENV),
+        }
+        assert_eq!(got, Some(Duration::from_secs(12)));
+    }
+
+    #[test]
+    fn run_with_timeout_breaks_slow_work() {
+        let started = Instant::now();
+        let result: Result<(), ConvertError> = run_with_timeout(Duration::from_millis(50), || {
+            thread::sleep(Duration::from_millis(500));
+            Ok(())
+        });
+        let elapsed = started.elapsed();
+        let err = result.expect_err("slow work must time out");
+        let message = err.to_string();
+        assert!(
+            message.contains("timeout"),
+            "expected timeout message, got {message}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(400),
+            "wall clock should return near budget, got {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn run_with_timeout_allows_fast_work() {
+        let result: Result<&'static str, ConvertError> =
+            run_with_timeout(Duration::from_secs(2), || {
+                thread::sleep(Duration::from_millis(10));
+                Ok("ok")
+            });
+        assert_eq!(result.unwrap(), "ok");
+    }
+
+    #[test]
+    fn detailed_timeout_uses_failed_kind() {
+        let err: DetailedConvertError = run_with_timeout(Duration::from_millis(40), || {
+            thread::sleep(Duration::from_millis(400));
+            Ok::<(), DetailedConvertError>(())
+        })
+        .expect_err("must time out");
+        let dto = err.to_dto();
+        assert_eq!(dto.kind.as_str(), "failed");
+        assert!(dto.message.contains("timeout"));
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,8 +3,13 @@
 //! Lệnh:
 //!   fileconv speed <corpus_dir> [report.md]   - đo tốc độ theo file & page
 //!   fileconv accuracy <manifest> [report.md]  - đo độ chính xác CER/WER vs ground truth
-//!   fileconv one <file>                       - convert 1 file, in markdown ra stdout
+//!   fileconv one <file> [--timeout 30s]       - convert 1 file, in markdown ra stdout
+//!   fileconv one-detailed <file> [--timeout 30s]
+//!                                              - convert 1 file, in JSON report (có soft warnings)
 //!   fileconv info                             - hiển thị định dạng file hỗ trợ, đường dẫn pdfium (có tồn tại không), và model whisper tìm thấy trong models/
+//!
+//! Timeout (optional): `--timeout 30s` hoặc env `FILECONV_CONVERT_TIMEOUT_SEC`
+//! (flag thắng env). Không set → không giới hạn wall-clock (hành vi cũ).
 //!
 //! Manifest accuracy: mỗi dòng "<đường_dẫn_file>\t<đường_dẫn_text_chuẩn>\t<nhãn_kịch_bản>".
 
@@ -21,7 +26,50 @@ use fileconv_core::intelligence::{CorpusDocument, HandoffOptions};
 use fileconv_core::{Converter, FormatKind};
 use walkdir::WalkDir;
 
+mod convert_timeout;
 mod metrics;
+
+/// Shared flags for `one` / `one-detailed`. `allow_no_pdf_ocr` enables `--no-pdf-ocr`
+/// (detailed report only). Unknown flags such as `--timeout` are ignored here.
+fn parse_one_options(rest: &[String], allow_no_pdf_ocr: bool) -> fileconv_core::ConverterOptions {
+    let mut opts = fileconv_core::ConverterOptions::default();
+    if rest.iter().any(|a| a == "--ocr-images") {
+        opts.pdf_ocr_images = true;
+    }
+    if allow_no_pdf_ocr && rest.iter().any(|a| a == "--no-pdf-ocr") {
+        opts.pdf_ocr = false;
+    }
+    if let Some(l) = rest
+        .iter()
+        .position(|a| a == "--lang")
+        .and_then(|i| rest.get(i + 1))
+    {
+        opts.ocr_langs = l.clone();
+    }
+    if let Some(p) = rest
+        .iter()
+        .position(|a| a == "--pages")
+        .and_then(|i| rest.get(i + 1))
+    {
+        opts.pdf_pages = Some(p.split(',').filter_map(|x| x.trim().parse().ok()).collect());
+    }
+    if let Some(s) = rest
+        .iter()
+        .position(|a| a == "--sheet")
+        .and_then(|i| rest.get(i + 1))
+    {
+        opts.xlsx_sheet = Some(s.clone());
+    }
+    if let Some(m) = rest
+        .iter()
+        .position(|a| a == "--max-chars")
+        .and_then(|i| rest.get(i + 1))
+        .and_then(|x| x.parse().ok())
+    {
+        opts.max_chars = Some(m);
+    }
+    opts
+}
 
 /// Registered top-level CLI commands (keep in sync with `main` match arms).
 fn registered_commands() -> &'static [&'static str] {
@@ -81,44 +129,18 @@ fn main() -> Result<()> {
         }
         "one" => {
             let f = args.get(2).context("thiếu file")?;
-            // Cờ phụ để test: --ocr-images (OCR ảnh nhúng trang trộn), --lang <vie+eng>.
+            // Cờ phụ để test: --ocr-images, --lang, --timeout 30s (hoặc env
+            // FILECONV_CONVERT_TIMEOUT_SEC), --ocr-defer-dir.
             let rest = &args[3..];
-            let mut opts = fileconv_core::ConverterOptions::default();
-            if rest.iter().any(|a| a == "--ocr-images") {
-                opts.pdf_ocr_images = true;
-            }
-            if let Some(l) = rest
-                .iter()
-                .position(|a| a == "--lang")
-                .and_then(|i| rest.get(i + 1))
-            {
-                opts.ocr_langs = l.clone();
-            }
-            if let Some(p) = rest
-                .iter()
-                .position(|a| a == "--pages")
-                .and_then(|i| rest.get(i + 1))
-            {
-                opts.pdf_pages = Some(p.split(',').filter_map(|x| x.trim().parse().ok()).collect());
-            }
-            if let Some(s) = rest
-                .iter()
-                .position(|a| a == "--sheet")
-                .and_then(|i| rest.get(i + 1))
-            {
-                opts.xlsx_sheet = Some(s.clone());
-            }
-            if let Some(m) = rest
-                .iter()
-                .position(|a| a == "--max-chars")
-                .and_then(|i| rest.get(i + 1))
-                .and_then(|x| x.parse().ok())
-            {
-                opts.max_chars = Some(m);
-            }
+            let timeout = convert_timeout::resolve_timeout_from_args(rest)?;
+            let opts = parse_one_options(rest, false);
             let ocr_config = ocr_run_config_from_args(rest);
             let conv = Converter::with_options_and_ocr_config(opts, ocr_config);
-            let r = conv.convert_path(Path::new(f))?;
+            let path = Path::new(f);
+            let r = match timeout {
+                Some(budget) => convert_timeout::convert_path_with_timeout(conv, path, budget)?,
+                None => conv.convert_path(path)?,
+            };
             println!("{}", r.markdown);
             Ok(())
         }
@@ -127,46 +149,18 @@ fn main() -> Result<()> {
             // Hard failures serialize `{message, kind}` DTOs (kind is a field, not text-only).
             let f = args.get(2).context("thiếu file")?;
             let rest = &args[3..];
-            let mut opts = fileconv_core::ConverterOptions::default();
-            if rest.iter().any(|a| a == "--ocr-images") {
-                opts.pdf_ocr_images = true;
-            }
-            if rest.iter().any(|a| a == "--no-pdf-ocr") {
-                opts.pdf_ocr = false;
-            }
-            if let Some(l) = rest
-                .iter()
-                .position(|a| a == "--lang")
-                .and_then(|i| rest.get(i + 1))
-            {
-                opts.ocr_langs = l.clone();
-            }
-            if let Some(p) = rest
-                .iter()
-                .position(|a| a == "--pages")
-                .and_then(|i| rest.get(i + 1))
-            {
-                opts.pdf_pages = Some(p.split(',').filter_map(|x| x.trim().parse().ok()).collect());
-            }
-            if let Some(s) = rest
-                .iter()
-                .position(|a| a == "--sheet")
-                .and_then(|i| rest.get(i + 1))
-            {
-                opts.xlsx_sheet = Some(s.clone());
-            }
-            if let Some(m) = rest
-                .iter()
-                .position(|a| a == "--max-chars")
-                .and_then(|i| rest.get(i + 1))
-                .and_then(|x| x.parse().ok())
-            {
-                opts.max_chars = Some(m);
-            }
+            let timeout = convert_timeout::resolve_timeout_from_args(rest)?;
+            let opts = parse_one_options(rest, true);
             let ocr_config = ocr_run_config_from_args(rest);
-            match Converter::with_options_and_ocr_config(opts, ocr_config)
-                .convert_path_detailed(Path::new(f))
-            {
+            let conv = Converter::with_options_and_ocr_config(opts, ocr_config);
+            let path = Path::new(f);
+            let result = match timeout {
+                Some(budget) => {
+                    convert_timeout::convert_path_detailed_with_timeout(conv, path, budget)
+                }
+                None => conv.convert_path_detailed(path),
+            };
+            match result {
                 Ok(report) => {
                     println!(
                         "{}",


### PR DESCRIPTION
Closes #366

## Summary
- Add CLI wall-clock timeout for `fileconv one` / `one-detailed` via `--timeout` and `FILECONV_CONVERT_TIMEOUT_SEC`.
- Implements the intern-28 improvement: macOS lacks GNU `timeout`; core previously had no convert deadline.
- Scope: `crates/cli` only (2 files). No core/desktop/MCP/server changes.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo metadata --locked --format-version 1 --no-deps`
- [x] `python3 scripts/check-dependency-policy.py`
- [x] `cargo test -p fileconv-cli metrics` (scoped CI command)
- [x] `cargo test -p fileconv-cli convert_timeout` (deterministic break)
- [x] Manual: `page-bomb.pdf --timeout 1s` → exit 1 + `convert timeout sau 1s`
- [x] Manual: adversarial dir loop `--timeout 30s` (no hang; page-bomb + long-silence.wav hit 30s)

## Notes
- Worker thread may continue after timeout (Rust join abandon); documented.
- Scoped CI runs only `fileconv-cli` tests matching `metrics`; timeout unit tests are compile-checked and run locally.