### PR TITLE
fix(deps): bump nanoid override to 3.3.18 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "overrides": {
       "js-yaml": "4.3.1",
-      "nanoid": "3.3.17",
+      "nanoid": "3.3.18",
       "postcss": "8.5.23",
       "undici": "7.29.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   js-yaml: 4.3.1
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   postcss: 8.5.23
   undici: 7.29.0
 
@@ -1871,8 +1871,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4250,7 +4250,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -4337,7 +4337,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

- Bump pnpm override `nanoid` 3.3.17 → 3.3.18 (root `package.json` + lockfile) để vá advisory **high** [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) ("custom generators can loop indefinitely when size is zero", patched >=3.3.18; path `app > vite > postcss > nanoid`).
- Advisory mới publish nên job CI `security-deps` (`pnpm audit --audit-level high`) hiện fail trên mọi PR (thấy đầu tiên ở [#424](https://github.com/anhnth24/project-example/pull/424)) — fix này cần merge trước để mở lại pipeline.

## Test plan

- [x] `pnpm install` — lockfile chỉ đổi nanoid 3.3.17 → 3.3.18 (+2 −3 packages resolve lại)
- [x] `pnpm audit --audit-level high` → "No known vulnerabilities found" (exit 0)
