### PR TITLE
docs(roadmap): add Phase 2Q - QA quality catalog (9 issues)

### DIFF
--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,6 +1,6 @@
 # Lộ trình dự án
 
-> Trạng thái tính đến 2026-08-01. Backlog desktop rút từ
+> Trạng thái tính đến 2026-08-18. Backlog desktop rút từ
 > [`../bench/RESEARCH_COMPETITORS.md`](../bench/RESEARCH_COMPETITORS.md) và điểm yếu đã biết
 > trong các `REPORT*.md`. Tiến độ Markhand Web: [`../plans/markhand-web/README.md`](../plans/markhand-web/README.md).
 
@@ -63,6 +63,18 @@ không claim retention. Exit gate denial/security còn mở. Phase 2 **13/19 Don
 trên mock/CI (#311–#318, #327, #332); còn P2-10, P2-15, P2-16 và ba issue mở rộng
 P2-17…19. Phase 3–4 chưa activate (Backlog). Catalog aggregate: **79 Done**,
 **8 In progress**, **0 Review**, **29 Backlog**.
+
+**Workstream ngoài catalog — nâng cấp chất lượng Q&A (2026-08-17/18,
+[`../plans/260817-qa-quality-upgrade.md`](../plans/260817-qa-quality-upgrade.md)):**
+đã xong P0.0 (retry embedding transient), P0.0b (migration 0037 split file-token
+FTS — "công văn 1502" match được `1502/CV-CNTT`), P0.2 (auto-attach citation
+propose-then-validate); eval đa định dạng v2 85.7 → **92.9**, eval version giữ
+89.1. Cùng đợt (chưa có issue): convert worker Windows same-host qua subprocess
+(`workers/converter_subprocess.rs`), chuẩn hoá Markdown sau OCR
+(`services/ocr_normalize.rs`), vòng UX web (full-screen, scroll lịch sử chat,
+dịch warning tiếng Việt) và chitchat routing (đã trên master). Chín hạng mục còn
+lại của plan được track thành **Phase 2Q** trong catalog
+([`../plans/markhand-web/backlog/phase-2q/issues/README.md`](../plans/markhand-web/backlog/phase-2q/issues/README.md)).
 
 Dashboard: [`../plans/markhand-web/roadmap.html`](../plans/markhand-web/roadmap.html) ·
 Issue catalog: [`../plans/markhand-web/backlog/`](../plans/markhand-web/backlog/)

--- a/plans/260817-qa-quality-upgrade.md
+++ b/plans/260817-qa-quality-upgrade.md
@@ -1,0 +1,267 @@
+# Plan nâng cấp chất lượng Q&A (học từ RAGFlow, VersionRAG, groundguard/Warrant, Onyx, Kotaemon)
+
+Ngày lập: 2026-08-17. Đã qua red-team (ak:predict, verdict CAUTION) ngày
+2026-08-17 — bản này đã sửa theo toàn bộ khuyến nghị: P2.2 thiết kế lại để
+không phá mô hình citation integrity, P0.2 đảo thứ tự đề-xuất-trước-validate-sau,
+P0.3 hạ xuống warning-only, thêm P0.0, eval câu hỏi change lên trước change
+index, siết tiêu chí đo.
+
+Nguồn: deep-dive kiến trúc + code của các hệ document-to-QA mã nguồn mở, đối
+chiếu từng điểm với code Markhand hiện tại.
+
+## 0. Hiện trạng và baseline đo được
+
+Điểm eval hiện tại (harness `mh-eval-version.py` / `mh-eval-format.py`, corpus IT
+versioned + đa định dạng, 2026-08-17):
+
+| Bộ đo | Điểm | Ghi chú |
+| --- | --- | --- |
+| Version-aware (32 câu) | 98.8 | reasoning mặc định; 90.6 khi `MARKHAND_CHAT_REASONING=off` |
+| Đa định dạng tổng | 91.8 | DOCX 91.7 · XLSX 94.3 · Image 85.0 · Trap 100 |
+
+Những gì Markhand ĐÃ có (không làm lại):
+
+- Pipeline chuẩn ngành: convert → `ocr_normalize` → chunk theo heading →
+  Postgres FTS (accent-fold) + Qdrant vector → merge rerank + anchor-aware
+  diversity → LLM + citation `[CITE-]` → grounding fail-closed.
+- Hạ tầng version **mạnh hơn đa số repo ngoài**: `document_versions` bất biến,
+  `effective_from/to`, con trỏ `is_current` DB-enforced
+  (`migrations/0005`), `VersionVisibility::{Current, VersionIds}`,
+  `resolve_as_of_version_ids`, 4 mode ask `current/as_of/compare/history` đã
+  nối tới tận UI (`ChatPanel.tsx`).
+- Grounding lexical: `passage_supports_sentence` (giá trị số/mã bắt buộc khớp),
+  `negation_contradicts`, prune từng câu, citation retry 1 lần.
+- **Ràng buộc kiến trúc phải tôn trọng** (red-team xác nhận từ `citation.rs`):
+  mọi chunk được cite phải có `span_start/span_end` xác minh byte-exact vào
+  canonical markdown (`verify_dual_spans`, `chunk_identity`, `stable_anchor`).
+  Không hạng mục nào được sinh "chunk tổng hợp" không có span thật.
+
+## 1. Khoảng trống so với các repo tham chiếu
+
+| # | Khoảng trống | Repo tham chiếu / bằng chứng |
+| --- | --- | --- |
+| G0 | Lỗi transient "Embedding timed out" lúc ask làm rớt nguyên câu hỏi (Image 85.0 trong eval 2026-08-17 có 1 câu rớt vì lỗi này) | — (phát hiện nội bộ, red-team bổ sung) |
+| G1 | Embedding input chỉ có `heading_path + body` — thiếu tiêu đề tài liệu (`workers/embedding.rs` `canonical_input`) | RAGFlow embed title+text; Onyx thêm contextual metadata khi chunk. Câu hỏi cross-doc ("PM2", "Thông tư 36") hiện chỉ được cứu ở tầng rerank (anchor diversity), muộn hơn cần thiết |
+| G2 | Structured entailment chưa có → dev-gate cảnh báo "unverified" | Warrant/anchor-guard: NLI cross-encoder **local** kiểm entailment từng câu, không cần API ngoài |
+| G3 | Kiểm claim chưa có tầng bắt xung đột số liệu riêng (30% vs 300%, 4.8 vs 5) khi câu không chứa giá trị trích được | groundguard tier 2.5 "numerical detector" chạy trước LLM |
+| G4 | Citation retry tốn thêm 1 lượt LLM; retry fail → rớt extractive dù nội dung đúng | RAGFlow `insert_citations` (rag/nlp/search.py:261): gắn citation hậu kỳ bằng hybrid similarity (token 0.1 + vector 0.9, ngưỡng 0.63 giảm dần ×0.8), không tốn LLM |
+| G5 | Người dùng phải TỰ chọn mode as_of/compare/history; câu hỏi tự nhiên "PM2 đổi gì ở bản 2.0?" gõ ở mode current không được route | VersionRAG: intent classification (content/version/change) rồi route — 90% vs 58% naive trên câu hỏi version-sensitive |
+| G6 | Chưa trả lời được thay đổi NGẦM giữa version — chỉ trả lời được thay đổi corpus tự ghi trong "Lịch sử thay đổi" | VersionRAG: change index (explicit từ changelog + implicit từ diff) nâng implicit-change accuracy 0–10% → 60% |
+| G7 | Một chiến lược chunk duy nhất (heading) cho mọi loại tài liệu | RAGFlow: template per-type (laws theo Điều/Khoản, table giữ header từng chunk, presentation per slide) |
+| G8 | Không xem/sửa được chunk đã parse — OCR hỏng chỉ phát hiện khi Q&A sai | RAGFlow: UI xem + sửa chunk, "quality in, quality out" |
+
+Đã cân nhắc và KHÔNG đưa vào plan: cross-encoder rerank model (hybrid weights
+hiện đủ ở quy mô này, thêm model = thêm latency); GraphRAG/knowledge graph
+(VersionRAG chứng minh graph tối giản theo domain thắng GraphRAG tổng quát với
+1/16 chi phí index); question decomposition đa hop (anchor diversity đang xử lý
+được lớp câu hỏi hiện tại — chỉ mở lại nếu eval xuất hiện câu multi-hop fail).
+
+## 2. Các phase
+
+Nguyên tắc: mỗi hạng mục một PR riêng (quy tắc repo). Tiêu chí đo chung ở mục 3.
+
+### Phase 0 — Quick wins (retrieval + citation, không đổi schema)
+
+**P0.0 Retry lỗi embedding transient lúc ask** (sửa G0 — rẻ nhất toàn plan)
+- Đường ask/ask_stream: lỗi "Embedding timed out"/transient từ provider →
+  retry đúng 1 lần với backoff ngắn trước khi trả lỗi cho người dùng.
+- Không retry lỗi 4xx/quota (không phải transient). Warning khi phải retry.
+- Kỳ vọng: xóa nhóm lỗi đã làm Image mất ~10 điểm trong một lần chạy eval.
+- ✅ DONE 2026-08-17: `embed_query_with_retry` trong
+  `crates/server/src/services/retrieval/mod.rs` (retry 1 lần, backoff 400ms,
+  chỉ retry timeout + `EmbeddingError::Http`); warning
+  "Embedding recovered after one retry" đã có bản dịch tiếng Việt + test
+  (`warningPresentation.test.ts`). 37 test retrieval pass, fmt sạch.
+
+**P0.0b Split file-token trong FTS tsv** (phát hiện eval format v2, 2026-08-18)
+- Triệu chứng: hỏi "công văn 1502" không bao giờ ra tài liệu
+  `CÔNG VĂN SỐ 1502/CV-CNTT` — parser `simple` của PostgreSQL coi
+  "1502/CV-CNTT" (và ngày "27/08/2026") là MỘT token kiểu `file`, token
+  truy vấn "1502" không match. Ảnh hưởng mọi số hiệu văn bản hành chính VN.
+- ✅ DONE 2026-08-18: migration `0037_expand_chunks_split_file_tokens_tsv.sql`
+  — tsv = hợp của 2 folding (nguyên khối + thay `/` bằng space); backfill cần
+  `SET LOCAL row_security = off` vì `chunks` bật FORCE RLS (bài học: backfill
+  0016 trước đây cũng bị RLS nuốt im lặng). Verify: query "công văn 1502",
+  "quyết định 88/QĐ-CNTT tổ AI" đều trả đúng tài liệu ở hit #1.
+- Known issue còn lại (chưa sửa): câu hỏi DÀI vẫn có thể trượt FTS vì
+  `plainto_tsquery` AND toàn bộ token (thiếu 1 từ như "phải" là fail) —
+  vector leg phải gánh; P0.1 (title vào embedding) sẽ giúp thêm.
+
+**Known issue OCR (2026-08-18, chưa có hạng mục)**: vision model dừng sớm
+tái lập ổn định với `quyet-dinh-thanh-lap-to-ai.png` (chỉ trả 112 ký tự
+tiêu đề, mất Điều 1–3; ảnh render đầy đủ, `finish_reason` không phải
+"length", re-OCR 2 lần cùng kết quả). 4 ảnh còn lại của đợt 2 OCR đủ.
+Cần hạng mục riêng: completeness check sau OCR (ví dụ so mật độ text
+render vs độ dài output) trước khi index.
+
+**P0.1 Thêm tiêu đề tài liệu vào embedding input** (sửa G1)
+- `ApprovedEmbeddingRuntime::canonical_input(title, heading_path, body)`.
+- LƯU Ý 1: đổi canonical input ⇒ đổi `input_sha256` và index signature ⇒ phải
+  là **generation index mới** + reindex (đi đúng đường `index_metadata`
+  generation đã có). Không hồi tố lên generation đang active.
+- LƯU Ý 2 (red-team): code + `approved_signature`/config phải cập nhật trong
+  **cùng một lượt deploy**, lệch nhịp là worker từ chối job embedding
+  ("index signature mismatch"). Ghi checklist deploy vào PR.
+- Sau khi reindex: **re-baseline cả hai eval** trước khi đánh giá bất kỳ PR
+  nào sau đó.
+- Đo: eval format (kỳ vọng XLSX/cross-doc tăng), eval version không giảm.
+
+**P0.2 Gắn citation hậu kỳ — đề xuất trước, validate sau** (sửa G4)
+- Thứ tự bắt buộc (red-team: claim-check hiện chạy THEO pin đã cite, nên
+  không tồn tại trạng thái "pass claim-check nhưng thiếu cite"):
+  1. Câu trong draft thiếu `[CITE-]` → tìm passage ứng viên có token-overlap
+     cao nhất với câu (trên `snippet/body` của `hybrid` hits sẵn có — không
+     gọi embed lại) vượt ngưỡng;
+  2. Gắn thử `[CITE-xxxx]` của ứng viên vào câu;
+  3. Chạy **nguyên bộ** validation hiện có (`validate_answer_citations` +
+     claim-check + negation) với pin đó;
+  4. Pass → giữ câu với citation đã gắn + warning "citation auto-attached";
+     fail → prune như hiện tại. Fail-closed nguyên vẹn.
+- Vị trí so với citation retry: thử auto-attach TRƯỚC; chỉ retry LLM khi
+  auto-attach không cứu được câu nào (tiết kiệm 1 call LLM/câu lỗi).
+- "Cứu được 3/22 câu DOCX" là **giả thuyết cần đo**, không phải kỳ vọng cam kết.
+- Warning mới phải kèm entry `WARNING_TRANSLATIONS` + test (quy ước từ nay
+  áp cho mọi PR có warning mới).
+- ✅ DONE 2026-08-18: `propose_citation_for_sentence` (grounding.rs — overlap
+  ≥2 token và ≥35% token câu) + `attach_citations_to_uncited_lines` (mod.rs —
+  gắn thử rồi chạy NGUYÊN BỘ `validate_answer_citations`, fail → None).
+  Hook cả 2 chỗ theo đúng thứ tự plan: (1) trước prune trong
+  `resolve_llm_answer`; (2) trước citation-retry trong `ask()` +
+  `ask_stream` (cứu được thì khỏi tốn lượt LLM nhắc lại). Warning
+  "Auto-attached citations to N sentence(s)" có bản dịch + test web.
+  50 unit test qa pass; verify live: câu "Lịch chốt số liệu đối soát…"
+  được auto-attach 2 câu, không cần retry.
+- 📊 Đo 2026-08-18 (eval format v2, 51 câu + 4 trap): run3 (sau P0.2 + P0.0b)
+  **92.9** vs run1 baseline 85.7 (run2 79.4 nhiễu 429 OpenRouter giờ cao
+  điểm — 2 câu 0 hits vì embedding 429 cả 2 lượt). DOCX 96.9 / XLSX 97.5 /
+  Image 82.0 / trap 4/4. Auto-attach kích hoạt 15/51 câu; fallback_extractive
+  giảm 8 → 1. Điểm image còn lại kẹt ở 2 câu quyet-dinh-to-ai (OCR cụt —
+  known issue trên) + 1 câu hỏi dài trượt FTS AND-semantics (chờ P0.1).
+  Eval version (IT corpus) 89.1 = đúng baseline, không tụt.
+
+**P0.3 Tầng bắt xung đột số liệu — warning-only trước** (sửa G3)
+- `grounding.rs`: khi câu có số nhưng KHÔNG trích được value theo pattern hiện
+  tại, so số theo **kiểu giá trị** (% với %, tiền với tiền, MWh với MWh —
+  không so số trần) giữa câu và passage; lệch → **warning**, chưa prune.
+- Red-team: số Việt Nam (1.234,56), "Điều 5", số hiệu văn bản, ngày tháng
+  không phải claim giá trị — phải loại trước khi so.
+- Chỉ nâng thành gate (prune) ở PR sau, khi đo được FP rate qua eval +
+  đối chiếu warning log < ngưỡng thống nhất (đề xuất: 0 FP trên 2 bộ eval).
+- Unit test bằng case groundguard nêu: 300%↔30%, 4.8↔5, cộng case số Việt.
+
+### Phase 1 — Structured entailment local (mở khóa dev-gate, sửa G2)
+
+- **Gate vào phase (làm trước, fail thì dừng cả phase)**: bench NLI đa ngữ
+  trên tiếng Việt bằng bộ câu grounded/ungrounded gán nhãn từ eval log
+  (ứng viên: mDeBERTa-v3-base-xnli, XLM-R NLI — XNLI có tiếng Việt; license
+  kiểm tra như quy trình PhoWhisper). Đo cả precision lẫn **latency thật**:
+  ước lượng 100–400ms/cặp CPU là hiện thực, không phải ≤50ms.
+- Model binary không commit vào repo, không ghi identifier vào code (quy tắc
+  CLAUDE.md); phân phối qua cơ chế approved-runtime đã có
+  (`UnapprovedEmbeddingRuntime` pattern) — đây là thay đổi grounding/LLM
+  policy ⇒ review bắt buộc theo `repository-delivery.mdc`.
+- Vị trí: sau claim-check lexical, chỉ chạy cho câu ĐÃ pass lexical (giảm số
+  cặp phải chấm); entailment ≥ ngưỡng → grounded; ngược lại prune.
+- Ngân sách thời gian có cắt (timeout budget cho cả answer): quá hạn →
+  giữ nguyên hành vi dev-gate hiện tại, không silent-pass, không treo stream.
+- Precision kém trên tiếng Việt → hạ vai trò xuống tín hiệu warning (không
+  gate), giữ dev-gate warning như cũ.
+- Khi runtime có model và gate bật: gỡ đường warning "structured entailment
+  is NOT available"; không có model → hành vi hiện tại.
+
+### Phase 2 — Version intelligence (VersionRAG-lite, sửa G5+G6)
+
+**P2.1 Tự nhận diện intent version từ câu hỏi**
+- Tầng 1 rule-based (không LLM, deterministic): pattern "phiên bản/bản X",
+  "thay đổi gì / khác gì / vì sao đổi", "so với", "trước ngày / tại thời
+  điểm", số hiệu thông tư + "cũ/mới" → suy ra mode `compare/as_of/history`
+  và tham số (version number, mốc thời gian) khi xác định được document
+  qua anchor token.
+- UI: hiển thị mode đã tự nhận diện **nổi bật** + revert 1 click (red-team:
+  auto-route nhầm khi câu nhắc "trước ngày" tình cờ sẽ trả lời từ version cũ
+  mà user không nhận ra). Log tỷ lệ người dùng override để đo chất lượng rule.
+- Không tự route được thì giữ nguyên `current` (an toàn, hành vi cũ).
+- Không đổi contract `AskRequest` — client tự set các field sẵn có.
+
+**P2.2 Bộ câu hỏi implicit-change cho eval (làm TRƯỚC change index)**
+- Mở rộng `mh-eval-version.py`: nhóm câu hỏi về thay đổi KHÔNG ghi trong
+  changelog của corpus (đo được hiện tại chắc chắn thấp — đó chính là
+  baseline). Không có bộ này thì P2.3 không có tiêu chí nghiệm thu.
+  (VersionRAG cũng xây benchmark trước khi xây hệ.)
+
+**P2.3 Index thay đổi giữa version — bảng riêng, citation 2 span thật**
+- **Thiết kế lại theo red-team** (bản cũ sinh "change chunk" tổng hợp — phá
+  mô hình citation integrity vì không có byte-span trong canonical markdown):
+  - Bảng mới `version_changes` (migration expand-only): mỗi bản ghi = một
+    section thay đổi giữa version N và version cha, lưu **tham chiếu 2 span
+    thật**: (chunk_id/span ở version cũ) + (chunk_id/span ở version mới),
+    heading, loại thay đổi (thêm/sửa/xóa), text diff tóm tắt deterministic.
+  - Sinh lúc publish version N>1: diff canonical markdown ĐÃ normalize theo
+    section heading; bỏ khác biệt whitespace; ngưỡng tối thiểu độ dài.
+  - Retrieval: intent "change" (từ P2.1) → tra `version_changes` của document
+    liên quan, hydrate 2 chunk thật ở 2 version làm passage; citation của câu
+    trả lời trỏ vào 2 chunk thật đó — khớp mô hình pin compare-mode đã có,
+    `verify_dual_spans` hoạt động bình thường.
+  - Không sinh chunk mới, không đưa gì vào index vector ở bước đầu (FTS/tra
+    trực tiếp theo document đủ dùng vì đã biết document từ intent); cân nhắc
+    embed diff text ở PR sau nếu eval cho thấy cần.
+- Mode current không bị ô nhiễm: `version_changes` chỉ được tra khi intent
+  là change — không nằm trong đường retrieval thường.
+- Đo bằng bộ câu hỏi P2.2.
+
+### Phase 3 — Chunking theo loại tài liệu (sửa G7)
+
+- `chunk.rs`: thêm biến thể theo `FormatKind`/cấu trúc phát hiện được:
+  - Văn bản pháp quy: ranh giới chunk khóa theo Điều/Khoản (đã có
+    `promote_legal_headings` phía server — đảm bảo chunker không cắt giữa Điều).
+  - Bảng (XLSX/CSV/bảng markdown): lặp lại hàng header trong mỗi chunk con khi
+    bảng dài phải cắt.
+  - PPTX: mỗi slide một chunk.
+- Đây là code dùng chung CLI/desktop/server (`fileconv-core`) — đo lại bằng
+  `fileconv accuracy`/`speed` theo quy tắc CLAUDE.md, ngoài eval server.
+
+### Phase 4 — Vận hành chất lượng (sửa G8, làm sau cùng)
+
+- UI "xem chunk đã parse" cho một document version (read-only trước): lộ
+  heading_path + body từng chunk, đánh dấu chunk `heading_path` rỗng hoặc mật
+  độ ký tự lạ cao (dấu hiệu OCR hỏng). Sửa tay (RAGFlow-style) để giai đoạn
+  sau — đụng immutability của chunks nên cần thiết kế riêng (re-publish
+  version mới thay vì sửa tại chỗ).
+
+## 3. Thứ tự, phụ thuộc, tiêu chí giữ/loại
+
+```
+P0.0        ──►  độc lập, làm ĐẦU TIÊN (rẻ nhất, xóa noise eval)
+P0.2, P0.3  ──►  Phase 1 (cùng vùng grounding — làm P0 trước để đo sạch)
+P0.1        ──►  độc lập (cần reindex + re-baseline — làm sớm)
+Phase 1     ──►  gate bench NLI đạt mới vào phase
+P2.1        ──►  P2.2 (eval) ──► P2.3 (change index)
+Phase 3, 4  ──►  độc lập, sau khi 0–2 ổn định
+```
+
+Tiêu chí mỗi PR:
+- (a) Eval quyết định giữ/loại chạy **≥2 lần lấy median** (LLM nondeterministic,
+  1 lần chạy có noise > 1 điểm): median không giảm quá 1 điểm so với baseline
+  gần nhất, hạng mục nhắm tới phải tăng. Sau mỗi lần đổi index generation
+  (P0.1) phải re-baseline trước khi đánh giá PR kế tiếp.
+- (b) Test QA/retrieval/web pass.
+- (c) `cargo fmt --all -- --check`, `cargo metadata --locked`, dependency
+  policy script pass.
+- (d) Hạng mục đụng grounding/LLM policy/contract/migration đi qua review
+  bắt buộc theo `repository-delivery.mdc`.
+- (e) PR có warning mới phải kèm entry `WARNING_TRANSLATIONS` + test.
+
+## 4. Rủi ro chính (sau red-team)
+
+- **P0.1 reindex**: bắt buộc generation mới, corpus phải re-embed — chi phí
+  provider; deploy code + signature cùng nhịp (worker từ chối job nếu lệch);
+  làm trên dev, re-baseline, rồi mới nói chuyện production.
+- **Phase 1 NLI tiếng Việt**: precision chưa chắc; latency thật 100–400ms/cặp
+  — gate bench đầu phase quyết định đi tiếp/dừng; kém thì hạ xuống warning.
+- **P2.1 auto-route nhầm**: UI phải hiển thị mode nhận diện + revert 1 click;
+  log override rate.
+- **P2.3 diff nhiễu**: chỉ diff canonical markdown đã normalize, bỏ whitespace,
+  ngưỡng độ dài; mọi citation đều trỏ span thật nên không có đường "citation
+  ảo" kể cả khi diff sai — tệ nhất là không tìm thấy thay đổi (fail-closed).
+- **Phase 3 đụng converter dùng chung**: ảnh hưởng CLI/desktop — bench
+  `fileconv accuracy` bắt buộc trước khi merge (quy tắc CLAUDE.md).

--- a/plans/markhand-web/README.md
+++ b/plans/markhand-web/README.md
@@ -14,7 +14,7 @@ Kế hoạch này biến report kiến trúc thành các gói việc có depende
 test và gate đo được. Không dùng thời gian lịch làm tiêu chí; chỉ chuyển phase khi
 gate kỹ thuật của phase trước đã đạt.
 
-Issue-level backlog (120 issues):
+Issue-level backlog (129 issues):
 [`backlog/README.md`](backlog/README.md).
 
 Roadmap dashboard tương tác:
@@ -46,13 +46,14 @@ không bị local override cũ che mất.
 | 1B | POC single-org hoàn chỉnh: upload → convert → index → Q&A citation | [Phase plan](phase-1b-single-org-poc.md) | [24 issues](backlog/phase-1b/issues/README.md) |
 | 1C | Multi-org, RBAC/ACL, quota atomic và denial test | [Phase plan](phase-1c-multi-org-security.md) | [13 issues](backlog/phase-1c/issues/README.md) |
 | 2 | Web SPA MVP: login, library, Q&A, admin tối thiểu | [Phase plan](phase-2-web-spa.md) | [23 issues](backlog/phase-2/issues/README.md) |
+| 2Q | Nâng cấp chất lượng Q&A: embedding input, grounding, version intelligence, chunking, vận hành | [Phase plan](phase-2q-qa-quality.md) | [9 issues](backlog/phase-2q/issues/README.md) |
 | 3 | Port intelligence: BRD/PRD, quality, PII, bảng, version, export | [Phase plan](phase-3-intelligence.md) | [14 issues](backlog/phase-3/issues/README.md) |
 | 4 | OIDC/SSO, hardening production, DR và onboarding/help | [Phase plan](phase-4-production-hardening.md) | [14 issues](backlog/phase-4/issues/README.md) |
 
 ## Tiến độ milestone (2026-08-06)
 
-Tổng **120 issue** trong catalog: **81 Done**, **5 In progress**, **1 Review**,
-**0 Ready**, **4 Blocked**, **29 Backlog**.
+Tổng **129 issue** trong catalog: **81 Done**, **5 In progress**, **1 Review**,
+**0 Ready**, **4 Blocked**, **38 Backlog**.
 Nguồn sự thật là `**Status:**` trong từng issue catalog; bảng dưới tóm tắt theo phase.
 GitHub milestone progress được đồng bộ bởi workflow
 [`Sync Markhand Web issues`](../../.github/workflows/sync-markhand-issues.yml) khi
@@ -66,6 +67,7 @@ GitHub milestone progress được đồng bộ bởi workflow
 | 1B | 24/24 | 0 | 0 | 0 | 0 | **Gate đạt** — R06 hanging soak pass 2026-07-31 |
 | 1C | 10/13 | 2 | 0 | 0 | 1 | 1C-04/07/09/10/11 Done (CI `6833f57`, run 30678318560); 1C-08 CI half / deployed → PR 5; exit gate 1C-12/1C-13 còn mở |
 | 2 | 15/23 | 4 | 0 | 4 | 0 | P2-15 umbrella blocked; P2-20 `Review` (PR #395); exit gate chờ full-stack evidence + 1C + blocking real/DAST matrix |
+| 2Q | 0/9 | 0 | 0 | 0 | 9 | Workstream chất lượng Q&A (plan nguồn [`260817-qa-quality-upgrade.md`](../260817-qa-quality-upgrade.md)); chạy song song đuôi Phase 2, không chờ Phase 2 gate |
 | 3 | 0/14 | 0 | 0 | 0 | 14 | Chưa activate — chờ Phase 2 complete |
 | 4 | 0/14 | 0 | 0 | 0 | 14 | Chưa activate — chờ Phase 3 |
 
@@ -78,6 +80,13 @@ Issue Phase 2 gần đây: **P2-10/P2-17 → Done** sau independent review; P2-2
 landed trên [#395](https://github.com/anhnth24/project-example/pull/395) với whole-branch
 review APPROVE; P2-18 Project grouping và P2-19 Chat history vẫn In progress. P2-21…23
 blocked theo dependency/security gate.
+
+**Workstream chất lượng Q&A (2026-08-17/18):** plan nguồn
+[`../260817-qa-quality-upgrade.md`](../260817-qa-quality-upgrade.md) đã giao
+P0.0/P0.0b/P0.2 (eval đa định dạng 85.7 → 92.9, version giữ baseline) cùng
+convert worker Windows same-host, `ocr_normalize`, vòng UX web và chitchat
+routing — các phần đã giao này không tạo issue hồi tố. Chín hạng mục còn lại
+được track thành **Phase 2Q** ([catalog](backlog/phase-2q/issues/README.md)).
 
 ## Dependency và đường găng
 

--- a/plans/markhand-web/backlog/github-issues.json
+++ b/plans/markhand-web/backlog/github-issues.json
@@ -49,6 +49,14 @@
       "issue_count": 23
     },
     {
+      "code": "2Q",
+      "title": "Phase 2Q — QA Quality",
+      "description": "Markhand Web phase `2Q`.\n\n**Outcome:** Nâng cấp chất lượng Q&A: embedding input, grounding, version intelligence, chunking, vận hành\n**Issues:** 9\n**Phase plan:** `phase-2q-qa-quality.md`\n**Issue catalog:** `backlog/phase-2q/issues/README.md`",
+      "plan": "phase-2q-qa-quality.md",
+      "catalog": "backlog/phase-2q/issues/README.md",
+      "issue_count": 9
+    },
+    {
       "code": "3",
       "title": "Phase 3 — Document Intelligence",
       "description": "Markhand Web phase `3`.\n\n**Outcome:** Port intelligence: BRD/PRD, quality, PII, bảng, version, export\n**Issues:** 14\n**Phase plan:** `phase-3-intelligence.md`\n**Issue catalog:** `backlog/phase-3/issues/README.md`",
@@ -1360,6 +1368,141 @@
       "catalog": "backlog/phase-2/issues/README.md"
     },
     {
+      "phase": "2Q",
+      "id": "P2Q-01",
+      "title": "P2Q-01 — Title tài liệu vào embedding input (index generation mới)",
+      "status": "backlog",
+      "milestone": "Phase 2Q — QA Quality",
+      "labels": [
+        "markhand-web",
+        "docs",
+        "web-p2q",
+        "backlog"
+      ],
+      "body": "## Metadata\n\n- Milestone: Phase 2Q — QA Quality\n- Phase code: 2Q\n- Issue ID: P2Q-01\n- Status: `backlog`\n- Catalog: `backlog/phase-2q/issues/README.md`\n- Phase plan: `phase-2q-qa-quality.md`\n\n## Dependencies / blocks\n\nkhông; sau reindex phải re-baseline cả hai eval trước khi đánh\ngiá PR kế tiếp. **Acceptance/tests:** eval format tăng nhóm cross-doc/XLSX,\neval version không giảm >1 điểm median (≥2 run); test worker từ chối job khi\nsignature lệch.\n\n## Security and migration notes\n\nđổi index signature/reindex — review bắt buộc; không\nđổi schema PostgreSQL. **Out:** đổi embedding provider/model/dimension.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "catalog": "backlog/phase-2q/issues/README.md"
+    },
+    {
+      "phase": "2Q",
+      "id": "P2Q-02",
+      "title": "P2Q-02 — Tầng cảnh báo xung đột số liệu (warning-only)",
+      "status": "backlog",
+      "milestone": "Phase 2Q — QA Quality",
+      "labels": [
+        "markhand-web",
+        "docs",
+        "web-p2q",
+        "backlog"
+      ],
+      "body": "## Metadata\n\n- Milestone: Phase 2Q — QA Quality\n- Phase code: 2Q\n- Issue ID: P2Q-02\n- Status: `backlog`\n- Catalog: `backlog/phase-2q/issues/README.md`\n- Phase plan: `phase-2q-qa-quality.md`\n\n## Dependencies / blocks\n\nP0.2 (đã giao).\n300%↔30%, 4.8↔5 + case số Việt; không prune câu nào vòng này; nâng thành\ngate chỉ ở PR sau khi đo FP = 0 trên 2 bộ eval.\n\n## Required tests / evidence\n\nunit case groundguard\n\n## Security and migration notes\n\ngrounding policy — review bắt buộc.\nvòng này; so số trần không phân kiểu.\n\n## Out of scope\n\nprune/gate ngay\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "catalog": "backlog/phase-2q/issues/README.md"
+    },
+    {
+      "phase": "2Q",
+      "id": "P2Q-03",
+      "title": "P2Q-03 — Completeness check sau OCR trước khi index",
+      "status": "backlog",
+      "milestone": "Phase 2Q — QA Quality",
+      "labels": [
+        "markhand-web",
+        "docs",
+        "web-p2q",
+        "backlog"
+      ],
+      "body": "## Metadata\n\n- Milestone: Phase 2Q — QA Quality\n- Phase code: 2Q\n- Issue ID: P2Q-03\n- Status: `backlog`\n- Catalog: `backlog/phase-2q/issues/README.md`\n- Phase plan: `phase-2q-qa-quality.md`\n\n## Dependencies / blocks\n\nkhông.\n`quyet-dinh-thanh-lap-to-ai.png` (OCR trả 112 ký tự tiêu đề, mất Điều 1–3,\ntái lập ổn định) bị bắt; 4 ảnh đủ chữ của corpus đợt 2 không false-positive;\nflag/warning hiển thị được ở web.\n\n## Required tests / evidence\n\ncase thật\n\n## Security and migration notes\n\nkhông log nội dung tài liệu; đụng OCR/LLM path — review bắt\nbuộc. **Out:** đổi model/provider OCR; auto re-OCR không giới hạn.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "catalog": "backlog/phase-2q/issues/README.md"
+    },
+    {
+      "phase": "2Q",
+      "id": "P2Q-04",
+      "title": "P2Q-04 — Bench gate + structured entailment NLI local",
+      "status": "backlog",
+      "milestone": "Phase 2Q — QA Quality",
+      "labels": [
+        "markhand-web",
+        "docs",
+        "web-p2q",
+        "backlog"
+      ],
+      "body": "## Metadata\n\n- Milestone: Phase 2Q — QA Quality\n- Phase code: 2Q\n- Issue ID: P2Q-04\n- Status: `backlog`\n- Catalog: `backlog/phase-2q/issues/README.md`\n- Phase plan: `phase-2q-qa-quality.md`\n\n## Dependencies / blocks\n\ngate bench pass mới triển khai; fail thì đóng issue với evidence\nbench. **Acceptance/tests:** báo cáo bench precision/latency; khi bật: đường\nwarning \"structured entailment is NOT available\" được gỡ; không có model →\nhành vi hiện tại nguyên vẹn.\n\n## Security and migration notes\n\nmodel binary không commit, identifier không vào code\n(CLAUDE.md); grounding/LLM policy + native binary — review bắt buộc.\n**Out:** gọi API ngoài để entailment; cross-encoder rerank.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "catalog": "backlog/phase-2q/issues/README.md"
+    },
+    {
+      "phase": "2Q",
+      "id": "P2Q-05",
+      "title": "P2Q-05 — Tự nhận diện intent version từ câu hỏi (rule-based)",
+      "status": "backlog",
+      "milestone": "Phase 2Q — QA Quality",
+      "labels": [
+        "markhand-web",
+        "docs",
+        "web-p2q",
+        "backlog"
+      ],
+      "body": "## Metadata\n\n- Milestone: Phase 2Q — QA Quality\n- Phase code: 2Q\n- Issue ID: P2Q-05\n- Status: `backlog`\n- Catalog: `backlog/phase-2q/issues/README.md`\n- Phase plan: `phase-2q-qa-quality.md`\n\n## Dependencies / blocks\n\nhạ tầng version modes hiện có (P1B/P2-10).\nma trận rule unit test; câu version-sensitive gõ ở mode current được route;\nkhông nhận diện được → giữ `current`; UI test revert.\n\n## Security and migration notes\n\nN/A — không đổi persisted contract; rủi ro đọc nhầm version cũ\nđược chặn bằng UI revert bắt buộc. **Out:** LLM intent classifier.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "catalog": "backlog/phase-2q/issues/README.md"
+    },
+    {
+      "phase": "2Q",
+      "id": "P2Q-06",
+      "title": "P2Q-06 — Bộ câu hỏi implicit-change cho eval version",
+      "status": "backlog",
+      "milestone": "Phase 2Q — QA Quality",
+      "labels": [
+        "markhand-web",
+        "docs",
+        "web-p2q",
+        "backlog"
+      ],
+      "body": "## Metadata\n\n- Milestone: Phase 2Q — QA Quality\n- Phase code: 2Q\n- Issue ID: P2Q-06\n- Status: `backlog`\n- Catalog: `backlog/phase-2q/issues/README.md`\n- Phase plan: `phase-2q-qa-quality.md`\n\n## Dependencies / blocks\n\nP2Q-05 (route intent để chạy đúng mode).\nbộ câu + số baseline nằm trong report; là tiêu chí nghiệm thu của P2Q-07.\n\n## Security and migration notes\n\ncorpus tự sinh, không dữ liệu khách hàng.\nindex (P2Q-07).\n\n## Out of scope\n\nchange\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "catalog": "backlog/phase-2q/issues/README.md"
+    },
+    {
+      "phase": "2Q",
+      "id": "P2Q-07",
+      "title": "P2Q-07 — Bảng `version_changes` và retrieval theo intent change",
+      "status": "backlog",
+      "milestone": "Phase 2Q — QA Quality",
+      "labels": [
+        "markhand-web",
+        "docs",
+        "web-p2q",
+        "backlog"
+      ],
+      "body": "## Metadata\n\n- Milestone: Phase 2Q — QA Quality\n- Phase code: 2Q\n- Issue ID: P2Q-07\n- Status: `backlog`\n- Catalog: `backlog/phase-2q/issues/README.md`\n- Phase plan: `phase-2q-qa-quality.md`\n\n## Dependencies / blocks\n\nP2Q-05, P2Q-06.\nmode current không ô nhiễm (`version_changes` không nằm trong retrieval\nthường); diff không thấy thay đổi → fail-closed, không citation ảo.\n\n## Required tests / evidence\n\nđiểm bộ P2Q-06 tăng;\n\n## Security and migration notes\n\nSQL/RLS/migration — review bắt buộc; RLS org-scope\nnhư các bảng khác. **Out:** embed diff text vào vector (cân nhắc PR sau);\nGraphRAG.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "catalog": "backlog/phase-2q/issues/README.md"
+    },
+    {
+      "phase": "2Q",
+      "id": "P2Q-08",
+      "title": "P2Q-08 — Chunking theo loại tài liệu (fileconv-core, đa consumer)",
+      "status": "backlog",
+      "milestone": "Phase 2Q — QA Quality",
+      "labels": [
+        "markhand-web",
+        "docs",
+        "web-p2q",
+        "backlog"
+      ],
+      "body": "## Metadata\n\n- Milestone: Phase 2Q — QA Quality\n- Phase code: 2Q\n- Issue ID: P2Q-08\n- Status: `backlog`\n- Catalog: `backlog/phase-2q/issues/README.md`\n- Phase plan: `phase-2q-qa-quality.md`\n\n## Dependencies / blocks\n\nlàm sau khi P2Q-01 re-baseline (tránh nhiễu chồng).\n**Acceptance/tests:** `fileconv accuracy`/`speed` không thoái hóa\n(quy tắc CLAUDE.md); eval server tăng nhóm bảng/pháp quy; desktop CI xanh.\n\n## Security and migration notes\n\nchunking version nằm trong index signature pin\n(invariant 7) ⇒ áp lên server cần generation mới + re-baseline như P2Q-01;\nreview bắt buộc. **Out:** đổi API `chunk.rs` public contract ngoài mức cần;\nsửa chunk tay.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "catalog": "backlog/phase-2q/issues/README.md"
+    },
+    {
+      "phase": "2Q",
+      "id": "P2Q-09",
+      "title": "P2Q-09 — UI xem chunk đã parse (read-only)",
+      "status": "backlog",
+      "milestone": "Phase 2Q — QA Quality",
+      "labels": [
+        "markhand-web",
+        "docs",
+        "web-p2q",
+        "backlog"
+      ],
+      "body": "## Metadata\n\n- Milestone: Phase 2Q — QA Quality\n- Phase code: 2Q\n- Issue ID: P2Q-09\n- Status: `backlog`\n- Catalog: `backlog/phase-2q/issues/README.md`\n- Phase plan: `phase-2q-qa-quality.md`\n\n## Dependencies / blocks\n\nkhông bắt buộc; flag từ P2Q-03 làm giàu hiển thị.\n**Acceptance/tests:** xem đúng chunk theo version; denial test cross-org/\ncross-user theo khuôn ACL hiện có; không lộ chunk ngoài quyền.\n\n## Security and migration notes\n\nsurface đọc mới trên chunks — ACL/RLS review bắt buộc;\nread-only. **Out:** sửa chunk tại chỗ (re-publish version — thiết kế riêng\ngiai đoạn sau).\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "catalog": "backlog/phase-2q/issues/README.md"
+    },
+    {
       "phase": "3",
       "id": "P3-01",
       "title": "P3-01 — Reusable intelligence service boundary",
@@ -1476,7 +1619,7 @@
         "web-p3",
         "backlog"
       ],
-      "body": "## Metadata\n\n- Milestone: Phase 3 — Document Intelligence\n- Phase code: 3\n- Issue ID: P3-08\n- Status: `backlog`\n- Catalog: `backlog/phase-3/issues/README.md`\n- Phase plan: `phase-3-intelligence.md`\n\n## Dependencies / blocks\n\nP3-02/03 + RBAC.\nauthorized; precision/recall/completeness/overlap/Unicode/permission tests.\n\n## Required tests / evidence\n\nOriginal hash unchanged; findings\n\n## Security and migration notes\n\nNo PII logs; prohibited data no GLM.\n\n## Out of scope\n\nlegal completeness guarantee.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
+      "body": "## Metadata\n\n- Milestone: Phase 3 — Document Intelligence\n- Phase code: 3\n- Issue ID: P3-08\n- Status: `backlog`\n- Catalog: `backlog/phase-3/issues/README.md`\n- Phase plan: `phase-3-intelligence.md`\n\n## Dependencies / blocks\n\nP3-02/03 + RBAC.\nauthorized; precision/recall/completeness/overlap/Unicode/permission tests.\n\n## Required tests / evidence\n\nOriginal hash unchanged; findings\n\n## Security and migration notes\n\nNo PII logs; prohibited-classification data never leaves for any\nexternal LLM/embedding provider (hiện tại OpenRouter Qwen — chat/OCR/embedding,\nADR 0016; tương lai self-host local model khi có GPU). Cover cả đường cloud\nembedding: index build gửi toàn bộ chunk text, không chỉ Q&A top-K.\n**Out:** legal completeness guarantee.\n\n## Source\n\nGenerated from Markhand Web backlog catalog. Update the catalog first, then re-run `python3 scripts/sync-github-issues.py --update` if specs change.\n",
       "catalog": "backlog/phase-3/issues/README.md"
     },
     {

--- a/plans/markhand-web/backlog/phase-2q/issues/README.md
+++ b/plans/markhand-web/backlog/phase-2q/issues/README.md
@@ -1,0 +1,147 @@
+# Phase 2Q issues — Nâng cấp chất lượng Q&A
+
+Parent plan: [`../../../phase-2q-qa-quality.md`](../../../phase-2q-qa-quality.md)
+
+<!-- roadmap-default-status: backlog -->
+
+Mọi issue ở **Backlog**. Thiết kế chi tiết từng hạng mục nằm ở plan nguồn
+[`../../../../260817-qa-quality-upgrade.md`](../../../../260817-qa-quality-upgrade.md)
+(đã red-team 2026-08-17); catalog này là authority về scope/trạng thái.
+P0.0/P0.0b/P0.2 của plan nguồn đã giao trước khi lập phase — không có issue
+hồi tố.
+
+## Dependency
+
+```text
+P2Q-01 (reindex + re-baseline) ── độc lập, làm sớm
+P2Q-02, P2Q-03 ── độc lập
+P2Q-04 ── gate bench NLI đầu issue quyết đi tiếp/hạ warning
+P2Q-05 → P2Q-06 → P2Q-07
+P2Q-08 ── sau khi P2Q-01 re-baseline; đụng fileconv-core (CLI/desktop/server)
+P2Q-09 ── độc lập; hữu ích sau P2Q-03
+```
+
+## P2Q-01 — Title tài liệu vào embedding input (index generation mới)
+
+- **Plan/files:** `workers/embedding.rs` `canonical_input(title, heading_path,
+  body)`; đổi `input_sha256` ⇒ index signature mới ⇒ **generation mới** qua
+  đường `index_metadata` đã có, không hồi tố generation active; code +
+  `approved_signature`/config deploy **cùng nhịp** (lệch là worker từ chối job
+  — ghi checklist deploy vào PR).
+- **Depends:** không; sau reindex phải re-baseline cả hai eval trước khi đánh
+  giá PR kế tiếp. **Acceptance/tests:** eval format tăng nhóm cross-doc/XLSX,
+  eval version không giảm >1 điểm median (≥2 run); test worker từ chối job khi
+  signature lệch.
+- **Security/migration:** đổi index signature/reindex — review bắt buộc; không
+  đổi schema PostgreSQL. **Out:** đổi embedding provider/model/dimension.
+
+## P2Q-02 — Tầng cảnh báo xung đột số liệu (warning-only)
+
+- **Plan/files:** `services/qa/grounding.rs`: câu có số nhưng không trích được
+  value theo pattern hiện tại → so số theo **kiểu giá trị** (% với %, tiền với
+  tiền, MWh với MWh) giữa câu và passage; lệch → warning, chưa prune. Loại
+  trước khi so: số VN `1.234,56`, "Điều 5", số hiệu văn bản, ngày tháng.
+  Warning kèm entry `WARNING_TRANSLATIONS` + test web.
+- **Depends:** P0.2 (đã giao). **Acceptance/tests:** unit case groundguard
+  300%↔30%, 4.8↔5 + case số Việt; không prune câu nào vòng này; nâng thành
+  gate chỉ ở PR sau khi đo FP = 0 trên 2 bộ eval.
+- **Security:** grounding policy — review bắt buộc. **Out:** prune/gate ngay
+  vòng này; so số trần không phân kiểu.
+
+## P2Q-03 — Completeness check sau OCR trước khi index
+
+- **Plan/files:** worker convert / `services/vision_ocr.rs` /
+  `services/ocr_normalize.rs`: so tín hiệu mật độ text của ảnh render với độ
+  dài/độ phủ output OCR; nghi thiếu → retry giới hạn rồi flag document +
+  warning, không index thầm bản cụt.
+- **Depends:** không. **Acceptance/tests:** case thật
+  `quyet-dinh-thanh-lap-to-ai.png` (OCR trả 112 ký tự tiêu đề, mất Điều 1–3,
+  tái lập ổn định) bị bắt; 4 ảnh đủ chữ của corpus đợt 2 không false-positive;
+  flag/warning hiển thị được ở web.
+- **Security:** không log nội dung tài liệu; đụng OCR/LLM path — review bắt
+  buộc. **Out:** đổi model/provider OCR; auto re-OCR không giới hạn.
+
+## P2Q-04 — Bench gate + structured entailment NLI local
+
+- **Plan/files:** Gate đầu issue: bench NLI đa ngữ trên tiếng Việt
+  (ứng viên mDeBERTa-v3-xnli, XLM-R NLI; license check theo quy trình
+  PhoWhisper) bằng bộ câu grounded/ungrounded gán nhãn từ eval log — đo cả
+  precision lẫn latency thật (ước 100–400ms/cặp CPU). Đạt → chạy sau
+  claim-check lexical cho câu đã pass, entailment ≥ ngưỡng mới grounded, có
+  timeout budget cho cả answer (quá hạn giữ hành vi dev-gate, không silent-pass,
+  không treo stream); kém → hạ vai trò xuống warning-only.
+- **Depends:** gate bench pass mới triển khai; fail thì đóng issue với evidence
+  bench. **Acceptance/tests:** báo cáo bench precision/latency; khi bật: đường
+  warning "structured entailment is NOT available" được gỡ; không có model →
+  hành vi hiện tại nguyên vẹn.
+- **Security:** model binary không commit, identifier không vào code
+  (CLAUDE.md); grounding/LLM policy + native binary — review bắt buộc.
+  **Out:** gọi API ngoài để entailment; cross-encoder rerank.
+
+## P2Q-05 — Tự nhận diện intent version từ câu hỏi (rule-based)
+
+- **Plan/files:** tầng rule deterministic (không LLM): pattern
+  "phiên bản/bản X", "thay đổi gì/khác gì/vì sao đổi", "so với", "trước
+  ngày/tại thời điểm" → suy mode `compare/as_of/history` + tham số khi xác
+  định được document qua anchor token; UI hiển thị mode đã nhận diện **nổi
+  bật** + revert 1 click; log tỷ lệ override. Không đổi contract `AskRequest`
+  — client set field sẵn có.
+- **Depends:** hạ tầng version modes hiện có (P1B/P2-10). **Acceptance/tests:**
+  ma trận rule unit test; câu version-sensitive gõ ở mode current được route;
+  không nhận diện được → giữ `current`; UI test revert.
+- **Security:** N/A — không đổi persisted contract; rủi ro đọc nhầm version cũ
+  được chặn bằng UI revert bắt buộc. **Out:** LLM intent classifier.
+
+## P2Q-06 — Bộ câu hỏi implicit-change cho eval version
+
+- **Plan/files:** mở rộng harness eval version: nhóm câu về thay đổi KHÔNG
+  ghi trong changelog corpus; đo và commit baseline (chắc chắn thấp — đó là
+  baseline) vào `bench/markhand_web/reports/` trước khi làm P2Q-07.
+- **Depends:** P2Q-05 (route intent để chạy đúng mode). **Acceptance/tests:**
+  bộ câu + số baseline nằm trong report; là tiêu chí nghiệm thu của P2Q-07.
+- **Security:** corpus tự sinh, không dữ liệu khách hàng. **Out:** change
+  index (P2Q-07).
+
+## P2Q-07 — Bảng `version_changes` và retrieval theo intent change
+
+- **Plan/files:** migration expand-only bảng `version_changes`: mỗi bản ghi =
+  một section thay đổi giữa version N và version cha, lưu **tham chiếu 2 span
+  thật** (chunk_id/span version cũ + mới), heading, loại thay đổi, diff tóm
+  tắt deterministic; sinh lúc publish version N>1 (diff canonical markdown đã
+  normalize, bỏ whitespace, ngưỡng độ dài). Retrieval chỉ tra khi intent là
+  change; hydrate 2 chunk thật làm passage; citation trỏ 2 chunk thật —
+  `verify_dual_spans` nguyên vẹn. Không sinh chunk mới, không vào index vector
+  bước đầu.
+- **Depends:** P2Q-05, P2Q-06. **Acceptance/tests:** điểm bộ P2Q-06 tăng;
+  mode current không ô nhiễm (`version_changes` không nằm trong retrieval
+  thường); diff không thấy thay đổi → fail-closed, không citation ảo.
+- **Security/migration:** SQL/RLS/migration — review bắt buộc; RLS org-scope
+  như các bảng khác. **Out:** embed diff text vào vector (cân nhắc PR sau);
+  GraphRAG.
+
+## P2Q-08 — Chunking theo loại tài liệu (fileconv-core, đa consumer)
+
+- **Plan/files:** `crates/core/src/chunk.rs` biến thể theo `FormatKind`: văn
+  bản pháp quy khóa ranh giới chunk theo Điều/Khoản (khớp
+  `promote_legal_headings` phía server); bảng dài lặp header mỗi chunk con;
+  PPTX mỗi slide một chunk. **Consumers:** CLI `fileconv`, desktop Markhand,
+  server worker index — thay đổi core-only nhưng phải đo cả ba.
+- **Depends:** làm sau khi P2Q-01 re-baseline (tránh nhiễu chồng).
+  **Acceptance/tests:** `fileconv accuracy`/`speed` không thoái hóa
+  (quy tắc CLAUDE.md); eval server tăng nhóm bảng/pháp quy; desktop CI xanh.
+- **Security/migration:** chunking version nằm trong index signature pin
+  (invariant 7) ⇒ áp lên server cần generation mới + re-baseline như P2Q-01;
+  review bắt buộc. **Out:** đổi API `chunk.rs` public contract ngoài mức cần;
+  sửa chunk tay.
+
+## P2Q-09 — UI xem chunk đã parse (read-only)
+
+- **Plan/files:** API list chunk theo document version (ACL như preview,
+  org-scope + RLS hiện có) + web UI: hiện `heading_path` + body từng chunk,
+  đánh dấu chunk nghi hỏng OCR (heading rỗng, mật độ ký tự bất thường).
+- **Depends:** không bắt buộc; flag từ P2Q-03 làm giàu hiển thị.
+  **Acceptance/tests:** xem đúng chunk theo version; denial test cross-org/
+  cross-user theo khuôn ACL hiện có; không lộ chunk ngoài quyền.
+- **Security:** surface đọc mới trên chunks — ACL/RLS review bắt buộc;
+  read-only. **Out:** sửa chunk tại chỗ (re-publish version — thiết kế riêng
+  giai đoạn sau).

--- a/plans/markhand-web/phase-2q-qa-quality.md
+++ b/plans/markhand-web/phase-2q-qa-quality.md
@@ -1,0 +1,38 @@
+# Phase 2Q — Nâng cấp chất lượng Q&A
+
+Workstream chất lượng trả lời (retrieval, grounding, version intelligence,
+chunking, vận hành chất lượng) tách từ plan đã red-team
+[`../260817-qa-quality-upgrade.md`](../260817-qa-quality-upgrade.md). Phase này
+chạy song song với đuôi Phase 2 — không phụ thuộc Phase 2 completion gate vì
+không đổi surface auth/ACL; từng issue tự khai dependency riêng.
+
+## Mục tiêu
+
+Nâng chất lượng Q&A đo được bằng hai bộ eval (đa định dạng + version-aware)
+mà không phá các bất biến đã có: citation phải có span byte-exact vào canonical
+markdown (`verify_dual_spans`), grounding fail-closed, index signature pin.
+
+## Baseline và nguồn
+
+- Baseline sau P0.0/P0.0b/P0.2 (đã giao 2026-08-18, trước khi lập phase):
+  eval đa định dạng v2 **92.9**, eval version **89.1**. Chi tiết đo, khoảng
+  trống G0–G8 và thiết kế từng hạng mục: xem plan nguồn ở trên — plan nguồn là
+  tài liệu thiết kế, catalog issue của phase này là authority về trạng thái.
+
+## Gate của phase
+
+- Mỗi PR: eval quyết định giữ/loại chạy **≥2 lần lấy median**; median không
+  giảm quá 1 điểm so baseline gần nhất, hạng mục nhắm tới phải tăng.
+- Sau mỗi lần đổi index generation (P2Q-01, P2Q-08 khi áp lên server) phải
+  **re-baseline** cả hai eval trước khi đánh giá PR kế tiếp.
+- Hạng mục đụng grounding/LLM policy/migration/native binary đi qua review
+  bắt buộc theo `.cursor/rules/repository-delivery.mdc`.
+- Warning mới phải kèm entry `WARNING_TRANSLATIONS` + test web.
+
+## Ngoài phạm vi phase
+
+Cross-encoder rerank, GraphRAG/knowledge graph, question decomposition đa hop
+(lý do loại: xem plan nguồn mục 1); sửa chunk tại chỗ (immutability — chỉ
+read-only viewer trong phase này).
+
+Issue catalog: [`backlog/phase-2q/issues/README.md`](backlog/phase-2q/issues/README.md)

--- a/plans/markhand-web/roadmap.html
+++ b/plans/markhand-web/roadmap.html
@@ -919,7 +919,7 @@
     };
 
     /* ROADMAP_DATA_START */
-    const ROADMAP_SOURCE_HASH = "7befe4f674d7e497";
+    const ROADMAP_SOURCE_HASH = "2ad77335daa87fe1";
     const phases = [
       {
         "id": "phase-f",
@@ -1438,6 +1438,61 @@
             "P2-23",
             "Blocking real-E2E/OWASP qualification gate",
             "blocked"
+          ]
+        ]
+      },
+      {
+        "id": "phase-2q",
+        "code": "2Q",
+        "name": "Nâng cấp chất lượng Q&A",
+        "description": "Nâng cấp chất lượng Q&A: embedding input, grounding, version intelligence, chunking, vận hành",
+        "plan": "phase-2q-qa-quality.md",
+        "catalog": "backlog/phase-2q/issues/README.md",
+        "issues": [
+          [
+            "P2Q-01",
+            "Title tài liệu vào embedding input (index generation mới)",
+            "backlog"
+          ],
+          [
+            "P2Q-02",
+            "Tầng cảnh báo xung đột số liệu (warning-only)",
+            "backlog"
+          ],
+          [
+            "P2Q-03",
+            "Completeness check sau OCR trước khi index",
+            "backlog"
+          ],
+          [
+            "P2Q-04",
+            "Bench gate + structured entailment NLI local",
+            "backlog"
+          ],
+          [
+            "P2Q-05",
+            "Tự nhận diện intent version từ câu hỏi (rule-based)",
+            "backlog"
+          ],
+          [
+            "P2Q-06",
+            "Bộ câu hỏi implicit-change cho eval version",
+            "backlog"
+          ],
+          [
+            "P2Q-07",
+            "Bảng `version_changes` và retrieval theo intent change",
+            "backlog"
+          ],
+          [
+            "P2Q-08",
+            "Chunking theo loại tài liệu (fileconv-core, đa consumer)",
+            "backlog"
+          ],
+          [
+            "P2Q-09",
+            "UI xem chunk đã parse (read-only)",
+            "backlog"
           ]
         ]
       },

--- a/scripts/sync-github-issues.py
+++ b/scripts/sync-github-issues.py
@@ -36,6 +36,7 @@ PHASE_LABELS = {
     "1B": ("web-p1b", "Phase 1B — Single-org POC"),
     "1C": ("web-p1c", "Phase 1C — Multi-org Security"),
     "2": ("web-p2", "Phase 2 — Web SPA MVP"),
+    "2Q": ("web-p2q", "Phase 2Q — QA Quality"),
     "3": ("web-p3", "Phase 3 — Document Intelligence"),
     "4": ("web-p4", "Phase 4 — Production Hardening"),
 }


### PR DESCRIPTION
## Summary

- Track workstream nâng cấp chất lượng Q&A (plan đã red-team `plans/260817-qa-quality-upgrade.md`) thành **Phase 2Q** trong catalog authority: phase plan `plans/markhand-web/phase-2q-qa-quality.md` + catalog `backlog/phase-2q/issues/README.md` với 9 issue `P2Q-01…09` (tất cả Backlog).
- Registry/count cập nhật: tổng 120 → **129 issue**; thêm hàng 2Q vào bảng phase + bảng tiến độ; `roadmap.html` regen; `github-issues.json` export lại; `sync-github-issues.py` thêm `PHASE_LABELS["2Q"]` (`web-p2q`, milestone "Phase 2Q — QA Quality").
- `docs/project-roadmap.md`: cập nhật mốc trạng thái 2026-08-18 + ghi nhận phần đã giao của workstream (P0.0/P0.0b/P0.2, eval 85.7 → 92.9) — không tạo issue hồi tố cho việc đã Done theo convention.

## Notes

- Code của P0.0/P0.0b/P0.2 (retry embedding, migration 0037, auto-attach citation) **chưa nằm trong PR này** — sẽ đi PR riêng theo rule một PR một outcome.
- Khi merge vào `master`, workflow `Sync Markhand Web issues` sẽ tự tạo milestone Phase 2Q + 9 GitHub issue (status backlog).
- P2Q-08 (chunking) đụng `fileconv-core` dùng chung — card đã ghi rõ consumer scope CLI/desktop/server + bench `fileconv accuracy/speed` bắt buộc; reviewer cân nhắc nếu muốn tách tracking core riêng.

## Test plan

- [x] `python scripts/build-roadmap.py` + `--check` pass (129 issues, dashboard khớp catalog)
- [x] `python scripts/sync-github-issues.py --dry-run` render milestone 2Q + 9 issue đúng ID/label
- [x] `python scripts/check-github-issue-consistency.py` OK (129 issues)
